### PR TITLE
feat(wsl): add windows installer with docker desktop support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@ SERVER_IP=auto
 # SERVER_BIND_IP is the local interface/IP the game sockets listen on.
 # Leave unset for auto-detection, or set it to the Docker host LAN/public interface IP.
 # In NAT/port-forward setups, SERVER_BIND_IP is usually the LAN IP and SERVER_IP is the public WAN IP.
+# On Docker Desktop + WSL2, bind IP is often the Docker Desktop host-network IP (e.g. 192.168.65.x)
+# while SERVER_IP may be the WSL/Linux IP (e.g. 172.x.x.x). See WSL_README.md troubleshooting
+# "Players stuck on Connecting (Docker Desktop networking)" if clients hang on Connecting.
 # Example:
 # SERVER_BIND_IP=10.0.0.240
 # SERVER_IP_MODE=public
@@ -14,6 +17,8 @@ SERVER_IP_MODE=public
 
 # Docker Desktop/WSL2 only: override where game servers connect for RabbitMQ.
 # Native Linux normally uses 127.0.0.1 automatically.
+# RabbitMQ should remain reachable on the WSL/Linux side; see WSL_README.md if players
+# get stuck on Connecting after the server appears in the browser.
 # DUNE_RMQ_GAME_HOST=
 # DUNE_RMQ_ADMIN_HOST=
 
@@ -41,7 +46,8 @@ BATTLEGROUP_ID=
 # runtime/secrets/funcom-token.txt
 
 # Optional Arrakis Server Console web UI.
-ADMIN_BIND_HOST=auto
+# Bind on all interfaces inside the container; Docker publishes ADMIN_BIND_PORT to the host.
+ADMIN_BIND_HOST=0.0.0.0
 ADMIN_BIND_PORT=8088
 ADMIN_AUTH_DISABLED=0
 ADMIN_SECURE_COOKIES=0

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Local config / secrets
+.cursor/
 .env
+.wsl/
 runtime/secrets/
 runtime/generated/
 runtime/backups/

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Quick start from the repo root:
 powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
-This installs **Docker Engine inside WSL** by default (not Docker Desktop on Windows). Use `-ContainerRuntime podman` to opt in to Podman inside WSL instead.
+**Docker Desktop is required** on Windows/WSL. `install.ps1` uses it via WSL integration so containers appear in the Docker Desktop UI. If Docker Desktop is missing, the installer stops with a link to [download Docker Desktop](https://www.docker.com/products/docker-desktop/). Use `-ContainerRuntime docker` only as an advanced opt-in for embedded Engine, or `-ContainerRuntime podman` for Podman. See **[WSL_README.md](WSL_README.md)** for integration setup and troubleshooting.
 
 **Updates**
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,31 @@ bash -c 'set -euo pipefail; if ! command -v curl >/dev/null 2>&1; then sudo apt-
 
 The installer downloads the latest release, prepares the server, starts the Web UI, and tells you what address to open in your browser. If you are on the same network as the server, use the same-network address. If you are connecting over the internet, use the public address and allow TCP `8088` in your firewall.
 
+### Windows (WSL2)
+
+See **[WSL_README.md](WSL_README.md)** for the full Windows workflow, parameters, troubleshooting, and `.wsl/` state layout.
+
+Quick start from the repo root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+This installs **Docker Engine inside WSL** by default (not Docker Desktop on Windows). Use `-ContainerRuntime podman` to opt in to Podman inside WSL instead.
+
+**Updates**
+
+```powershell
+.\update.ps1
+.\update.ps1 -RebuildConsole      # when admin-server / web / Dockerfile changed
+.\update.ps1 -RebuildOrchestrator
+.\update.ps1 -FullStack
+```
+
+Open the Web UI from Windows at **http://localhost:8088**.
+
+For Docker Desktop/WSL2 RabbitMQ overrides, see [`.env.example`](.env.example).
+
 ## Contributing & Project Notes
 
 - Issues, fixes, and improvements are welcome.

--- a/WSL_README.md
+++ b/WSL_README.md
@@ -1,0 +1,214 @@
+# Windows / WSL Install Guide
+
+This guide covers the PowerShell installers for running Dune Docker Console on **Windows via WSL2**. Container workloads run **inside the WSL distro** (Docker Engine installed in WSL by default). This does **not** use Docker Desktop or Podman Desktop on Windows.
+
+## Overview
+
+| Item | Location / name |
+|------|-----------------|
+| Windows installer | [`install.ps1`](install.ps1) |
+| Windows updater | [`update.ps1`](update.ps1) |
+| WSL install state | `.wsl/install.json` (gitignored) |
+| WSL distro data | `.wsl/distro/Debian_Dune/` (default) |
+| Default WSL distro name | `Debian_Dune` |
+| Default container runtime | **Docker Engine** inside WSL |
+| Web UI (from Windows) | **http://localhost:8088** |
+
+Flow:
+
+1. `install.ps1` provisions WSL2 Debian as `Debian_Dune`, creates your Linux user, enables systemd.
+2. `wsl-bootstrap.sh` prepares the chosen container runtime inside WSL.
+3. `install.sh` installs Docker (or Podman if opted in), builds the console container, and starts the Web UI.
+
+## Prerequisites
+
+- Windows 10/11 with **WSL2** enabled
+- This repository cloned to a Windows path (e.g. `D:\workspace\dune-awakening-selfhost-docker`)
+- PowerShell 5.1+
+
+## Quick start
+
+From the repository root in PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\install.ps1
+```
+
+On first run you will be prompted for a **WSL username and password** (unless you pass `-WslUser` / `-WslPassword`).
+
+Open the Web UI from **Windows**:
+
+```
+http://localhost:8088
+```
+
+Use `localhost`, not the WSL internal IP (e.g. `172.x.x.x`). WSL2 forwards the port to Windows when the console container is running.
+
+## install.ps1
+
+Main Windows installer. Run from the repo root.
+
+### Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `-WslDistro` | `Debian_Dune` | Registered WSL distribution name (`wsl -l`) |
+| `-WslDistroDir` | `.wsl/distro/Debian_Dune` | Where WSL stores the distro (under repo) |
+| `-WslUser` | (prompt) | Linux user created inside WSL |
+| `-WslPassword` | (prompt) | Password for that user (never saved to disk) |
+| `-WorkspaceDir` | `.` | Repo mount path inside WSL; use `.wsl/workspace` for a nested clone |
+| `-ContainerRuntime` | `docker` | `docker` or `podman` — engine **inside WSL** |
+| `-RepoUrl` | GitHub URL | Used when `-WorkspaceDir .wsl/workspace` clones the repo |
+| `-SkipWslInstall` | off | Skip WSL package install if distro already exists |
+| `-Update` | off | Git pull only (same as `update.ps1` default) |
+
+### Examples
+
+```powershell
+# First install with explicit credentials
+.\install.ps1 -WslUser local -WslPassword 'your-secure-password'
+
+# Opt in to Podman inside WSL instead of Docker
+.\install.ps1 -ContainerRuntime podman
+
+# Re-run after clone (reads .wsl/install.json)
+.\install.ps1
+
+# Git pull only
+.\install.ps1 -Update
+```
+
+### What install.ps1 does
+
+1. Creates `.wsl/` for local state (gitignored).
+2. Installs/registers Debian WSL as `Debian_Dune` under `.wsl/distro/`.
+3. Creates the WSL user, passwordless sudo for install tasks, enables **systemd** in `/etc/wsl.conf`.
+4. Runs `wsl-bootstrap.sh` then `install.sh` inside WSL with `DUNE_CONTAINER_RUNTIME` set.
+5. Writes `.wsl/install.json` and prints the admin password + **http://localhost:8088**.
+
+## update.ps1
+
+Pulls latest git changes. Container rebuild is **optional**.
+
+```powershell
+.\update.ps1                      # git pull only
+.\update.ps1 -RebuildConsole      # rebuild Web UI container
+.\update.ps1 -RebuildOrchestrator # rebuild orchestrator
+.\update.ps1 -FullStack           # both rebuilds
+```
+
+Uses `containerRuntime` from `.wsl/install.json` (default `docker`).
+
+## .wsl/install.json
+
+Written by `install.ps1`. Example fields:
+
+| Field | Purpose |
+|-------|---------|
+| `wslDistro` | WSL distribution name |
+| `wslDistroInstallDir` | Windows path to distro root |
+| `wslUser` | Linux install user |
+| `containerRuntime` | `docker` or `podman` |
+| `repoRootWindows` / `repoRootWsl` | Repository paths |
+| `workspaceDirWsl` | Where `install.sh` runs |
+| `installedAt` | ISO timestamp |
+
+The WSL password is **never** stored.
+
+## Container runtime
+
+### Docker (default)
+
+- Docker Engine is installed **inside WSL** via `install.sh` (get.docker.com).
+- Uses `docker compose` and `/var/run/docker.sock`.
+- Does not require Docker Desktop on Windows.
+
+### Podman (opt-in)
+
+```powershell
+.\install.ps1 -ContainerRuntime podman
+```
+
+Uses Podman packages, socket setup, and `podman-compose` on WSL. Only choose this if you have a specific reason; Docker is the supported default.
+
+### Switching runtimes
+
+```powershell
+# Move to Docker
+.\install.ps1 -ContainerRuntime docker
+
+# Stay on Podman
+.\install.ps1 -ContainerRuntime podman
+```
+
+You may need to remove a stale console container once when switching:
+
+```bash
+docker rm -f redblink-dune-docker-console    # or podman rm -f ...
+```
+
+## Accessing the Web UI
+
+| From | URL |
+|------|-----|
+| Windows browser | **http://localhost:8088** |
+| Inside WSL only | `http://127.0.0.1:8088` or WSL eth IP |
+
+The installer prints an admin password from `runtime/secrets/admin-web-password.txt`.
+
+## Troubleshooting
+
+### localhost:8088 does not load
+
+1. Check the container inside WSL:
+
+   ```bash
+   docker ps
+   # or: podman ps
+   ```
+
+2. If missing, start manually:
+
+   ```bash
+   cd /mnt/d/path/to/dune-awakening-selfhost-docker
+   export ADMIN_BIND_HOST=0.0.0.0 ADMIN_BIND_PORT=8088
+   docker compose -f docker-compose.web.yml up -d --build --force-recreate redblink-dune-docker-console
+   ```
+
+3. Wait for the image build to finish (first run can take several minutes).
+
+### sudo: a password is required
+
+Re-run `.\install.ps1` so it can configure passwordless sudo for the install user (`enable-wsl-install-sudo.sh`).
+
+### systemd not running
+
+Ensure `/etc/wsl.conf` contains:
+
+```ini
+[boot]
+systemd=true
+```
+
+Then from Windows: `wsl --shutdown`, reopen WSL, run `install.ps1` again.
+
+### Stale container name
+
+```bash
+docker rm -f redblink-dune-docker-console
+```
+
+### WSL logs
+
+Install steps are appended to `.wsl/install.log`.
+
+## Related files
+
+| File | Role |
+|------|------|
+| [`install.sh`](install.sh) | Linux installer (called from WSL) |
+| [`runtime/scripts/wsl-bootstrap.sh`](runtime/scripts/wsl-bootstrap.sh) | WSL preflight + runtime prep |
+| [`runtime/scripts/ensure-podman-socket.sh`](runtime/scripts/ensure-podman-socket.sh) | Compose startup helpers (Docker and Podman paths) |
+| [`docker-compose.web.yml`](docker-compose.web.yml) | Web UI service definition |
+
+For Linux server installs (non-Windows), use [`install.sh`](install.sh) directly — see the main [README.md](README.md).

--- a/WSL_README.md
+++ b/WSL_README.md
@@ -1,6 +1,33 @@
 # Windows / WSL Install Guide
 
-This guide covers the PowerShell installers for running Dune Docker Console on **Windows via WSL2**. Container workloads run **inside the WSL distro** (Docker Engine installed in WSL by default). This does **not** use Docker Desktop or Podman Desktop on Windows.
+**New here?** Follow the [simple checklist](#start-here-simple-checklist) first. If anything fails, the installer prints numbered steps — do them in order, then run `install.ps1` again.
+
+This guide covers the PowerShell installers for running Dune Docker Console on **Windows via WSL2**. Container workloads are started **from inside** the `Debian_Dune` WSL distro using **Docker Desktop** via WSL integration (recommended by Docker for WSL). Containers and images appear in the **Docker Desktop UI**. Advanced opt-in: embedded Docker Engine (`-ContainerRuntime docker`) or Podman.
+
+## Start here (simple checklist)
+
+Do these in order. Use **Run as administrator** for PowerShell when possible.
+
+1. **Install [Docker Desktop](https://www.docker.com/products/docker-desktop/)** for Windows and start it. Wait until it says running (whale icon in the system tray).
+2. **Turn on WSL integration** in Docker Desktop: Settings (gear) → General → **Use the WSL 2 based engine** → Resources → **WSL Integration** → enable **`Debian_Dune`** → Apply & restart.
+3. **Open PowerShell as Administrator** (Start menu → type PowerShell → right-click → Run as administrator).
+4. **Go to this project folder** (where `install.ps1` lives):
+
+   ```powershell
+   cd D:\path\to\dune-awakening-selfhost-docker
+   ```
+
+5. **Run the installer:**
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File .\install.ps1
+   ```
+
+6. When it finishes, **open in your browser:** http://localhost:8088  
+   Use **localhost** only — not a `172.x.x.x` address.
+7. **Sign in** with the password the installer prints and complete the setup wizard.
+
+**Something broke?** Read the yellow/green boxes the installer printed. Full help is below in [Troubleshooting](#troubleshooting). Log file: `.wsl/install.log`.
 
 ## Overview
 
@@ -11,20 +38,26 @@ This guide covers the PowerShell installers for running Dune Docker Console on *
 | WSL install state | `.wsl/install.json` (gitignored) |
 | WSL distro data | `.wsl/distro/Debian_Dune/` (default) |
 | Default WSL distro name | `Debian_Dune` |
-| Default container runtime | **Docker Engine** inside WSL |
+| Default container runtime | **Docker Desktop** (required unless you opt in to embedded Engine or Podman) |
+| Docker Desktop UI | Containers/images visible when using the `docker-desktop` backend |
 | Web UI (from Windows) | **http://localhost:8088** |
 
 Flow:
 
 1. `install.ps1` provisions WSL2 Debian as `Debian_Dune`, creates your Linux user, enables systemd.
-2. `wsl-bootstrap.sh` prepares the chosen container runtime inside WSL.
-3. `install.sh` installs Docker (or Podman if opted in), builds the console container, and starts the Web UI.
+2. If Docker Desktop is installed: verify WSL integration for `Debian_Dune` (one-time in Docker Desktop settings).
+3. `wsl-bootstrap.sh` prepares the chosen container runtime (Desktop integration, embedded Engine, or Podman).
+4. When switching to Docker Desktop, embedded `docker.service` inside WSL is stopped/disabled automatically.
+5. `install.sh` builds the console container and starts the Web UI.
 
 ## Prerequisites
 
 - Windows 10/11 with **WSL2** enabled
 - This repository cloned to a Windows path (e.g. `D:\workspace\dune-awakening-selfhost-docker`)
 - PowerShell 5.1+
+- **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** for Windows with the WSL 2 backend — [WSL integration docs](https://docs.docker.com/desktop/features/wsl/)
+
+If Docker Desktop is not installed, `install.ps1` stops with download instructions instead of installing Docker Engine inside WSL automatically.
 
 ## Quick start
 
@@ -35,6 +68,8 @@ powershell -ExecutionPolicy Bypass -File .\install.ps1
 ```
 
 On first run you will be prompted for a **WSL username and password** (unless you pass `-WslUser` / `-WslPassword`).
+
+If Docker Desktop is installed, enable WSL integration for `Debian_Dune` before or when the installer prompts you (see [Docker Desktop WSL integration](#docker-desktop-wsl-integration-one-time-setup) below).
 
 Open the Web UI from **Windows**:
 
@@ -57,16 +92,31 @@ Main Windows installer. Run from the repo root.
 | `-WslUser` | (prompt) | Linux user created inside WSL |
 | `-WslPassword` | (prompt) | Password for that user (never saved to disk) |
 | `-WorkspaceDir` | `.` | Repo mount path inside WSL; use `.wsl/workspace` for a nested clone |
-| `-ContainerRuntime` | `docker` | `docker` or `podman` — engine **inside WSL** |
+| `-ContainerRuntime` | *(auto)* | See [Container runtime](#container-runtime) |
 | `-RepoUrl` | GitHub URL | Used when `-WorkspaceDir .wsl/workspace` clones the repo |
 | `-SkipWslInstall` | off | Skip WSL package install if distro already exists |
 | `-Update` | off | Git pull only (same as `update.ps1` default) |
+
+**`-ContainerRuntime` values**
+
+| Value | Meaning |
+|-------|---------|
+| *(auto)* | **Docker Desktop** via WSL integration (`docker-desktop`); installer stops if Desktop is missing |
+| `docker-desktop` | Force Docker Desktop backend (containers visible in Docker Desktop UI) |
+| `docker` | **Opt-in only:** embedded Docker Engine inside WSL (not visible in Docker Desktop UI) |
+| `podman` | Podman inside WSL |
 
 ### Examples
 
 ```powershell
 # First install with explicit credentials
 .\install.ps1 -WslUser local -WslPassword 'your-secure-password'
+
+# Force embedded Docker Engine in WSL (opt out of Docker Desktop)
+.\install.ps1 -ContainerRuntime docker
+
+# Force Docker Desktop backend explicitly
+.\install.ps1 -ContainerRuntime docker-desktop
 
 # Opt in to Podman inside WSL instead of Docker
 .\install.ps1 -ContainerRuntime podman
@@ -81,10 +131,14 @@ Main Windows installer. Run from the repo root.
 ### What install.ps1 does
 
 1. Creates `.wsl/` for local state (gitignored).
-2. Installs/registers Debian WSL as `Debian_Dune` under `.wsl/distro/`.
-3. Creates the WSL user, passwordless sudo for install tasks, enables **systemd** in `/etc/wsl.conf`.
-4. Runs `wsl-bootstrap.sh` then `install.sh` inside WSL with `DUNE_CONTAINER_RUNTIME` set.
-5. Writes `.wsl/install.json` and prints the admin password + **http://localhost:8088**.
+2. Checks Windows/WSL2 support and installs WSL if needed.
+3. Installs/registers Debian WSL as `Debian_Dune` under `.wsl/distro/`.
+4. Creates the WSL user, passwordless sudo for install tasks, enables **systemd** in `/etc/wsl.conf`.
+5. Auto-detects Docker Desktop and selects the `docker-desktop` backend when available.
+6. Verifies Docker Desktop WSL integration for `Debian_Dune` when using `docker-desktop`.
+7. Runs `wsl-bootstrap.sh` then `install.sh` inside WSL with `DUNE_CONTAINER_RUNTIME` set.
+8. Stops/disables embedded `docker.service` when migrating to Docker Desktop.
+9. Writes `.wsl/install.json` and prints the admin password + **http://localhost:8088**.
 
 ## update.ps1
 
@@ -97,7 +151,7 @@ Pulls latest git changes. Container rebuild is **optional**.
 .\update.ps1 -FullStack           # both rebuilds
 ```
 
-Uses `containerRuntime` from `.wsl/install.json` (default `docker`).
+Uses `containerRuntime` from `.wsl/install.json` (default `docker` or `docker-desktop` after install).
 
 ## .wsl/install.json
 
@@ -108,7 +162,7 @@ Written by `install.ps1`. Example fields:
 | `wslDistro` | WSL distribution name |
 | `wslDistroInstallDir` | Windows path to distro root |
 | `wslUser` | Linux install user |
-| `containerRuntime` | `docker` or `podman` |
+| `containerRuntime` | `docker-desktop`, `docker`, or `podman` |
 | `repoRootWindows` / `repoRootWsl` | Repository paths |
 | `workspaceDirWsl` | Where `install.sh` runs |
 | `installedAt` | ISO timestamp |
@@ -117,11 +171,26 @@ The WSL password is **never** stored.
 
 ## Container runtime
 
-### Docker (default)
+### Docker Desktop (default — required on Windows)
 
-- Docker Engine is installed **inside WSL** via `install.sh` (get.docker.com).
-- Uses `docker compose` and `/var/run/docker.sock`.
-- Does not require Docker Desktop on Windows.
+- **Required** for the default Windows/WSL install path.
+- If Docker Desktop is not detected, `install.ps1` stops and points you to [download Docker Desktop](https://www.docker.com/products/docker-desktop/).
+- Uses Docker Desktop’s daemon via **WSL integration** — containers and images show in the Docker Desktop UI.
+- Does **not** install `docker-ce` inside WSL via get.docker.com on the default path.
+- Stops/disables embedded `docker.service` if it was running from a prior install.
+- Requires one-time WSL integration setup (below).
+
+### Embedded Docker Engine (advanced opt-in)
+
+```powershell
+.\install.ps1 -ContainerRuntime docker
+```
+
+- Only when you **explicitly** pass `-ContainerRuntime docker`.
+- Installs Docker Engine **inside WSL** via `install.sh` (get.docker.com).
+- Uses `docker compose` and `/var/run/docker.sock` on the in-WSL daemon.
+- **Separate** from Docker Desktop — containers will **not** appear in the Docker Desktop UI.
+- Not used automatically when Docker Desktop is missing.
 
 ### Podman (opt-in)
 
@@ -129,22 +198,50 @@ The WSL password is **never** stored.
 .\install.ps1 -ContainerRuntime podman
 ```
 
-Uses Podman packages, socket setup, and `podman-compose` on WSL. Only choose this if you have a specific reason; Docker is the supported default.
+Uses Podman packages, socket setup, and `podman-compose` on WSL. Only choose this if you have a specific reason.
+
+### Docker Desktop WSL integration (one-time setup)
+
+Required when using the `docker-desktop` backend:
+
+1. Install and **start Docker Desktop**; wait until the engine is running.
+2. **Settings → General → Use the WSL 2 based engine** (enabled).
+3. **Settings → Resources → WSL Integration → enable `Debian_Dune`**.
+4. If the WSL Integration tab is missing: Docker tray icon → **Switch to Linux containers**.
+5. Verify from PowerShell:
+
+   ```powershell
+   wsl -d Debian_Dune -- docker info --format '{{.OperatingSystem}}'
+   ```
+
+   Expected output contains `Docker Desktop`.
+
+Official guide: https://docs.docker.com/desktop/features/wsl/
 
 ### Switching runtimes
 
 ```powershell
-# Move to Docker
+# Use Docker Desktop (default)
+.\install.ps1 -ContainerRuntime docker-desktop
+
+# Use embedded Docker Engine in WSL
 .\install.ps1 -ContainerRuntime docker
 
-# Stay on Podman
+# Use Podman
 .\install.ps1 -ContainerRuntime podman
 ```
 
-You may need to remove a stale console container once when switching:
+When switching, you may need to remove a stale console container once:
 
 ```bash
 docker rm -f redblink-dune-docker-console    # or podman rm -f ...
+```
+
+If moving from embedded Docker to Docker Desktop, the installer stops embedded `dockerd` automatically. To do it manually:
+
+```bash
+sudo systemctl stop docker
+sudo systemctl disable docker
 ```
 
 ## Accessing the Web UI
@@ -153,12 +250,137 @@ docker rm -f redblink-dune-docker-console    # or podman rm -f ...
 |------|-----|
 | Windows browser | **http://localhost:8088** |
 | Inside WSL only | `http://127.0.0.1:8088` or WSL eth IP |
+| Docker Desktop UI | Containers / Images tabs (when using `docker-desktop`) |
 
 The installer prints an admin password from `runtime/secrets/admin-web-password.txt`.
 
 ## Troubleshooting
 
+### Docker Desktop not installed
+
+`install.ps1` does not fall back to embedded Docker Engine on the default path. Install Docker Desktop:
+
+1. Download from [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/)
+2. Install and start Docker Desktop
+3. Complete [WSL integration setup](#docker-desktop-wsl-integration-one-time-setup)
+4. Re-run `.\install.ps1`
+
+### Containers not visible in Docker Desktop
+
+1. Confirm runtime is `docker-desktop` in `.wsl/install.json` (or re-run `.\install.ps1` without `-ContainerRuntime docker`).
+2. Enable WSL integration for **`Debian_Dune`** in Docker Desktop → Settings → Resources → WSL Integration.
+3. Check embedded dockerd is not still running inside WSL:
+
+   ```bash
+   systemctl status docker
+   ```
+
+   If active, run `.\install.ps1` again or stop/disable manually (see [Switching runtimes](#switching-runtimes)).
+4. Confirm Docker Desktop is in **Linux containers** mode (tray icon).
+5. Verify integration:
+
+   ```powershell
+   wsl -d Debian_Dune -- docker info --format '{{.OperatingSystem}}'
+   ```
+
+### Docker Desktop WSL integration failed
+
+Follow the steps in [Docker Desktop WSL integration](#docker-desktop-wsl-integration-one-time-setup). The installer prints self-help with links when integration is missing. See also https://docs.docker.com/desktop/features/wsl/
+
+### Both Docker Desktop and embedded Engine were running
+
+This causes split visibility — Desktop shows only its own daemon’s containers. Re-run `.\install.ps1` to migrate to Docker Desktop (embedded `docker.service` is stopped/disabled). Or manually:
+
+```bash
+sudo systemctl stop docker
+sudo systemctl disable docker
+```
+
+Then enable WSL integration and re-run the installer.
+
+### Players stuck on Connecting (Docker Desktop networking)
+
+If your server appears in the in-game browser but players get stuck on **Connecting**, Windows may be routing traffic through the wrong virtual network adapter.
+
+This often happens when Hyper-V, VMware, WSL2, or Docker Desktop create multiple virtual adapters — especially when **VMware Bridge Protocol** is enabled on the wrong adapter.
+
+#### Expected setup on Docker Desktop + WSL
+
+A common working configuration:
+
+| Role | Typical IP | Notes |
+|------|------------|--------|
+| Game server **bind** (`SERVER_BIND_IP`) | Docker Desktop host-network IP, e.g. `192.168.65.3` | Where game sockets listen (auto-detected via [`runtime-env.sh`](runtime/scripts/runtime-env.sh) on Docker Desktop) |
+| Server **advertised** to clients (`SERVER_IP`) | WSL/Linux IP, e.g. `172.x.x.x` | What clients use to connect |
+| RabbitMQ | Reachable on the WSL/Linux side | See `DUNE_RMQ_*` overrides in [`.env.example`](.env.example) if needed |
+
+The installer and runtime scripts try to detect Docker Desktop bind IPs automatically. If routing is wrong, fix adapters first (below), then verify IPs.
+
+#### Fix Windows network adapters
+
+When you run `install.ps1` **as Administrator** with the Docker Desktop runtime, it automatically **disables VMware Bridge Protocol** on Hyper-V `vEthernet` adapters (including **vEthernet (Default Switch)**) if that binding is enabled.
+
+Manual fix if you are not elevated, VMware is not installed, or the automatic step could not run:
+
+1. Open **Control Panel → Network and Internet → Network Connections** (or `ncpa.cpl`).
+2. Right-click **vEthernet (Default Switch)** → **Properties**.
+3. **Uncheck VMware Bridge Protocol** (if present) → **OK**.
+4. Repeat for other virtual adapters if VMware/Hyper-V conflicts persist — VMware Bridge should not be bound to adapters used by Docker Desktop/WSL unless you know you need it.
+5. **Restart Docker Desktop**.
+6. Restart WSL from PowerShell:
+
+   ```powershell
+   wsl --shutdown
+   ```
+
+7. Start the Dune Docker stack again (Web UI setup wizard or `./runtime/scripts/dune` commands).
+
+#### Verify routing (inside WSL)
+
+From your repo directory in WSL:
+
+```bash
+ip -4 route get 1.1.1.1
+
+docker run --rm --network host --entrypoint sh redblink-dune-docker-console:dev \
+  -c 'ip -4 route get 1.1.1.1'
+```
+
+Compare the `src` IPs. The host-network container route should reflect the Docker Desktop bind path; the WSL route should reflect the Linux side used for advertised connectivity and RabbitMQ.
+
+#### Restart game services (inside WSL)
+
+If routing looks correct after the restarts above:
+
+```bash
+runtime/scripts/start-rabbitmq.sh
+./runtime/scripts/dune restart director
+./runtime/scripts/dune restart gateway
+./runtime/scripts/dune restart text-router
+./runtime/scripts/dune restart survival
+./runtime/scripts/dune restart overmap
+```
+
+#### Readiness checks
+
+```bash
+./runtime/scripts/dune ready
+```
+
+Confirm:
+
+- `dune-rmq-game` is running
+- `dune-rmq-admin` is running
+- Survival and Overmap logs show **listening for Clients**
+- No repeated **RMQ runnable failed** errors
+
+Once those are clean, try joining again.
+
+For bind/advertise IP overrides, see [`.env.example`](.env.example) (`SERVER_BIND_IP`, `SERVER_IP`, `DUNE_RMQ_GAME_HOST`, `DUNE_RMQ_ADMIN_HOST`).
+
 ### localhost:8088 does not load
+
+The console uses a **published Docker port** (`8088:8088`), not host networking, so Windows can open http://localhost:8088 through Docker Desktop.
 
 1. Check the container inside WSL:
 
@@ -176,6 +398,35 @@ The installer prints an admin password from `runtime/secrets/admin-web-password.
    ```
 
 3. Wait for the image build to finish (first run can take several minutes).
+
+### `registry.funcom.com: no such host` / boot auto-start exit 125
+
+This usually means **Funcom images are not loaded yet**, not that your internet is broken.
+
+- `registry.funcom.com/...` is the **local tag name** for images shipped inside the Steam self-host package.
+- They are loaded with `docker load` from tarballs (via the Web UI setup wizard or `runtime/scripts/update.sh install`), **not** pulled from a public registry.
+- When Postgres or game images are missing, `docker run` tries to pull and fails with `lookup registry.funcom.com: no such host`.
+
+**Fix**
+
+1. Open http://localhost:8088 and complete first-time setup (downloads Steam files and loads images), **or** inside WSL:
+
+   ```bash
+   cd /mnt/d/path/to/dune-awakening-selfhost-docker
+   runtime/scripts/update.sh install
+   ```
+
+2. Confirm images exist:
+
+   ```bash
+   docker images | grep registry.funcom.com
+   ```
+
+**WSL DNS** (only affects name resolution inside WSL; Docker Desktop uses its own VM DNS):
+
+- `install.ps1` configures `/etc/wsl.conf` (`generateResolvConf=false`) and `/etc/resolv.conf` using your Windows DNS servers.
+- Override: create `.wsl/dns-servers.txt` in the repo (one IPv4 nameserver per line), then re-run `.\install.ps1`.
+- Embedded Docker Engine (`-ContainerRuntime docker`) also gets matching DNS in `/etc/docker/daemon.json`.
 
 ### sudo: a password is required
 
@@ -208,6 +459,8 @@ Install steps are appended to `.wsl/install.log`.
 |------|------|
 | [`install.sh`](install.sh) | Linux installer (called from WSL) |
 | [`runtime/scripts/wsl-bootstrap.sh`](runtime/scripts/wsl-bootstrap.sh) | WSL preflight + runtime prep |
+| [`runtime/scripts/configure-wsl-dns.sh`](runtime/scripts/configure-wsl-dns.sh) | WSL `/etc/wsl.conf` + `/etc/resolv.conf` and embedded Docker DNS |
+| [`runtime/scripts/docker-desktop-wsl.sh`](runtime/scripts/docker-desktop-wsl.sh) | Docker Desktop WSL integration helpers |
 | [`runtime/scripts/ensure-podman-socket.sh`](runtime/scripts/ensure-podman-socket.sh) | Compose startup helpers (Docker and Podman paths) |
 | [`docker-compose.web.yml`](docker-compose.web.yml) | Web UI service definition |
 

--- a/docker-compose.web.yml
+++ b/docker-compose.web.yml
@@ -6,9 +6,12 @@ services:
     image: redblink-dune-docker-console:dev
     container_name: redblink-dune-docker-console
     restart: unless-stopped
-    # Host networking lets the console reach RedBlink defaults such as
-    # Postgres on 127.0.0.1:15432 and bind ADMIN_BIND_PORT directly.
-    network_mode: host
+    # Bridge + published port so Windows can open http://localhost:8088 through Docker Desktop.
+    # (host network binds inside the Docker Desktop VM; Windows localhost does not reach it.)
+    ports:
+      - "${ADMIN_BIND_PORT:-8088}:${ADMIN_BIND_PORT:-8088}"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     environment:
       DUNE_DOCKER_DIR: /repo
       DUNE_CONTAINER_REPO_ROOT: /repo
@@ -27,7 +30,7 @@ services:
       ADMIN_MOCK_MODE: "${ADMIN_MOCK_MODE:-0}"
       ADMIN_STATIC_DIR: /app/web-dist
       ADMIN_DATABASE_URL: "${ADMIN_DATABASE_URL:-}"
-      DUNE_DB_HOST: "${DUNE_DB_HOST:-}"
+      DUNE_DB_HOST: "${DUNE_DB_HOST:-host.docker.internal}"
       DUNE_DB_PORT: "${DUNE_DB_PORT:-}"
       DUNE_DB_NAME: "${DUNE_DB_NAME:-}"
       DUNE_DB_USER: "${DUNE_DB_USER:-}"

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,1311 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [string]$WslDistro = 'Debian_Dune',
+    [string]$WslDistroDir = '',
+    [string]$WslUser = '',
+    [string]$WslPassword = '',
+    [string]$WorkspaceDir = '',
+    [string]$RepoUrl = 'https://github.com/Red-Blink/dune-awakening-selfhost-docker.git',
+    [ValidateSet('docker', 'podman', '')]
+    [string]$ContainerRuntime = '',
+    [switch]$SkipWslInstall,
+    [switch]$Update
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Script:RepoRoot = $PSScriptRoot
+$Script:WslFolder = Join-Path $RepoRoot '.wsl'
+$Script:InstallConfigPath = Join-Path $WslFolder 'install.json'
+$Script:InstallLogPath = Join-Path $WslFolder 'install.log'
+$Script:DefaultWorkspaceDir = '.'
+$Script:WslUserName = ''
+$Script:WslPasswordPlain = ''
+$Script:WslDistroPackage = 'Debian'
+$Script:WslHelpText = ''
+$Script:WslDocLinks = @{
+    InstallGuide         = 'https://learn.microsoft.com/en-us/windows/wsl/install'
+    ManualInstall        = 'https://learn.microsoft.com/en-us/windows/wsl/install-manual'
+    Troubleshooting      = 'https://learn.microsoft.com/en-us/windows/wsl/troubleshooting'
+    UpdateWsl            = 'https://learn.microsoft.com/en-us/windows/wsl/basic-commands#update-wsl'
+    Virtualization       = 'https://learn.microsoft.com/en-us/windows/wsl/troubleshooting#error-0x80370102-the-virtual-machine-platform-is-not-enabled'
+    SystemRequirements   = 'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2'
+    SetDefaultVersion    = 'https://learn.microsoft.com/en-us/windows/wsl/basic-commands#set-default-version-to-wsl-1-or-wsl-2'
+    ExecutionPolicy      = 'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies'
+}
+
+function Join-BashScriptLines {
+    param(
+        [Parameter(ValueFromRemainingArguments = $true)]
+        [string[]]$Line
+    )
+    return ($Line -join "`n")
+}
+
+function Write-InstallLog {
+    param([string]$Message)
+    $line = "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] $Message"
+    if (Test-Path -LiteralPath $Script:WslFolder) {
+        Add-Content -LiteralPath $Script:InstallLogPath -Value $line
+    }
+}
+
+function Write-InstallBanner {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host $Message
+}
+
+function Write-InstallStep {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "==> $Message"
+    Write-InstallLog $Message
+}
+
+function Initialize-WslFolder {
+    if (-not (Test-Path -LiteralPath $Script:WslFolder)) {
+        New-Item -ItemType Directory -Path $Script:WslFolder -Force | Out-Null
+    }
+}
+
+function Resolve-ContainerRuntime {
+    if ($ContainerRuntime) {
+        return $ContainerRuntime
+    }
+    $config = Get-InstallConfig
+    if ($config -and $config.containerRuntime) {
+        return [string]$config.containerRuntime
+    }
+    return 'docker'
+}
+
+function Get-InstallConfig {
+    if (-not (Test-Path -LiteralPath $Script:InstallConfigPath)) {
+        return $null
+    }
+    return Get-Content -LiteralPath $Script:InstallConfigPath -Raw | ConvertFrom-Json
+}
+
+function Set-InstallConfig {
+    param(
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Config
+    )
+    Initialize-WslFolder
+    ($Config | ConvertTo-Json -Depth 5) | Set-Content -LiteralPath $Script:InstallConfigPath -Encoding UTF8
+}
+
+function Get-WslOutputLine {
+    param($Item)
+    if ($Item -is [System.Management.Automation.ErrorRecord]) {
+        return $Item.ToString()
+    }
+    return [string]$Item
+}
+
+function Write-WslStreamLine {
+    param([string]$Line)
+    if ([string]::IsNullOrWhiteSpace($Line)) {
+        return
+    }
+    Write-Host $Line
+}
+
+function New-WslCommandArgs {
+    param(
+        [string]$Distro,
+        [string]$User,
+        [string]$Command
+    )
+    $wslArgList = New-Object 'System.Collections.Generic.List[string]'
+    [void]$wslArgList.Add('-d')
+    [void]$wslArgList.Add($Distro)
+    if ($User) {
+        [void]$wslArgList.Add('-u')
+        [void]$wslArgList.Add($User)
+    }
+    [void]$wslArgList.Add('--')
+    [void]$wslArgList.Add('bash')
+    [void]$wslArgList.Add('-lc')
+    [void]$wslArgList.Add($Command)
+    return $wslArgList.ToArray()
+}
+
+function ConvertTo-WslBashPipeCommand {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ScriptContent
+    )
+    $unixContent = ($ScriptContent -replace "`r`n", "`n") -replace "`r", "`n"
+    $scriptB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($unixContent))
+    $run = 'echo ''__SCRIPT_B64__'' | base64 -d | bash'
+    return $run.Replace('__SCRIPT_B64__', $scriptB64)
+}
+
+function Invoke-Wsl {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+        [string]$Distro = $WslDistro,
+        [string]$User = '',
+        [switch]$StreamOutput
+    )
+    if ($Command -match '[\r\n]') {
+        $Command = ConvertTo-WslBashPipeCommand -ScriptContent $Command
+    }
+    $wslArgs = New-WslCommandArgs -Distro $Distro -User $User -Command $Command
+
+    if ($StreamOutput) {
+        $lines = New-Object System.Collections.Generic.List[string]
+        $prevErrorAction = $ErrorActionPreference
+        $ErrorActionPreference = 'Continue'
+        try {
+            & wsl.exe @wslArgs 2>&1 | ForEach-Object {
+                $line = Get-WslOutputLine $_
+                [void]$lines.Add($line)
+                Write-WslStreamLine -Line $line
+            }
+        }
+        finally {
+            $ErrorActionPreference = $prevErrorAction
+        }
+        if ($LASTEXITCODE -ne 0) {
+            $joined = ($lines -join [Environment]::NewLine)
+            Write-WslCommandFailureHelp -OutputText $joined
+            throw ('WSL command failed (exit {0}): {1}{2}{3}' -f $LASTEXITCODE, $Command, [Environment]::NewLine, $joined)
+        }
+        return $lines
+    }
+
+    $output = & wsl.exe @wslArgs 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        $outputText = if ($output -is [array]) { ($output -join [Environment]::NewLine) } else { [string]$output }
+        Write-WslCommandFailureHelp -OutputText $outputText
+        throw ('WSL command failed (exit {0}): {1}{2}{3}' -f $LASTEXITCODE, $Command, [Environment]::NewLine, $outputText)
+    }
+    return $output
+}
+
+function Invoke-WslBashScript {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ScriptContent,
+        [string]$Distro = $WslDistro,
+        [string]$User = '',
+        [string]$ScriptName = 'wsl-task.sh'
+    )
+    $run = ConvertTo-WslBashPipeCommand -ScriptContent $ScriptContent
+
+    Invoke-Wsl -Distro $Distro -User $User -Command $run | Out-Null
+}
+
+function Test-WslUsername {
+    param([Parameter(Mandatory = $true)][string]$Name)
+    if ($Name -notmatch '^[a-z_][a-z0-9_-]*$') {
+        throw "Invalid WSL username '$Name'. Use lowercase letters, numbers, underscore, or hyphen."
+    }
+}
+
+function Read-WslPasswordPlain {
+    $secure = Read-Host 'WSL password' -AsSecureString
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+    try {
+        return [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
+    }
+    finally {
+        if ($bstr -ne [IntPtr]::Zero) {
+            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
+        }
+    }
+}
+
+function Resolve-WslCredentials {
+    param(
+        [switch]$RequirePassword
+    )
+    $config = Get-InstallConfig
+    if (-not $WslUser -and $config -and $config.wslUser) {
+        $Script:WslUserName = [string]$config.wslUser
+    }
+    elseif ($WslUser) {
+        $Script:WslUserName = $WslUser.Trim()
+    }
+
+    if (-not $Script:WslUserName) {
+        $Script:WslUserName = (Read-Host 'WSL username').Trim()
+    }
+
+    Test-WslUsername -Name $Script:WslUserName
+
+    if ($WslPassword) {
+        $Script:WslPasswordPlain = $WslPassword
+        return
+    }
+    if ($RequirePassword) {
+        $Script:WslPasswordPlain = Read-WslPasswordPlain
+        return
+    }
+    if ($config -and $config.wslUser -eq $Script:WslUserName) {
+        return
+    }
+    $Script:WslPasswordPlain = Read-WslPasswordPlain
+}
+
+function Initialize-WslLinuxUser {
+    param(
+        [string]$Distro = $WslDistro,
+        [string]$User = $Script:WslUserName,
+        [string]$Password = $Script:WslPasswordPlain
+    )
+    if (-not $Password) {
+        return
+    }
+
+    Write-InstallStep "Configuring WSL user: $User"
+    $userB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($User))
+    $passB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Password))
+    $configureUserPath = Join-Path $Script:RepoRoot 'runtime/scripts/configure-wsl-user.sh'
+    $configureUser = Get-Content -LiteralPath $configureUserPath -Raw
+    $configureUser = $configureUser -replace '__USER_B64__', $userB64 -replace '__PASS_B64__', $passB64
+
+    Invoke-WslBashScript -Distro $Distro -User root -ScriptContent $configureUser -ScriptName 'configure-user.sh' | Out-Null
+    wsl.exe --shutdown | Out-Null
+    Start-Sleep -Seconds 3
+    Invoke-Wsl -Distro $Distro -User $User -Command 'echo WSL user is ready.' | Out-Null
+}
+
+function Set-WslInstallUserSudo {
+    param(
+        [string]$Distro = $WslDistro,
+        [string]$User = $Script:WslUserName
+    )
+    if (-not $User) {
+        return
+    }
+
+    Test-WslUsername -Name $User
+    Write-InstallStep "Ensuring passwordless sudo for WSL install user: $User"
+    $enableSudoPath = Join-Path $Script:RepoRoot 'runtime/scripts/enable-wsl-install-sudo.sh'
+    $enableSudo = Get-Content -LiteralPath $enableSudoPath -Raw
+    $enableSudo = $enableSudo -replace '__USER__', $User
+    Invoke-WslBashScript -Distro $Distro -User root -ScriptContent $enableSudo -ScriptName 'enable-wsl-install-sudo.sh' | Out-Null
+}
+
+function Invoke-WslAsInstallUser {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+        [string]$Distro = $WslDistro,
+        [switch]$StreamOutput
+    )
+    Invoke-Wsl -Distro $Distro -User $Script:WslUserName -Command $Command -StreamOutput:$StreamOutput
+}
+
+function Get-WslDistroBasePath {
+    param([string]$Distro = $WslDistro)
+    $keys = Get-ChildItem 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Lxss' -ErrorAction SilentlyContinue
+    foreach ($key in $keys) {
+        $props = Get-ItemProperty -LiteralPath $key.PSPath -ErrorAction SilentlyContinue
+        if ($props -and [string]$props.DistributionName -eq $Distro) {
+            return [string]$props.BasePath
+        }
+    }
+    return ''
+}
+
+function Resolve-WslDistroInstallDir {
+    $config = Get-InstallConfig
+    if ($WslDistroDir) {
+        $relative = $WslDistroDir.Trim()
+        if ([IO.Path]::IsPathRooted($relative)) {
+            return (Resolve-Path -LiteralPath $relative).Path
+        }
+        return (Join-Path $Script:RepoRoot ($relative -replace '/', [IO.Path]::DirectorySeparatorChar))
+    }
+    if ($config -and $config.wslDistroInstallDir) {
+        return [string]$config.wslDistroInstallDir
+    }
+    return Join-Path $Script:WslFolder 'distro' $WslDistro
+}
+
+function Test-WslDistroAtInstallDir {
+    param(
+        [string]$Distro = $WslDistro,
+        [string]$InstallDir
+    )
+    if (-not (Test-Path -LiteralPath $InstallDir)) {
+        return $false
+    }
+    $current = Get-WslDistroBasePath -Distro $Distro
+    if (-not $current) {
+        return $false
+    }
+    try {
+        $expected = (Resolve-Path -LiteralPath $InstallDir).Path
+        $actual = (Resolve-Path -LiteralPath $current).Path
+        return $expected -eq $actual
+    }
+    catch {
+        return $false
+    }
+}
+
+function Write-WslSelfHelp {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Title,
+        [string[]]$Steps = @(),
+        [string[]]$Links = @()
+    )
+    Write-Host ""
+    Write-Host "=== $Title ===" -ForegroundColor Yellow
+    foreach ($step in $Steps) {
+        Write-Host "  - $step"
+    }
+    if ($Links.Count -gt 0) {
+        Write-Host ""
+        Write-Host "Helpful links:"
+        foreach ($link in $Links) {
+            Write-Host "  $link"
+        }
+    }
+    Write-Host ""
+    Write-Host "Local guide: $(Join-Path $Script:RepoRoot 'WSL_README.md')"
+    if (Test-Path -LiteralPath $Script:InstallLogPath) {
+        Write-Host "Install log:   $($Script:InstallLogPath)"
+    }
+}
+
+function Test-IsAdministrator {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Test-WindowsWslSupport {
+    $os = Get-CimInstance Win32_OperatingSystem
+    $build = [int]$os.BuildNumber
+    $arch = $env:PROCESSOR_ARCHITECTURE
+    $issues = @()
+
+    if ($arch -notin @('AMD64', 'ARM64')) {
+        $issues += "Unsupported CPU architecture '$arch'. WSL2 needs 64-bit x64 or ARM64 Windows."
+    }
+    if ($build -lt 19041) {
+        $issues += "Windows build $build is below the WSL2 minimum (19041 / Windows 10 version 2004). Update Windows and try again."
+    }
+
+    return @{
+        Supported    = ($issues.Count -eq 0)
+        Issues       = $issues
+        BuildNumber  = $build
+        Architecture = $arch
+        OsCaption    = [string]$os.Caption
+    }
+}
+
+function Test-WslVirtualizationEnabled {
+    try {
+        if ((Get-CimInstance Win32_ComputerSystem -ErrorAction Stop).HypervisorPresent) {
+            return $true
+        }
+    }
+    catch {
+        # fall through
+    }
+    try {
+        $cpu = Get-CimInstance Win32_Processor -ErrorAction Stop | Select-Object -First 1
+        if ($null -ne $cpu.VirtualizationFirmwareEnabled) {
+            return [bool]$cpu.VirtualizationFirmwareEnabled
+        }
+    }
+    catch {
+        return $null
+    }
+    return $null
+}
+
+function Test-WindowsRebootPending {
+    if (Test-Path -LiteralPath 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired') {
+        return $true
+    }
+    if (Test-Path -LiteralPath 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending') {
+        return $true
+    }
+    return $false
+}
+
+function Get-WslOptionalFeatureState {
+    param([Parameter(Mandatory = $true)][string]$FeatureName)
+    if (-not (Test-IsAdministrator)) {
+        return $null
+    }
+    try {
+        $feature = Get-WindowsOptionalFeature -Online -FeatureName $FeatureName -ErrorAction Stop
+        return [string]$feature.State
+    }
+    catch {
+        return $null
+    }
+}
+
+function Get-WslPlatformStatus {
+    $status = @{
+        WslExeAvailable    = $false
+        WslVersionText     = ''
+        DefaultVersion     = ''
+        StatusText         = ''
+        Features           = @{}
+        RebootRequired     = (Test-WindowsRebootPending)
+    }
+
+    if (Get-Command wsl.exe -ErrorAction SilentlyContinue) {
+        $status.WslExeAvailable = $true
+        $status.WslVersionText = (wsl.exe --version 2>&1 | Out-String).Trim()
+        $status.StatusText = (wsl.exe --status 2>&1 | Out-String).Trim()
+        if ($status.StatusText -match 'Default Version:\s*(\d+)') {
+            $status.DefaultVersion = $Matches[1]
+        }
+    }
+
+    foreach ($featureName in @('Microsoft-Windows-Subsystem-Linux', 'VirtualMachinePlatform')) {
+        $state = Get-WslOptionalFeatureState -FeatureName $featureName
+        if ($state) {
+            $status.Features[$featureName] = $state
+        }
+    }
+
+    return $status
+}
+
+function Test-WslPlatformReady {
+    param([hashtable]$PlatformStatus)
+
+    if (-not $PlatformStatus.WslExeAvailable) {
+        return $false
+    }
+    if ($PlatformStatus.WslVersionText -notmatch 'WSL version') {
+        return $false
+    }
+    if ($PlatformStatus.DefaultVersion -and $PlatformStatus.DefaultVersion -ne '2') {
+        return $false
+    }
+
+    $wslFeature = $PlatformStatus.Features['Microsoft-Windows-Subsystem-Linux']
+    $vmpFeature = $PlatformStatus.Features['VirtualMachinePlatform']
+    if ($wslFeature -and $wslFeature -ne 'Enabled') {
+        return $false
+    }
+    if ($vmpFeature -and $vmpFeature -ne 'Enabled') {
+        return $false
+    }
+
+    return $true
+}
+
+function Enable-WslWindowsFeatures {
+    Write-InstallStep "Enabling Windows optional features for WSL2"
+    $needsReboot = $false
+    foreach ($featureName in @('Microsoft-Windows-Subsystem-Linux', 'VirtualMachinePlatform')) {
+        $state = Get-WslOptionalFeatureState -FeatureName $featureName
+        if ($state -eq 'Enabled') {
+            Write-Host "  $featureName is already enabled."
+            continue
+        }
+        Write-Host "  Enabling $featureName ..."
+        $dismOutput = & dism.exe /online /enable-feature /featurename:$featureName /all /norestart 2>&1
+        $dismOutput | ForEach-Object { Write-Host $_ }
+        if ($LASTEXITCODE -ne 0) {
+            Write-WslSelfHelp -Title "Could not enable Windows feature '$featureName'" -Steps @(
+                "Run PowerShell as Administrator and try again.",
+                "Or open 'Turn Windows features on or off' and enable 'Windows Subsystem for Linux' and 'Virtual Machine Platform' manually."
+            ) -Links @(
+                $Script:WslDocLinks.ManualInstall,
+                $Script:WslDocLinks.Troubleshooting
+            )
+            throw "Failed to enable Windows feature '$featureName' (dism exit $LASTEXITCODE)."
+        }
+        $needsReboot = $true
+    }
+    return $needsReboot
+}
+
+function Install-WslPlatformComponents {
+    Write-InstallStep "Installing WSL2 platform (kernel and components, no Linux distro yet)"
+    if (Test-WslCliOption '--install') {
+        wsl.exe --install --no-distribution 2>&1 | ForEach-Object { Write-Host $_ }
+        if ($LASTEXITCODE -eq 0) {
+            return $true
+        }
+        Write-InstallLog "wsl --install --no-distribution failed (exit $LASTEXITCODE); trying wsl --install."
+    }
+    wsl.exe --install 2>&1 | ForEach-Object { Write-Host $_ }
+    return ($LASTEXITCODE -eq 0)
+}
+
+function Set-WslDefaultVersion2 {
+    if (-not (Get-Command wsl.exe -ErrorAction SilentlyContinue)) {
+        return
+    }
+    $statusText = (wsl.exe --status 2>&1 | Out-String)
+    if ($statusText -match 'Default Version:\s*2\b') {
+        return
+    }
+    Write-InstallStep "Setting WSL default version to 2"
+    wsl.exe --set-default-version 2 2>&1 | ForEach-Object { Write-Host $_ }
+}
+
+function Request-WindowsRebootAndStop {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Reason
+    )
+    Write-WslSelfHelp -Title $Reason -Steps @(
+        "Save your work and restart Windows.",
+        "After reboot, open PowerShell in this repository folder.",
+        "Run: .\install.ps1"
+    ) -Links @(
+        $Script:WslDocLinks.InstallGuide,
+        $Script:WslDocLinks.ManualInstall
+    )
+    throw "Reboot Windows, then re-run install.ps1 from: $Script:RepoRoot"
+}
+
+function Request-AdministratorAndStop {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Reason
+    )
+    Write-WslSelfHelp -Title $Reason -Steps @(
+        "Close this PowerShell window.",
+        "Right-click PowerShell or Windows Terminal and choose 'Run as administrator'.",
+        "cd '$Script:RepoRoot'",
+        "Run: powershell -ExecutionPolicy Bypass -File .\install.ps1"
+    ) -Links @(
+        $Script:WslDocLinks.InstallGuide,
+        $Script:WslDocLinks.ExecutionPolicy
+    )
+    throw "Re-run install.ps1 from an elevated PowerShell session."
+}
+
+function Write-WslCommandFailureHelp {
+    param([string]$OutputText)
+
+    if ($OutputText -match '0x80370102|virtual machine platform|Virtual Machine Platform') {
+        Write-WslSelfHelp -Title 'Virtualization or Virtual Machine Platform is not enabled' -Steps @(
+            "Enable Intel VT-x / AMD-V in BIOS/UEFI if it is disabled.",
+            "Run install.ps1 as Administrator so it can enable the Virtual Machine Platform Windows feature.",
+            "On managed PCs, IT may need to allow virtualization."
+        ) -Links @(
+            $Script:WslDocLinks.Virtualization,
+            $Script:WslDocLinks.Troubleshooting
+        )
+        return
+    }
+    if ($OutputText -match 'WSL 2 requires an update|kernel component|Please update WSL') {
+        Write-WslSelfHelp -Title 'WSL needs an update' -Steps @(
+            "From an elevated PowerShell run: wsl --update",
+            "Then run: wsl --shutdown",
+            "Re-run: .\install.ps1"
+        ) -Links @(
+            $Script:WslDocLinks.UpdateWsl,
+            $Script:WslDocLinks.Troubleshooting
+        )
+        return
+    }
+    if ($OutputText -match 'cannot find|is not registered|No such file|does not exist') {
+        Write-WslSelfHelp -Title 'WSL distribution is missing or not registered' -Steps @(
+            "Run install.ps1 without -SkipWslInstall to create the Debian WSL distro.",
+            "List distros with: wsl -l -v",
+            "See WSL_README.md for manual recovery steps."
+        ) -Links @(
+            $Script:WslDocLinks.InstallGuide,
+            $Script:WslDocLinks.Troubleshooting
+        )
+        return
+    }
+    if ($OutputText -match 'permission denied|access is denied|sudo: a password is required') {
+        Write-WslSelfHelp -Title 'Permission or sudo issue inside WSL' -Steps @(
+            "Re-run install.ps1 so it can configure passwordless sudo for the install user.",
+            "If you changed the WSL user, pass -WslUser and -WslPassword again."
+        ) -Links @(
+            (Join-Path $Script:RepoRoot 'WSL_README.md')
+        )
+    }
+}
+
+function Ensure-WslPlatform {
+    Write-InstallStep "Checking Windows and WSL2 support"
+
+    $support = Test-WindowsWslSupport
+    Write-Host "  OS: $($support.OsCaption) (build $($support.BuildNumber), $($support.Architecture))"
+    if (-not $support.Supported) {
+        Write-WslSelfHelp -Title 'This PC does not meet WSL2 requirements' -Steps $support.Issues -Links @(
+            $Script:WslDocLinks.SystemRequirements,
+            $Script:WslDocLinks.InstallGuide
+        )
+        throw 'WSL2 is not supported on this system.'
+    }
+
+    $virt = Test-WslVirtualizationEnabled
+    if ($virt -eq $false) {
+        Write-WslSelfHelp -Title 'Hardware virtualization appears disabled' -Steps @(
+            'Enable Intel VT-x or AMD-V in BIOS/UEFI firmware settings.',
+            'Reboot into firmware (often Del, F2, or F10 at startup) and look for Virtualization Technology.',
+            'If BIOS options are missing, your PC or corporate policy may block virtualization.'
+        ) -Links @(
+            $Script:WslDocLinks.Virtualization,
+            $Script:WslDocLinks.Troubleshooting
+        )
+    }
+
+    $platform = Get-WslPlatformStatus
+    if ($platform.RebootRequired) {
+        Request-WindowsRebootAndStop -Reason 'Windows reboot is pending from a previous update or feature install'
+    }
+
+    if (Test-WslPlatformReady -PlatformStatus $platform) {
+        Write-Host "  WSL2 platform is installed (default version: $($platform.DefaultVersion))."
+        Set-WslDefaultVersion2
+        return
+    }
+
+    if (-not (Test-IsAdministrator)) {
+        Request-AdministratorAndStop -Reason 'Administrator privileges are required to install or enable WSL2 on this PC'
+    }
+
+    $wslFeature = $platform.Features['Microsoft-Windows-Subsystem-Linux']
+    $vmpFeature = $platform.Features['VirtualMachinePlatform']
+    $featuresNeedEnable = ($wslFeature -and $wslFeature -ne 'Enabled') -or ($vmpFeature -and $vmpFeature -ne 'Enabled')
+
+    if ($featuresNeedEnable -or -not $platform.WslExeAvailable) {
+        $rebootAfterFeatures = Enable-WslWindowsFeatures
+        if ($rebootAfterFeatures) {
+            Request-WindowsRebootAndStop -Reason 'Windows must restart after enabling WSL optional features'
+        }
+        $platform = Get-WslPlatformStatus
+    }
+
+    if (-not (Test-WslPlatformReady -PlatformStatus $platform)) {
+        if (-not (Install-WslPlatformComponents)) {
+            Write-WslSelfHelp -Title 'Automatic WSL installation failed' -Steps @(
+                'Confirm you are running PowerShell as Administrator.',
+                'Run manually: wsl --install',
+                'If prompted, reboot Windows and run install.ps1 again.',
+                'Check Windows Update is current.'
+            ) -Links @(
+                $Script:WslDocLinks.InstallGuide,
+                $Script:WslDocLinks.ManualInstall,
+                $Script:WslDocLinks.Troubleshooting
+            )
+            throw "Could not install the WSL2 platform. See the links above."
+        }
+        Request-WindowsRebootAndStop -Reason 'WSL2 platform was installed; Windows usually needs a restart before the Debian distro can be created'
+    }
+
+    Set-WslDefaultVersion2
+    Write-Host "  WSL2 platform is ready."
+}
+
+function Get-WslHelpText {
+    if (-not $Script:WslHelpText) {
+        $Script:WslHelpText = (wsl.exe --help 2>&1 | Out-String)
+    }
+    return $Script:WslHelpText
+}
+
+function Test-WslCliOption {
+    param([Parameter(Mandatory = $true)][string]$Option)
+    return (Get-WslHelpText -match [regex]::Escape($Option))
+}
+
+function Export-ImportWslDistro {
+    param(
+        [Parameter(Mandatory = $true)][string]$SourceDistro,
+        [Parameter(Mandatory = $true)][string]$TargetDistro,
+        [Parameter(Mandatory = $true)][string]$InstallDir
+    )
+    Write-InstallStep "Relocating WSL via export/import (fallback): '$SourceDistro' -> '$TargetDistro'"
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+
+    $exportTar = Join-Path $Script:WslFolder ("distro-export-{0}.tar" -f ($TargetDistro -replace '\s', '-'))
+    if (Test-Path -LiteralPath $exportTar) {
+        Remove-Item -LiteralPath $exportTar -Force
+    }
+
+    wsl.exe --shutdown | Out-Null
+    Start-Sleep -Seconds 2
+
+    wsl.exe --export $SourceDistro $exportTar 2>&1 | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to export WSL distro '$SourceDistro'."
+    }
+
+    wsl.exe --unregister $SourceDistro 2>&1 | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to unregister WSL distro '$SourceDistro'."
+    }
+
+    if ($SourceDistro -ne $TargetDistro -and (Test-WslDistro -Distro $TargetDistro)) {
+        wsl.exe --unregister $TargetDistro 2>&1 | Out-Null
+    }
+
+    wsl.exe --import $TargetDistro $InstallDir $exportTar --version 2 2>&1 | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to import WSL distro '$TargetDistro' into $InstallDir."
+    }
+
+    Remove-Item -LiteralPath $exportTar -Force
+    wsl.exe --set-default $TargetDistro | Out-Null
+}
+
+function Move-WslDistroToInstallDir {
+    param(
+        [string]$TargetDistro = $WslDistro,
+        [string]$InstallDir
+    )
+    if (Test-WslDistroAtInstallDir -Distro $TargetDistro -InstallDir $InstallDir) {
+        Write-InstallLog "WSL distro '$TargetDistro' already located at $InstallDir"
+        wsl.exe --set-default $TargetDistro | Out-Null
+        return
+    }
+
+    if (-not (Test-WslDistro -Distro $TargetDistro)) {
+        Write-WslSelfHelp -Title "WSL distro '$TargetDistro' is not installed" -Steps @(
+            "Run install.ps1 without -SkipWslInstall to create it.",
+            "List registered distros: wsl -l -v"
+        ) -Links @(
+            $Script:WslDocLinks.InstallGuide,
+            $Script:WslDocLinks.Troubleshooting
+        )
+        throw "WSL distro '$TargetDistro' is not installed."
+    }
+
+    Write-InstallStep "Moving WSL distro '$TargetDistro' to $InstallDir"
+    wsl.exe --shutdown | Out-Null
+    Start-Sleep -Seconds 2
+
+    if (Test-WslCliOption '--manage') {
+        wsl.exe --manage $TargetDistro --move $InstallDir 2>&1 | ForEach-Object { Write-Host $_ }
+        if ($LASTEXITCODE -eq 0 -and (Test-WslDistroAtInstallDir -Distro $TargetDistro -InstallDir $InstallDir)) {
+            wsl.exe --set-default $TargetDistro | Out-Null
+            return
+        }
+        Write-InstallLog "wsl --manage --move failed or is unavailable; falling back to export/import."
+    }
+
+    Export-ImportWslDistro -SourceDistro $TargetDistro -TargetDistro $TargetDistro -InstallDir $InstallDir
+}
+
+function Install-WslDistro {
+    param(
+        [string]$Package = $Script:WslDistroPackage,
+        [string]$Name = $WslDistro,
+        [string]$InstallDir
+    )
+    New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+    Write-InstallStep "Installing WSL package '$Package' as '$Name'"
+
+    $installArgs = New-Object 'System.Collections.Generic.List[string]'
+    [void]$installArgs.Add('--install')
+    [void]$installArgs.Add('-d')
+    [void]$installArgs.Add($Package)
+    [void]$installArgs.Add('--no-launch')
+    if (Test-WslCliOption '--name') {
+        [void]$installArgs.Add('--name')
+        [void]$installArgs.Add($Name)
+    }
+    if (Test-WslCliOption '--location') {
+        [void]$installArgs.Add('--location')
+        [void]$installArgs.Add($InstallDir)
+    }
+    $installArgArray = $installArgs.ToArray()
+
+    wsl.exe @installArgArray 2>&1 | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) {
+        wsl.exe --install $Package --no-launch 2>&1 | ForEach-Object { Write-Host $_ }
+    }
+    if ($LASTEXITCODE -ne 0) {
+        Write-WslSelfHelp -Title "Could not install WSL Linux package '$Package'" -Steps @(
+            "Confirm WSL2 is installed: wsl --version",
+            "Update WSL: wsl --update (run PowerShell as Administrator)",
+            "If Windows asked for a reboot after WSL setup, restart first.",
+            "Install Debian manually: wsl --install -d Debian",
+            "Then re-run install.ps1"
+        ) -Links @(
+            $Script:WslDocLinks.InstallGuide,
+            $Script:WslDocLinks.ManualInstall,
+            $Script:WslDocLinks.Troubleshooting
+        )
+        throw "Could not install WSL package '$Package'. See the self-help steps above."
+    }
+
+    if (Test-WslDistro -Distro $Name) {
+        if (-not (Test-WslDistroAtInstallDir -Distro $Name -InstallDir $InstallDir)) {
+            Move-WslDistroToInstallDir -TargetDistro $Name -InstallDir $InstallDir
+        }
+        wsl.exe --set-default $Name | Out-Null
+        return
+    }
+
+    if (Test-WslDistro -Distro $Package) {
+        Export-ImportWslDistro -SourceDistro $Package -TargetDistro $Name -InstallDir $InstallDir
+        return
+    }
+
+    throw "WSL install finished but distro '$Name' was not registered. Run: wsl -l -v"
+}
+
+function Initialize-WslDistro {
+    param(
+        [string]$TargetDistro = $WslDistro,
+        [string]$InstallDir
+    )
+    if ($SkipWslInstall) {
+        if (-not (Test-WslDistro -Distro $TargetDistro)) {
+            Write-WslSelfHelp -Title "WSL distro '$TargetDistro' is not installed" -Steps @(
+                "Remove -SkipWslInstall and run install.ps1 again to create it automatically.",
+                "Or install Debian manually: wsl --install -d Debian",
+                "List distros: wsl -l -v"
+            ) -Links @(
+                $Script:WslDocLinks.InstallGuide,
+                $Script:WslDocLinks.Troubleshooting
+            )
+            throw "WSL distro '$TargetDistro' is not installed."
+        }
+        if (-not (Test-WslDistroAtInstallDir -Distro $TargetDistro -InstallDir $InstallDir)) {
+            Write-WslSelfHelp -Title "WSL distro '$TargetDistro' is not at the expected install directory" -Steps @(
+                "Run install.ps1 without -SkipWslInstall to relocate the distro to:",
+                "  $InstallDir",
+                "Or pass -WslDistroDir with the correct path."
+            ) -Links @(
+                (Join-Path $Script:RepoRoot 'WSL_README.md')
+            )
+            throw "WSL distro '$TargetDistro' is not at $InstallDir."
+        }
+        wsl.exe --set-default $TargetDistro | Out-Null
+        return
+    }
+
+    if (Test-WslDistroAtInstallDir -Distro $TargetDistro -InstallDir $InstallDir) {
+        wsl.exe --set-default $TargetDistro | Out-Null
+        return
+    }
+
+    if (Test-WslDistro -Distro $TargetDistro) {
+        Move-WslDistroToInstallDir -TargetDistro $TargetDistro -InstallDir $InstallDir
+        return
+    }
+
+    if (Test-WslDistro -Distro $Script:WslDistroPackage) {
+        Export-ImportWslDistro -SourceDistro $Script:WslDistroPackage -TargetDistro $TargetDistro -InstallDir $InstallDir
+        return
+    }
+
+    Install-WslDistro -Package $Script:WslDistroPackage -Name $TargetDistro -InstallDir $InstallDir
+}
+
+function Test-WslDistro {
+    param([string]$Distro = $WslDistro)
+    wsl.exe -d $Distro -- echo ok 2>$null | Out-Null
+    return $LASTEXITCODE -eq 0
+}
+
+function Set-WslSystemd {
+    param([string]$Distro = $WslDistro)
+    $check = Join-BashScriptLines `
+        'if test -f /etc/wsl.conf && grep -q ''^systemd=true'' /etc/wsl.conf 2>/dev/null; then' `
+        '  echo configured' `
+        'else' `
+        '  echo needs-config' `
+        'fi'
+    $status = (Invoke-WslAsInstallUser -Distro $Distro -Command $check).Trim()
+    if ($status -eq 'configured') {
+        return
+    }
+    Write-InstallStep "Enabling systemd inside WSL (required for Podman/Docker services)."
+    $wslBootSection = [string][char]91 + 'boot' + [char]93
+    $bootPrintfLine = '  printf ''%s\n'' ''{0}'' ''systemd=true'' | sudo tee -a /etc/wsl.conf >/dev/null' -f $wslBootSection
+    $configure = Join-BashScriptLines `
+        'set -euo pipefail' `
+        ("if test -f /etc/wsl.conf && grep -q '^{0}' /etc/wsl.conf; then" -f $wslBootSection) `
+        '  if grep -q ''^systemd=true'' /etc/wsl.conf; then' `
+        '    exit 0' `
+        '  fi' `
+        ("  sudo sed -i '/^{0}/a systemd=true' /etc/wsl.conf" -f $wslBootSection) `
+        'else' `
+        $bootPrintfLine `
+        'fi'
+    Invoke-WslAsInstallUser -Distro $Distro -Command $configure | Out-Null
+    Write-InstallStep "Restarting WSL to apply systemd setting."
+    wsl.exe --shutdown | Out-Null
+    Start-Sleep -Seconds 3
+    Invoke-WslAsInstallUser -Distro $Distro -Command 'echo WSL restarted.' | Out-Null
+}
+
+function ConvertTo-WslPath {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$WindowsPath,
+        [string]$Distro = $WslDistro
+    )
+    $fullPath = [System.IO.Path]::GetFullPath($WindowsPath)
+
+    if (Test-WslDistro -Distro $Distro) {
+        $wslPath = (wsl.exe -d $Distro -- wslpath -a $fullPath 2>&1 | Out-String).Trim()
+        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($wslPath)) {
+            return ($wslPath -replace '\\', '/')
+        }
+    }
+
+    if ($fullPath -match '^([A-Za-z]):\\(.*)$') {
+        $drive = $Matches[1].ToLowerInvariant()
+        $rest = ($Matches[2] -replace '\\', '/')
+        return "/mnt/$drive/$rest"
+    }
+
+    throw "Could not convert Windows path to WSL path: $WindowsPath"
+}
+
+function Resolve-WorkspaceDirRelative {
+    $config = Get-InstallConfig
+    if ($WorkspaceDir) {
+        return $WorkspaceDir
+    }
+    if ($config -and $config.workspaceDirRelative) {
+        return [string]$config.workspaceDirRelative
+    }
+    return $Script:DefaultWorkspaceDir
+}
+
+function Resolve-WorkspacePaths {
+    param([string]$RelativeDir)
+    $relative = $RelativeDir.Trim()
+    if (-not $relative -or $relative -eq '.') {
+        $windowsPath = $Script:RepoRoot
+    }
+    else {
+        $windowsPath = Join-Path $Script:RepoRoot ($relative -replace '/', [IO.Path]::DirectorySeparatorChar)
+    }
+    $wslPath = ConvertTo-WslPath -WindowsPath $windowsPath
+    return @{
+        Relative = if ($relative) { $relative } else { '.' }
+        Windows  = $windowsPath
+        Wsl      = ($wslPath -replace '\\', '/')
+    }
+}
+
+function Initialize-Workspace {
+    param(
+        [hashtable]$Paths,
+        [string]$Distro = $WslDistro
+    )
+    if ($Paths.Relative -eq '.wsl/workspace') {
+        Write-InstallStep "Preparing optional nested workspace at .wsl/workspace"
+        $workspaceWindows = Join-Path $Script:WslFolder 'workspace'
+        if (-not (Test-Path -LiteralPath $workspaceWindows)) {
+            New-Item -ItemType Directory -Path $workspaceWindows -Force | Out-Null
+        }
+        $cloneCmd = Join-BashScriptLines `
+            'set -euo pipefail' `
+            "mkdir -p '$($Paths.Wsl)'" `
+            "if test ! -d '$($Paths.Wsl)/.git'; then" `
+            "  git clone '$RepoUrl' '$($Paths.Wsl)'" `
+            'else' `
+            "  echo 'Workspace clone already exists.'" `
+            'fi'
+        Invoke-WslAsInstallUser -Distro $Distro -Command $cloneCmd | ForEach-Object { Write-Host $_ }
+    }
+    elseif (-not (Test-Path -LiteralPath $Paths.Windows)) {
+        throw "Workspace path does not exist: $($Paths.Windows)"
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $Script:RepoRoot 'install.sh'))) {
+        throw "install.sh was not found in $Script:RepoRoot. Run this script from the repository root."
+    }
+}
+
+function Get-ContainerRuntime {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ConfiguredRuntime,
+        [string]$Distro = $WslDistro,
+        [string]$WorkspaceWsl
+    )
+    $detect = @"
+set -euo pipefail
+cd '$WorkspaceWsl'
+configured='$ConfiguredRuntime'
+if [ "`$configured" = docker ] && docker info >/dev/null 2>&1; then
+  echo docker
+elif [ "`$configured" = podman ] && podman info >/dev/null 2>&1; then
+  echo podman
+elif docker info >/dev/null 2>&1; then
+  echo docker
+elif podman info >/dev/null 2>&1; then
+  echo podman
+else
+  echo unknown
+fi
+"@
+    return (Invoke-WslAsInstallUser -Distro $Distro -Command $detect).Trim()
+}
+
+function Invoke-GitPull {
+    param(
+        [string]$WorkspaceWsl,
+        [string]$Distro = $WslDistro
+    )
+    Write-InstallStep "Pulling latest changes"
+    $pull = @"
+set -euo pipefail
+cd '$WorkspaceWsl'
+git pull --ff-only
+"@
+    Invoke-WslAsInstallUser -Distro $Distro -Command $pull | ForEach-Object { Write-Host $_ }
+    Write-InstallBanner "Updated. Shell script changes are live via the repo mount."
+    Write-InstallBanner "Use update.ps1 -RebuildConsole or -RebuildOrchestrator if Dockerfiles or bundled web/admin code changed."
+}
+
+function Invoke-WslInstall {
+    param(
+        [hashtable]$Paths,
+        [string]$Distro = $WslDistro,
+        [string]$ContainerRuntime = 'docker'
+    )
+    $prepareScripts = @"
+set -euo pipefail
+cd '$($Paths.Wsl)'
+chmod +x runtime/scripts/wsl-bootstrap.sh install.sh runtime/scripts/*.sh 2>/dev/null || true
+echo 'Scripts are executable.'
+"@
+    Write-InstallStep "Preparing install scripts inside WSL"
+    Invoke-WslAsInstallUser -Distro $Distro -Command $prepareScripts -StreamOutput | Out-Null
+
+    Write-InstallStep "WSL bootstrap: container runtime prep ($ContainerRuntime)"
+    Write-InstallBanner "Live output from wsl-bootstrap.sh appears below."
+    if ($ContainerRuntime -eq 'podman') {
+        Write-InstallBanner "apt-get may pause while downloading indexes; more lines will appear as packages install."
+    }
+    else {
+        Write-InstallBanner "Docker Engine will be installed inside WSL if it is not already present."
+    }
+    $bootstrap = @"
+set -euo pipefail
+cd '$($Paths.Wsl)'
+export DUNE_HOST_REPO_ROOT="`$(pwd -P)"
+export DUNE_CONTAINER_RUNTIME='$ContainerRuntime'
+export CONTAINER_RUNTIME='$ContainerRuntime'
+./runtime/scripts/wsl-bootstrap.sh
+"@
+    Invoke-WslAsInstallUser -Distro $Distro -Command $bootstrap -StreamOutput | Out-Null
+
+    Write-InstallStep "Running install.sh: container runtime, images, and console"
+    Write-InstallBanner "Live output from install.sh appears below."
+    $installSh = @"
+set -euo pipefail
+cd '$($Paths.Wsl)'
+export DUNE_HOST_REPO_ROOT="`$(pwd -P)"
+export DUNE_CONTAINER_RUNTIME='$ContainerRuntime'
+export CONTAINER_RUNTIME='$ContainerRuntime'
+export DUNE_INSTALL_FROM_WINDOWS=1
+./install.sh
+"@
+    Invoke-WslAsInstallUser -Distro $Distro -Command $installSh -StreamOutput | Out-Null
+}
+
+function Test-ConsoleContainerRunning {
+    param(
+        [string]$Distro = $WslDistro,
+        [string]$ContainerRuntime = 'docker'
+    )
+    $runtime = $ContainerRuntime
+    if ($runtime -eq 'unknown') {
+        $runtime = 'docker'
+    }
+    $check = @'
+if docker ps --format '{{.Names}}' 2>/dev/null | grep -qx redblink-dune-docker-console; then
+  echo running
+elif sudo docker ps --format '{{.Names}}' 2>/dev/null | grep -qx redblink-dune-docker-console; then
+  echo running
+else
+  echo missing
+fi
+'@
+    $result = (Invoke-WslAsInstallUser -Distro $Distro -Command $check | Out-String).Trim()
+    return ($result -eq 'running')
+}
+
+function Test-ConsoleHttpFromWindows {
+    param([int]$Port = 8088)
+    try {
+        $null = Invoke-WebRequest -Uri "http://127.0.0.1:$Port/" -UseBasicParsing -TimeoutSec 8 -ErrorAction Stop
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+function Show-Finish {
+    param(
+        [hashtable]$Paths,
+        [string]$ContainerRuntime,
+        [string]$Distro = $WslDistro
+    )
+    $finish = Join-BashScriptLines `
+        'set -euo pipefail' `
+        "cd '$($Paths.Wsl)'" `
+        'export DUNE_HOST_REPO_ROOT="$(pwd -P)"' `
+        'ip=$(hostname -I 2>/dev/null | head -1 | sed "s/ .*//" || true)' `
+        'if test -z "$ip"; then ip=127.0.0.1; fi' `
+        'port=${ADMIN_BIND_PORT:-8088}' `
+        'password_file=runtime/secrets/admin-web-password.txt' `
+        'password=' `
+        'if test -r "$password_file" && test -s "$password_file"; then' `
+        '  password=$(tr -d ''\r\n'' < "$password_file")' `
+        'fi' `
+        'echo "DUNE_CONSOLE_IP=$ip"' `
+        'echo "DUNE_CONSOLE_PORT=$port"' `
+        'echo "DUNE_CONSOLE_PASSWORD=$password"'
+    $lines = Invoke-WslAsInstallUser -Distro $Distro -Command $finish
+    $info = @{}
+    foreach ($line in $lines) {
+        if ($line -match '^([^=]+)=(.*)$') {
+            $info[$Matches[1]] = $Matches[2]
+        }
+    }
+    Write-InstallBanner "Dune Docker Console is ready."
+    Write-Host ""
+    $port = if ($info['DUNE_CONSOLE_PORT']) { [int]$info['DUNE_CONSOLE_PORT'] } else { 8088 }
+    $containerRunning = Test-ConsoleContainerRunning -Distro $Distro -ContainerRuntime $ContainerRuntime
+    $httpReady = Test-ConsoleHttpFromWindows -Port $port
+
+    Write-Host "Open the Web UI from Windows in your browser:"
+    Write-Host "  http://localhost:$port"
+    Write-Host ""
+    Write-Host "Use localhost from Windows (not the WSL-only IP). WSL forwards port $port to Windows automatically."
+    if ($info['DUNE_CONSOLE_IP'] -and $info['DUNE_CONSOLE_IP'] -ne '127.0.0.1') {
+        Write-Host "  WSL internal address (Linux-only, not for Windows browsers): http://$($info['DUNE_CONSOLE_IP']):$port"
+    }
+    Write-Host ""
+    if (-not $containerRunning) {
+        Write-Host "Warning: the console container is not running inside WSL."
+        Write-Host "Re-run install.ps1 or start it manually inside WSL:"
+        if ($ContainerRuntime -eq 'podman') {
+            Write-Host "  export ADMIN_BIND_HOST=0.0.0.0 ADMIN_BIND_PORT=8088"
+            Write-Host "  podman rm -f redblink-dune-docker-console 2>/dev/null"
+            Write-Host "  podman-compose -f docker-compose.web.yml up -d --build --force-recreate redblink-dune-docker-console"
+        }
+        else {
+            Write-Host "  export ADMIN_BIND_HOST=0.0.0.0 ADMIN_BIND_PORT=8088"
+            Write-Host "  docker rm -f redblink-dune-docker-console 2>/dev/null"
+            Write-Host "  docker compose -f docker-compose.web.yml up -d --build --force-recreate redblink-dune-docker-console"
+        }
+        Write-Host ""
+        Write-Host "Troubleshooting: $(Join-Path $Script:RepoRoot 'WSL_README.md')"
+        Write-Host ""
+    }
+    elseif (-not $httpReady) {
+        Write-Host "Warning: localhost:$port is not responding from Windows yet."
+        Write-Host "Wait a minute for the build to finish, then try again."
+        Write-Host "If it still fails: wsl --shutdown (from PowerShell), reopen WSL, re-run install.ps1."
+        Write-Host "Guide: $(Join-Path $Script:RepoRoot 'WSL_README.md')"
+        Write-Host ""
+    }
+    Write-Host "Container runtime: $ContainerRuntime"
+    Write-Host "WSL distro: $WslDistro"
+    Write-Host "WSL user: $Script:WslUserName"
+    Write-Host "Workspace (WSL): $($Paths.Wsl)"
+    if ($info['DUNE_CONSOLE_PASSWORD']) {
+        Write-Host ""
+        Write-Host "Your first admin password:"
+        Write-Host "  $($info['DUNE_CONSOLE_PASSWORD'])"
+    }
+    else {
+        Write-Host ""
+        Write-Host "Admin password was not ready yet. Wait a few seconds and run install.ps1 again to show it."
+    }
+}
+
+function Write-InstallState {
+    param(
+        [hashtable]$Paths,
+        [string]$ContainerRuntime,
+        [string]$Distro = $WslDistro
+    )
+    Set-InstallConfig -Config @{
+        wslDistro            = $Distro
+        wslDistroInstallDir  = (Resolve-WslDistroInstallDir)
+        wslUser              = $Script:WslUserName
+        repoRootWindows      = $Script:RepoRoot
+        repoRootWsl          = (ConvertTo-WslPath -WindowsPath $Script:RepoRoot)
+        workspaceDirRelative = $Paths.Relative
+        workspaceDirWsl      = $Paths.Wsl
+        containerRuntime     = $ContainerRuntime
+        repoUrl              = $RepoUrl
+        installedAt          = (Get-Date).ToUniversalTime().ToString('o')
+    }
+}
+
+# --- Main ---
+
+Write-InstallBanner "Starting Dune Docker Console Windows Installer."
+Write-Host "Self-help: WSL_README.md in this repo | Microsoft WSL docs: $($Script:WslDocLinks.InstallGuide)"
+
+if (-not (Test-Path -LiteralPath (Join-Path $Script:RepoRoot 'install.sh'))) {
+    throw "Run install.ps1 from the repository root (install.sh must be present)."
+}
+
+Initialize-WslFolder
+Ensure-WslPlatform
+
+if ($Update) {
+    $config = Get-InstallConfig
+    if (-not $config) {
+        Write-WslSelfHelp -Title 'No prior Windows install state found' -Steps @(
+            'Run install.ps1 without -Update for the first-time setup.',
+            'That creates .wsl/install.json and provisions WSL.'
+        ) -Links @(
+            (Join-Path $Script:RepoRoot 'WSL_README.md'),
+            $Script:WslDocLinks.InstallGuide
+        )
+        throw 'No .wsl/install.json found. Run install.ps1 without -Update first.'
+    }
+    if ($config.wslUser) {
+        $Script:WslUserName = [string]$config.wslUser
+    }
+    $paths = Resolve-WorkspacePaths -RelativeDir (Resolve-WorkspaceDirRelative)
+    if ($WorkspaceDir) {
+        $paths = Resolve-WorkspacePaths -RelativeDir $WorkspaceDir
+    }
+    Invoke-GitPull -WorkspaceWsl $paths.Wsl
+    exit 0
+}
+
+$wslDistroInstallDir = Resolve-WslDistroInstallDir
+Initialize-WslDistro -InstallDir $wslDistroInstallDir
+$existingConfig = Get-InstallConfig
+$needsUserSetup = (-not $existingConfig) -or (-not $existingConfig.wslUser) -or [bool]$WslPassword -or (
+    $WslUser -and ($existingConfig -and [string]$existingConfig.wslUser -ne $WslUser.Trim())
+)
+Resolve-WslCredentials -RequirePassword:$needsUserSetup
+Initialize-WslLinuxUser
+Set-WslInstallUserSudo
+Set-WslSystemd
+
+$paths = Resolve-WorkspacePaths -RelativeDir (Resolve-WorkspaceDirRelative)
+Initialize-Workspace -Paths $paths
+
+$resolvedRuntime = Resolve-ContainerRuntime
+Write-InstallStep "Container runtime: $resolvedRuntime (inside WSL, not Docker Desktop on Windows)"
+Invoke-WslInstall -Paths $paths -ContainerRuntime $resolvedRuntime
+$runtime = Get-ContainerRuntime -ConfiguredRuntime $resolvedRuntime -WorkspaceWsl $paths.Wsl
+Write-InstallState -Paths $paths -ContainerRuntime $runtime
+Show-Finish -Paths $paths -ContainerRuntime $runtime
+
+Write-InstallLog "Install completed successfully."
+
+$Script:WslPasswordPlain = ''

--- a/install.ps1
+++ b/install.ps1
@@ -4,13 +4,14 @@ param(
     [string]$WslDistro = 'Debian_Dune',
     [string]$WslDistroDir = '',
     [string]$WslUser = '',
-    [string]$WslPassword = '',
+    [SecureString]$WslPassword,
     [string]$WorkspaceDir = '',
     [string]$RepoUrl = 'https://github.com/Red-Blink/dune-awakening-selfhost-docker.git',
-    [ValidateSet('docker', 'podman', '')]
+    [ValidateSet('docker', 'docker-desktop', 'podman', '')]
     [string]$ContainerRuntime = '',
     [switch]$SkipWslInstall,
-    [switch]$Update
+    [switch]$Update,
+    [switch]$Force
 )
 
 Set-StrictMode -Version Latest
@@ -25,6 +26,7 @@ $Script:WslUserName = ''
 $Script:WslPasswordPlain = ''
 $Script:WslDistroPackage = 'Debian'
 $Script:WslHelpText = ''
+$Script:DockerDesktopNetworkRepairNeedsRestart = $false
 $Script:WslDocLinks = @{
     InstallGuide         = 'https://learn.microsoft.com/en-us/windows/wsl/install'
     ManualInstall        = 'https://learn.microsoft.com/en-us/windows/wsl/install-manual'
@@ -34,6 +36,8 @@ $Script:WslDocLinks = @{
     SystemRequirements   = 'https://learn.microsoft.com/en-us/windows/wsl/install-manual#step-2---check-requirements-for-running-wsl-2'
     SetDefaultVersion    = 'https://learn.microsoft.com/en-us/windows/wsl/basic-commands#set-default-version-to-wsl-1-or-wsl-2'
     ExecutionPolicy      = 'https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies'
+    DockerDesktopWsl     = 'https://docs.docker.com/desktop/features/wsl/'
+    DockerDesktopDownload = 'https://www.docker.com/products/docker-desktop/'
 }
 
 function Join-BashScriptLines {
@@ -72,14 +76,306 @@ function Initialize-WslFolder {
 }
 
 function Resolve-ContainerRuntime {
-    if ($ContainerRuntime) {
-        return $ContainerRuntime
+    if ($ContainerRuntime -eq 'docker') {
+        return 'docker'
     }
+    if ($ContainerRuntime -eq 'podman') {
+        return 'podman'
+    }
+    if ($ContainerRuntime -eq 'docker-desktop') {
+        return 'docker-desktop'
+    }
+
     $config = Get-InstallConfig
-    if ($config -and $config.containerRuntime) {
-        return [string]$config.containerRuntime
+    if ($config -and [string]$config.containerRuntime -eq 'podman') {
+        return 'podman'
     }
-    return 'docker'
+
+    if (Test-DockerDesktopAvailable) {
+        return 'docker-desktop'
+    }
+
+    Request-DockerDesktopInstallAndStop
+}
+
+function Request-DockerDesktopInstallAndStop {
+    $steps = @(
+        'Open your web browser.'
+        "Go to: $($Script:WslDocLinks.DockerDesktopDownload)"
+        'Download Docker Desktop for Windows (choose the right chip: AMD64 for most PCs).'
+        'Run the installer and accept the defaults unless you know otherwise.'
+        'Start Docker Desktop from the Start menu.'
+        'Wait until the whale icon shows Docker is running - not "Starting..." or "Stopped".'
+    ) + (Get-DockerDesktopIntegrationSteps) + @(
+        "Open PowerShell in this folder (see commands below)."
+        'Run install.ps1 again.'
+    )
+    Write-WslSelfHelp -Title 'Docker Desktop is required - install it first' -Steps $steps -Commands @(
+        "cd '$Script:RepoRoot'"
+        'powershell -ExecutionPolicy Bypass -File .\install.ps1'
+        (Get-DockerDesktopIntegrationStartDistroCommand)
+        (Get-DockerDesktopIntegrationVerifyCommand)
+    ) -Links @(
+        $Script:WslDocLinks.DockerDesktopDownload,
+        $Script:WslDocLinks.DockerDesktopWsl
+    )
+    throw 'Install Docker Desktop, complete WSL integration, then re-run install.ps1.'
+}
+
+function Test-DockerDesktopInstalled {
+    $candidates = @(
+        (Join-Path ${env:ProgramFiles} 'Docker\Docker\Docker Desktop.exe'),
+        (Join-Path ${env:ProgramFiles} 'Docker\Docker\resources\docker.exe')
+    )
+    if (${env:ProgramFiles(x86)}) {
+        $candidates += Join-Path ${env:ProgramFiles(x86)} 'Docker\Docker\Docker Desktop.exe'
+    }
+    foreach ($path in $candidates) {
+        if ($path -and (Test-Path -LiteralPath $path)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Test-DockerDesktopRunningOnWindows {
+    if (-not (Get-Command docker.exe -ErrorAction SilentlyContinue)) {
+        return $false
+    }
+    $prevErrorAction = $ErrorActionPreference
+    $ErrorActionPreference = 'SilentlyContinue'
+    try {
+        & docker.exe version 2>$null | Out-Null
+        return ($LASTEXITCODE -eq 0)
+    }
+    finally {
+        $ErrorActionPreference = $prevErrorAction
+    }
+}
+
+function Test-DockerDesktopAvailable {
+    if (Test-DockerDesktopInstalled) {
+        return $true
+    }
+    return (Test-DockerDesktopRunningOnWindows)
+}
+
+function Test-DockerDesktopWslIntegration {
+    param(
+        [string]$Distro = $WslDistro,
+        [string]$User = $Script:WslUserName
+    )
+    if (-not $User) {
+        return $false
+    }
+    $check = @'
+set -euo pipefail
+command -v docker >/dev/null 2>&1
+docker info --format '{{.OperatingSystem}}' 2>/dev/null | grep -qi 'docker desktop'
+docker compose version >/dev/null 2>&1
+'@
+    try {
+        Invoke-Wsl -Distro $Distro -User $User -Command $check | Out-Null
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+function Wait-DockerDesktopWslIntegration {
+    param(
+        [string]$Distro = $WslDistro,
+        [string]$User = $Script:WslUserName,
+        [int]$MaxAttempts = 12,
+        [int]$DelaySeconds = 5
+    )
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        if (Test-DockerDesktopWslIntegration -Distro $Distro -User $User) {
+            return $true
+        }
+        if ($attempt -eq 1) {
+            Write-Host ""
+            Write-Host "  REQUIRED: Docker Desktop -> Settings -> Resources -> WSL Integration -> turn ON '$Distro'." -ForegroundColor Yellow
+            Write-Host "  If '$Distro' is missing from that list, run: wsl -d $Distro -- echo ok" -ForegroundColor Yellow
+            Write-Host ""
+        }
+        if ($attempt -lt $MaxAttempts) {
+            Write-Host "  Docker Desktop WSL integration not ready yet (attempt $attempt/$MaxAttempts)..."
+            Start-Sleep -Seconds $DelaySeconds
+        }
+    }
+    return $false
+}
+
+function Get-EmbeddedDockerInstallCommand {
+    return "powershell -ExecutionPolicy Bypass -File .\install.ps1 -ContainerRuntime docker"
+}
+
+function Write-EmbeddedDockerEngineSelfHelp {
+    param(
+        [string]$Title = 'Docker Desktop cannot pull images - use Docker Engine inside WSL'
+    )
+    Write-WslSelfHelp -Title $Title -Steps @(
+        'Symptom: docker hello-world works, but other images fail to download through Docker Desktop.'
+        'Fix: install Docker Engine inside WSL using the official script at https://get.docker.com (the installer runs it for you).'
+        'Re-run this installer with -ContainerRuntime docker (command below).'
+        'Containers will run in WSL only - they will NOT show in the Docker Desktop UI (that is expected).'
+        'Optional: Docker Desktop -> Settings -> Resources -> WSL Integration -> turn OFF this distro to avoid mixing runtimes.'
+        'Verify embedded Engine: wsl -d Debian_Dune -- docker info (should NOT say Docker Desktop).'
+    ) -Commands @(
+        (Get-EmbeddedDockerInstallCommand)
+        "cd '$Script:RepoRoot'"
+        "wsl -d $WslDistro -- docker info --format '{{.OperatingSystem}}'"
+    ) -Links @(
+        'https://get.docker.com/',
+        $Script:WslDocLinks.DockerDesktopWsl,
+        (Join-Path $Script:RepoRoot 'WSL_README.md')
+    )
+}
+
+function Write-DockerDesktopSelfHelp {
+    param(
+        [string]$Title = 'Docker Desktop setup required',
+        [switch]$IncludeDownloadSteps
+    )
+    $steps = Get-DockerDesktopIntegrationSteps + @(
+        'Run the verify command below. The output should contain the words "Docker Desktop".'
+    )
+    if ($IncludeDownloadSteps) {
+        $steps = @(
+            'Download and install Docker Desktop for Windows from the link below.',
+            'Start Docker Desktop and wait until it is fully running.'
+        ) + $steps
+    }
+    Write-WslSelfHelp -Title $Title -Steps $steps -Commands @(
+        (Get-DockerDesktopIntegrationStartDistroCommand)
+        (Get-DockerDesktopIntegrationVerifyCommand)
+        "cd '$Script:RepoRoot'"
+        'powershell -ExecutionPolicy Bypass -File .\install.ps1'
+    ) -Links @(
+        $Script:WslDocLinks.DockerDesktopDownload,
+        $Script:WslDocLinks.DockerDesktopWsl
+    )
+}
+
+function Initialize-DockerDesktopForWsl {
+    param(
+        [string]$Distro = $WslDistro
+    )
+    if (-not (Test-DockerDesktopAvailable)) {
+        Request-DockerDesktopInstallAndStop
+    }
+    if (-not (Test-DockerDesktopRunningOnWindows)) {
+        Write-DockerDesktopSelfHelp -Title 'Docker Desktop is installed but not running - start it first'
+        throw 'Start Docker Desktop, wait until it is running, then re-run install.ps1.'
+    }
+    Start-WslDistroIfNeeded -Distro $Distro
+    if (-not (Wait-DockerDesktopWslIntegration -Distro $Distro)) {
+        Write-DockerDesktopSelfHelp -Title "Docker Desktop is running but WSL integration is OFF for '$Distro'"
+        throw "Enable Docker Desktop -> Settings -> Resources -> WSL Integration for '$Distro', then re-run install.ps1."
+    }
+    Write-InstallLog "Docker Desktop WSL integration verified for $Distro"
+}
+
+function Get-VirtualEthernetAdapters {
+    if (-not (Get-Command Get-NetAdapter -ErrorAction SilentlyContinue)) {
+        return @()
+    }
+    return @(Get-NetAdapter -ErrorAction SilentlyContinue | Where-Object {
+            $_.Name -like 'vEthernet*' -or $_.InterfaceDescription -like 'Hyper-V Virtual Ethernet*'
+        })
+}
+
+function Get-VmwareBridgeBindingsOnVirtualEthernet {
+    if (-not (Get-Command Get-NetAdapterBinding -ErrorAction SilentlyContinue)) {
+        return @()
+    }
+    $bindings = New-Object System.Collections.Generic.List[object]
+    foreach ($adapter in (Get-VirtualEthernetAdapters)) {
+        $adapterBindings = Get-NetAdapterBinding -Name $adapter.Name -ErrorAction SilentlyContinue |
+            Where-Object { $_.DisplayName -like '*VMware*Bridge*' -and $_.Enabled }
+        foreach ($binding in $adapterBindings) {
+            [void]$bindings.Add($binding)
+        }
+    }
+    return @($bindings.ToArray())
+}
+
+function Repair-DockerDesktopVirtualAdapterBindings {
+    $problemBindings = @(Get-VmwareBridgeBindingsOnVirtualEthernet)
+    if ($problemBindings.Count -eq 0) {
+        return @{
+            Changed           = $false
+            RepairedAdapters  = @()
+            NeedsAdmin        = $false
+            NeedsRestart      = $false
+        }
+    }
+
+    if (-not (Test-IsAdministrator)) {
+        Write-WslSelfHelp -Title 'VMware Bridge is breaking Docker/WSL networking - run as Administrator to fix automatically' -Steps @(
+            'This often causes players to get stuck on "Connecting" even when the server shows in the browser.'
+            'The installer can turn off VMware Bridge on Hyper-V adapters for you - but only when PowerShell is elevated.'
+            'Open an admin PowerShell: Start menu -> type PowerShell -> Ctrl+Shift+Enter -> Yes.'
+            'Or from this window, run the "open admin PowerShell" command below.'
+            'In the admin window, go to this repo folder and run install.ps1 again (commands below).'
+            'OR fix manually: press Win+R, type ncpa.cpl, Enter -> right-click "vEthernet (Default Switch)" -> Properties -> uncheck "VMware Bridge Protocol" -> OK.'
+            'Then restart Docker Desktop and run: wsl --shutdown'
+        ) -Commands @(
+            (Get-ElevatedInstallCommand)
+            "cd '$Script:RepoRoot'"
+            'powershell -ExecutionPolicy Bypass -File .\install.ps1'
+            'wsl --shutdown'
+        ) -Links @(
+            (Join-Path $Script:RepoRoot 'WSL_README.md')
+        )
+        return @{
+            Changed           = $false
+            RepairedAdapters  = @()
+            NeedsAdmin        = $true
+            NeedsRestart      = $false
+        }
+    }
+
+    Write-InstallStep 'Repairing Hyper-V virtual adapter bindings for Docker Desktop'
+    $repaired = New-Object System.Collections.Generic.List[string]
+    foreach ($binding in $problemBindings) {
+        Write-Host "  Disabling '$($binding.DisplayName)' on '$($binding.Name)'..."
+        try {
+            Disable-NetAdapterBinding -Name $binding.Name -ComponentID $binding.ComponentID -Confirm:$false -ErrorAction Stop
+            [void]$repaired.Add($binding.Name)
+            Write-InstallLog "Disabled $($binding.DisplayName) on $($binding.Name)"
+        }
+        catch {
+            Write-Host "  Warning: could not disable '$($binding.DisplayName)' on '$($binding.Name)': $($_.Exception.Message)"
+            Write-InstallLog "Failed to disable $($binding.DisplayName) on $($binding.Name): $($_.Exception.Message)"
+        }
+    }
+
+    if ($repaired.Count -gt 0) {
+        Show-NetworkRepairRestartSteps
+    }
+
+    return @{
+        Changed           = ($repaired.Count -gt 0)
+        RepairedAdapters  = $repaired.ToArray()
+        NeedsAdmin        = $false
+        NeedsRestart      = ($repaired.Count -gt 0)
+    }
+}
+
+function Ensure-DockerDesktopNetworkAdapters {
+    return (Repair-DockerDesktopVirtualAdapterBindings)
+}
+
+function Get-ContainerRuntimeDescription {
+    param([string]$Runtime)
+    switch ($Runtime) {
+        'docker-desktop' { return 'Docker Desktop via WSL integration (containers visible in Docker Desktop UI)' }
+        'podman' { return 'Podman inside WSL' }
+        default { return 'embedded Docker Engine inside WSL' }
+    }
 }
 
 function Get-InstallConfig {
@@ -106,12 +402,42 @@ function Get-WslOutputLine {
     return [string]$Item
 }
 
+$Script:WslStreamProgressLineLength = 0
+
+function Complete-WslStreamProgressLine {
+    if ($Script:WslStreamProgressLineLength -gt 0) {
+        Write-Host ''
+        $Script:WslStreamProgressLineLength = 0
+    }
+}
+
 function Write-WslStreamLine {
     param([string]$Line)
-    if ([string]::IsNullOrWhiteSpace($Line)) {
+    if ([string]::IsNullOrEmpty($Line)) {
         return
     }
-    Write-Host $Line
+
+    # Docker BuildKit uses carriage returns to redraw one progress line on a TTY.
+    # Through wsl.exe -> PowerShell those updates become staggered whitespace unless normalized.
+    if ($Line -match "`r") {
+        $segments = $Line -split "`r"
+        $Line = $segments[$segments.Length - 1]
+        if ([string]::IsNullOrWhiteSpace($Line)) {
+            return
+        }
+        $pad = [Math]::Max(0, $Script:WslStreamProgressLineLength - $Line.Length)
+        Write-Host ("`r$Line$(' ' * $pad)") -NoNewline
+        $Script:WslStreamProgressLineLength = [Math]::Max($Script:WslStreamProgressLineLength, $Line.Length)
+        if ($Line -match '( done| CACHED| ERROR| CANCELED)\s*$') {
+            Complete-WslStreamProgressLine
+        }
+        return
+    }
+
+    Complete-WslStreamProgressLine
+    if (-not [string]::IsNullOrWhiteSpace($Line)) {
+        Write-Host $Line
+    }
 }
 
 function New-WslCommandArgs {
@@ -170,11 +496,15 @@ function Invoke-Wsl {
             }
         }
         finally {
+            Complete-WslStreamProgressLine
             $ErrorActionPreference = $prevErrorAction
         }
         if ($LASTEXITCODE -ne 0) {
             $joined = ($lines -join [Environment]::NewLine)
-            Write-WslCommandFailureHelp -OutputText $joined
+            $helpShown = Write-WslCommandFailureHelp -OutputText $joined
+            if ($helpShown) {
+                throw "WSL install failed. Follow the steps above, then re-run install.ps1 from: $Script:RepoRoot"
+            }
             throw ('WSL command failed (exit {0}): {1}{2}{3}' -f $LASTEXITCODE, $Command, [Environment]::NewLine, $joined)
         }
         return $lines
@@ -183,7 +513,10 @@ function Invoke-Wsl {
     $output = & wsl.exe @wslArgs 2>&1
     if ($LASTEXITCODE -ne 0) {
         $outputText = if ($output -is [array]) { ($output -join [Environment]::NewLine) } else { [string]$output }
-        Write-WslCommandFailureHelp -OutputText $outputText
+        $helpShown = Write-WslCommandFailureHelp -OutputText $outputText
+        if ($helpShown) {
+            throw "WSL install failed. Follow the steps above, then re-run install.ps1 from: $Script:RepoRoot"
+        }
         throw ('WSL command failed (exit {0}): {1}{2}{3}' -f $LASTEXITCODE, $Command, [Environment]::NewLine, $outputText)
     }
     return $output
@@ -209,9 +542,99 @@ function Test-WslUsername {
     }
 }
 
-function Read-WslPasswordPlain {
-    $secure = Read-Host 'WSL password' -AsSecureString
-    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secure)
+function Test-WslLinuxUserExists {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$User,
+        [string]$Distro = $WslDistro
+    )
+    Test-WslUsername -Name $User
+    try {
+        Invoke-Wsl -Distro $Distro -User root -Command "id -u $User >/dev/null 2>&1" | Out-Null
+        return $true
+    }
+    catch {
+        return $false
+    }
+}
+
+function Repair-WslConfMissingDefaultUser {
+    param([string]$Distro = $WslDistro)
+    Write-InstallStep 'Checking WSL default user in /etc/wsl.conf'
+    $manageArgs = @('--manage', $Distro, '--set-default-user', 'root')
+    $null = & wsl.exe @manageArgs 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        wsl.exe --shutdown | Out-Null
+        Start-Sleep -Seconds 2
+    }
+    $repair = @'
+set -euo pipefail
+if [ ! -f /etc/wsl.conf ]; then
+  exit 0
+fi
+default="$(awk '
+  /^\[user\]/ { in_user=1; next }
+  /^\[/ { in_user=0 }
+  in_user && /^default=/ { sub(/^default=/, ""); gsub(/[[:space:]]/, ""); print; exit }
+' /etc/wsl.conf)"
+if [ -z "$default" ]; then
+  exit 0
+fi
+if id "$default" >/dev/null 2>&1; then
+  echo "WSL default user '$default' exists."
+  exit 0
+fi
+echo "WSL default user '$default' is missing; resetting default to root until install creates the user."
+if grep -q '^default=' /etc/wsl.conf; then
+  sed -i 's/^default=.*/default=root/' /etc/wsl.conf
+else
+  printf '\n[user]\ndefault=root\n' >> /etc/wsl.conf
+fi
+'@
+    try {
+        Invoke-WslBashScript -Distro $Distro -User root -ScriptContent $repair -ScriptName 'repair-wsl-conf-default-user.sh' | Out-Null
+        wsl.exe --shutdown | Out-Null
+        Start-Sleep -Seconds 3
+    }
+    catch {
+        Write-WslSelfHelp -Title 'WSL cannot start because /etc/wsl.conf points at a missing user' -Steps @(
+            'The distro default user in /etc/wsl.conf does not exist (often after a partial install).'
+            'From PowerShell, open root shell: wsl -d Debian_Dune -u root'
+            'Inside that shell run: sed -i "s/^default=.*/default=root/" /etc/wsl.conf'
+            'Then from Windows run: wsl --shutdown'
+            'Re-run install.ps1 and enter your WSL username and password when prompted.'
+        ) -Commands @(
+            "wsl -d $Distro -u root"
+            "cd '$Script:RepoRoot'"
+            'powershell -ExecutionPolicy Bypass -File .\install.ps1'
+        )
+        throw "WSL default user is missing in $Distro. Follow the steps above, then re-run install.ps1."
+    }
+}
+
+function Write-WslMissingUserSelfHelp {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$User
+    )
+    Write-WslSelfHelp -Title "WSL user '$User' does not exist inside $WslDistro yet" -Steps @(
+        "The installer has username '$User' saved, but that Linux user was never created (partial prior run)."
+        'Re-run install.ps1 and enter the WSL password when prompted so the user can be created.'
+        'Or pass username and password explicitly on the command line (see below).'
+    ) -Commands @(
+        "cd '$Script:RepoRoot'"
+        "powershell -ExecutionPolicy Bypass -File .\install.ps1 -WslUser $User"
+    ) -Links @(
+        (Join-Path $Script:RepoRoot 'WSL_README.md')
+    )
+}
+
+function Convert-SecureStringToPlainText {
+    param(
+        [Parameter(Mandatory = $true)]
+        [SecureString]$SecureString
+    )
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureString)
     try {
         return [Runtime.InteropServices.Marshal]::PtrToStringAuto($bstr)
     }
@@ -220,6 +643,84 @@ function Read-WslPasswordPlain {
             [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
         }
     }
+}
+
+function Test-PasswordPromptAnsiTerminal {
+    return [bool](
+        $env:WT_SESSION -or
+        $env:TERM_PROGRAM -or
+        $env:CURSOR_TRACE_ID -or
+        $env:VSCODE_IPC_HOOK
+    )
+}
+
+function Write-PasswordPromptBackspace {
+    if (Test-PasswordPromptAnsiTerminal) {
+        Write-Host "$([char]27)[1D$([char]27)[K" -NoNewline
+    }
+    else {
+        Write-Host "`b `b" -NoNewline
+    }
+}
+
+function Read-WslSecurePasswordViaCredentialDialog {
+    $userLabel = if ($Script:WslUserName) { $Script:WslUserName } else { 'WSL user' }
+    Write-Host "Enter the WSL password in the Windows dialog (user: $userLabel)." -ForegroundColor Cyan
+    $cred = Get-Credential -UserName $userLabel -Message 'WSL password for Dune install (used only inside WSL, not saved to disk)'
+    if (-not $cred -or -not $cred.Password) {
+        throw 'WSL password is required.'
+    }
+    return $cred.Password
+}
+
+function Read-WslSecurePassword {
+    if (-not [Environment]::UserInteractive -or [Console]::IsInputRedirected) {
+        return Read-Host 'WSL password' -AsSecureString
+    }
+
+    if ($Host.Name -ne 'ConsoleHost') {
+        return Read-WslSecurePasswordViaCredentialDialog
+    }
+
+    try {
+        Write-Host 'WSL password: ' -NoNewline
+        $chars = New-Object System.Collections.Generic.List[char]
+        while ($true) {
+            $key = [Console]::ReadKey($true)
+            if ($key.Key -in @('Enter', 'Return') -or $key.KeyChar -in @([char]13, [char]10)) {
+                Write-Host ''
+                break
+            }
+            if ($key.Key -in @('Backspace', 'Delete') -or $key.KeyChar -in @([char]8, [char]127)) {
+                if ($chars.Count -gt 0) {
+                    [void]$chars.RemoveAt($chars.Count - 1)
+                    Write-PasswordPromptBackspace
+                }
+                continue
+            }
+            if ($key.KeyChar -eq [char]0) {
+                continue
+            }
+            if ([char]::IsControl($key.KeyChar)) {
+                continue
+            }
+            [void]$chars.Add($key.KeyChar)
+            Write-Host '*' -NoNewline
+        }
+
+        $secure = New-Object System.Security.SecureString
+        foreach ($ch in $chars) {
+            $secure.AppendChar($ch) | Out-Null
+        }
+        return $secure
+    }
+    catch {
+        return Read-WslSecurePasswordViaCredentialDialog
+    }
+}
+
+function Read-WslPasswordPlain {
+    return Convert-SecureStringToPlainText -SecureString (Read-WslSecurePassword)
 }
 
 function Resolve-WslCredentials {
@@ -240,8 +741,8 @@ function Resolve-WslCredentials {
 
     Test-WslUsername -Name $Script:WslUserName
 
-    if ($WslPassword) {
-        $Script:WslPasswordPlain = $WslPassword
+    if ($PSBoundParameters.ContainsKey('WslPassword') -and $WslPassword) {
+        $Script:WslPasswordPlain = Convert-SecureStringToPlainText -SecureString $WslPassword
         return
     }
     if ($RequirePassword) {
@@ -249,7 +750,14 @@ function Resolve-WslCredentials {
         return
     }
     if ($config -and $config.wslUser -eq $Script:WslUserName) {
-        return
+        if (Test-WslLinuxUserExists -User $Script:WslUserName) {
+            return
+        }
+        Write-InstallStep "Saved WSL user '$($Script:WslUserName)' is missing inside the distro; password required to recreate it."
+    }
+    if (-not $RequirePassword) {
+        Write-WslMissingUserSelfHelp -User $Script:WslUserName
+        throw "WSL user '$($Script:WslUserName)' does not exist. Re-run install.ps1 and enter the WSL password when prompted."
     }
     $Script:WslPasswordPlain = Read-WslPasswordPlain
 }
@@ -257,16 +765,19 @@ function Resolve-WslCredentials {
 function Initialize-WslLinuxUser {
     param(
         [string]$Distro = $WslDistro,
-        [string]$User = $Script:WslUserName,
-        [string]$Password = $Script:WslPasswordPlain
+        [string]$User = $Script:WslUserName
     )
-    if (-not $Password) {
+    if (Test-WslLinuxUserExists -User $User) {
         return
+    }
+    if (-not $Script:WslPasswordPlain) {
+        Write-WslMissingUserSelfHelp -User $User
+        throw "WSL user '$User' does not exist. Re-run install.ps1 and enter the WSL password when prompted."
     }
 
     Write-InstallStep "Configuring WSL user: $User"
     $userB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($User))
-    $passB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Password))
+    $passB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($Script:WslPasswordPlain))
     $configureUserPath = Join-Path $Script:RepoRoot 'runtime/scripts/configure-wsl-user.sh'
     $configureUser = Get-Content -LiteralPath $configureUserPath -Raw
     $configureUser = $configureUser -replace '__USER_B64__', $userB64 -replace '__PASS_B64__', $passB64
@@ -287,11 +798,66 @@ function Set-WslInstallUserSudo {
     }
 
     Test-WslUsername -Name $User
+    if (-not (Test-WslLinuxUserExists -User $User)) {
+        Write-WslMissingUserSelfHelp -User $User
+        throw "Cannot configure sudo until WSL user '$User' exists. Re-run install.ps1 with the WSL password."
+    }
     Write-InstallStep "Ensuring passwordless sudo for WSL install user: $User"
     $enableSudoPath = Join-Path $Script:RepoRoot 'runtime/scripts/enable-wsl-install-sudo.sh'
     $enableSudo = Get-Content -LiteralPath $enableSudoPath -Raw
     $enableSudo = $enableSudo -replace '__USER__', $User
     Invoke-WslBashScript -Distro $Distro -User root -ScriptContent $enableSudo -ScriptName 'enable-wsl-install-sudo.sh' | Out-Null
+}
+
+function Get-WindowsDnsServerList {
+    $servers = @()
+    try {
+        $addresses = Get-DnsClientServerAddress -ErrorAction SilentlyContinue |
+            Where-Object { $_.AddressFamily -eq 2 -and $_.ServerAddresses } |
+            ForEach-Object { $_.ServerAddresses } |
+            Select-Object -Unique
+        foreach ($addr in $addresses) {
+            if ($addr -match '^\d{1,3}(\.\d{1,3}){3}$') {
+                $servers += $addr
+            }
+        }
+    }
+    catch {
+        # Best effort when Get-DnsClientServerAddress is unavailable.
+    }
+    return @($servers)
+}
+
+function Initialize-WslDns {
+    param([string]$Distro = $WslDistro)
+    Write-InstallStep 'Configuring WSL DNS (/etc/wsl.conf and /etc/resolv.conf)'
+    $dnsServers = @(Get-WindowsDnsServerList)
+    $dnsEnv = if ($dnsServers.Count -gt 0) { ($dnsServers -join ',') } else { '' }
+    $repoWsl = ConvertTo-WslPath -WindowsPath $Script:RepoRoot -Distro $Distro
+    $configureDns = @(
+        "cd '$repoWsl'"
+        if ($dnsEnv) { "export DUNE_WSL_DNS='$dnsEnv'" }
+        'bash runtime/scripts/configure-wsl-dns.sh'
+    ) -join '; '
+    try {
+        Invoke-WslBashScript -Distro $Distro -User root -ScriptContent $configureDns -ScriptName 'configure-wsl-dns.sh' | Out-Null
+        wsl.exe --shutdown | Out-Null
+        Start-Sleep -Seconds 3
+        Invoke-Wsl -Distro $Distro -User root -Command 'echo WSL DNS configured.' | Out-Null
+    }
+    catch {
+        Write-WslSelfHelp -Title 'WSL DNS configuration failed' -Steps @(
+            'The installer could not write /etc/wsl.conf or /etc/resolv.conf inside WSL.'
+            'Create .wsl/dns-servers.txt in the repo (one IPv4 DNS server per line), then re-run install.ps1.'
+            'Example contents: your router IP (often 192.168.x.1) or 1.1.1.1'
+        ) -Commands @(
+            "cd '$Script:RepoRoot'"
+            'powershell -ExecutionPolicy Bypass -File .\install.ps1'
+        ) -Links @(
+            (Join-Path $Script:RepoRoot 'WSL_README.md')
+        )
+        throw "WSL DNS configuration failed. See steps above, then re-run install.ps1."
+    }
 }
 
 function Invoke-WslAsInstallUser {
@@ -328,7 +894,7 @@ function Resolve-WslDistroInstallDir {
     if ($config -and $config.wslDistroInstallDir) {
         return [string]$config.wslDistroInstallDir
     }
-    return Join-Path $Script:WslFolder 'distro' $WslDistro
+    return Join-Path (Join-Path $Script:WslFolder 'distro') $WslDistro
 }
 
 function Test-WslDistroAtInstallDir {
@@ -358,25 +924,126 @@ function Write-WslSelfHelp {
         [Parameter(Mandatory = $true)]
         [string]$Title,
         [string[]]$Steps = @(),
-        [string[]]$Links = @()
+        [string[]]$Commands = @(),
+        [string[]]$Links = @(),
+        [string]$Footer = 'When you have finished the steps above, run install.ps1 again from this folder.'
     )
     Write-Host ""
-    Write-Host "=== $Title ===" -ForegroundColor Yellow
-    foreach ($step in $Steps) {
-        Write-Host "  - $step"
+    Write-Host "================================================================" -ForegroundColor Yellow
+    Write-Host "  $Title" -ForegroundColor Yellow
+    Write-Host "================================================================" -ForegroundColor Yellow
+    Write-Host ""
+    if ($Steps.Count -gt 0) {
+        for ($i = 0; $i -lt $Steps.Count; $i++) {
+            Write-Host ("  {0}. {1}" -f ($i + 1), $Steps[$i])
+        }
+    }
+    if ($Commands.Count -gt 0) {
+        Write-Host ""
+        Write-Host "  Copy and paste (one line at a time):" -ForegroundColor Cyan
+        foreach ($cmd in $Commands) {
+            Write-Host "    $cmd" -ForegroundColor White
+        }
     }
     if ($Links.Count -gt 0) {
         Write-Host ""
-        Write-Host "Helpful links:"
+        Write-Host "  Links:"
         foreach ($link in $Links) {
-            Write-Host "  $link"
+            Write-Host "    $link"
         }
     }
     Write-Host ""
-    Write-Host "Local guide: $(Join-Path $Script:RepoRoot 'WSL_README.md')"
+    Write-Host "  Full guide: $(Join-Path $Script:RepoRoot 'WSL_README.md')"
     if (Test-Path -LiteralPath $Script:InstallLogPath) {
-        Write-Host "Install log:   $($Script:InstallLogPath)"
+        Write-Host "  Install log: $($Script:InstallLogPath)"
     }
+    if ($Footer) {
+        Write-Host ""
+        Write-Host "  $Footer" -ForegroundColor Cyan
+    }
+    Write-Host ""
+}
+
+function Start-WslDistroIfNeeded {
+    param([string]$Distro = $WslDistro)
+    Write-InstallStep "Starting WSL distro '$Distro' (Docker Desktop must see it under Settings -> Resources -> WSL Integration)"
+    wsl.exe -d $Distro -- echo ok 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not start WSL distro '$Distro'. Run: wsl -l -v"
+    }
+}
+
+function Get-DockerDesktopIntegrationStartDistroCommand {
+    return "wsl -d $WslDistro -- echo ok"
+}
+
+function Get-DockerDesktopIntegrationSteps {
+    return @(
+        'Open Docker Desktop (whale icon in the Windows system tray - bottom-right).'
+        'Wait until Docker Desktop is fully running (not "Starting..." or "Stopped").'
+        'Click the gear icon -> Settings.'
+        'Settings -> General: turn ON "Use the WSL 2 based engine".'
+        'Settings -> Resources -> WSL Integration: this is the screen you must enable (easy to miss).'
+        "On that WSL Integration page, turn ON the switch next to '$WslDistro'."
+        "If '$WslDistro' is not listed: run the start-distro command below, restart Docker Desktop, open Settings -> Resources -> WSL Integration again."
+        'Click Apply & restart (or Apply) and wait until Docker is running again.'
+        'If you do not see "WSL Integration" at all: right-click the whale icon -> Switch to Linux containers, then open Settings again.'
+    )
+}
+
+function Get-DockerDesktopIntegrationVerifyCommand {
+    return "wsl -d $WslDistro -- docker info --format '{{.OperatingSystem}}'"
+}
+
+function Show-InstallPreflightChecklist {
+    Write-InstallBanner "Before you start - quick checklist"
+    Write-Host @"
+  This installer sets up WSL + Docker Desktop + the Dune web console on Windows.
+  You do not need to be a Linux expert; follow the numbered steps if anything stops.
+
+  Recommended (first time):
+    1. Install Docker Desktop: $($Script:WslDocLinks.DockerDesktopDownload)
+    2. Start Docker Desktop and wait until it is fully running (not "Starting...")
+    3. REQUIRED - enable WSL Integration for this installer:
+         Docker Desktop -> Settings -> Resources -> WSL Integration -> turn ON '$WslDistro'
+       (If '$WslDistro' is not in the list, run: wsl -d $WslDistro -- echo ok, restart Docker Desktop, try again.)
+       Verify: $(Get-DockerDesktopIntegrationVerifyCommand)
+    4. If hello-world works but other images fail to pull, use embedded Engine instead:
+         $(Get-EmbeddedDockerInstallCommand)
+       (installs Docker inside WSL via https://get.docker.com - containers stay in WSL, not Docker Desktop UI)
+    5. Open PowerShell as Administrator (Start menu -> type PowerShell -> Ctrl+Shift+Enter -> Yes)
+    6. In PowerShell, go to this folder:
+         cd '$Script:RepoRoot'
+    7. Run:
+         powershell -ExecutionPolicy Bypass -File .\install.ps1
+
+  No Ctrl+Shift+Enter? From any PowerShell window, paste this to open an admin window:
+         $(Get-ElevatedInstallCommand)
+
+  Windows says reboot required? Add -Force to try anyway (may fail until you restart):
+         powershell -ExecutionPolicy Bypass -File .\install.ps1 -Force
+
+  When install finishes, open http://localhost:8088 in your browser.
+
+  Stuck? Open WSL_README.md in this folder or check .wsl\install.log
+"@
+}
+
+function Show-NetworkRepairRestartSteps {
+    Write-WslSelfHelp -Title 'IMPORTANT: Restart Docker and WSL (network settings were changed)' -Steps @(
+        'Quit Docker Desktop completely: right-click the whale icon in the system tray -> Quit Docker Desktop.'
+        'Start Docker Desktop again from the Start menu and wait until it is running.'
+        'Close any open WSL/terminal windows that were using Linux.'
+        'In PowerShell, run the command below (this restarts WSL).'
+        'Run install.ps1 again, or restart your Dune game stack from the web UI / WSL.'
+        'If players were stuck on "Connecting" in-game, see WSL_README.md -> Players stuck on Connecting.'
+    ) -Commands @(
+        'wsl --shutdown'
+        "cd '$Script:RepoRoot'"
+        'powershell -ExecutionPolicy Bypass -File .\install.ps1'
+    ) -Links @(
+        (Join-Path $Script:RepoRoot 'WSL_README.md')
+    ) -Footer 'Do not skip the restart steps - hosting may not work until Docker and WSL have restarted.'
 }
 
 function Test-IsAdministrator {
@@ -558,15 +1225,50 @@ function Set-WslDefaultVersion2 {
     wsl.exe --set-default-version 2 2>&1 | ForEach-Object { Write-Host $_ }
 }
 
+function Get-ElevatedInstallCommand {
+    $installPath = Join-Path $Script:RepoRoot 'install.ps1'
+    return "Start-Process powershell -Verb RunAs -ArgumentList '-NoProfile','-ExecutionPolicy','Bypass','-File','$installPath'"
+}
+
+function Get-AdminPowerShellSteps {
+    return @(
+        'You need an Administrator PowerShell window. Use ONE of these (neither needs "Run as administrator" on a right-click menu):'
+        '  A) Start menu -> type PowerShell -> press Ctrl+Shift+Enter -> click Yes on the UAC prompt.'
+        '  B) From this window, paste the "open admin PowerShell" command below (opens a new elevated window).'
+        'In the admin window, go to this project folder and run install.ps1 (commands below).'
+    )
+}
+
+function Continue-DespitePendingReboot {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Reason
+    )
+    if (-not $Force) {
+        Request-WindowsRebootAndStop -Reason $Reason
+    }
+    Write-Host ""
+    Write-Host "  Warning: $Reason" -ForegroundColor Yellow
+    Write-Host "  Continuing anyway (-Force). Install may fail until you restart Windows." -ForegroundColor Yellow
+    Write-Host ""
+    Write-InstallLog "Skipped reboot stop (-Force): $Reason"
+}
+
 function Request-WindowsRebootAndStop {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Reason
     )
     Write-WslSelfHelp -Title $Reason -Steps @(
-        "Save your work and restart Windows.",
-        "After reboot, open PowerShell in this repository folder.",
-        "Run: .\install.ps1"
+        'Save your work and close other programs.'
+        'Restart Windows (Start menu -> Power -> Restart).'
+        'After login, open PowerShell as Administrator (Start menu -> type PowerShell -> Ctrl+Shift+Enter).'
+        'Go to this project folder and run install.ps1 again (commands below).'
+        'Cannot reboot yet? Re-run with -Force to try anyway (may fail until you restart).'
+    ) -Commands @(
+        "cd '$Script:RepoRoot'"
+        'powershell -ExecutionPolicy Bypass -File .\install.ps1'
+        'powershell -ExecutionPolicy Bypass -File .\install.ps1 -Force'
     ) -Links @(
         $Script:WslDocLinks.InstallGuide,
         $Script:WslDocLinks.ManualInstall
@@ -579,21 +1281,38 @@ function Request-AdministratorAndStop {
         [Parameter(Mandatory = $true)]
         [string]$Reason
     )
-    Write-WslSelfHelp -Title $Reason -Steps @(
-        "Close this PowerShell window.",
-        "Right-click PowerShell or Windows Terminal and choose 'Run as administrator'.",
-        "cd '$Script:RepoRoot'",
-        "Run: powershell -ExecutionPolicy Bypass -File .\install.ps1"
+    Write-WslSelfHelp -Title $Reason -Steps (Get-AdminPowerShellSteps) -Commands @(
+        (Get-ElevatedInstallCommand)
+        "cd '$Script:RepoRoot'"
+        'powershell -ExecutionPolicy Bypass -File .\install.ps1'
     ) -Links @(
         $Script:WslDocLinks.InstallGuide,
         $Script:WslDocLinks.ExecutionPolicy
     )
-    throw "Re-run install.ps1 from an elevated PowerShell session."
+    throw 'Re-run install.ps1 from an elevated (Administrator) PowerShell window.'
 }
 
 function Write-WslCommandFailureHelp {
     param([string]$OutputText)
 
+    if ($OutputText -match 'getpwnam\(|CreateProcessParseCommon') {
+        Write-WslSelfHelp -Title 'WSL default user in /etc/wsl.conf does not exist' -Steps @(
+            'This usually means /etc/wsl.conf sets default=local (or another name) but that Linux user was never created.'
+            'The installer will try to reset default=root on the next run after Repair-WslConfMissingDefaultUser.'
+            'If it keeps failing: wsl -d Debian_Dune -u root'
+            'Then: sed -i "s/^default=.*/default=root/" /etc/wsl.conf'
+            'Then: wsl --shutdown'
+            'Re-run install.ps1 and enter WSL username + password when prompted.'
+        ) -Commands @(
+            "wsl -d $WslDistro -u root"
+            'wsl --shutdown'
+            "cd '$Script:RepoRoot'"
+            'powershell -ExecutionPolicy Bypass -File .\install.ps1'
+        ) -Links @(
+            (Join-Path $Script:RepoRoot 'WSL_README.md')
+        )
+        return $true
+    }
     if ($OutputText -match '0x80370102|virtual machine platform|Virtual Machine Platform') {
         Write-WslSelfHelp -Title 'Virtualization or Virtual Machine Platform is not enabled' -Steps @(
             "Enable Intel VT-x / AMD-V in BIOS/UEFI if it is disabled.",
@@ -603,7 +1322,32 @@ function Write-WslCommandFailureHelp {
             $Script:WslDocLinks.Virtualization,
             $Script:WslDocLinks.Troubleshooting
         )
-        return
+        return $true
+    }
+    if ($OutputText -match 'Docker Desktop WSL integration is not active|Docker Compose is not available through Docker Desktop|could not be found in this WSL|activate the WSL integration') {
+        Write-DockerDesktopSelfHelp -Title "Docker Desktop WSL integration is OFF for '$WslDistro'"
+        return $true
+    }
+    if ($OutputText -match 'registry\.funcom\.com.*no such host|lookup registry\.funcom\.com|registry\.funcom\.com.*failed to resolve') {
+        Write-WslSelfHelp -Title 'Funcom images are not pulled from the public internet' -Steps @(
+            'registry.funcom.com is a private Funcom registry tag name, not a public Docker Hub-style registry.'
+            'Server images are downloaded via Steam and loaded locally: docker load -i *.tar (the update wizard does this).'
+            'Boot auto-start failed because igw-postgres is not loaded yet - complete setup or run runtime/scripts/update.sh install inside WSL.'
+            'WSL DNS was configured by install.ps1; this error usually means images are missing, not that DNS is wrong.'
+            'If general DNS is broken inside WSL, add nameservers to .wsl/dns-servers.txt and re-run install.ps1.'
+            'Docker Desktop pulls use the Desktop VM DNS; for full WSL control use: install.ps1 -ContainerRuntime docker'
+        ) -Commands @(
+            "wsl -d $WslDistro -- bash -lc 'cd ''$(ConvertTo-WslPath -WindowsPath $Script:RepoRoot)'' && docker images | grep funcom || true'"
+            "wsl -d $WslDistro -- bash -lc 'cd ''$(ConvertTo-WslPath -WindowsPath $Script:RepoRoot)'' && runtime/scripts/update.sh install'"
+            (Get-EmbeddedDockerInstallCommand)
+        ) -Links @(
+            (Join-Path $Script:RepoRoot 'WSL_README.md')
+        )
+        return $true
+    }
+    if ($OutputText -match 'pull access denied|failed to resolve|TLS handshake timeout|Error response from daemon.*pull|unable to fetch|network is unreachable|403 Forbidden|manifest unknown|Get "https://registry|i/o timeout|connection reset|short read|no such host') {
+        Write-EmbeddedDockerEngineSelfHelp
+        return $true
     }
     if ($OutputText -match 'WSL 2 requires an update|kernel component|Please update WSL') {
         Write-WslSelfHelp -Title 'WSL needs an update' -Steps @(
@@ -614,7 +1358,7 @@ function Write-WslCommandFailureHelp {
             $Script:WslDocLinks.UpdateWsl,
             $Script:WslDocLinks.Troubleshooting
         )
-        return
+        return $true
     }
     if ($OutputText -match 'cannot find|is not registered|No such file|does not exist') {
         Write-WslSelfHelp -Title 'WSL distribution is missing or not registered' -Steps @(
@@ -625,7 +1369,7 @@ function Write-WslCommandFailureHelp {
             $Script:WslDocLinks.InstallGuide,
             $Script:WslDocLinks.Troubleshooting
         )
-        return
+        return $true
     }
     if ($OutputText -match 'permission denied|access is denied|sudo: a password is required') {
         Write-WslSelfHelp -Title 'Permission or sudo issue inside WSL' -Steps @(
@@ -634,7 +1378,9 @@ function Write-WslCommandFailureHelp {
         ) -Links @(
             (Join-Path $Script:RepoRoot 'WSL_README.md')
         )
+        return $true
     }
+    return $false
 }
 
 function Ensure-WslPlatform {
@@ -664,7 +1410,7 @@ function Ensure-WslPlatform {
 
     $platform = Get-WslPlatformStatus
     if ($platform.RebootRequired) {
-        Request-WindowsRebootAndStop -Reason 'Windows reboot is pending from a previous update or feature install'
+        Continue-DespitePendingReboot -Reason 'Windows reboot is pending from a previous update or feature install'
     }
 
     if (Test-WslPlatformReady -PlatformStatus $platform) {
@@ -684,7 +1430,7 @@ function Ensure-WslPlatform {
     if ($featuresNeedEnable -or -not $platform.WslExeAvailable) {
         $rebootAfterFeatures = Enable-WslWindowsFeatures
         if ($rebootAfterFeatures) {
-            Request-WindowsRebootAndStop -Reason 'Windows must restart after enabling WSL optional features'
+            Continue-DespitePendingReboot -Reason 'Windows must restart after enabling WSL optional features'
         }
         $platform = Get-WslPlatformStatus
     }
@@ -703,7 +1449,7 @@ function Ensure-WslPlatform {
             )
             throw "Could not install the WSL2 platform. See the links above."
         }
-        Request-WindowsRebootAndStop -Reason 'WSL2 platform was installed; Windows usually needs a restart before the Debian distro can be created'
+        Continue-DespitePendingReboot -Reason 'WSL2 platform was installed; Windows usually needs a restart before the Debian distro can be created'
     }
 
     Set-WslDefaultVersion2
@@ -954,17 +1700,35 @@ function ConvertTo-WslPath {
     )
     $fullPath = [System.IO.Path]::GetFullPath($WindowsPath)
 
-    if (Test-WslDistro -Distro $Distro) {
-        $wslPath = (wsl.exe -d $Distro -- wslpath -a $fullPath 2>&1 | Out-String).Trim()
-        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($wslPath)) {
-            return ($wslPath -replace '\\', '/')
-        }
-    }
-
-    if ($fullPath -match '^([A-Za-z]):\\(.*)$') {
+    # Map D:\foo\bar -> /mnt/d/foo/bar locally. Avoids wslpath: bash eats \w, \d, etc. in args.
+    if ($fullPath -match '^([A-Za-z]):[\\/](.*)$') {
         $drive = $Matches[1].ToLowerInvariant()
         $rest = ($Matches[2] -replace '\\', '/')
         return "/mnt/$drive/$rest"
+    }
+
+    if (Test-WslDistro -Distro $Distro) {
+        $pathForWsl = $fullPath -replace '\\', '/'
+        $prevErrorAction = $ErrorActionPreference
+        $ErrorActionPreference = 'SilentlyContinue'
+        try {
+            $wslPathOutput = & wsl.exe -d $Distro -- wslpath -a $pathForWsl 2>$null
+        }
+        finally {
+            $ErrorActionPreference = $prevErrorAction
+        }
+        if ($LASTEXITCODE -eq 0) {
+            $wslPath = if ($wslPathOutput -is [array]) {
+                ($wslPathOutput -join [Environment]::NewLine)
+            }
+            else {
+                [string]$wslPathOutput
+            }
+            $wslPath = $wslPath.Trim()
+            if (-not [string]::IsNullOrWhiteSpace($wslPath)) {
+                return ($wslPath -replace '\\', '/')
+            }
+        }
     }
 
     throw "Could not convert Windows path to WSL path: $WindowsPath"
@@ -1038,14 +1802,16 @@ function Get-ContainerRuntime {
 set -euo pipefail
 cd '$WorkspaceWsl'
 configured='$ConfiguredRuntime'
-if [ "`$configured" = docker ] && docker info >/dev/null 2>&1; then
-  echo docker
+if docker info --format '{{.OperatingSystem}}' 2>/dev/null | grep -qi 'docker desktop'; then
+  echo docker-desktop
 elif [ "`$configured" = podman ] && podman info >/dev/null 2>&1; then
   echo podman
-elif docker info >/dev/null 2>&1; then
+elif [ "`$configured" = docker ] && docker info >/dev/null 2>&1; then
   echo docker
 elif podman info >/dev/null 2>&1; then
   echo podman
+elif docker info >/dev/null 2>&1; then
+  echo docker
 else
   echo unknown
 fi
@@ -1089,8 +1855,18 @@ echo 'Scripts are executable.'
     if ($ContainerRuntime -eq 'podman') {
         Write-InstallBanner "apt-get may pause while downloading indexes; more lines will appear as packages install."
     }
+    elseif ($ContainerRuntime -eq 'docker-desktop') {
+        Write-InstallBanner "Using Docker Desktop via WSL integration; containers will appear in the Docker Desktop UI."
+        if (-not (Test-DockerDesktopWslIntegration -Distro $Distro)) {
+            Write-DockerDesktopSelfHelp -Title "Docker Desktop WSL integration is OFF for '$Distro' (checked before bootstrap)"
+            throw "Enable Docker Desktop -> Settings -> Resources -> WSL Integration for '$Distro', then re-run install.ps1."
+        }
+    }
+    elseif ($ContainerRuntime -eq 'docker') {
+        Write-InstallBanner "Using embedded Docker Engine (https://get.docker.com). Containers will NOT appear in Docker Desktop UI."
+    }
     else {
-        Write-InstallBanner "Docker Engine will be installed inside WSL if it is not already present."
+        Write-InstallBanner "Embedded Docker Engine will be installed inside WSL if it is not already present."
     }
     $bootstrap = @"
 set -euo pipefail
@@ -1104,6 +1880,7 @@ export CONTAINER_RUNTIME='$ContainerRuntime'
 
     Write-InstallStep "Running install.sh: container runtime, images, and console"
     Write-InstallBanner "Live output from install.sh appears below."
+    Write-InstallBanner "Docker downloads use plain progress lines (easier to read in PowerShell)."
     $installSh = @"
 set -euo pipefail
 cd '$($Paths.Wsl)'
@@ -1111,6 +1888,9 @@ export DUNE_HOST_REPO_ROOT="`$(pwd -P)"
 export DUNE_CONTAINER_RUNTIME='$ContainerRuntime'
 export CONTAINER_RUNTIME='$ContainerRuntime'
 export DUNE_INSTALL_FROM_WINDOWS=1
+export ADMIN_BIND_HOST=0.0.0.0
+export BUILDKIT_PROGRESS=plain
+export COMPOSE_PROGRESS=plain
 ./install.sh
 "@
     Invoke-WslAsInstallUser -Distro $Distro -Command $installSh -StreamOutput | Out-Null
@@ -1177,56 +1957,94 @@ function Show-Finish {
             $info[$Matches[1]] = $Matches[2]
         }
     }
-    Write-InstallBanner "Dune Docker Console is ready."
-    Write-Host ""
     $port = if ($info['DUNE_CONSOLE_PORT']) { [int]$info['DUNE_CONSOLE_PORT'] } else { 8088 }
     $containerRunning = Test-ConsoleContainerRunning -Distro $Distro -ContainerRuntime $ContainerRuntime
     $httpReady = Test-ConsoleHttpFromWindows -Port $port
 
-    Write-Host "Open the Web UI from Windows in your browser:"
-    Write-Host "  http://localhost:$port"
+    Write-InstallBanner "Dune Docker Console - install finished"
     Write-Host ""
-    Write-Host "Use localhost from Windows (not the WSL-only IP). WSL forwards port $port to Windows automatically."
-    if ($info['DUNE_CONSOLE_IP'] -and $info['DUNE_CONSOLE_IP'] -ne '127.0.0.1') {
-        Write-Host "  WSL internal address (Linux-only, not for Windows browsers): http://$($info['DUNE_CONSOLE_IP']):$port"
+    Write-Host "================================================================" -ForegroundColor Green
+    Write-Host "  WHAT TO DO NOW (read in order)" -ForegroundColor Green
+    Write-Host "================================================================" -ForegroundColor Green
+    Write-Host ""
+
+    $stepNum = 1
+    if ($Script:DockerDesktopNetworkRepairNeedsRestart) {
+        Write-Host "  $stepNum. RESTART DOCKER AND WSL FIRST (network was fixed during install):" -ForegroundColor Yellow
+        Write-Host "       - Quit Docker Desktop (tray whale icon -> Quit Docker Desktop)"
+        Write-Host "       - Start Docker Desktop again and wait until running"
+        Write-Host "       - In PowerShell run: wsl --shutdown"
+        Write-Host "       - Then continue with the steps below (or re-run install.ps1)"
+        Write-Host ""
+        $stepNum++
+    }
+
+    Write-Host "  $stepNum. Open this address in your web browser (Chrome/Edge/Firefox on Windows):"
+    Write-Host "       http://localhost:$port" -ForegroundColor Cyan
+    Write-Host "       Do NOT use a 172.x.x.x address - use localhost only."
+    Write-Host ""
+    $stepNum++
+
+    if ($info['DUNE_CONSOLE_PASSWORD']) {
+        Write-Host "  $stepNum. Sign in with this admin password (copy it exactly):"
+        Write-Host "       $($info['DUNE_CONSOLE_PASSWORD'])" -ForegroundColor Cyan
+        Write-Host ""
+        $stepNum++
+        Write-Host "  $stepNum. Follow the setup wizard in the browser to finish server setup."
+    }
+    else {
+        Write-Host "  $stepNum. Wait 30 seconds, then run install.ps1 again to print your admin password."
+        Write-Host ""
+        $stepNum++
+        Write-Host "  $stepNum. Sign in at http://localhost:$port and follow the setup wizard."
     }
     Write-Host ""
-    if (-not $containerRunning) {
-        Write-Host "Warning: the console container is not running inside WSL."
-        Write-Host "Re-run install.ps1 or start it manually inside WSL:"
-        if ($ContainerRuntime -eq 'podman') {
-            Write-Host "  export ADMIN_BIND_HOST=0.0.0.0 ADMIN_BIND_PORT=8088"
-            Write-Host "  podman rm -f redblink-dune-docker-console 2>/dev/null"
-            Write-Host "  podman-compose -f docker-compose.web.yml up -d --build --force-recreate redblink-dune-docker-console"
-        }
-        else {
-            Write-Host "  export ADMIN_BIND_HOST=0.0.0.0 ADMIN_BIND_PORT=8088"
-            Write-Host "  docker rm -f redblink-dune-docker-console 2>/dev/null"
-            Write-Host "  docker compose -f docker-compose.web.yml up -d --build --force-recreate redblink-dune-docker-console"
-        }
+    $stepNum++
+
+    if ($ContainerRuntime -eq 'docker-desktop') {
+        Write-Host "  $stepNum. Docker containers: open the Docker Desktop app (whale icon) -> Containers / Images."
+        Write-Host "       Keep WSL integration ON for '$Distro' (Settings -> Resources -> WSL Integration)."
         Write-Host ""
-        Write-Host "Troubleshooting: $(Join-Path $Script:RepoRoot 'WSL_README.md')"
+        $stepNum++
+    }
+
+    Write-Host "================================================================" -ForegroundColor Green
+    Write-Host "  IF SOMETHING IS WRONG" -ForegroundColor Green
+    Write-Host "================================================================" -ForegroundColor Green
+    Write-Host ""
+
+    if (-not $containerRunning) {
+        Write-Host "  Problem: Console container is not running." -ForegroundColor Yellow
+        Write-Host "  Fix: Re-run install.ps1 from an Administrator PowerShell in this folder:"
+        Write-Host "       cd '$Script:RepoRoot'"
+        Write-Host "       powershell -ExecutionPolicy Bypass -File .\install.ps1"
         Write-Host ""
     }
     elseif (-not $httpReady) {
-        Write-Host "Warning: localhost:$port is not responding from Windows yet."
-        Write-Host "Wait a minute for the build to finish, then try again."
-        Write-Host "If it still fails: wsl --shutdown (from PowerShell), reopen WSL, re-run install.ps1."
-        Write-Host "Guide: $(Join-Path $Script:RepoRoot 'WSL_README.md')"
+        Write-Host "  Problem: http://localhost:$port is not loading yet." -ForegroundColor Yellow
+        Write-Host "  Fix: Wait 2 - 3 minutes (first build is slow), refresh the browser."
+        Write-Host "       Still broken? Run: wsl --shutdown"
+        Write-Host "       Then re-run install.ps1."
         Write-Host ""
     }
-    Write-Host "Container runtime: $ContainerRuntime"
-    Write-Host "WSL distro: $WslDistro"
-    Write-Host "WSL user: $Script:WslUserName"
-    Write-Host "Workspace (WSL): $($Paths.Wsl)"
-    if ($info['DUNE_CONSOLE_PASSWORD']) {
+
+    if ($ContainerRuntime -eq 'docker-desktop') {
+        Write-Host "  Docker Desktop cannot pull some images (hello-world OK, others fail)?"
+        Write-Host "  -> Re-run with embedded Engine: $(Get-EmbeddedDockerInstallCommand)"
+        Write-Host "  -> Uses https://get.docker.com inside WSL; containers stay in WSL (not Desktop UI)."
         Write-Host ""
-        Write-Host "Your first admin password:"
-        Write-Host "  $($info['DUNE_CONSOLE_PASSWORD'])"
+        Write-Host "  Players stuck on ""Connecting"" in-game (server shows in browser)?"
+        Write-Host "  -> Open WSL_README.md -> section ""Players stuck on Connecting"""
+        Write-Host "  -> Run install.ps1 as Administrator (fixes VMware Bridge on vEthernet adapters)"
+        Write-Host ""
     }
-    else {
-        Write-Host ""
-        Write-Host "Admin password was not ready yet. Wait a few seconds and run install.ps1 again to show it."
+
+    Write-Host "  Full help:  $(Join-Path $Script:RepoRoot 'WSL_README.md')"
+    Write-Host "  Install log: $($Script:InstallLogPath)"
+    Write-Host ""
+    Write-Host "  Details: runtime=$ContainerRuntime | WSL=$Distro | user=$Script:WslUserName"
+    if ($info['DUNE_CONSOLE_IP'] -and $info['DUNE_CONSOLE_IP'] -ne '127.0.0.1') {
+        Write-Host "  (Ignore for browser: WSL-only IP http://$($info['DUNE_CONSOLE_IP']):$port )"
     }
 }
 
@@ -1253,9 +2071,18 @@ function Write-InstallState {
 # --- Main ---
 
 Write-InstallBanner "Starting Dune Docker Console Windows Installer."
-Write-Host "Self-help: WSL_README.md in this repo | Microsoft WSL docs: $($Script:WslDocLinks.InstallGuide)"
+Show-InstallPreflightChecklist
 
 if (-not (Test-Path -LiteralPath (Join-Path $Script:RepoRoot 'install.sh'))) {
+    Write-WslSelfHelp -Title 'Wrong folder - run install.ps1 from the repository root' -Steps @(
+        'The file install.sh must be in the same folder as install.ps1.'
+        'Open File Explorer and go to the folder where you cloned or extracted this project.'
+        'Shift + right-click in that folder -> Open PowerShell window here (or use cd in PowerShell).'
+        'Run install.ps1 from that folder (command below).'
+    ) -Commands @(
+        "cd '$Script:RepoRoot'"
+        'powershell -ExecutionPolicy Bypass -File .\install.ps1'
+    ) -Footer 'If install.sh is missing, re-clone or re-download the full repository.'
     throw "Run install.ps1 from the repository root (install.sh must be present)."
 }
 
@@ -1287,20 +2114,38 @@ if ($Update) {
 
 $wslDistroInstallDir = Resolve-WslDistroInstallDir
 Initialize-WslDistro -InstallDir $wslDistroInstallDir
+Repair-WslConfMissingDefaultUser
 $existingConfig = Get-InstallConfig
-$needsUserSetup = (-not $existingConfig) -or (-not $existingConfig.wslUser) -or [bool]$WslPassword -or (
+$candidateUser = if ($WslUser) { $WslUser.Trim() } elseif ($existingConfig -and $existingConfig.wslUser) { [string]$existingConfig.wslUser } else { '' }
+$userMissingInWsl = [bool]($candidateUser -and -not (Test-WslLinuxUserExists -User $candidateUser))
+$needsUserSetup = (-not $existingConfig) -or (-not $existingConfig.wslUser) -or $userMissingInWsl -or $PSBoundParameters.ContainsKey('WslPassword') -or (
     $WslUser -and ($existingConfig -and [string]$existingConfig.wslUser -ne $WslUser.Trim())
 )
+if ($userMissingInWsl) {
+    Write-InstallStep "WSL user '$candidateUser' is saved but missing inside $WslDistro - will recreate it."
+}
 Resolve-WslCredentials -RequirePassword:$needsUserSetup
 Initialize-WslLinuxUser
 Set-WslInstallUserSudo
 Set-WslSystemd
+Initialize-WslDns
 
 $paths = Resolve-WorkspacePaths -RelativeDir (Resolve-WorkspaceDirRelative)
 Initialize-Workspace -Paths $paths
 
 $resolvedRuntime = Resolve-ContainerRuntime
-Write-InstallStep "Container runtime: $resolvedRuntime (inside WSL, not Docker Desktop on Windows)"
+Write-InstallStep "Container runtime: $resolvedRuntime ($((Get-ContainerRuntimeDescription -Runtime $resolvedRuntime)))"
+if ($resolvedRuntime -eq 'docker') {
+    Write-InstallBanner "Embedded Docker Engine mode: installs via https://get.docker.com inside WSL."
+    Write-InstallBanner "Use this when Docker Desktop hello-world works but other image pulls fail."
+}
+if ($resolvedRuntime -eq 'docker-desktop') {
+    Initialize-DockerDesktopForWsl -Distro $WslDistro
+    $networkRepair = Ensure-DockerDesktopNetworkAdapters
+    if ($networkRepair.NeedsRestart) {
+        $Script:DockerDesktopNetworkRepairNeedsRestart = $true
+    }
+}
 Invoke-WslInstall -Paths $paths -ContainerRuntime $resolvedRuntime
 $runtime = Get-ContainerRuntime -ConfiguredRuntime $resolvedRuntime -WorkspaceWsl $paths.Wsl
 Write-InstallState -Paths $paths -ContainerRuntime $runtime

--- a/install.sh
+++ b/install.sh
@@ -16,11 +16,45 @@ if [ -n "${DUNE_CONTAINER_RUNTIME:-}" ]; then
   export CONTAINER_RUNTIME
 fi
 
+if [ -f runtime/scripts/docker-desktop-wsl.sh ]; then
+  # shellcheck disable=SC1091
+  . runtime/scripts/docker-desktop-wsl.sh
+fi
+
 preferred_container_runtime() {
   case "${DUNE_CONTAINER_RUNTIME:-}" in
-    docker|podman) printf '%s' "$DUNE_CONTAINER_RUNTIME" ;;
+    docker|docker-desktop|podman) printf '%s' "$DUNE_CONTAINER_RUNTIME" ;;
     *) printf '%s' '' ;;
   esac
+}
+
+using_docker_desktop_runtime() {
+  [ "$(preferred_container_runtime)" = "docker-desktop" ] || [ "$CONTAINER_RUNTIME" = "docker-desktop" ]
+}
+
+force_embedded_docker_runtime() {
+  [ "$(preferred_container_runtime)" = "docker" ]
+}
+
+configure_embedded_docker_env() {
+  if force_embedded_docker_runtime; then
+    export DOCKER_HOST=unix:///var/run/docker.sock
+    CONTAINER_RUNTIME=docker
+  fi
+}
+
+configure_embedded_docker_env
+
+set_docker_runtime_kind() {
+  if force_embedded_docker_runtime; then
+    CONTAINER_RUNTIME=docker
+    return
+  fi
+  if command -v is_docker_desktop_daemon >/dev/null 2>&1 && is_docker_desktop_daemon; then
+    CONTAINER_RUNTIME=docker-desktop
+  else
+    CONTAINER_RUNTIME=docker
+  fi
 }
 
 say() {
@@ -85,11 +119,18 @@ install_podman() {
 }
 
 install_docker() {
-  if command -v docker >/dev/null 2>&1; then
-    return
+  if force_embedded_docker_runtime; then
+    if command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; then
+      if ! docker info --format '{{.OperatingSystem}}' 2>/dev/null | grep -qi 'docker desktop'; then
+        return 0
+      fi
+      step "Docker Desktop is active; installing embedded Docker Engine via https://get.docker.com ..."
+    fi
+  elif command -v docker >/dev/null 2>&1; then
+    return 0
   fi
 
-  step "Docker is missing. Installing Docker now."
+  step "Installing Docker Engine via https://get.docker.com ..."
   install_basic_tools
 
   if ! command -v curl >/dev/null 2>&1; then
@@ -107,6 +148,13 @@ install_container_runtime() {
   fi
 
   case "$(preferred_container_runtime)" in
+    docker-desktop)
+      echo "Docker Desktop is required but the docker CLI is not reachable in WSL." >&2
+      if command -v print_docker_desktop_integration_help >/dev/null 2>&1; then
+        print_docker_desktop_integration_help
+      fi
+      exit 1
+      ;;
     docker)
       install_docker
       ;;
@@ -142,19 +190,38 @@ select_podman_command() {
 }
 
 select_docker_command() {
+  if force_embedded_docker_runtime; then
+    export DOCKER_HOST=unix:///var/run/docker.sock
+    if docker info >/dev/null 2>&1; then
+      if ! docker info --format '{{.OperatingSystem}}' 2>/dev/null | grep -qi 'docker desktop'; then
+        DOCKER=(docker)
+        CONTAINER_RUNTIME=docker
+        return 0
+      fi
+    fi
+    if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo DOCKER_HOST=unix:///var/run/docker.sock docker info >/dev/null 2>&1; then
+      if ! sudo DOCKER_HOST=unix:///var/run/docker.sock docker info --format '{{.OperatingSystem}}' 2>/dev/null | grep -qi 'docker desktop'; then
+        DOCKER=(sudo docker)
+        CONTAINER_RUNTIME=docker
+        return 0
+      fi
+    fi
+    return 1
+  fi
+
   if docker info >/dev/null 2>&1; then
     DOCKER=(docker)
-    CONTAINER_RUNTIME=docker
+    set_docker_runtime_kind
     return 0
   fi
   if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo docker info >/dev/null 2>&1; then
     DOCKER=(sudo docker)
-    CONTAINER_RUNTIME=docker
+    set_docker_runtime_kind
     return 0
   fi
   if [ "$(id -u)" -eq 0 ] && docker info >/dev/null 2>&1; then
     DOCKER=(docker)
-    CONTAINER_RUNTIME=docker
+    set_docker_runtime_kind
     return 0
   fi
   return 1
@@ -162,6 +229,11 @@ select_docker_command() {
 
 select_container_command() {
   case "$(preferred_container_runtime)" in
+    docker-desktop)
+      if select_docker_command; then
+        return 0
+      fi
+      ;;
     docker)
       if select_docker_command; then
         return 0
@@ -212,6 +284,19 @@ ensure_podman_socket() {
 }
 
 start_container_runtime() {
+  if using_docker_desktop_runtime; then
+    if select_docker_command; then
+      disable_embedded_docker_engine
+      ensure_podman_socket
+      return
+    fi
+    echo "Docker Desktop WSL integration is required but docker is not reachable." >&2
+    if command -v print_docker_desktop_integration_help >/dev/null 2>&1; then
+      print_docker_desktop_integration_help
+    fi
+    exit 1
+  fi
+
   if select_container_command; then
     ensure_podman_socket
     return
@@ -262,6 +347,9 @@ start_container_runtime() {
 }
 
 ensure_docker_group_access() {
+  if using_docker_desktop_runtime; then
+    return
+  fi
   local target_user
   target_user="${SUDO_USER:-${USER:-}}"
   if [ -z "$target_user" ] || [ "$target_user" = "root" ]; then
@@ -365,7 +453,13 @@ start_console() {
     . runtime/scripts/ensure-podman-socket.sh
     run_compose_up "$WEB_COMPOSE" "$WEB_SERVICE"
   else
-    "${DOCKER[@]}" compose -f "$WEB_COMPOSE" up -d --build "$WEB_SERVICE"
+    compose_progress=()
+    if [ "${DUNE_INSTALL_FROM_WINDOWS:-0}" = "1" ]; then
+      export BUILDKIT_PROGRESS=plain
+      export COMPOSE_PROGRESS=plain
+      compose_progress=(--progress plain)
+    fi
+    "${DOCKER[@]}" compose "${compose_progress[@]}" -f "$WEB_COMPOSE" up -d --build "$WEB_SERVICE"
   fi
 }
 
@@ -437,6 +531,9 @@ install_container_runtime
 start_container_runtime
 if [ "$CONTAINER_RUNTIME" = "docker" ]; then
   ensure_docker_group_access
+fi
+if using_docker_desktop_runtime; then
+  disable_embedded_docker_engine
 fi
 ensure_compose
 ensure_podman_socket

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,20 @@ WEB_COMPOSE="docker-compose.web.yml"
 WEB_SERVICE="redblink-dune-docker-console"
 WEB_PORT="${ADMIN_BIND_PORT:-8088}"
 DOCKER=(docker)
+CONTAINER_RUNTIME=docker
 DOCKER_GROUP_UPDATED=0
+
+if [ -n "${DUNE_CONTAINER_RUNTIME:-}" ]; then
+  CONTAINER_RUNTIME="$DUNE_CONTAINER_RUNTIME"
+  export CONTAINER_RUNTIME
+fi
+
+preferred_container_runtime() {
+  case "${DUNE_CONTAINER_RUNTIME:-}" in
+    docker|podman) printf '%s' "$DUNE_CONTAINER_RUNTIME" ;;
+    *) printf '%s' '' ;;
+  esac
+}
 
 say() {
   printf '\n%s\n' "$1"
@@ -53,6 +66,24 @@ install_basic_tools() {
   fi
 }
 
+install_podman() {
+  if command -v podman >/dev/null 2>&1; then
+    return
+  fi
+
+  step "Podman is missing. Installing Podman now."
+  install_basic_tools
+
+  if command -v apt-get >/dev/null 2>&1; then
+    need_sudo apt-get update
+    need_sudo apt-get install -y podman podman-compose podman-docker
+    return
+  fi
+
+  echo "Podman is missing and this operating system is not supported for automatic Podman installation."
+  return 1
+}
+
 install_docker() {
   if command -v docker >/dev/null 2>&1; then
     return
@@ -70,50 +101,162 @@ install_docker() {
   curl -fsSL https://get.docker.com | need_sudo sh
 }
 
-select_docker_command() {
-  if docker info >/dev/null 2>&1; then
-    DOCKER=(docker)
+install_container_runtime() {
+  if select_container_command; then
+    return
+  fi
+
+  case "$(preferred_container_runtime)" in
+    docker)
+      install_docker
+      ;;
+    podman)
+      install_podman || true
+      if select_container_command; then
+        return
+      fi
+      install_docker
+      ;;
+    *)
+      install_podman || true
+      if select_container_command; then
+        return
+      fi
+      install_docker
+      ;;
+  esac
+}
+
+select_podman_command() {
+  if podman info >/dev/null 2>&1; then
+    DOCKER=(podman)
+    CONTAINER_RUNTIME=podman
     return 0
   fi
-  if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo docker info >/dev/null 2>&1; then
-    DOCKER=(sudo docker)
-    return 0
-  fi
-  if [ "$(id -u)" -eq 0 ] && docker info >/dev/null 2>&1; then
-    DOCKER=(docker)
+  if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo podman info >/dev/null 2>&1; then
+    DOCKER=(sudo podman)
+    CONTAINER_RUNTIME=podman
     return 0
   fi
   return 1
 }
 
-start_docker() {
-  if select_docker_command; then
+select_docker_command() {
+  if docker info >/dev/null 2>&1; then
+    DOCKER=(docker)
+    CONTAINER_RUNTIME=docker
+    return 0
+  fi
+  if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo docker info >/dev/null 2>&1; then
+    DOCKER=(sudo docker)
+    CONTAINER_RUNTIME=docker
+    return 0
+  fi
+  if [ "$(id -u)" -eq 0 ] && docker info >/dev/null 2>&1; then
+    DOCKER=(docker)
+    CONTAINER_RUNTIME=docker
+    return 0
+  fi
+  return 1
+}
+
+select_container_command() {
+  case "$(preferred_container_runtime)" in
+    docker)
+      if select_docker_command; then
+        return 0
+      fi
+      if select_podman_command; then
+        return 0
+      fi
+      ;;
+    podman)
+      if select_podman_command; then
+        return 0
+      fi
+      if select_docker_command; then
+        return 0
+      fi
+      ;;
+    *)
+      if select_podman_command; then
+        return 0
+      fi
+      if select_docker_command; then
+        return 0
+      fi
+      ;;
+  esac
+  return 1
+}
+
+ensure_podman_socket() {
+  if [ "$CONTAINER_RUNTIME" != "podman" ]; then
     return
   fi
 
-  step "Docker is installed but is not running yet. Starting Docker now."
-
-  if has_systemd; then
-    need_sudo systemctl enable --now docker || true
-  elif command -v service >/dev/null 2>&1; then
-    need_sudo service docker start || true
+  if [ -f runtime/scripts/ensure-podman-socket.sh ]; then
+    # shellcheck disable=SC1091
+    . runtime/scripts/ensure-podman-socket.sh
+    configure_podman_for_compose || true
+    export_podman_docker_host || true
+  elif has_systemd; then
+    need_sudo systemctl enable --now podman.socket >/dev/null 2>&1 || true
   fi
 
-  if select_docker_command; then
+  if [ "$CONTAINER_RUNTIME" = "podman" ] && ! command -v docker >/dev/null 2>&1; then
+    if command -v apt-get >/dev/null 2>&1; then
+      need_sudo apt-get install -y podman-docker >/dev/null 2>&1 || true
+    fi
+  fi
+}
+
+start_container_runtime() {
+  if select_container_command; then
+    ensure_podman_socket
     return
   fi
 
-  if [ "$(id -u)" -ne 0 ] && getent group docker >/dev/null 2>&1; then
-    step "Giving your user access to Docker."
-    need_sudo usermod -aG docker "$USER" || true
+  install_container_runtime
+
+  if select_container_command; then
+    ensure_podman_socket
+    return
+  fi
+
+  if [ "$CONTAINER_RUNTIME" = "docker" ] || command -v docker >/dev/null 2>&1; then
+    step "Docker is installed but is not running yet. Starting Docker now."
+
+    if has_systemd; then
+      need_sudo systemctl enable --now docker || true
+    elif command -v service >/dev/null 2>&1; then
+      need_sudo service docker start || true
+    fi
+
     if select_docker_command; then
-      echo "Docker is ready. Setup can continue."
+      return
+    fi
+
+    if [ "$(id -u)" -ne 0 ] && getent group docker >/dev/null 2>&1; then
+      step "Giving your user access to Docker."
+      need_sudo usermod -aG docker "$USER" || true
+      if select_docker_command; then
+        echo "Docker is ready. Setup can continue."
+        return
+      fi
+    fi
+  fi
+
+  if [ "$CONTAINER_RUNTIME" = "podman" ] || command -v podman >/dev/null 2>&1; then
+    ensure_podman_socket
+    if select_podman_command; then
       return
     fi
   fi
 
-  echo "Docker is installed, but this installer still cannot reach the Docker engine."
+  echo "A container runtime is installed, but this installer still cannot reach it."
   echo "If you use Docker Desktop, start Docker Desktop and wait until it says it is running."
+  echo "If you use Podman, make sure podman.socket is enabled inside WSL."
   echo "Then run this installer again."
   exit 1
 }
@@ -137,13 +280,26 @@ ensure_docker_group_access() {
 }
 
 ensure_compose() {
+  if [ -f runtime/scripts/ensure-podman-socket.sh ]; then
+    # shellcheck disable=SC1091
+    . runtime/scripts/ensure-podman-socket.sh
+    if should_use_podman_compose; then
+      configure_podman_for_compose 2>/dev/null || true
+      export_podman_docker_host 2>/dev/null || true
+      podman-compose --version >/dev/null 2>&1 && return
+    fi
+  fi
+
   if "${DOCKER[@]}" compose version >/dev/null 2>&1; then
     return
   fi
 
   step "Docker Compose is missing. Installing the Compose plugin now."
 
-  if command -v apt-get >/dev/null 2>&1; then
+  if [ "$CONTAINER_RUNTIME" = "podman" ] && command -v apt-get >/dev/null 2>&1; then
+    need_sudo apt-get update
+    need_sudo apt-get install -y podman-compose podman-docker
+  elif command -v apt-get >/dev/null 2>&1; then
     need_sudo apt-get update
     need_sudo apt-get install -y docker-compose-plugin
   elif command -v dnf >/dev/null 2>&1; then
@@ -203,7 +359,14 @@ start_console() {
 
   step "Starting the Web UI."
   export DUNE_HOST_REPO_ROOT="${DUNE_HOST_REPO_ROOT:-$(pwd -P)}"
-  "${DOCKER[@]}" compose -f "$WEB_COMPOSE" up -d --build "$WEB_SERVICE"
+  export CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+  if [ -f runtime/scripts/ensure-podman-socket.sh ]; then
+    # shellcheck disable=SC1091
+    . runtime/scripts/ensure-podman-socket.sh
+    run_compose_up "$WEB_COMPOSE" "$WEB_SERVICE"
+  else
+    "${DOCKER[@]}" compose -f "$WEB_COMPOSE" up -d --build "$WEB_SERVICE"
+  fi
 }
 
 read_admin_password() {
@@ -223,6 +386,10 @@ read_admin_password() {
 }
 
 show_finish() {
+  if [ "${DUNE_INSTALL_FROM_WINDOWS:-0}" = "1" ]; then
+    return
+  fi
+
   local ip public password_file admin_password
   ip="$(host_ip)"
   public="$(public_ip)"
@@ -262,14 +429,17 @@ say "Starting Dune Docker Console Installer."
 
 if ! is_linux; then
   echo "This automatic installer runs on Linux servers."
-  echo "For Docker Desktop on Windows or another VM setup, start Docker Desktop first, then start the Web UI from the extracted release folder."
+  echo "On Windows, run: powershell -ExecutionPolicy Bypass -File .\\install.ps1"
   exit 1
 fi
 
-install_docker
-start_docker
-ensure_docker_group_access
+install_container_runtime
+start_container_runtime
+if [ "$CONTAINER_RUNTIME" = "docker" ]; then
+  ensure_docker_group_access
+fi
 ensure_compose
+ensure_podman_socket
 install_cli_command
 start_console
 show_finish

--- a/runtime/scripts/configure-wsl-dns.sh
+++ b/runtime/scripts/configure-wsl-dns.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# Configure WSL DNS (/etc/wsl.conf + /etc/resolv.conf) and embedded Docker daemon DNS.
+# Intended for WSL installs only; does not modify Windows or user shell profiles.
+set -euo pipefail
+
+is_wsl() {
+  grep -qiE '(microsoft|wsl)' /proc/version 2>/dev/null
+}
+
+need_sudo() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+    return
+  fi
+  if ! command -v sudo >/dev/null 2>&1; then
+    echo "WSL DNS setup needs root access, but sudo was not found." >&2
+    exit 1
+  fi
+  if ! sudo -n true 2>/dev/null; then
+    echo "WSL DNS setup needs sudo. Re-run install.ps1 to configure passwordless sudo." >&2
+    exit 1
+  fi
+  sudo "$@"
+}
+
+append_unique_server() {
+  local candidate="$1"
+  shift
+  local existing
+  candidate="${candidate// /}"
+  [ -n "$candidate" ] || return 0
+  printf '%s\n' "$candidate" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' || return 0
+  for existing in "$@"; do
+    [ "$existing" = "$candidate" ] && return 0
+  done
+  printf '%s' "$candidate"
+}
+
+collect_dns_servers() {
+  local servers=()
+  local token server win_host line
+
+  if [ -n "${DUNE_WSL_DNS:-}" ]; then
+    for token in ${DUNE_WSL_DNS//,/ }; do
+      server="$(append_unique_server "$token" "${servers[@]:-}")"
+      if [ -n "$server" ]; then
+        servers+=("$server")
+      fi
+    done
+  fi
+
+  if [ -f .wsl/dns-servers.txt ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="${line%%#*}"
+      line="${line// /}"
+      server="$(append_unique_server "$line" "${servers[@]:-}")"
+      if [ -n "$server" ]; then
+        servers+=("$server")
+      fi
+    done < .wsl/dns-servers.txt
+  fi
+
+  if [ "${#servers[@]}" -eq 0 ] && [ -f /etc/resolv.conf ]; then
+    while IFS= read -r line || [ -n "$line" ]; do
+      case "$line" in
+        nameserver\ *)
+          server="$(append_unique_server "${line#nameserver }" "${servers[@]:-}")"
+          if [ -n "$server" ]; then
+            servers+=("$server")
+          fi
+          ;;
+      esac
+    done < /etc/resolv.conf
+  fi
+
+  if [ "${#servers[@]}" -eq 0 ] && command -v ip >/dev/null 2>&1; then
+    win_host="$(ip route show default 2>/dev/null | awk '/default/ { print $3; exit }' || true)"
+    server="$(append_unique_server "$win_host" "${servers[@]:-}")"
+    if [ -n "$server" ]; then
+      servers+=("$server")
+    fi
+  fi
+
+  if [ "${#servers[@]}" -eq 0 ]; then
+    servers=(1.1.1.1 8.8.8.8)
+  fi
+
+  printf '%s\n' "${servers[@]}"
+}
+
+ensure_wsl_conf_generate_resolv_conf_disabled() {
+  if [ ! -f /etc/wsl.conf ]; then
+    need_sudo tee /etc/wsl.conf >/dev/null <<'EOF'
+[network]
+generateResolvConf = false
+EOF
+    return 0
+  fi
+
+  if grep -q '^\[network\]' /etc/wsl.conf; then
+    if grep -q '^generateResolvConf' /etc/wsl.conf; then
+      need_sudo sed -i 's/^generateResolvConf.*/generateResolvConf = false/' /etc/wsl.conf
+    else
+      need_sudo sed -i '/^\[network\]/a generateResolvConf = false' /etc/wsl.conf
+    fi
+    return 0
+  fi
+
+  need_sudo tee -a /etc/wsl.conf >/dev/null <<'EOF'
+
+[network]
+generateResolvConf = false
+EOF
+}
+
+write_resolv_conf() {
+  local servers=()
+  local server tmp
+  mapfile -t servers < <(collect_dns_servers)
+
+  tmp="$(mktemp)"
+  {
+    printf '# Managed by dune-awakening-selfhost-docker (configure-wsl-dns.sh)\n'
+    printf '# WSL will not overwrite this file while generateResolvConf=false.\n'
+    for server in "${servers[@]}"; do
+      printf 'nameserver %s\n' "$server"
+    done
+    printf 'options timeout:2 attempts:3 rotate\n'
+  } >"$tmp"
+  need_sudo cp "$tmp" /etc/resolv.conf
+  need_sudo chmod 644 /etc/resolv.conf
+  rm -f "$tmp"
+  echo "WSL DNS servers: ${servers[*]}"
+}
+
+configure_embedded_docker_dns() {
+  if ! command -v docker >/dev/null 2>&1; then
+    return 0
+  fi
+  if docker info --format '{{.OperatingSystem}}' 2>/dev/null | grep -qi 'docker desktop'; then
+    return 0
+  fi
+  if ! command -v systemctl >/dev/null 2>&1 || [ ! -d /run/systemd/system ]; then
+    return 0
+  fi
+
+  local servers=()
+  local server daemon_dir daemon_file tmp json
+  mapfile -t servers < <(collect_dns_servers)
+
+  daemon_dir="/etc/docker"
+  daemon_file="$daemon_dir/daemon.json"
+  need_sudo mkdir -p "$daemon_dir"
+
+  if [ -f "$daemon_file" ] && command -v python3 >/dev/null 2>&1; then
+    tmp="$(mktemp)"
+    DUNE_DAEMON_FILE="$daemon_file" DUNE_WSL_DNS="${servers[*]}" python3 - <<'PY' >"$tmp"
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["DUNE_DAEMON_FILE"])
+servers = [s for s in os.environ.get("DUNE_WSL_DNS", "").split() if s]
+data = {}
+if path.exists():
+    data = json.loads(path.read_text(encoding="utf-8") or "{}")
+data["dns"] = servers
+print(json.dumps(data, indent=2))
+PY
+    need_sudo cp "$tmp" "$daemon_file"
+    rm -f "$tmp"
+  else
+    tmp="$(mktemp)"
+    {
+      printf '{\n  "dns": ['
+      local first=1
+      for server in "${servers[@]}"; do
+        if [ "$first" -eq 1 ]; then
+          first=0
+        else
+          printf ', '
+        fi
+        printf '"%s"' "$server"
+      done
+      printf ']\n}\n'
+    } >"$tmp"
+    need_sudo cp "$tmp" "$daemon_file"
+    rm -f "$tmp"
+  fi
+  need_sudo chmod 644 "$daemon_file"
+
+  if systemctl is-active docker >/dev/null 2>&1; then
+    echo "Restarting embedded Docker Engine to apply DNS settings..."
+    need_sudo systemctl restart docker || true
+  fi
+}
+
+verify_general_dns() {
+  local probe host
+  for probe in cloudflare.com example.com; do
+    if getent hosts "$probe" >/dev/null 2>&1; then
+      echo "WSL DNS check passed ($probe resolves)."
+      return 0
+    fi
+  done
+  echo "WSL DNS check failed: common hostnames still do not resolve inside WSL." >&2
+  echo "Edit .wsl/dns-servers.txt (one IPv4 nameserver per line) and re-run install.ps1." >&2
+  return 1
+}
+
+print_funcom_registry_note() {
+  if getent hosts registry.funcom.com >/dev/null 2>&1; then
+    echo "registry.funcom.com resolves inside WSL."
+    return 0
+  fi
+  echo "Note: registry.funcom.com does not resolve via public DNS (this is expected)."
+  echo "Funcom server images are loaded locally from Steam tarballs (docker load), not pulled from the internet."
+  echo "Complete setup in the Web UI or run: runtime/scripts/update.sh install"
+}
+
+if ! is_wsl; then
+  exit 0
+fi
+
+ensure_wsl_conf_generate_resolv_conf_disabled
+write_resolv_conf
+configure_embedded_docker_dns
+verify_general_dns
+print_funcom_registry_note

--- a/runtime/scripts/configure-wsl-user.sh
+++ b/runtime/scripts/configure-wsl-user.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+dune_wsl_user="$(printf '%s' '__USER_B64__' | base64 -d 2>/dev/null || printf '%s' '__USER_B64__' | base64 --decode)"
+dune_wsl_pass="$(printf '%s' '__PASS_B64__' | base64 -d 2>/dev/null || printf '%s' '__PASS_B64__' | base64 --decode)"
+if [ -z "$dune_wsl_user" ]; then
+  echo "Decoded WSL username is empty." >&2
+  exit 1
+fi
+if ! id "$dune_wsl_user" >/dev/null 2>&1; then
+  useradd -m -s /bin/bash "$dune_wsl_user"
+fi
+echo "$dune_wsl_user:$dune_wsl_pass" | chpasswd
+if getent group sudo >/dev/null 2>&1; then
+  usermod -aG sudo "$dune_wsl_user"
+elif getent group wheel >/dev/null 2>&1; then
+  usermod -aG wheel "$dune_wsl_user"
+fi
+if getent group docker >/dev/null 2>&1; then
+  usermod -aG docker "$dune_wsl_user"
+fi
+if getent group podman >/dev/null 2>&1; then
+  usermod -aG podman "$dune_wsl_user"
+fi
+sudoers_file="/etc/sudoers.d/90-dune-install-${dune_wsl_user}"
+printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$dune_wsl_user" > "$sudoers_file"
+chmod 440 "$sudoers_file"
+if command -v visudo >/dev/null 2>&1; then
+  visudo -cf "$sudoers_file"
+fi
+if grep -q '^\[user\]' /etc/wsl.conf 2>/dev/null; then
+  if grep -q '^default=' /etc/wsl.conf; then
+    sed -i "s/^default=.*/default=$dune_wsl_user/" /etc/wsl.conf
+  else
+    sed -i "/^\[user\]/a default=$dune_wsl_user" /etc/wsl.conf
+  fi
+else
+  printf '\n[user]\ndefault=%s\n' "$dune_wsl_user" >> /etc/wsl.conf
+fi

--- a/runtime/scripts/docker-desktop-wsl.sh
+++ b/runtime/scripts/docker-desktop-wsl.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Docker Desktop WSL integration helpers. Source this file; do not execute directly.
+
+_dd_wsl_need_sudo() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+    sudo "$@"
+  else
+    echo "Docker Desktop setup needs sudo inside WSL." >&2
+    return 1
+  fi
+}
+
+_dd_wsl_has_systemd() {
+  command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]
+}
+
+is_docker_desktop_daemon() {
+  command -v docker >/dev/null 2>&1 || return 1
+  docker info --format '{{.OperatingSystem}}' 2>/dev/null | grep -qi 'docker desktop'
+}
+
+print_docker_desktop_integration_help() {
+  echo "Docker Desktop WSL integration is not active in this distribution." >&2
+  echo "" >&2
+  echo "Fix it from Windows:" >&2
+  echo "  1. Start Docker Desktop and wait until the engine is running." >&2
+  echo "  2. Settings -> General -> enable 'Use the WSL 2 based engine'." >&2
+  echo "  3. Settings -> Resources -> WSL Integration -> enable this distro." >&2
+  echo "  4. If WSL Integration is missing, switch to Linux containers from the Docker tray icon." >&2
+  echo "  5. Verify: docker info --format '{{.OperatingSystem}}' (should mention Docker Desktop)." >&2
+  echo "" >&2
+  echo "Guide: https://docs.docker.com/desktop/features/wsl/" >&2
+  echo "Local: WSL_README.md in this repository." >&2
+}
+
+ensure_docker_desktop_cli() {
+  if ! command -v docker >/dev/null 2>&1; then
+    print_docker_desktop_integration_help
+    return 1
+  fi
+  if ! is_docker_desktop_daemon; then
+    print_docker_desktop_integration_help
+    return 1
+  fi
+  if ! docker compose version >/dev/null 2>&1; then
+    echo "Docker Compose is not available through Docker Desktop in this WSL distro." >&2
+    echo "Update Docker Desktop and confirm WSL integration is enabled." >&2
+    return 1
+  fi
+  return 0
+}
+
+disable_embedded_docker_engine() {
+  if ! is_docker_desktop_daemon; then
+    return 0
+  fi
+  if ! _dd_wsl_has_systemd; then
+    return 0
+  fi
+  if ! systemctl list-unit-files docker.service >/dev/null 2>&1; then
+    return 0
+  fi
+  if systemctl is-active docker >/dev/null 2>&1; then
+    echo "Stopping embedded Docker Engine (using Docker Desktop instead)..."
+    _dd_wsl_need_sudo systemctl stop docker || true
+  fi
+  if systemctl is-enabled docker >/dev/null 2>&1; then
+    echo "Disabling embedded Docker Engine service..."
+    _dd_wsl_need_sudo systemctl disable docker || true
+  fi
+}
+
+ensure_wsl_dns() {
+  if [ ! -f runtime/scripts/configure-wsl-dns.sh ]; then
+    return 0
+  fi
+  echo "Configuring WSL DNS (/etc/wsl.conf, /etc/resolv.conf)..."
+  bash runtime/scripts/configure-wsl-dns.sh
+}
+
+verify_wsl_dns_for_docker() {
+  local probe_ok=0
+  if getent hosts cloudflare.com >/dev/null 2>&1 || getent hosts example.com >/dev/null 2>&1; then
+    probe_ok=1
+  fi
+  if [ "$probe_ok" -eq 0 ]; then
+    echo "WSL DNS does not resolve common hostnames. Docker pulls may fail." >&2
+    echo "Re-run install.ps1 or add nameservers to .wsl/dns-servers.txt (one per line)." >&2
+    return 1
+  fi
+  if ! getent hosts registry.funcom.com >/dev/null 2>&1; then
+    echo "registry.funcom.com is not reachable via DNS (expected on public networks)."
+    echo "Funcom images are loaded from Steam tarballs with docker load, not pulled from the registry."
+  fi
+  return 0
+}

--- a/runtime/scripts/enable-wsl-install-sudo.sh
+++ b/runtime/scripts/enable-wsl-install-sudo.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+target_user='__USER__'
+sudoers_file="/etc/sudoers.d/90-dune-install-${target_user}"
+printf '%s ALL=(ALL) NOPASSWD:ALL\n' "$target_user" > "$sudoers_file"
+chmod 440 "$sudoers_file"
+if command -v visudo >/dev/null 2>&1; then
+  visudo -cf "$sudoers_file"
+fi

--- a/runtime/scripts/ensure-podman-socket.sh
+++ b/runtime/scripts/ensure-podman-socket.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# Shared Podman socket setup for Linux/WSL. Source this file; do not execute directly.
+set -euo pipefail
+
+_ep_need_sudo() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+    sudo "$@"
+  else
+    echo "Podman setup needs sudo inside WSL." >&2
+    return 1
+  fi
+}
+
+_ep_is_wsl() {
+  grep -qiE '(microsoft|wsl)' /proc/version 2>/dev/null
+}
+
+_ep_has_systemd() {
+  command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]
+}
+
+_ep_wait_for_socket() {
+  local path="$1"
+  local attempt
+  for attempt in $(seq 1 20); do
+    if [ -S "$path" ]; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+_ep_start_user_podman_socket() {
+  local user uid runtime_dir
+  user="${USER:-root}"
+  uid="$(id -u)"
+  runtime_dir="/run/user/${uid}"
+
+  _ep_need_sudo loginctl enable-linger "$user" 2>/dev/null || true
+
+  if [ ! -d "$runtime_dir" ]; then
+    _ep_need_sudo mkdir -p "$runtime_dir" 2>/dev/null || true
+    _ep_need_sudo chown "${user}:${user}" "$runtime_dir" 2>/dev/null || true
+  fi
+
+  export XDG_RUNTIME_DIR="$runtime_dir"
+  if [ -S "${runtime_dir}/bus" ] || [ -d "${runtime_dir}/systemd" ]; then
+    systemctl --user enable --now podman.socket 2>/dev/null || \
+      systemctl --user start podman.socket 2>/dev/null || true
+  fi
+
+  if [ ! -S "${runtime_dir}/podman/podman.sock" ]; then
+    _ep_need_sudo -u "$user" env XDG_RUNTIME_DIR="$runtime_dir" \
+      systemctl --user enable --now podman.socket 2>/dev/null || true
+  fi
+}
+
+configure_podman_for_compose() {
+  if ! command -v podman >/dev/null 2>&1; then
+    return 1
+  fi
+  if ! _ep_has_systemd; then
+    return 1
+  fi
+
+  local uid user
+  user="${USER:-root}"
+  uid="$(id -u)"
+
+  if getent group podman >/dev/null 2>&1; then
+    _ep_need_sudo usermod -aG podman "$user" 2>/dev/null || true
+  fi
+
+  _ep_need_sudo systemctl enable --now podman.socket 2>/dev/null || true
+  if _ep_wait_for_socket /run/podman/podman.sock; then
+    export DOCKER_HOST='unix:///run/podman/podman.sock'
+    return 0
+  fi
+
+  if _ep_is_wsl; then
+    _ep_start_user_podman_socket
+    if _ep_wait_for_socket "/run/user/${uid}/podman/podman.sock"; then
+      export DOCKER_HOST="unix:///run/user/${uid}/podman/podman.sock"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+export_podman_docker_host() {
+  if [ -S /run/podman/podman.sock ]; then
+    export DOCKER_HOST='unix:///run/podman/podman.sock'
+    return 0
+  fi
+  local user_sock="/run/user/$(id -u)/podman/podman.sock"
+  if [ -S "$user_sock" ]; then
+    export DOCKER_HOST="unix://${user_sock}"
+    return 0
+  fi
+  return 1
+}
+
+should_use_podman_compose() {
+  [ "${CONTAINER_RUNTIME:-docker}" = "podman" ] && _ep_is_wsl && command -v podman-compose >/dev/null 2>&1
+}
+
+resolve_container_cmd() {
+  CONTAINER_CMD=()
+  if declare -p DOCKER >/dev/null 2>&1; then
+    CONTAINER_CMD=("${DOCKER[@]}")
+    return
+  fi
+  if [ "${CONTAINER_RUNTIME:-docker}" = "podman" ]; then
+    CONTAINER_CMD=(podman)
+  else
+    CONTAINER_CMD=(docker)
+  fi
+}
+
+verify_console_container() {
+  local name="${1:-redblink-dune-docker-console}"
+  local attempt
+  resolve_container_cmd
+
+  for attempt in $(seq 1 20); do
+    if "${CONTAINER_CMD[@]}" ps --format '{{.Names}}' 2>/dev/null | grep -qx "$name"; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Console container '$name' is not running after startup." >&2
+  "${CONTAINER_CMD[@]}" ps -a --filter "name=${name}" --format 'table {{.Names}}\t{{.Status}}' 2>/dev/null || true
+  echo "Recent container logs:" >&2
+  "${CONTAINER_CMD[@]}" logs --tail 30 "$name" 2>/dev/null || true
+  return 1
+}
+
+remove_stale_console_container() {
+  local name="${1:-redblink-dune-docker-console}"
+  resolve_container_cmd
+
+  if ! "${CONTAINER_CMD[@]}" ps -a --format '{{.Names}}' 2>/dev/null | grep -qx "$name"; then
+    return
+  fi
+  if ! "${CONTAINER_CMD[@]}" ps --format '{{.Names}}' 2>/dev/null | grep -qx "$name"; then
+    echo "Removing stopped console container: $name"
+    "${CONTAINER_CMD[@]}" rm -f "$name" 2>/dev/null || true
+    return
+  fi
+  if ! "${CONTAINER_CMD[@]}" exec "$name" true 2>/dev/null; then
+    echo "Removing unhealthy console container: $name"
+    "${CONTAINER_CMD[@]}" rm -f "$name" 2>/dev/null || true
+  fi
+}
+
+export_console_compose_env() {
+  export DUNE_HOST_REPO_ROOT="${DUNE_HOST_REPO_ROOT:-$(pwd -P)}"
+  export ADMIN_BIND_HOST="${ADMIN_BIND_HOST:-0.0.0.0}"
+  export ADMIN_BIND_PORT="${ADMIN_BIND_PORT:-8088}"
+  export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-dune-awakening-selfhost-docker}"
+}
+
+run_compose_up() {
+  local compose_file="$1"
+  local service="$2"
+  export_console_compose_env
+  remove_stale_console_container "$service"
+
+  if should_use_podman_compose; then
+    configure_podman_for_compose 2>/dev/null || true
+    export_podman_docker_host 2>/dev/null || true
+    echo "Using podman-compose to start the Web UI on port ${ADMIN_BIND_PORT}."
+    podman-compose -f "$compose_file" up -d --build --force-recreate "$service"
+    if ! verify_console_container "$service"; then
+      echo "Warning: console container verification failed; check logs above." >&2
+    fi
+    return
+  fi
+
+  echo "Using docker compose to start the Web UI on port ${ADMIN_BIND_PORT}."
+  if declare -p DOCKER >/dev/null 2>&1; then
+    "${DOCKER[@]}" compose -f "$compose_file" up -d --build --force-recreate "$service"
+  else
+    docker compose -f "$compose_file" up -d --build --force-recreate "$service"
+  fi
+  if ! verify_console_container "$service"; then
+    echo "Warning: console container verification failed; check logs above." >&2
+  fi
+}

--- a/runtime/scripts/ensure-podman-socket.sh
+++ b/runtime/scripts/ensure-podman-socket.sh
@@ -163,6 +163,10 @@ export_console_compose_env() {
   export ADMIN_BIND_HOST="${ADMIN_BIND_HOST:-0.0.0.0}"
   export ADMIN_BIND_PORT="${ADMIN_BIND_PORT:-8088}"
   export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-dune-awakening-selfhost-docker}"
+  if [ "${DUNE_INSTALL_FROM_WINDOWS:-0}" = "1" ]; then
+    export BUILDKIT_PROGRESS=plain
+    export COMPOSE_PROGRESS=plain
+  fi
 }
 
 run_compose_up() {
@@ -183,10 +187,14 @@ run_compose_up() {
   fi
 
   echo "Using docker compose to start the Web UI on port ${ADMIN_BIND_PORT}."
+  compose_progress=()
+  if [ "${DUNE_INSTALL_FROM_WINDOWS:-0}" = "1" ]; then
+    compose_progress=(--progress plain)
+  fi
   if declare -p DOCKER >/dev/null 2>&1; then
-    "${DOCKER[@]}" compose -f "$compose_file" up -d --build --force-recreate "$service"
+    "${DOCKER[@]}" compose "${compose_progress[@]}" -f "$compose_file" up -d --build --force-recreate "$service"
   else
-    docker compose -f "$compose_file" up -d --build --force-recreate "$service"
+    docker compose "${compose_progress[@]}" -f "$compose_file" up -d --build --force-recreate "$service"
   fi
   if ! verify_console_container "$service"; then
     echo "Warning: console container verification failed; check logs above." >&2

--- a/runtime/scripts/wsl-bootstrap.sh
+++ b/runtime/scripts/wsl-bootstrap.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+step() {
+  printf '\n==> %s\n' "$1"
+}
+
+is_wsl() {
+  grep -qiE '(microsoft|wsl)' /proc/version 2>/dev/null
+}
+
+need_sudo() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+    return
+  fi
+  if ! command -v sudo >/dev/null 2>&1; then
+    echo "This step needs root access inside WSL, but sudo was not found." >&2
+    exit 1
+  fi
+  if ! sudo -n true 2>/dev/null; then
+    echo "sudo requires a password, but the Windows installer cannot prompt inside WSL." >&2
+    echo "Re-run install.ps1 so it can configure passwordless sudo for your WSL user." >&2
+    exit 1
+  fi
+  sudo "$@"
+}
+
+run_apt_get() {
+  export DEBIAN_FRONTEND=noninteractive
+  if command -v stdbuf >/dev/null 2>&1; then
+    need_sudo stdbuf -oL -eL apt-get "$@"
+  else
+    need_sudo apt-get "$@"
+  fi
+}
+
+has_systemd() {
+  command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]
+}
+
+ensure_podman_packages() {
+  command -v apt-get >/dev/null 2>&1 || return 0
+  step "Updating package lists (apt-get update)..."
+  echo "Downloading Debian package indexes (first run can take several minutes)..."
+  run_apt_get update
+  echo "Package lists updated."
+  step "Installing Podman packages (podman, podman-compose, podman-docker)..."
+  echo "Installing packages; download and setup progress appears below..."
+  run_apt_get install -y podman podman-compose podman-docker
+  step "Podman packages installed."
+}
+
+ensure_podman_socket() {
+  has_systemd || return 0
+  if [ -f runtime/scripts/ensure-podman-socket.sh ]; then
+    # shellcheck disable=SC1091
+    . runtime/scripts/ensure-podman-socket.sh
+    step "Configuring Podman socket for WSL..."
+    if configure_podman_for_compose; then
+      step "Podman socket is ready at ${DOCKER_HOST:-podman socket}."
+      return 0
+    fi
+  fi
+  step "Enabling Podman socket via systemd..."
+  need_sudo systemctl enable --now podman.socket || true
+  step "Podman socket is enabled."
+}
+
+ensure_docker_service() {
+  has_systemd || return 0
+  step "Ensuring Docker Engine service is enabled..."
+  need_sudo systemctl enable --now docker || true
+  if getent group docker >/dev/null 2>&1 && [ -n "${USER:-}" ] && [ "$USER" != root ]; then
+    need_sudo usermod -aG docker "$USER" 2>/dev/null || true
+  fi
+  if docker info >/dev/null 2>&1; then
+    step "Docker Engine is running."
+    return 0
+  fi
+  echo "Docker Engine is installed but not reachable yet." >&2
+  echo "install.sh will finish Docker setup." >&2
+}
+
+bootstrap_docker() {
+  step "Container runtime: Docker Engine (default for WSL)."
+  if docker info >/dev/null 2>&1; then
+    echo "Docker is available."
+    ensure_docker_service
+    return
+  fi
+  echo "Docker is not running yet; install.sh will install and start Docker Engine."
+}
+
+bootstrap_podman() {
+  step "Container runtime: Podman (opt-in)."
+  if podman info >/dev/null 2>&1; then
+    echo "Podman is available."
+    ensure_podman_packages
+    ensure_podman_socket
+    return
+  fi
+  if docker info >/dev/null 2>&1; then
+    echo "Docker is available; skipping Podman package install."
+    return
+  fi
+  echo "No container runtime detected yet; installing Podman packages."
+  ensure_podman_packages
+  ensure_podman_socket
+}
+
+step "WSL bootstrap starting."
+
+if ! is_wsl; then
+  echo "wsl-bootstrap.sh is intended to run inside WSL." >&2
+  exit 1
+fi
+
+step "Checking systemd..."
+if ! has_systemd; then
+  echo "systemd is not running inside WSL." >&2
+  echo "Enable it in /etc/wsl.conf with:" >&2
+  echo "  [boot]" >&2
+  echo "  systemd=true" >&2
+  echo "Then restart WSL from Windows: wsl --shutdown" >&2
+  exit 1
+fi
+echo "systemd is running."
+
+export DUNE_HOST_REPO_ROOT="$(pwd -P)"
+step "Repository root: $DUNE_HOST_REPO_ROOT"
+
+RUNTIME="${DUNE_CONTAINER_RUNTIME:-docker}"
+step "Configured container runtime: $RUNTIME"
+
+case "$RUNTIME" in
+  podman) bootstrap_podman ;;
+  *) bootstrap_docker ;;
+esac
+
+step "WSL bootstrap finished."
+
+exit 0

--- a/runtime/scripts/wsl-bootstrap.sh
+++ b/runtime/scripts/wsl-bootstrap.sh
@@ -41,6 +41,10 @@ has_systemd() {
   command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]
 }
 
+force_embedded_docker_runtime() {
+  [ "${DUNE_CONTAINER_RUNTIME:-${CONTAINER_RUNTIME:-}}" = "docker" ]
+}
+
 ensure_podman_packages() {
   command -v apt-get >/dev/null 2>&1 || return 0
   step "Updating package lists (apt-get update)..."
@@ -85,13 +89,36 @@ ensure_docker_service() {
 }
 
 bootstrap_docker() {
-  step "Container runtime: Docker Engine (default for WSL)."
+  step "Container runtime: Docker Engine (embedded in WSL via get.docker.com when needed)."
+  if force_embedded_docker_runtime; then
+    export DOCKER_HOST=unix:///var/run/docker.sock
+    if command -v is_docker_desktop_daemon >/dev/null 2>&1 && is_docker_desktop_daemon; then
+      echo "Docker Desktop is active; install.sh will install embedded Docker Engine (https://get.docker.com)."
+    elif docker info >/dev/null 2>&1; then
+      echo "Embedded Docker is available."
+      ensure_docker_service
+      return
+    fi
+    echo "install.sh will install and start embedded Docker Engine."
+    return
+  fi
   if docker info >/dev/null 2>&1; then
     echo "Docker is available."
     ensure_docker_service
     return
   fi
   echo "Docker is not running yet; install.sh will install and start Docker Engine."
+}
+
+bootstrap_docker_desktop() {
+  step "Container runtime: Docker Desktop (WSL integration)."
+  # shellcheck disable=SC1091
+  . runtime/scripts/docker-desktop-wsl.sh
+  if ! ensure_docker_desktop_cli; then
+    exit 1
+  fi
+  disable_embedded_docker_engine
+  step "Docker Desktop is ready via WSL integration."
 }
 
 bootstrap_podman() {
@@ -135,10 +162,22 @@ step "Repository root: $DUNE_HOST_REPO_ROOT"
 RUNTIME="${DUNE_CONTAINER_RUNTIME:-docker}"
 step "Configured container runtime: $RUNTIME"
 
+step "Ensuring WSL DNS configuration..."
+if [ -f runtime/scripts/configure-wsl-dns.sh ]; then
+  bash runtime/scripts/configure-wsl-dns.sh || true
+fi
+
 case "$RUNTIME" in
   podman) bootstrap_podman ;;
+  docker-desktop) bootstrap_docker_desktop ;;
   *) bootstrap_docker ;;
 esac
+
+if [ -f runtime/scripts/docker-desktop-wsl.sh ]; then
+  # shellcheck disable=SC1091
+  . runtime/scripts/docker-desktop-wsl.sh
+  verify_wsl_dns_for_docker || true
+fi
 
 step "WSL bootstrap finished."
 

--- a/stop-dockerdesktop.ps1
+++ b/stop-dockerdesktop.ps1
@@ -1,0 +1,57 @@
+function Stop-DockerDesktop {
+    <#
+    .SYNOPSIS
+        Forcibly stops Docker Desktop service and all related processes.
+
+    .DESCRIPTION
+        This function stops the Docker Desktop Service and forcibly terminates
+        all Docker Desktop related processes.
+
+    .EXAMPLE
+        Stop-DockerDesktop
+    #>
+    [CmdletBinding()]
+    param()
+
+    # Stop the Docker Desktop Service
+    $serviceName = 'com.docker.service'
+    $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
+
+    if ($service) {
+        if ($service.Status -eq 'Running') {
+            Write-Verbose "Stopping service: $serviceName"
+            Stop-Service -Name $serviceName -Force -ErrorAction SilentlyContinue
+        }
+        else {
+            Write-Verbose "Service '$serviceName' is not running (Status: $($service.Status))"
+        }
+    }
+    else {
+        Write-Warning "Service '$serviceName' not found"
+    }
+
+    # Define the processes to kill
+    $processNames = @(
+        'Docker Desktop'
+        'com.docker.build'
+        'com.docker.service'
+        'com.docker.backend'
+    )
+
+    # Forcibly stop each process
+    foreach ($processName in $processNames) {
+        $processes = Get-Process -Name $processName -ErrorAction SilentlyContinue
+
+        if ($processes) {
+            Write-Verbose "Stopping process(es): $processName (Count: $($processes.Count))"
+            $processes | Stop-Process -Force -ErrorAction SilentlyContinue
+        }
+        else {
+            Write-Verbose "No running process found: $processName"
+        }
+    }
+
+    Write-Output "Docker Desktop has been forcibly stopped."
+}
+
+Stop-DockerDesktop

--- a/update.ps1
+++ b/update.ps1
@@ -1,0 +1,175 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [string]$WslDistro = '',
+    [string]$WorkspaceDir = '',
+    [switch]$RebuildConsole,
+    [switch]$RebuildOrchestrator,
+    [switch]$FullStack
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Script:RepoRoot = $PSScriptRoot
+$Script:WslFolder = Join-Path $RepoRoot '.wsl'
+$Script:InstallConfigPath = Join-Path $WslFolder 'install.json'
+
+function Get-InstallConfig {
+    if (-not (Test-Path -LiteralPath $Script:InstallConfigPath)) {
+        return $null
+    }
+    return Get-Content -LiteralPath $Script:InstallConfigPath -Raw | ConvertFrom-Json
+}
+
+function Invoke-Wsl {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Command,
+        [string]$Distro,
+        [string]$User = ''
+    )
+    $wslArgs = @('-d', $Distro)
+    if ($User) {
+        $wslArgs += @('-u', $User)
+    }
+    $wslArgs += @('--', 'bash', '-lc', $Command)
+    $output = & wsl.exe @wslArgs 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "WSL command failed (exit $LASTEXITCODE): $Command`n$output"
+    }
+    return $output
+}
+
+function Get-ComposeCommand {
+    param(
+        [string]$ConfiguredRuntime,
+        [string]$WorkspaceWsl,
+        [string]$Distro,
+        [string]$User
+    )
+    if ($ConfiguredRuntime -eq 'podman') {
+        $detect = @"
+set -euo pipefail
+cd '$WorkspaceWsl'
+if podman info >/dev/null 2>&1; then echo podman; else echo none; fi
+"@
+    }
+    else {
+        $detect = @"
+set -euo pipefail
+cd '$WorkspaceWsl'
+if docker info >/dev/null 2>&1; then echo docker; else echo none; fi
+"@
+    }
+    $runtime = (Invoke-Wsl -Distro $Distro -User $User -Command $detect).Trim()
+    if ($runtime -eq 'none') {
+        throw "Configured runtime '$ConfiguredRuntime' is not available inside WSL. Run install.ps1 first."
+    }
+    return $runtime
+}
+
+function Invoke-ComposeRebuild {
+    param(
+        [string]$WorkspaceWsl,
+        [string]$Distro,
+        [string]$User,
+        [string]$ConfiguredRuntime,
+        [string]$ComposeFile,
+        [string[]]$Services
+    )
+    $runtime = Get-ComposeCommand -ConfiguredRuntime $ConfiguredRuntime -WorkspaceWsl $WorkspaceWsl -Distro $Distro -User $User
+    $serviceList = ($Services | ForEach-Object { "'$_'" }) -join ' '
+    if ($runtime -eq 'podman') {
+        $cmd = @"
+set -euo pipefail
+cd '$WorkspaceWsl'
+export DUNE_HOST_REPO_ROOT="`$(pwd -P)"
+export ADMIN_BIND_HOST=0.0.0.0
+export ADMIN_BIND_PORT=8088
+podman-compose -f '$ComposeFile' up -d --build --force-recreate $serviceList
+"@
+    }
+    else {
+        $cmd = @"
+set -euo pipefail
+cd '$WorkspaceWsl'
+export DUNE_HOST_REPO_ROOT="`$(pwd -P)"
+$runtime compose -f '$ComposeFile' up -d --build --force-recreate $serviceList
+"@
+    }
+    Write-Host ""
+    Write-Host "==> Rebuilding: $ComposeFile ($($Services -join ', ')) via $runtime"
+    Invoke-Wsl -Distro $Distro -User $User -Command $cmd | ForEach-Object { Write-Host $_ }
+}
+
+$config = Get-InstallConfig
+if (-not $config) {
+    throw "No .wsl/install.json found. Run install.ps1 from this repository first."
+}
+
+$distro = if ($WslDistro) { $WslDistro } else { [string]$config.wslDistro }
+if (-not $distro) {
+    $distro = 'Debian_Dune'
+}
+$wslUser = if ($config.wslUser) { [string]$config.wslUser } else { '' }
+$configuredRuntime = if ($config.containerRuntime) { [string]$config.containerRuntime } else { 'docker' }
+
+$relative = if ($WorkspaceDir) {
+    $WorkspaceDir
+}
+elseif ($config.workspaceDirRelative) {
+    [string]$config.workspaceDirRelative
+}
+else {
+    '.'
+}
+
+if ($relative -eq '.' -or [string]::IsNullOrWhiteSpace($relative)) {
+    $workspaceWsl = [string]$config.repoRootWsl
+    if ($config.workspaceDirWsl) {
+        $workspaceWsl = [string]$config.workspaceDirWsl
+    }
+}
+else {
+    $workspaceWsl = [string]$config.workspaceDirWsl
+    if ($WorkspaceDir) {
+        $sep = [IO.Path]::DirectorySeparatorChar
+        $windowsPath = Join-Path $Script:RepoRoot ($WorkspaceDir -replace '/', $sep)
+        $workspaceWsl = (wsl.exe wslpath -a $windowsPath 2>&1 | Out-String).Trim() -replace '\\', '/'
+    }
+}
+
+Write-Host ""
+Write-Host "==> Pulling latest changes"
+$pull = @"
+set -euo pipefail
+cd '$workspaceWsl'
+git pull --ff-only
+"@
+Invoke-Wsl -Distro $distro -User $wslUser -Command $pull | ForEach-Object { Write-Host $_ }
+
+Write-Host ""
+Write-Host "Updated. Shell script changes are live via the repo mount."
+
+if ($FullStack) {
+    $RebuildConsole = $true
+    $RebuildOrchestrator = $true
+}
+
+if ($RebuildConsole) {
+    Invoke-ComposeRebuild -WorkspaceWsl $workspaceWsl -Distro $distro -User $wslUser -ConfiguredRuntime $configuredRuntime `
+        -ComposeFile 'docker-compose.web.yml' `
+        -Services @('redblink-dune-docker-console')
+}
+
+if ($RebuildOrchestrator) {
+    Invoke-ComposeRebuild -WorkspaceWsl $workspaceWsl -Distro $distro -User $wslUser -ConfiguredRuntime $configuredRuntime `
+        -ComposeFile 'docker-compose.yml' `
+        -Services @('orchestrator')
+}
+
+if (-not $RebuildConsole -and -not $RebuildOrchestrator) {
+    Write-Host "No container rebuild requested."
+    Write-Host "Use -RebuildConsole, -RebuildOrchestrator, or -FullStack when Dockerfiles or bundled app code changed."
+}


### PR DESCRIPTION
add install.ps1 and update.ps1 to provision debian_dune on wsl2, create the linux user, enable systemd, and delegate to install.sh.

default container runtime is docker desktop via wsl integration; opt in to embedded docker engine (-containerruntime docker) or podman.

add wsl bootstrap scripts, docker desktop helpers, user/sudo/dns setup, and wsl_readme.md with troubleshooting (integration, networking, funcom images).

extend install.sh for docker-desktop and embedded docker paths; improve compose startup helpers in ensure-podman-socket.sh.

publish console port 8088 in docker-compose.web.yml instead of host network so http://localhost:8088 works from windows through docker desktop; route postgres via host.docker.internal.

document wsl bind/advertise ip and overrides in .env.example and readme.md.