### PR TITLE
Add read-only Discord companion bot

### DIFF
--- a/.github/workflows/discord-bot-security-gates.yml
+++ b/.github/workflows/discord-bot-security-gates.yml
@@ -1,0 +1,209 @@
+name: Discord Bot Security Gates
+
+on:
+  pull_request:
+    paths:
+      - "discord-bot/**"
+      - "console/api/src/integrations/discord/**"
+      - "console/api/test/discord*.test.js"
+      - "docs/discord-control-bot/**"
+      - ".github/workflows/discord-bot-security-gates.yml"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+  push:
+    branches:
+      - feature/discord-control-bot
+    paths:
+      - "discord-bot/**"
+      - "console/api/src/integrations/discord/**"
+      - "console/api/test/discord*.test.js"
+      - "docs/discord-control-bot/**"
+      - ".github/workflows/discord-bot-security-gates.yml"
+      - ".github/PULL_REQUEST_TEMPLATE.md"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  policy-gates:
+    name: Policy Gates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure bot workspace exists
+        run: |
+          test -d discord-bot
+          test -f discord-bot/package.json
+          test -f docs/discord-control-bot/security-gates.md
+          test -f docs/discord-control-bot/feature-priority.md
+          test -f docs/discord-control-bot/roadmap.md
+          test -f docs/discord-control-bot/development-standards.md
+          test -f docs/discord-control-bot/soc2-control-matrix.md
+          test -f docs/discord-control-bot/templates/adr-template.md
+          test -f docs/discord-control-bot/templates/threat-model-template.md
+          test -f docs/discord-control-bot/templates/release-checklist.md
+          test -f docs/discord-control-bot/api-adapter-contract.md
+          test -f docs/discord-control-bot/adr/0001-experimental-read-only-companion-bot.md
+          test -f .github/PULL_REQUEST_TEMPLATE.md
+
+      - name: Ensure adapter scaffold exists
+        run: |
+          test -f console/api/src/integrations/discord/policy.js
+          test -f console/api/src/integrations/discord/sanitize.js
+          test -f console/api/src/integrations/discord/audit.js
+          test -f console/api/src/integrations/discord/adapter.js
+          test -f console/api/src/integrations/discord/routes.js
+          test -f console/api/test/discordPolicy.test.js
+          test -f console/api/test/discordSanitize.test.js
+          test -f console/api/test/discordAudit.test.js
+          test -f console/api/test/discordAdapter.test.js
+          test -f console/api/test/discordRoutes.test.js
+
+      - name: Block Docker socket mounts in bot runtime assets
+        run: |
+          if grep -R --line-number --fixed-strings \
+            --include='Dockerfile' \
+            --include='*.yml' \
+            --include='*.yaml' \
+            --include='*.json' \
+            "/var/run/docker.sock" discord-bot; then
+            echo "::error::Discord bot runtime assets must not mount /var/run/docker.sock."
+            exit 1
+          fi
+
+      - name: Block privileged container mode in bot runtime assets
+        run: |
+          if grep -R --line-number -E \
+            --include='Dockerfile' \
+            --include='*.yml' \
+            --include='*.yaml' \
+            --include='*.json' \
+            "privileged:[[:space:]]*true" discord-bot; then
+            echo "::error::Discord bot container must not use privileged mode."
+            exit 1
+          fi
+
+      - name: Block obvious secret material
+        run: |
+          node discord-bot/scripts/check-secrets.mjs
+
+      - name: Enforce lockfile presence
+        run: |
+          test -f discord-bot/package-lock.json
+
+      - name: Validate security documentation keywords
+        run: |
+          grep -q "SCA" docs/discord-control-bot/security-gates.md
+          grep -q "SAST" docs/discord-control-bot/security-gates.md
+          grep -q "DCA" docs/discord-control-bot/security-gates.md
+          grep -q "DAST" docs/discord-control-bot/security-gates.md
+          grep -q "Docker socket" docs/discord-control-bot/security-gates.md
+          grep -q "SOC 2" docs/discord-control-bot/soc2-control-matrix.md
+          grep -q "DC-SOC2-SEC-001" docs/discord-control-bot/soc2-control-matrix.md
+          grep -q "Definition of Done" docs/discord-control-bot/development-standards.md
+          grep -q "Milestone P0.1" docs/discord-control-bot/roadmap.md
+          grep -q "Authorization" docs/discord-control-bot/api-adapter-contract.md
+          grep -q "DAST Requirements" docs/discord-control-bot/api-adapter-contract.md
+          grep -q "experimental read-only" docs/discord-control-bot/adr/0001-experimental-read-only-companion-bot.md
+
+  npm-gates:
+    name: NPM / SCA Gates
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: discord-bot
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: discord-bot/package-lock.json
+
+      - name: Install locked dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run unit/security tests
+        run: npm test
+
+      - name: Run npm audit
+        run: npm audit --audit-level=high
+
+  console-api-adapter-tests:
+    name: Console API Discord Adapter Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: console/api
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: console/api/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run Discord adapter tests
+        run: node --test test/discord*.test.js
+
+  codeql:
+    name: CodeQL SAST
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+
+  container-policy:
+    name: Container Policy Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Dockerfile hardening markers
+        run: |
+          test -f discord-bot/Dockerfile
+          grep -q "USER" discord-bot/Dockerfile
+          grep -q "HEALTHCHECK" discord-bot/Dockerfile
+          if grep -n "FROM .*:latest" discord-bot/Dockerfile; then
+            echo "::error::Release Dockerfile must not use latest tag."
+            exit 1
+          fi
+
+      - name: Build bot image
+        run: docker build -t dune-discord-control-bot:ci discord-bot
+
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: dune-discord-control-bot:ci
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          ignore-unfixed: true

--- a/console/api/src/integrations/discord/adapter.js
+++ b/console/api/src/integrations/discord/adapter.js
@@ -1,0 +1,163 @@
+import { audit } from "../../audit.js";
+import { DISCORD_CAPABILITIES, normalizeDiscordActor, requireDiscordCapability } from "./policy.js";
+import { discordAuditEvent, discordBlockedAuditEvent } from "./audit.js";
+import { discordSafeError, sanitizeDiscordPublicStatus, sanitizeDiscordValue } from "./sanitize.js";
+
+export const DISCORD_ADAPTER_ROUTES = Object.freeze({
+  HEALTH: "/api/integrations/discord/health",
+  STATUS: "/api/integrations/discord/status",
+  READINESS: "/api/integrations/discord/readiness",
+  SERVICES: "/api/integrations/discord/services",
+  POPULATION: "/api/integrations/discord/population",
+  LOGS: "/api/integrations/discord/logs",
+  MAP_STATE: "/api/integrations/discord/map-state",
+  BACKUPS_LIST: "/api/integrations/discord/backups/list"
+});
+
+export const DISCORD_LIVE_ADAPTER_ROUTES = Object.freeze([
+  DISCORD_ADAPTER_ROUTES.HEALTH,
+  DISCORD_ADAPTER_ROUTES.STATUS,
+  DISCORD_ADAPTER_ROUTES.READINESS,
+  DISCORD_ADAPTER_ROUTES.SERVICES
+]);
+
+export const DISCORD_PLANNED_ADAPTER_ROUTES = Object.freeze(
+  Object.values(DISCORD_ADAPTER_ROUTES).filter((route) => !DISCORD_LIVE_ADAPTER_ROUTES.includes(route))
+);
+
+export function discordAdapterEnabled(config) {
+  return process.env.DUNE_DISCORD_ADAPTER_ENABLED === "true" || config?.discordAdapterEnabled === true;
+}
+
+export function discordWritesEnabled(_config) {
+  // Experimental companion bot is intentionally read-only.
+  return false;
+}
+
+export function discordRoleMappingFromEnv(env = process.env) {
+  return {
+    observerRoleIds: csv(env.DISCORD_OBSERVER_ROLE_IDS),
+    moderatorRoleIds: csv(env.DISCORD_MODERATOR_ROLE_IDS),
+    adminRoleIds: csv(env.DISCORD_ADMIN_ROLE_IDS),
+    ownerRoleIds: csv(env.DISCORD_OWNER_ROLE_IDS)
+  };
+}
+
+export function discordRolePolicyHealth(mapping = discordRoleMappingFromEnv()) {
+  return {
+    observerConfigured: mapping.observerRoleIds.length > 0,
+    moderatorConfigured: mapping.moderatorRoleIds.length > 0,
+    adminConfigured: mapping.adminRoleIds.length > 0,
+    ownerConfigured: mapping.ownerRoleIds.length > 0
+  };
+}
+
+export function validateDiscordActor(actorPayload) {
+  return normalizeDiscordActor(actorPayload);
+}
+
+export async function discordAdapterHealth(config) {
+  return {
+    ok: true,
+    service: "dune-console-discord-adapter",
+    enabled: discordAdapterEnabled(config),
+    experimental: true,
+    readOnly: true,
+    writesEnabled: false,
+    routes: DISCORD_LIVE_ADAPTER_ROUTES,
+    liveRoutes: DISCORD_LIVE_ADAPTER_ROUTES,
+    plannedRoutes: DISCORD_PLANNED_ADAPTER_ROUTES,
+    rolePolicy: discordRolePolicyHealth()
+  };
+}
+
+export async function discordAdapterStatus({ config, actorPayload, diagnostic = false, statusProvider }) {
+  const actor = validateDiscordActor(actorPayload);
+  const capability = diagnostic ? DISCORD_CAPABILITIES.LOGS_READ : DISCORD_CAPABILITIES.STATUS_READ;
+  const mapping = discordRoleMappingFromEnv();
+  requireDiscordCapability(actor, mapping, capability);
+
+  try {
+    const rawStatus = typeof statusProvider === "function" ? await statusProvider({ diagnostic }) : {};
+    const result = diagnostic ? sanitizeDiscordValue(rawStatus) : sanitizeDiscordPublicStatus(rawStatus);
+    audit(config, null, "discord.status", discordAuditEvent({
+      actor,
+      action: "discord.status",
+      capability,
+      risk: diagnostic ? "medium" : "low",
+      targetType: "server",
+      result: "success"
+    }));
+    return { ok: true, result };
+  } catch (error) {
+    audit(config, null, "discord.status", discordBlockedAuditEvent({
+      actor,
+      action: "discord.status",
+      capability,
+      reason: error.message || "status failed"
+    }));
+    throw error;
+  }
+}
+
+export async function discordAdapterReadiness({ config, actorPayload, readinessProvider }) {
+  return discordAdapterReadOnlyOperation({
+    config,
+    actorPayload,
+    provider: readinessProvider,
+    capability: DISCORD_CAPABILITIES.READINESS_READ,
+    action: "discord.readiness",
+    targetType: "server"
+  });
+}
+
+export async function discordAdapterServices({ config, actorPayload, servicesProvider }) {
+  return discordAdapterReadOnlyOperation({
+    config,
+    actorPayload,
+    provider: servicesProvider,
+    capability: DISCORD_CAPABILITIES.SERVICES_READ,
+    action: "discord.services",
+    targetType: "services"
+  });
+}
+
+async function discordAdapterReadOnlyOperation({ config, actorPayload, provider, capability, action, targetType }) {
+  const actor = validateDiscordActor(actorPayload);
+  const mapping = discordRoleMappingFromEnv();
+  requireDiscordCapability(actor, mapping, capability);
+
+  try {
+    const rawResult = typeof provider === "function" ? await provider() : {};
+    const result = sanitizeDiscordValue(rawResult);
+    audit(config, null, action, discordAuditEvent({
+      actor,
+      action,
+      capability,
+      risk: "low",
+      targetType,
+      result: "success"
+    }));
+    return { ok: true, result };
+  } catch (error) {
+    audit(config, null, action, discordBlockedAuditEvent({
+      actor,
+      action,
+      capability,
+      reason: error.message || `${action} failed`
+    }));
+    throw error;
+  }
+}
+
+export function discordAdapterErrorResponse(error) {
+  const statusCode = Number(error?.statusCode || 500);
+  return {
+    statusCode: Number.isInteger(statusCode) && statusCode >= 400 && statusCode <= 599 ? statusCode : 500,
+    body: discordSafeError(error)
+  };
+}
+
+function csv(value) {
+  return String(value || "").split(",").map((item) => item.trim()).filter(Boolean);
+}

--- a/console/api/src/integrations/discord/audit.js
+++ b/console/api/src/integrations/discord/audit.js
@@ -1,0 +1,37 @@
+import { redactValue } from "../../redact.js";
+
+export const DISCORD_AUDIT_EVIDENCE_MARKER = "audit event";
+
+export function discordAuditEvent({ actor, action, capability, risk = "low", targetType = "none", targetId = "", confirmationRequired = false, confirmationPassed = false, result = "unknown", detail = {} } = {}) {
+  return redactValue({
+    source: "discord",
+    discordGuildId: actor?.guildId || "",
+    discordChannelId: actor?.channelId || "",
+    discordUserId: actor?.userId || "",
+    discordUsername: actor?.username || "",
+    command: actor?.commandName || "",
+    action: String(action || ""),
+    capability: String(capability || ""),
+    risk: String(risk || "low"),
+    targetType: String(targetType || "none"),
+    targetId: String(targetId || ""),
+    confirmationRequired: Boolean(confirmationRequired),
+    confirmationPassed: Boolean(confirmationPassed),
+    result: String(result || "unknown"),
+    detail
+  });
+}
+
+export function discordBlockedAuditEvent({ actor, action, capability, reason, detail = {} } = {}) {
+  return discordAuditEvent({
+    actor,
+    action,
+    capability,
+    risk: "medium",
+    result: "blocked",
+    detail: {
+      reason: String(reason || "blocked"),
+      ...detail
+    }
+  });
+}

--- a/console/api/src/integrations/discord/policy.js
+++ b/console/api/src/integrations/discord/policy.js
@@ -1,0 +1,110 @@
+export const DISCORD_ROLE_TIERS = ["public", "observer", "moderator", "admin", "owner"];
+
+export const DISCORD_CAPABILITIES = Object.freeze({
+  STATUS_READ: "status:read",
+  READINESS_READ: "readiness:read",
+  SERVICES_READ: "services:read",
+  POPULATION_READ: "population:read",
+  LOGS_READ: "logs:read",
+  MAPS_READ: "maps:read",
+  BACKUPS_READ: "backups:read"
+});
+
+export const EXPERIMENTAL_READ_ONLY_CAPABILITIES = Object.freeze(new Set(Object.values(DISCORD_CAPABILITIES)));
+
+const CAPABILITY_BY_TIER = Object.freeze({
+  public: new Set([DISCORD_CAPABILITIES.STATUS_READ]),
+  observer: new Set([
+    DISCORD_CAPABILITIES.STATUS_READ,
+    DISCORD_CAPABILITIES.READINESS_READ,
+    DISCORD_CAPABILITIES.SERVICES_READ
+  ]),
+  moderator: new Set([
+    DISCORD_CAPABILITIES.STATUS_READ,
+    DISCORD_CAPABILITIES.READINESS_READ,
+    DISCORD_CAPABILITIES.SERVICES_READ,
+    DISCORD_CAPABILITIES.POPULATION_READ,
+    DISCORD_CAPABILITIES.MAPS_READ,
+    DISCORD_CAPABILITIES.BACKUPS_READ
+  ]),
+  admin: new Set(Object.values(DISCORD_CAPABILITIES)),
+  owner: new Set(Object.values(DISCORD_CAPABILITIES))
+});
+
+export function normalizeRoleMapping(value = {}) {
+  return {
+    observerRoleIds: normalizeStringList(value.observerRoleIds),
+    moderatorRoleIds: normalizeStringList(value.moderatorRoleIds),
+    adminRoleIds: normalizeStringList(value.adminRoleIds),
+    ownerRoleIds: normalizeStringList(value.ownerRoleIds)
+  };
+}
+
+export function normalizeDiscordActor(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw policyError("missing_actor", "Discord actor context is required.");
+  const actor = {
+    guildId: requiredString(value.guildId, "actor.guildId"),
+    channelId: requiredString(value.channelId, "actor.channelId"),
+    userId: requiredString(value.userId, "actor.userId"),
+    username: requiredString(value.username, "actor.username"),
+    roleIds: normalizeStringList(value.roleIds),
+    interactionId: optionalString(value.interactionId),
+    commandName: optionalString(value.commandName)
+  };
+  return actor;
+}
+
+export function discordActorTier(actor, mapping) {
+  const roleIds = new Set(normalizeStringList(actor?.roleIds));
+  const normalized = normalizeRoleMapping(mapping);
+  if (normalized.ownerRoleIds.some((roleId) => roleIds.has(roleId))) return "owner";
+  if (normalized.adminRoleIds.some((roleId) => roleIds.has(roleId))) return "admin";
+  if (normalized.moderatorRoleIds.some((roleId) => roleIds.has(roleId))) return "moderator";
+  if (normalized.observerRoleIds.some((roleId) => roleIds.has(roleId))) return "observer";
+  return "public";
+}
+
+export function discordActorCan(actor, mapping, capability) {
+  const normalizedCapability = requiredString(capability, "capability");
+  if (!Object.values(DISCORD_CAPABILITIES).includes(normalizedCapability)) throw policyError("invalid_capability", `Unsupported Discord capability: ${normalizedCapability}`);
+  return CAPABILITY_BY_TIER[discordActorTier(actor, mapping)].has(normalizedCapability);
+}
+
+export function requireDiscordCapability(actor, mapping, capability) {
+  requireExperimentalReadOnlyCapability(capability);
+  if (!discordActorCan(actor, mapping, capability)) {
+    throw policyError("not_authorized", `Discord actor is not authorized for ${capability}.`, 403);
+  }
+}
+
+export function requireExperimentalReadOnlyCapability(capability) {
+  const normalizedCapability = requiredString(capability, "capability");
+  if (!EXPERIMENTAL_READ_ONLY_CAPABILITIES.has(normalizedCapability)) {
+    throw policyError("not_read_only", `Capability is not allowed in experimental read-only mode: ${normalizedCapability}`, 403);
+  }
+}
+
+export function policyError(code, message, statusCode = 400) {
+  const error = new Error(message);
+  error.code = code;
+  error.statusCode = statusCode;
+  return error;
+}
+
+function requiredString(value, name) {
+  const text = String(value ?? "").trim();
+  if (!text) throw policyError("invalid_actor", `${name} is required.`);
+  if (text.length > 256) throw policyError("invalid_actor", `${name} is too long.`);
+  return text;
+}
+
+function optionalString(value) {
+  const text = String(value ?? "").trim();
+  return text ? text.slice(0, 256) : "";
+}
+
+function normalizeStringList(value) {
+  if (Array.isArray(value)) return value.map((item) => String(item ?? "").trim()).filter(Boolean).slice(0, 100);
+  if (typeof value === "string") return value.split(",").map((item) => item.trim()).filter(Boolean).slice(0, 100);
+  return [];
+}

--- a/console/api/src/integrations/discord/readOnlyProviders.js
+++ b/console/api/src/integrations/discord/readOnlyProviders.js
@@ -1,0 +1,129 @@
+import { buildDuneArgs, runDune } from "../../runner.js";
+import { sanitizeDiscordValue } from "./sanitize.js";
+
+const SERVICE_LABELS = new Map([
+  ["dune-postgres", "Database"],
+  ["dune-rmq-admin", "RabbitMQ Admin"],
+  ["dune-rmq-game", "RabbitMQ Game"],
+  ["dune-text-router", "Text Router"],
+  ["dune-director", "Director"],
+  ["dune-server-gateway", "Gateway"],
+  ["dune-server-survival-1", "Survival"],
+  ["dune-server-overmap", "Overmap"],
+  ["dune-orchestrator", "Orchestrator"],
+  ["dune-autoscaler", "Autoscaler"]
+]);
+
+export async function discordReadinessProvider(config) {
+  const result = await runDune(config, buildDuneArgs("readiness"), {
+    timeoutMs: 30000,
+    allowedExitCodes: [0, 1, 2]
+  });
+  return parseReadinessOutput(result.stdout || result.stderr || "", result.code);
+}
+
+export async function discordServicesProvider(config) {
+  const result = await runDune(config, buildDuneArgs("services"), {
+    timeoutMs: 30000,
+    allowedExitCodes: [0]
+  });
+  return parseServicesOutput(result.stdout || result.stderr || "");
+}
+
+export function parseReadinessOutput(stdout = "", exitCode = 0) {
+  const json = parseJsonObject(stdout);
+  if (Object.keys(json).length > 0) return publicReadinessSummary(json, exitCode);
+
+  const text = sanitizeDiscordValue(String(stdout || ""));
+  const issueLines = text.split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => /\b(FAIL|FAILED|MISSING|ERROR|ISSUE|NOT READY|WARN|WARNING)\b/i.test(line))
+    .map(compactOperationalLine)
+    .filter(Boolean)
+    .slice(0, 10);
+
+  const ready = exitCode === 0 && issueLines.length === 0 && !/\b(FAIL|FAILED|MISSING|ERROR|ISSUE|NOT READY)\b/i.test(text);
+  return {
+    ready,
+    overall: ready ? "READY" : "ISSUE",
+    issues: issueLines
+  };
+}
+
+export function parseServicesOutput(stdout = "") {
+  const services = [];
+  const issues = [];
+
+  for (const rawLine of String(stdout || "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || /^SERVICE\s+STATUS$/i.test(line) || /^===/.test(line)) continue;
+
+    const serviceName = [...SERVICE_LABELS.keys()].find((name) => line.startsWith(name));
+    if (!serviceName) continue;
+
+    const statusText = line.slice(serviceName.length).trim();
+    const status = normalizeServiceStatus(statusText);
+    const service = {
+      name: SERVICE_LABELS.get(serviceName),
+      status
+    };
+    services.push(service);
+    if (status !== "up") issues.push(`${service.name} is ${status}`);
+  }
+
+  return {
+    overall: issues.length === 0 ? "OK" : "ISSUE",
+    services,
+    issues
+  };
+}
+
+export function publicReadinessSummary(value = {}, exitCode = 0) {
+  const readyValue = value.ready ?? value.ok ?? value.readiness ?? value.status;
+  const ready = typeof readyValue === "boolean"
+    ? readyValue
+    : !/issue|fail|missing|error|not ready/i.test(String(readyValue || "")) && exitCode === 0;
+  return {
+    ready,
+    overall: ready ? "READY" : "ISSUE",
+    issues: Array.isArray(value.issues)
+      ? value.issues.map((issue) => compactOperationalLine(sanitizeDiscordValue(String(issue)))).filter(Boolean).slice(0, 10)
+      : []
+  };
+}
+
+function parseJsonObject(stdout = "") {
+  const text = String(stdout || "").trim();
+  const candidates = [];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "{") candidates.push(text.slice(i));
+  }
+  for (const candidate of candidates.reverse()) {
+    try {
+      const value = JSON.parse(candidate);
+      return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+    } catch {
+      // Try the next opening brace.
+    }
+  }
+  return {};
+}
+
+function normalizeServiceStatus(value = "") {
+  const text = String(value || "").trim();
+  if (/^up\b/i.test(text)) return "up";
+  if (/missing/i.test(text)) return "missing";
+  if (/exited|stopped|down/i.test(text)) return "down";
+  if (/starting|created|restarting/i.test(text)) return "starting";
+  return text ? "unknown" : "unknown";
+}
+
+function compactOperationalLine(line = "") {
+  return String(line || "")
+    .replace(/\b\d{1,5}\/(tcp|udp)\b/gi, "<port>")
+    .replace(/\bdune-[a-z0-9-]+\b/gi, (match) => SERVICE_LABELS.get(match) || "service")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 180);
+}

--- a/console/api/src/integrations/discord/routes.js
+++ b/console/api/src/integrations/discord/routes.js
@@ -1,0 +1,83 @@
+import { timingSafeEqual } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { discordAdapterEnabled, discordAdapterErrorResponse, discordAdapterHealth, discordAdapterReadiness, discordAdapterServices, discordAdapterStatus, DISCORD_ADAPTER_ROUTES } from "./adapter.js";
+import { policyError } from "./policy.js";
+
+export function isDiscordAdapterRoute(path) {
+  return Object.values(DISCORD_ADAPTER_ROUTES).includes(path);
+}
+
+export async function handleDiscordAdapterRoute({ req, res, path, config, readJson, json, statusProvider, readinessProvider, servicesProvider }) {
+  try {
+    if (!discordAdapterEnabled(config)) throw policyError("adapter_disabled", "Discord adapter is disabled.", 404);
+    requireDiscordBotToken(req, config);
+
+    if (path === DISCORD_ADAPTER_ROUTES.HEALTH && req.method === "GET") {
+      return json(res, 200, await discordAdapterHealth(config));
+    }
+
+    if (path === DISCORD_ADAPTER_ROUTES.STATUS && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, await discordAdapterStatus({
+        config,
+        actorPayload: body.actor,
+        diagnostic: Boolean(body.diagnostic),
+        statusProvider
+      }));
+    }
+
+    if (path === DISCORD_ADAPTER_ROUTES.READINESS && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, await discordAdapterReadiness({
+        config,
+        actorPayload: body.actor,
+        readinessProvider
+      }));
+    }
+
+    if (path === DISCORD_ADAPTER_ROUTES.SERVICES && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, await discordAdapterServices({
+        config,
+        actorPayload: body.actor,
+        servicesProvider
+      }));
+    }
+
+    throw policyError("not_found", "Discord adapter route not found.", 404);
+  } catch (error) {
+    const response = discordAdapterErrorResponse(error);
+    return json(res, response.statusCode, response.body);
+  }
+}
+
+export function requireDiscordBotToken(req, config) {
+  const expected = readDiscordBotApiToken(config);
+  if (!expected) throw policyError("bot_token_not_configured", "Adapter credential is not configured.", 503);
+
+  const actual = bearerToken(req?.headers?.authorization || req?.headers?.Authorization || "");
+  if (!actual) throw policyError("missing_bot_token", "Missing adapter credential.", 401);
+  if (!constantTimeStringEqual(actual, expected)) throw policyError("invalid_bot_token", "Invalid adapter credential.", 401);
+}
+
+export function readDiscordBotApiToken(config) {
+  const tokenFile = process.env.DUNE_BOT_API_TOKEN_FILE || config?.discordBotApiTokenFile || "";
+  if (!tokenFile) return "";
+  try {
+    return readFileSync(tokenFile, "utf8").trim();
+  } catch {
+    return "";
+  }
+}
+
+function bearerToken(value) {
+  const parts = String(value || "").split(/\s+/);
+  return parts.length === 2 && /^Bearer$/i.test(parts[0]) ? parts[1].trim() : "";
+}
+
+function constantTimeStringEqual(actual, expected) {
+  const actualBuffer = Buffer.from(String(actual));
+  const expectedBuffer = Buffer.from(String(expected));
+  if (actualBuffer.length !== expectedBuffer.length) return false;
+  return timingSafeEqual(actualBuffer, expectedBuffer);
+}

--- a/console/api/src/integrations/discord/sanitize.js
+++ b/console/api/src/integrations/discord/sanitize.js
@@ -1,0 +1,56 @@
+import { redact, redactValue } from "../../redact.js";
+
+const INTERNAL_IPV4_PATTERN = /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
+const INTERNAL_HOST_PORT_PATTERN = /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}):\d+\b/g;
+const CONNECTION_STRING_PATTERN = /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb|redis|amqp|amqps):\/\/[^\s"']+/gi;
+const ENV_PATH_PATTERN = /(?:^|\s)(?:\/repo|\/app|\/run\/secrets|runtime\/secrets|\.env)(?:[^\s,"']*)?/g;
+
+const PUBLIC_BLOCKED_KEYS = new Set([
+  "ssh_host",
+  "sshHost",
+  "databaseUrl",
+  "dbUrl",
+  "adminPassword",
+  "token",
+  "password",
+  "secret",
+  "funcomToken",
+  "env",
+  "environment"
+]);
+
+export function sanitizeDiscordPublicStatus(status = {}) {
+  const safe = {};
+  for (const [key, value] of Object.entries(status || {})) {
+    if (PUBLIC_BLOCKED_KEYS.has(key)) continue;
+    if (/host|ip|url|path|token|password|secret|env/i.test(key)) continue;
+    safe[key] = sanitizeDiscordValue(value);
+  }
+  return redactValue(safe);
+}
+
+export function sanitizeDiscordValue(value) {
+  if (Array.isArray(value)) return value.map((item) => sanitizeDiscordValue(item));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value)
+      .filter(([key]) => !PUBLIC_BLOCKED_KEYS.has(key) && !/host|ip|url|path|token|password|secret|env/i.test(key))
+      .map(([key, item]) => [key, sanitizeDiscordValue(item)]));
+  }
+  if (typeof value !== "string") return value;
+  return redact(value)
+    .replace(CONNECTION_STRING_PATTERN, "<redacted-connection-string>")
+    .replace(INTERNAL_HOST_PORT_PATTERN, "<internal-address>")
+    .replace(INTERNAL_IPV4_PATTERN, "<internal-address>")
+    .replace(ENV_PATH_PATTERN, " <internal-path>")
+    .trim();
+}
+
+export function discordSafeError(error) {
+  const code = String(error?.code || "adapter_error").replace(/[^a-z0-9_-]/gi, "_").toLowerCase();
+  const message = sanitizeDiscordValue(String(error?.message || "Request failed."));
+  return {
+    ok: false,
+    code,
+    error: message || "Request failed."
+  };
+}

--- a/console/api/src/integrations/discord/statusProvider.js
+++ b/console/api/src/integrations/discord/statusProvider.js
@@ -1,0 +1,146 @@
+import { buildDuneArgs, runDune } from "../../runner.js";
+import { sanitizeDiscordPublicStatus, sanitizeDiscordValue } from "./sanitize.js";
+
+const PUBLIC_STATUS_FIELDS = new Set([
+  "overall",
+  "title",
+  "region",
+  "mode",
+  "population",
+  "maps",
+  "issues"
+]);
+
+export async function discordStatusProvider(config, { diagnostic = false } = {}) {
+  const result = await runDune(config, buildDuneArgs("status"), {
+    timeoutMs: 15000,
+    allowedExitCodes: [0]
+  });
+  const parsed = parseStatusOutput(result.stdout);
+  if (diagnostic) return detailedStatusSummary(parsed, result.stdout);
+  return sanitizeDiscordPublicStatus(publicStatusSummary(parsed));
+}
+
+export function parseStatusOutput(stdout = "") {
+  const text = String(stdout || "").trim();
+  if (!text) return {};
+
+  const json = parseStatusJson(text);
+  if (Object.keys(json).length > 0) return json;
+
+  return parseTextStatus(text);
+}
+
+export function parseStatusJson(stdout = "") {
+  const text = String(stdout || "").trim();
+  if (!text) return {};
+
+  // Prefer the last JSON object in case the underlying script prints a banner first.
+  const candidates = [];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "{") candidates.push(text.slice(i));
+  }
+  for (const candidate of candidates.reverse()) {
+    try {
+      const value = JSON.parse(candidate);
+      return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+    } catch {
+      // Try the next opening brace.
+    }
+  }
+  return {};
+}
+
+export function parseTextStatus(stdout = "") {
+  const status = { maps: [], services: [], listeners: [], issues: [] };
+  let section = "";
+
+  for (const rawLine of String(stdout || "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const sectionMatch = line.match(/^===\s+(.+?)\s+===$/);
+    if (sectionMatch) {
+      section = sectionMatch[1].toLowerCase();
+      continue;
+    }
+
+    const keyValue = line.match(/^([A-Za-z][A-Za-z _-]+):\s+(.+)$/);
+    if (keyValue && section === "dune status") {
+      const key = normalizeStatusKey(keyValue[1]);
+      if (["overall", "title", "region", "mode", "population"].includes(key)) {
+        status[key] = keyValue[2].trim();
+      }
+      continue;
+    }
+
+    if (section === "containers") {
+      if (/^SERVICE\s+STATUS$/i.test(line)) continue;
+      const serviceMatch = line.match(/^(dune-[a-z0-9-]+)\s+(.+)$/i);
+      if (serviceMatch) {
+        const entry = { name: serviceMatch[1], status: normalizeRuntimeStatus(serviceMatch[2]) };
+        status.services.push(entry);
+        if (entry.status !== "up") status.issues.push(`${entry.name} is ${entry.status}`);
+      }
+      continue;
+    }
+
+    if (section === "listeners") {
+      if (/^CHECK\s+PORT\s+STATUS$/i.test(line)) continue;
+      const listenerMatch = line.match(/^(.+?)\s+\d{1,5}\/(tcp|udp)\s+([A-Z]+)$/i);
+      if (listenerMatch) {
+        const entry = { check: listenerMatch[1].trim(), status: listenerMatch[3].toUpperCase() };
+        status.listeners.push(entry);
+        if (entry.status !== "OK") status.issues.push(`${entry.check} is ${entry.status}`);
+      }
+      continue;
+    }
+
+    if (section === "game servers") {
+      if (/^MAP\s+STATE\s+UPTIME$/i.test(line)) continue;
+      const mapMatch = line.match(/^([A-Za-z0-9_-]+)\s+([A-Z_]+)\s+(.+)$/);
+      if (mapMatch) {
+        status.maps.push({
+          name: mapMatch[1],
+          state: mapMatch[2],
+          uptime: mapMatch[3]
+        });
+        if (mapMatch[2] !== "READY") status.issues.push(`${mapMatch[1]} is ${mapMatch[2]}`);
+      }
+      continue;
+    }
+  }
+
+  if (status.overall && status.overall !== "OK") status.issues.unshift(`Overall status is ${status.overall}`);
+  return status;
+}
+
+export function publicStatusSummary(status = {}) {
+  const summary = {};
+  for (const [key, value] of Object.entries(status || {})) {
+    if (PUBLIC_STATUS_FIELDS.has(key)) summary[key] = value;
+  }
+  if (!Array.isArray(summary.maps)) delete summary.maps;
+  if (!Array.isArray(summary.issues)) delete summary.issues;
+  return summary;
+}
+
+export function detailedStatusSummary(status = {}, rawOutput = "") {
+  return sanitizeDiscordValue({
+    ...status,
+    redactedOutput: sanitizeDiscordValue(String(rawOutput || "")).slice(0, 3000)
+  });
+}
+
+function normalizeStatusKey(value = "") {
+  return String(value || "").trim().toLowerCase().replace(/\s+/g, "_");
+}
+
+function normalizeRuntimeStatus(value = "") {
+  const text = String(value || "").trim();
+  if (/^up\b/i.test(text)) return "up";
+  if (/missing/i.test(text)) return "missing";
+  if (/exited|stopped|down/i.test(text)) return "down";
+  if (/starting|created|restarting/i.test(text)) return "starting";
+  return text ? "unknown" : "unknown";
+}

--- a/console/api/test/discordAdapter.test.js
+++ b/console/api/test/discordAdapter.test.js
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DISCORD_ADAPTER_ROUTES, discordAdapterErrorResponse, discordAdapterHealth, discordAdapterReadiness, discordAdapterServices, discordAdapterStatus, discordWritesEnabled } from "../src/integrations/discord/adapter.js";
+
+const OLD_ENV = { ...process.env };
+
+function resetEnv() {
+  process.env.DISCORD_OBSERVER_ROLE_IDS = "role-observer";
+  process.env.DISCORD_MODERATOR_ROLE_IDS = "role-moderator";
+  process.env.DISCORD_ADMIN_ROLE_IDS = "role-admin";
+  process.env.DISCORD_OWNER_ROLE_IDS = "role-owner";
+  process.env.DUNE_DISCORD_ADAPTER_ENABLED = "true";
+  process.env.DUNE_DISCORD_WRITES_ENABLED = "false";
+}
+
+function actor(roleIds = []) {
+  return {
+    guildId: "guild-1",
+    channelId: "channel-1",
+    userId: "user-1",
+    username: "tester",
+    roleIds,
+    interactionId: "interaction-1",
+    commandName: "/dune status"
+  };
+}
+
+const config = {
+  auditLog: "/tmp/dune-discord-adapter-test-audit.jsonl",
+  generatedDir: "/tmp/dune-discord-adapter-test-generated"
+};
+
+test.beforeEach(resetEnv);
+test.after(() => {
+  process.env = OLD_ENV;
+});
+
+test("reports adapter health as experimental read-only", async () => {
+  const result = await discordAdapterHealth({});
+  assert.equal(result.ok, true);
+  assert.equal(result.enabled, true);
+  assert.equal(result.experimental, true);
+  assert.equal(result.readOnly, true);
+  assert.equal(result.writesEnabled, false);
+  assert.deepEqual([...result.liveRoutes].sort(), [
+    "/api/integrations/discord/health",
+    "/api/integrations/discord/readiness",
+    "/api/integrations/discord/services",
+    "/api/integrations/discord/status"
+  ].sort());
+  assert.ok(result.plannedRoutes.includes("/api/integrations/discord/logs"));
+});
+
+test("forces writes disabled even if environment attempts to enable them", () => {
+  process.env.DUNE_DISCORD_WRITES_ENABLED = "true";
+  assert.equal(discordWritesEnabled({ discordWritesEnabled: true }), false);
+});
+
+test("exposes only experimental read-only route names", () => {
+  const routes = Object.values(DISCORD_ADAPTER_ROUTES);
+  assert.deepEqual(routes.sort(), [
+    "/api/integrations/discord/backups/list",
+    "/api/integrations/discord/health",
+    "/api/integrations/discord/logs",
+    "/api/integrations/discord/map-state",
+    "/api/integrations/discord/population",
+    "/api/integrations/discord/readiness",
+    "/api/integrations/discord/services",
+    "/api/integrations/discord/status"
+  ].sort());
+  for (const route of routes) {
+    assert.doesNotMatch(route, /write|execute|delete|restore|create|broadcast|restart|kick|grant|teleport|reset|admin/i);
+  }
+});
+
+test("returns sanitized public status", async () => {
+  const response = await discordAdapterStatus({
+    config,
+    actorPayload: actor([]),
+    diagnostic: false,
+    statusProvider: async () => ({
+      db_connected: true,
+      ssh_connected: true,
+      ssh_host: "172.19.240.122:22",
+      runtime: "docker"
+    })
+  });
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.db_connected, true);
+  assert.equal(response.result.ssh_connected, true);
+  assert.equal(response.result.runtime, "docker");
+  assert.equal(Object.hasOwn(response.result, "ssh_host"), false);
+});
+
+test("requires admin capability before diagnostic status provider runs", async () => {
+  let called = false;
+  await assert.rejects(() => discordAdapterStatus({
+    config,
+    actorPayload: actor(["role-moderator"]),
+    diagnostic: true,
+    statusProvider: async () => {
+      called = true;
+      return { ssh_host: "172.19.240.122:22" };
+    }
+  }), /not authorized/);
+  assert.equal(called, false);
+
+  const response = await discordAdapterStatus({
+    config,
+    actorPayload: actor(["role-admin"]),
+    diagnostic: true,
+    statusProvider: async () => ({ ssh_host: "172.19.240.122:22" })
+  });
+  assert.equal(response.result.ssh_host, undefined);
+});
+
+test("allows observer readiness and services", async () => {
+  const readiness = await discordAdapterReadiness({
+    config,
+    actorPayload: actor(["role-observer"]),
+    readinessProvider: async () => ({ ready: true, overall: "READY", issues: [] })
+  });
+  assert.equal(readiness.ok, true);
+  assert.equal(readiness.result.ready, true);
+
+  const services = await discordAdapterServices({
+    config,
+    actorPayload: actor(["role-observer"]),
+    servicesProvider: async () => ({ overall: "OK", services: [{ name: "Database", status: "up" }], issues: [] })
+  });
+  assert.equal(services.ok, true);
+  assert.equal(services.result.services[0].name, "Database");
+});
+
+test("blocks public readiness and services", async () => {
+  await assert.rejects(() => discordAdapterReadiness({
+    config,
+    actorPayload: actor([]),
+    readinessProvider: async () => ({ ready: true })
+  }), /not authorized/);
+
+  await assert.rejects(() => discordAdapterServices({
+    config,
+    actorPayload: actor([]),
+    servicesProvider: async () => ({ services: [] })
+  }), /not authorized/);
+});
+
+test("formats safe adapter errors", () => {
+  const error = new Error("Failed with marker sample-value at 127.0.0.1:15432");
+  error.code = "bad_request";
+  error.statusCode = 400;
+  const response = discordAdapterErrorResponse(error);
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.ok, false);
+  assert.equal(response.body.code, "bad_request");
+  assert.doesNotMatch(response.body.error, /127\.0\.0\.1/);
+});

--- a/console/api/test/discordAudit.test.js
+++ b/console/api/test/discordAudit.test.js
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { discordAuditEvent, discordBlockedAuditEvent } from "../src/integrations/discord/audit.js";
+
+const actor = {
+  guildId: "guild-1",
+  channelId: "channel-1",
+  userId: "user-1",
+  username: "tester",
+  commandName: "/dune backup restore"
+};
+
+test("builds structured Discord audit event", () => {
+  const event = discordAuditEvent({
+    actor,
+    action: "backup.restore",
+    capability: "backups:destructive",
+    risk: "critical",
+    targetType: "backup",
+    targetId: "backup-1",
+    confirmationRequired: true,
+    confirmationPassed: true,
+    result: "success"
+  });
+
+  assert.equal(event.source, "discord");
+  assert.equal(event.discordUserId, "user-1");
+  assert.equal(event.action, "backup.restore");
+  assert.equal(event.confirmationRequired, true);
+  assert.equal(event.confirmationPassed, true);
+  assert.equal(event.result, "success");
+});
+
+test("redacts sensitive audit details", () => {
+  const event = discordBlockedAuditEvent({
+    actor,
+    action: "settings.save-token",
+    capability: "settings:admin",
+    reason: "invalid token",
+    detail: {
+      discordBotToken: "Bot abcdefghijklmnopqrstuvwxyz1234567890",
+      password: "clear-text"
+    }
+  });
+
+  assert.equal(event.source, "discord");
+  assert.equal(event.result, "blocked");
+  assert.equal(event.detail.discordBotToken, "<redacted>");
+  assert.equal(event.detail.password, "<redacted>");
+});

--- a/console/api/test/discordPolicy.test.js
+++ b/console/api/test/discordPolicy.test.js
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DISCORD_CAPABILITIES, EXPERIMENTAL_READ_ONLY_CAPABILITIES, discordActorCan, discordActorTier, normalizeDiscordActor, requireDiscordCapability, requireExperimentalReadOnlyCapability } from "../src/integrations/discord/policy.js";
+
+const mapping = {
+  observerRoleIds: ["role-observer"],
+  moderatorRoleIds: ["role-moderator"],
+  adminRoleIds: ["role-admin"],
+  ownerRoleIds: ["role-owner"]
+};
+
+function actor(roleIds = []) {
+  return normalizeDiscordActor({
+    guildId: "guild-1",
+    channelId: "channel-1",
+    userId: "user-1",
+    username: "tester",
+    roleIds,
+    interactionId: "interaction-1",
+    commandName: "/dune test"
+  });
+}
+
+test("normalizes required Discord actor context", () => {
+  const result = actor(["role-admin"]);
+  assert.equal(result.guildId, "guild-1");
+  assert.equal(result.userId, "user-1");
+  assert.deepEqual(result.roleIds, ["role-admin"]);
+});
+
+test("rejects missing Discord actor context", () => {
+  assert.throws(() => normalizeDiscordActor(null), /Discord actor context is required/);
+});
+
+test("maps owner above admin above moderator above observer", () => {
+  assert.equal(discordActorTier(actor(["role-owner", "role-admin"]), mapping), "owner");
+  assert.equal(discordActorTier(actor(["role-admin", "role-moderator"]), mapping), "admin");
+  assert.equal(discordActorTier(actor(["role-moderator", "role-observer"]), mapping), "moderator");
+  assert.equal(discordActorTier(actor(["role-observer"]), mapping), "observer");
+  assert.equal(discordActorTier(actor([]), mapping), "public");
+});
+
+test("allows public actors to read status only", () => {
+  assert.equal(discordActorCan(actor([]), mapping, DISCORD_CAPABILITIES.STATUS_READ), true);
+  assert.equal(discordActorCan(actor([]), mapping, DISCORD_CAPABILITIES.READINESS_READ), false);
+  assert.equal(discordActorCan(actor([]), mapping, DISCORD_CAPABILITIES.POPULATION_READ), false);
+});
+
+test("allows observer to read readiness and services", () => {
+  assert.equal(discordActorCan(actor(["role-observer"]), mapping, DISCORD_CAPABILITIES.READINESS_READ), true);
+  assert.equal(discordActorCan(actor(["role-observer"]), mapping, DISCORD_CAPABILITIES.SERVICES_READ), true);
+  assert.equal(discordActorCan(actor(["role-observer"]), mapping, DISCORD_CAPABILITIES.LOGS_READ), false);
+});
+
+test("allows moderator to read population, map state, and backups", () => {
+  assert.equal(discordActorCan(actor(["role-moderator"]), mapping, DISCORD_CAPABILITIES.POPULATION_READ), true);
+  assert.equal(discordActorCan(actor(["role-moderator"]), mapping, DISCORD_CAPABILITIES.MAPS_READ), true);
+  assert.equal(discordActorCan(actor(["role-moderator"]), mapping, DISCORD_CAPABILITIES.BACKUPS_READ), true);
+  assert.equal(discordActorCan(actor(["role-moderator"]), mapping, DISCORD_CAPABILITIES.LOGS_READ), false);
+});
+
+test("requires admin for logs", () => {
+  assert.equal(discordActorCan(actor(["role-admin"]), mapping, DISCORD_CAPABILITIES.LOGS_READ), true);
+  assert.throws(() => requireDiscordCapability(actor(["role-moderator"]), mapping, DISCORD_CAPABILITIES.LOGS_READ), /not authorized/);
+});
+
+test("keeps all experimental capabilities read-only", () => {
+  for (const capability of Object.values(DISCORD_CAPABILITIES)) {
+    assert.equal(EXPERIMENTAL_READ_ONLY_CAPABILITIES.has(capability), true, capability);
+    assert.doesNotThrow(() => requireExperimentalReadOnlyCapability(capability));
+    assert.doesNotMatch(capability, /write|admin|destructive|execute|delete|restore|create|broadcast|restart|kick|grant|teleport|reset/i);
+  }
+});
+
+test("rejects non-read-only capabilities", () => {
+  assert.throws(() => requireExperimentalReadOnlyCapability("database:write"), /not allowed in experimental read-only mode/);
+  assert.throws(() => requireExperimentalReadOnlyCapability("backups:destructive"), /not allowed in experimental read-only mode/);
+});

--- a/console/api/test/discordRoutes.test.js
+++ b/console/api/test/discordRoutes.test.js
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { handleDiscordAdapterRoute, isDiscordAdapterRoute, requireDiscordBotToken } from "../src/integrations/discord/routes.js";
+import { DISCORD_ADAPTER_ROUTES } from "../src/integrations/discord/adapter.js";
+
+const OLD_ENV = { ...process.env };
+let tempDir;
+let tokenFile;
+
+function resetEnv() {
+  tempDir = mkdtempSync(join(tmpdir(), "dune-discord-routes-"));
+  tokenFile = join(tempDir, "bot-api.txt");
+  writeFileSync(tokenFile, "abc\n", { mode: 0o600 });
+  process.env.DUNE_BOT_API_TOKEN_FILE = tokenFile;
+  process.env.DUNE_DISCORD_ADAPTER_ENABLED = "true";
+  process.env.DISCORD_OBSERVER_ROLE_IDS = "role-observer";
+  process.env.DISCORD_MODERATOR_ROLE_IDS = "role-moderator";
+  process.env.DISCORD_ADMIN_ROLE_IDS = "role-admin";
+  process.env.DISCORD_OWNER_ROLE_IDS = "role-owner";
+}
+
+function cleanupEnv() {
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  process.env = { ...OLD_ENV };
+}
+
+function req({ method = "GET", authorization = "Bearer abc" } = {}) {
+  return { method, headers: { authorization } };
+}
+
+function captureJson() {
+  const calls = [];
+  return {
+    calls,
+    json: (_res, status, body) => {
+      calls.push({ status, body });
+      return body;
+    }
+  };
+}
+
+const config = {
+  auditLog: "/tmp/dune-discord-routes-audit.jsonl",
+  generatedDir: "/tmp/dune-discord-routes-generated"
+};
+
+function actor(roleIds = []) {
+  return {
+    guildId: "guild-1",
+    channelId: "channel-1",
+    userId: "user-1",
+    username: "tester",
+    roleIds,
+    interactionId: "interaction-1",
+    commandName: "/dune status"
+  };
+}
+
+test.beforeEach(resetEnv);
+test.afterEach(cleanupEnv);
+
+test("identifies experimental Discord adapter routes", () => {
+  assert.equal(isDiscordAdapterRoute(DISCORD_ADAPTER_ROUTES.HEALTH), true);
+  assert.equal(isDiscordAdapterRoute(DISCORD_ADAPTER_ROUTES.STATUS), true);
+  assert.equal(isDiscordAdapterRoute(DISCORD_ADAPTER_ROUTES.READINESS), true);
+  assert.equal(isDiscordAdapterRoute(DISCORD_ADAPTER_ROUTES.SERVICES), true);
+  assert.equal(isDiscordAdapterRoute("/api/integrations/discord/backups/delete"), false);
+  assert.equal(isDiscordAdapterRoute("/api/admin/broadcast"), false);
+});
+
+test("rejects disabled adapter before processing route", async () => {
+  process.env.DUNE_DISCORD_ADAPTER_ENABLED = "false";
+  const out = captureJson();
+  await handleDiscordAdapterRoute({
+    req: req(),
+    res: {},
+    path: DISCORD_ADAPTER_ROUTES.HEALTH,
+    config,
+    readJson: async () => ({}),
+    json: out.json
+  });
+  assert.equal(out.calls[0].status, 404);
+  assert.equal(out.calls[0].body.code, "adapter_disabled");
+});
+
+test("rejects missing bot API credential", async () => {
+  const out = captureJson();
+  await handleDiscordAdapterRoute({
+    req: req({ authorization: "" }),
+    res: {},
+    path: DISCORD_ADAPTER_ROUTES.HEALTH,
+    config,
+    readJson: async () => ({}),
+    json: out.json
+  });
+  assert.equal(out.calls[0].status, 401);
+  assert.equal(out.calls[0].body.code, "missing_bot_token");
+});
+
+test("rejects invalid bot API credential", () => {
+  assert.throws(() => requireDiscordBotToken(req({ authorization: "Bearer xyz" }), config), /Invalid adapter credential/);
+});
+
+test("allows health with valid bot API credential", async () => {
+  const out = captureJson();
+  await handleDiscordAdapterRoute({
+    req: req(),
+    res: {},
+    path: DISCORD_ADAPTER_ROUTES.HEALTH,
+    config,
+    readJson: async () => ({}),
+    json: out.json
+  });
+  assert.equal(out.calls[0].status, 200);
+  assert.equal(out.calls[0].body.ok, true);
+  assert.equal(out.calls[0].body.readOnly, true);
+  assert.equal(out.calls[0].body.writesEnabled, false);
+  assert.ok(out.calls[0].body.liveRoutes.includes(DISCORD_ADAPTER_ROUTES.STATUS));
+  assert.ok(out.calls[0].body.plannedRoutes.includes(DISCORD_ADAPTER_ROUTES.LOGS));
+});
+
+test("allows sanitized status with valid bot API credential", async () => {
+  const out = captureJson();
+  await handleDiscordAdapterRoute({
+    req: req({ method: "POST" }),
+    res: {},
+    path: DISCORD_ADAPTER_ROUTES.STATUS,
+    config,
+    readJson: async () => ({ actor: actor([]), diagnostic: false }),
+    json: out.json,
+    statusProvider: async () => ({ db_connected: true, ssh_host: "172.19.240.122:22", runtime: "docker" })
+  });
+  assert.equal(out.calls[0].status, 200);
+  assert.equal(out.calls[0].body.ok, true);
+  assert.equal(out.calls[0].body.result.db_connected, true);
+  assert.equal(Object.hasOwn(out.calls[0].body.result, "ssh_host"), false);
+});
+
+test("allows readiness with observer role", async () => {
+  const out = captureJson();
+  await handleDiscordAdapterRoute({
+    req: req({ method: "POST" }),
+    res: {},
+    path: DISCORD_ADAPTER_ROUTES.READINESS,
+    config,
+    readJson: async () => ({ actor: actor(["role-observer"]) }),
+    json: out.json,
+    readinessProvider: async () => ({ ready: true, overall: "READY", issues: [] })
+  });
+  assert.equal(out.calls[0].status, 200);
+  assert.equal(out.calls[0].body.result.ready, true);
+});
+
+test("allows services with observer role", async () => {
+  const out = captureJson();
+  await handleDiscordAdapterRoute({
+    req: req({ method: "POST" }),
+    res: {},
+    path: DISCORD_ADAPTER_ROUTES.SERVICES,
+    config,
+    readJson: async () => ({ actor: actor(["role-observer"]) }),
+    json: out.json,
+    servicesProvider: async () => ({ overall: "OK", services: [{ name: "Database", status: "up" }], issues: [] })
+  });
+  assert.equal(out.calls[0].status, 200);
+  assert.equal(out.calls[0].body.result.services[0].name, "Database");
+});

--- a/console/api/test/discordSanitize.test.js
+++ b/console/api/test/discordSanitize.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { discordSafeError, sanitizeDiscordPublicStatus, sanitizeDiscordValue } from "../src/integrations/discord/sanitize.js";
+
+test("removes internal SSH host and sensitive keys from public status", () => {
+  const result = sanitizeDiscordPublicStatus({
+    admin_reason_required: false,
+    db_connected: true,
+    ssh_connected: true,
+    ssh_host: "172.19.240.122:22",
+    runtime: "docker",
+    databaseUrl: "postgresql://dune:secret@127.0.0.1:15432/dune"
+  });
+
+  assert.equal(result.db_connected, true);
+  assert.equal(result.ssh_connected, true);
+  assert.equal(result.runtime, "docker");
+  assert.equal(Object.hasOwn(result, "ssh_host"), false);
+  assert.equal(Object.hasOwn(result, "databaseUrl"), false);
+});
+
+test("redacts internal addresses from string values", () => {
+  assert.equal(sanitizeDiscordValue("ssh 172.19.240.122:22 ok"), "ssh <internal-address> ok");
+  assert.equal(sanitizeDiscordValue("host 127.0.0.1"), "host <internal-address>");
+});
+
+test("safe error response strips internal details", () => {
+  const error = new Error("Failed to reach postgresql://dune:secret@127.0.0.1:15432/dune via 172.19.240.122:22");
+  error.code = "db_failed";
+  const result = discordSafeError(error);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "db_failed");
+  assert.match(result.error, /<redacted>|<internal-address>/);
+  assert.doesNotMatch(result.error, /secret/);
+  assert.doesNotMatch(result.error, /172\.19\.240\.122/);
+});

--- a/discord-bot/Dockerfile
+++ b/discord-bot/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS runtime
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY package.json package-lock.json ./
+RUN apk upgrade --no-cache \
+  && npm ci --omit=dev --ignore-scripts \
+  && npm cache clean --force \
+  && rm -rf /usr/local/lib/node_modules/npm /usr/local/bin/npm /usr/local/bin/npx /root/.npm
+
+COPY src ./src
+COPY scripts ./scripts
+
+RUN addgroup -S dune && adduser -S dune -G dune
+
+USER dune
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "process.exit(0)"
+
+CMD ["node", "scripts/discord-runtime.mjs"]

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -1,0 +1,109 @@
+# Dune Discord Companion Bot
+
+Experimental read-only Discord companion for Dune Docker Console.
+
+Full setup, installation, usage, troubleshooting, and role matrix:
+
+```text
+docs/discord-control-bot/README.md
+```
+
+## Current Command Surface
+
+| Discord command | Minimum role | Visibility | Writes |
+|---|---:|---|---:|
+| `/dune health` | Public | Ephemeral | No |
+| `/dune status public` | Public | Public | No |
+| `/dune status detail` | Admin | Ephemeral | No |
+| `/dune readiness` | Observer | Ephemeral | No |
+| `/dune services` | Observer | Ephemeral | No |
+| `/dune help` | Public | Ephemeral | No |
+| `/dune version` | Public | Ephemeral | No |
+
+## Setup Helpers
+
+Generate an install URL with the correct `bot` and `applications.commands` scopes:
+
+```bash
+npm run discord:invite
+```
+
+Discover application, guild, channel, and role IDs by name:
+
+```bash
+npm run discord:discover -- --guild "Spice Is Power"
+```
+
+Grant channel access by guild/channel name. Dry run first:
+
+```bash
+npm run discord:channel -- --guild "Spice Is Power" --channel "server-status"
+```
+
+Apply the channel permission overwrite:
+
+```bash
+npm run discord:channel -- --guild "Spice Is Power" --channel "server-status" --execute
+```
+
+## Bot Visibility in Discord
+
+If slash commands work but the bot is not listed as a channel member, the application was likely installed with only the `applications.commands` scope. Reinstall it with `bot applications.commands` by using `npm run discord:invite`, then grant channel access with `npm run discord:channel` or through Discord channel settings.
+
+If the bot has no icon/avatar, upload the application icon and bot avatar in Discord Developer Portal.
+
+## Local Runtime
+
+The local stack launcher uses the Console adapter on port `8090` and starts the Discord runtime:
+
+```bash
+sh discord-bot/scripts/run-local-discord-stack.sh
+```
+
+Expected runtime markers:
+
+```text
+slash_commands_registered
+gateway_open
+gateway_ready
+```
+
+The bot identifies with an online presence of `Watching Arrakis status`.
+
+## Role Model
+
+| Tier | Capabilities |
+|---|---|
+| Public | Public-safe status/help/version/health |
+| Observer | `status:read`, `readiness:read`, `services:read` |
+| Moderator | Observer capabilities plus future read-only population/map/backup visibility |
+| Admin | Moderator capabilities plus diagnostic visibility |
+| Owner | Same read-only capability set as Admin |
+
+The bot-side authorization model intentionally contains no write, destructive, broadcast, database-write, player-admin, map-write, addon-admin, or settings-admin capabilities.
+
+## Local Checks
+
+```bash
+cd discord-bot
+npm ci --ignore-scripts
+npm test
+npm run security:secrets
+npm run build
+```
+
+From `console/api`:
+
+```bash
+node --test test/discord*.test.js
+```
+
+## Security Constraints
+
+1. The bot is a Discord client, not the authority.
+2. Dune Docker Console remains responsible for final authorization, safety checks, redaction, audit logging, and execution.
+3. The bot must call a protected Console API.
+4. The bot must not mount `/var/run/docker.sock`.
+5. The bot must not write directly to Postgres.
+6. The bot must not execute destructive actions.
+7. Discord write/admin actions remain disabled and out of scope for the experimental release.

--- a/discord-bot/docker-compose.discord-bot.yml
+++ b/discord-bot/docker-compose.discord-bot.yml
@@ -1,0 +1,33 @@
+services:
+  dune-discord-control-bot:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: dune-discord-control-bot:dev
+    container_name: dune-discord-control-bot
+    restart: unless-stopped
+    read_only: true
+    user: "100:101"
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+      - /tmp
+    environment:
+      DISCORD_BOT_TOKEN_FILE: /run/secrets/discord-bot-token.txt
+      DUNE_BOT_API_TOKEN_FILE: /run/secrets/dune-bot-api-token.txt
+      DUNE_CONSOLE_API_URL: "${DUNE_CONSOLE_API_URL:-http://127.0.0.1:8088}"
+      DISCORD_CLIENT_ID: "${DISCORD_CLIENT_ID:-}"
+      DISCORD_GUILD_ID: "${DISCORD_GUILD_ID:-}"
+      DISCORD_OWNER_ROLE_IDS: "${DISCORD_OWNER_ROLE_IDS:-}"
+      DISCORD_ADMIN_ROLE_IDS: "${DISCORD_ADMIN_ROLE_IDS:-}"
+      DISCORD_MODERATOR_ROLE_IDS: "${DISCORD_MODERATOR_ROLE_IDS:-}"
+      DISCORD_OBSERVER_ROLE_IDS: "${DISCORD_OBSERVER_ROLE_IDS:-}"
+      DISCORD_PUBLIC_STATUS_CHANNEL_ID: "${DISCORD_PUBLIC_STATUS_CHANNEL_ID:-}"
+      DISCORD_ADMIN_ALERT_CHANNEL_ID: "${DISCORD_ADMIN_ALERT_CHANNEL_ID:-}"
+      DUNE_DISCORD_WRITES_ENABLED: "${DUNE_DISCORD_WRITES_ENABLED:-false}"
+    volumes:
+      - ../runtime/secrets:/run/secrets:ro
+      - ../runtime/discord-bot:/data
+    network_mode: host

--- a/discord-bot/package-lock.json
+++ b/discord-bot/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "dune-discord-control-bot",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dune-discord-control-bot",
+      "version": "0.1.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    }
+  }
+}

--- a/discord-bot/package.json
+++ b/discord-bot/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "dune-discord-control-bot",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Read-only Discord companion for Dune Docker Console.",
+  "type": "module",
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "scripts": {
+    "test": "node --test",
+    "security:secrets": "node scripts/check-secrets.mjs",
+    "start": "node scripts/discord-runtime.mjs",
+    "build": "node scripts/validate-scaffold.mjs",
+    "discord:invite": "node scripts/discord-install-url.mjs",
+    "discord:discover": "node scripts/discord-discover.mjs",
+    "discord:channel": "node scripts/discord-channel-access.mjs",
+    "smoke:health": "node scripts/command-smoke.mjs health public",
+    "smoke:status": "node scripts/command-smoke.mjs status public",
+    "smoke:status-detail": "node scripts/command-smoke.mjs statusDetail admin",
+    "smoke:readiness": "node scripts/command-smoke.mjs readiness observer",
+    "smoke:services": "node scripts/command-smoke.mjs services observer"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/discord-bot/scripts/check-secrets.mjs
+++ b/discord-bot/scripts/check-secrets.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+const IGNORED_DIRS = new Set(["node_modules", "dist", ".git"]);
+const IGNORED_FILES = new Set(["package-lock.json"]);
+
+const SECRET_PATTERNS = [
+  { name: "Discord bot token", pattern: /\b[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}\b/g },
+  { name: "Discord MFA token", pattern: /mfa\.[A-Za-z0-9._-]{20,}/gi },
+  { name: "Bearer token", pattern: /Bearer\s+[A-Za-z0-9._=-]{24,}/gi },
+  { name: "Private key", pattern: /-----BEGIN (?:RSA |EC |OPENSSH |PRIVATE )?PRIVATE KEY-----/g },
+  { name: "Postgres URL", pattern: /postgres(?:ql)?:\/\/[^\s"']+/gi },
+  { name: "Hardcoded env secret assignment", pattern: /(?:DISCORD_BOT_TOKEN|DUNE_BOT_API_TOKEN|ADMIN_PASSWORD|DUNE_DB_PASSWORD|FUNCOM_TOKEN)\s*=\s*['\"][^'\"]{8,}['\"]/g }
+];
+
+let failed = false;
+
+function walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    if (IGNORED_DIRS.has(entry)) continue;
+    const path = join(dir, entry);
+    const rel = relative(ROOT, path);
+    const stat = statSync(path);
+    if (stat.isDirectory()) {
+      walk(path);
+      continue;
+    }
+    if (!stat.isFile() || IGNORED_FILES.has(entry)) continue;
+    scanFile(path, rel);
+  }
+}
+
+function scanFile(path, rel) {
+  const text = readFileSync(path, "utf8");
+  for (const { name, pattern } of SECRET_PATTERNS) {
+    pattern.lastIndex = 0;
+    const match = pattern.exec(text);
+    if (match) {
+      failed = true;
+      console.error(`[secret-scan] ${name} detected in ${rel}`);
+    }
+  }
+}
+
+walk(ROOT);
+
+if (failed) {
+  console.error("Secret scan failed. Remove verified secrets and use *_FILE runtime secret paths instead.");
+  process.exit(1);
+}
+
+console.log("Secret scan passed.");

--- a/discord-bot/scripts/command-smoke.mjs
+++ b/discord-bot/scripts/command-smoke.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const command = process.argv[2] || "status";
+const role = process.argv[3] || "public";
+
+const apiUrl = requiredEnv("DUNE_CONSOLE_API_URL").replace(/\/$/, "");
+const apiToken = readFileSync(requiredEnv("DUNE_BOT_API_TOKEN_FILE"), "utf8").trim();
+
+const roleIds = role === "owner"
+  ? csv(process.env.DISCORD_OWNER_ROLE_IDS)
+  : role === "admin"
+    ? csv(process.env.DISCORD_ADMIN_ROLE_IDS)
+    : role === "moderator"
+      ? csv(process.env.DISCORD_MODERATOR_ROLE_IDS)
+      : role === "observer"
+        ? csv(process.env.DISCORD_OBSERVER_ROLE_IDS)
+        : [];
+
+const actor = {
+  guildId: process.env.DISCORD_GUILD_ID || "local-guild",
+  channelId: "local-channel",
+  userId: "local-user",
+  username: `local-${role}`,
+  roleIds,
+  commandName: `/dune ${command}`
+};
+
+const commandMap = {
+  health: { method: "GET", path: "/api/integrations/discord/health" },
+  status: { method: "POST", path: "/api/integrations/discord/status", body: { actor, diagnostic: false } },
+  statusDetail: { method: "POST", path: "/api/integrations/discord/status", body: { actor, diagnostic: true } },
+  readiness: { method: "POST", path: "/api/integrations/discord/readiness", body: { actor } },
+  services: { method: "POST", path: "/api/integrations/discord/services", body: { actor } }
+};
+
+if (!commandMap[command]) {
+  console.error(`Unsupported command: ${command}`);
+  console.error(`Use one of: ${Object.keys(commandMap).join(", ")}`);
+  process.exit(2);
+}
+
+const health = await call({ method: "GET", path: "/api/integrations/discord/health" });
+const request = commandMap[command];
+const result = await call(request);
+
+console.log(JSON.stringify({
+  command,
+  role,
+  actorRoleIdsSent: roleIds,
+  consoleRolePolicy: health.body?.rolePolicy || null,
+  status: result.status,
+  body: result.body
+}, null, 2));
+
+process.exitCode = result.ok ? 0 : 1;
+
+async function call(request) {
+  const response = await fetch(`${apiUrl}${request.path}`, {
+    method: request.method,
+    headers: {
+      authorization: `Bearer ${apiToken}`,
+      ...(request.body ? { "content-type": "application/json" } : {})
+    },
+    body: request.body ? JSON.stringify(request.body) : undefined
+  });
+  const body = await response.json().catch(() => ({ ok: false, code: "invalid_response", error: "Console returned non-JSON output." }));
+  return { ok: response.ok, status: response.status, body };
+}
+
+function requiredEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+function csv(value = "") {
+  return String(value).split(",").map((item) => item.trim()).filter(Boolean);
+}

--- a/discord-bot/scripts/discord-channel-access.mjs
+++ b/discord-bot/scripts/discord-channel-access.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+
+const DISCORD_API = "https://discord.com/api/v10";
+const ALLOW_BITS = String((1n << 10n) + (1n << 11n) + (1n << 14n) + (1n << 31n));
+const args = parseArgs(process.argv.slice(2));
+
+main().catch((error) => {
+  console.error(`Discord channel access helper failed: ${safeErrorMessage(error)}`);
+  process.exit(1);
+});
+
+async function main() {
+  const auth = readBotAuth(args.authFile || process.env.DISCORD_BOT_TOKEN_FILE);
+  const bot = await discordGet(auth, "/users/@me");
+  const guilds = await discordGet(auth, "/users/@me/guilds");
+  const guild = selectByName(guilds, args.guild, "guild");
+  if (!guild) {
+    console.log("Guilds visible to this bot:");
+    for (const item of guilds) console.log(`- ${item.name} (${item.id})`);
+    throw new Error("Pass --guild with one of the guild names above.");
+  }
+
+  const channels = await discordGet(auth, `/guilds/${encodeURIComponent(guild.id)}/channels`);
+  const textChannels = channels.filter((channel) => [0, 5, 10, 11, 12, 15].includes(channel.type));
+  const channel = selectByName(textChannels, String(args.channel || "").replace(/^#/, ""), "channel");
+  if (!channel) {
+    console.log(`Channels visible in ${guild.name}:`);
+    for (const item of textChannels) console.log(`- #${item.name} (${item.id})`);
+    throw new Error("Pass --channel with one of the channel names above.");
+  }
+
+  console.log("Discord channel access selection");
+  console.log("================================");
+  console.log(`Guild:   ${guild.name} (${guild.id})`);
+  console.log(`Channel: #${channel.name} (${channel.id})`);
+  console.log(`Bot:     ${bot.username || "unknown"} (${bot.id})`);
+  console.log(`Allow:   ${ALLOW_BITS} (View Channel, Send Messages, Embed Links, Use Application Commands)`);
+
+  if (!args.execute) {
+    console.log("");
+    console.log("Dry run only. Re-run with --execute to create/update the channel permission overwrite for the bot user.");
+    return;
+  }
+
+  const response = await fetch(`${DISCORD_API}/channels/${encodeURIComponent(channel.id)}/permissions/${encodeURIComponent(bot.id)}`, {
+    method: "PUT",
+    headers: {
+      authorization: `Bot ${auth}`,
+      "content-type": "application/json",
+      "x-audit-log-reason": encodeURIComponent("Grant Dune read-only Discord bot channel access")
+    },
+    body: JSON.stringify({
+      type: 1,
+      allow: ALLOW_BITS,
+      deny: "0"
+    })
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unable to update channel permissions: ${response.status} ${await response.text()}. The bot role likely needs Manage Channels, or you can grant View Channel, Send Messages, Embed Links, and Use Application Commands manually in Discord channel settings.`);
+  }
+
+  console.log("");
+  console.log("Channel permission overwrite created/updated.");
+}
+
+function selectByName(items, name, label) {
+  if (!name) return items.length === 1 ? items[0] : null;
+  const normalized = normalizeName(name);
+  const exact = items.find((item) => normalizeName(item.name) === normalized);
+  if (exact) return exact;
+  const partial = items.filter((item) => normalizeName(item.name).includes(normalized));
+  if (partial.length === 1) return partial[0];
+  if (partial.length > 1) throw new Error(`Multiple ${label}s match '${name}': ${partial.map((item) => item.name).join(", ")}`);
+  throw new Error(`No ${label} matches '${name}'.`);
+}
+
+function normalizeName(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function readBotAuth(path) {
+  if (!path) throw new Error("Set DISCORD_BOT_TOKEN_FILE or pass --auth-file.");
+  if (!existsSync(path)) throw new Error(`Auth file does not exist: ${path}`);
+  const value = readFileSync(path, "utf8").trim();
+  if (!value) throw new Error(`Auth file is empty: ${path}`);
+  return value;
+}
+
+async function discordGet(auth, path) {
+  const response = await fetch(`${DISCORD_API}${path}`, {
+    headers: { authorization: `Bot ${auth}` }
+  });
+  if (!response.ok) throw new Error(`Discord API request failed: ${response.status} ${await response.text()}`);
+  return response.json();
+}
+
+function parseArgs(argv) {
+  const parsed = { execute: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--auth-file" || arg === "--token-file") parsed.authFile = requireValue(argv, ++index, arg);
+    else if (arg === "--guild") parsed.guild = requireValue(argv, ++index, arg);
+    else if (arg === "--channel") parsed.channel = requireValue(argv, ++index, arg);
+    else if (arg === "--execute") parsed.execute = true;
+    else if (arg === "-h" || arg === "--help") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value.`);
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/discord-channel-access.mjs --guild NAME --channel NAME [--execute]\n\nOptions:\n  --token-file PATH     Discord bot token file. Defaults to DISCORD_BOT_TOKEN_FILE.\n  --guild NAME         Guild/server name.\n  --channel NAME       Channel name, with or without leading #.\n  --execute            Update the Discord channel permission overwrite. Omit for dry-run.\n`);
+}
+
+function safeErrorMessage(error) {
+  return String(error?.message || error || "Unknown error").replace(/(Bot|Bearer)\s+\S+/g, "$1 [REDACTED]");
+}

--- a/discord-bot/scripts/discord-discover.mjs
+++ b/discord-bot/scripts/discord-discover.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+
+const DISCORD_API = "https://discord.com/api/v10";
+const args = parseArgs(process.argv.slice(2));
+
+main().catch((error) => {
+  console.error(`Discord discovery failed: ${safeErrorMessage(error)}`);
+  process.exit(1);
+});
+
+async function main() {
+  const auth = readBotAuth(args.authFile || process.env.DISCORD_BOT_TOKEN_FILE);
+  const app = await discordGet(auth, "/oauth2/applications/@me");
+  const bot = await discordGet(auth, "/users/@me");
+  const guilds = await discordGet(auth, "/users/@me/guilds");
+
+  console.log("Discord bot discovery");
+  console.log("=====================");
+  console.log(`Application: ${app.name || "unknown"} (${app.id})`);
+  console.log(`Bot user:    ${bot.username || "unknown"} (${bot.id})`);
+  console.log("");
+  console.log("Suggested environment:");
+  console.log(`export DISCORD_CLIENT_ID=\"${app.id}\"`);
+
+  const guild = selectByName(guilds, args.guild, "guild");
+  if (!guild) {
+    console.log("");
+    console.log("Guilds visible to this bot:");
+    for (const item of guilds) console.log(`- ${item.name} (${item.id})`);
+    console.log("");
+    console.log("Re-run with --guild \"Guild Name\" to list channels and roles.");
+    return;
+  }
+
+  console.log(`export DISCORD_GUILD_ID=\"${guild.id}\"`);
+  console.log("");
+  console.log(`Selected guild: ${guild.name} (${guild.id})`);
+
+  const channels = await discordGet(auth, `/guilds/${encodeURIComponent(guild.id)}/channels`);
+  const textChannels = channels
+    .filter((channel) => [0, 5, 10, 11, 12, 15].includes(channel.type))
+    .sort((left, right) => String(left.name || "").localeCompare(String(right.name || "")));
+  const selectedChannel = args.channel ? selectByName(textChannels, args.channel.replace(/^#/, ""), "channel") : null;
+
+  if (selectedChannel) {
+    console.log(`export DUNE_DISCORD_CHANNEL_ID=\"${selectedChannel.id}\"`);
+    console.log(`Selected channel: #${selectedChannel.name} (${selectedChannel.id})`);
+  }
+
+  console.log("");
+  console.log("Channels:");
+  for (const channel of textChannels) console.log(`- #${channel.name} (${channel.id})`);
+
+  const roles = await discordGet(auth, `/guilds/${encodeURIComponent(guild.id)}/roles`);
+  const sortedRoles = roles
+    .filter((role) => role.name !== "@everyone")
+    .sort((left, right) => String(left.name || "").localeCompare(String(right.name || "")));
+
+  console.log("");
+  console.log("Roles:");
+  for (const role of sortedRoles) console.log(`- ${role.name} (${role.id})`);
+}
+
+function selectByName(items, name, label) {
+  if (!name) return items.length === 1 ? items[0] : null;
+  const normalized = normalizeName(name);
+  const exact = items.find((item) => normalizeName(item.name) === normalized);
+  if (exact) return exact;
+  const partial = items.filter((item) => normalizeName(item.name).includes(normalized));
+  if (partial.length === 1) return partial[0];
+  if (partial.length > 1) throw new Error(`Multiple ${label}s match '${name}': ${partial.map((item) => item.name).join(", ")}`);
+  throw new Error(`No ${label} matches '${name}'.`);
+}
+
+function normalizeName(value) {
+  return String(value || "").trim().toLowerCase();
+}
+
+function readBotAuth(path) {
+  if (!path) throw new Error("Set DISCORD_BOT_TOKEN_FILE or pass --auth-file.");
+  if (!existsSync(path)) throw new Error(`Auth file does not exist: ${path}`);
+  const value = readFileSync(path, "utf8").trim();
+  if (!value) throw new Error(`Auth file is empty: ${path}`);
+  return value;
+}
+
+async function discordGet(auth, path) {
+  const response = await fetch(`${DISCORD_API}${path}`, {
+    headers: { authorization: `Bot ${auth}` }
+  });
+  if (!response.ok) throw new Error(`Discord API request failed: ${response.status} ${await response.text()}`);
+  return response.json();
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--auth-file" || arg === "--token-file") parsed.authFile = requireValue(argv, ++index, arg);
+    else if (arg === "--guild") parsed.guild = requireValue(argv, ++index, arg);
+    else if (arg === "--channel") parsed.channel = requireValue(argv, ++index, arg);
+    else if (arg === "-h" || arg === "--help") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value.`);
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/discord-discover.mjs [options]\n\nOptions:\n  --token-file PATH     Discord bot token file. Defaults to DISCORD_BOT_TOKEN_FILE.\n  --guild NAME         Guild/server name. If omitted and the bot is in one guild, it is selected.\n  --channel NAME       Optional channel name to resolve.\n`);
+}
+
+function safeErrorMessage(error) {
+  return String(error?.message || error || "Unknown error").replace(/(Bot|Bearer)\s+\S+/g, "$1 [REDACTED]");
+}

--- a/discord-bot/scripts/discord-formatters.mjs
+++ b/discord-bot/scripts/discord-formatters.mjs
@@ -1,0 +1,359 @@
+const COLORS = {
+  ready: 0x2ecc71,
+  issue: 0xf1c40f,
+  down: 0xe74c3c,
+  neutral: 0x95a5a6,
+  info: 0x3498db
+};
+
+const FOOTER = {
+  text: "Read-only Discord adapter • No server mutation commands enabled"
+};
+
+const BAD_STATES = /^(issue|missing|down|error|failed|offline|degraded)$/i;
+
+export function formatCommandResponse(command, payload) {
+  const clean = redact(payload);
+  if (isFailure(clean)) return formatErrorResponse(commandTitle(command), clean);
+
+  if (command === "health") return formatHealthResponse(clean);
+  if (command === "status") return formatStatusCard(commandTitle(command), clean, { publicView: true });
+  if (command === "statusDetail") return formatStatusCard(commandTitle(command), clean, { diagnostic: true });
+  if (command === "readiness") return formatReadinessResponse(clean);
+  if (command === "services") return formatServicesResponse(clean);
+
+  return formatStatusCard(commandTitle(command), clean, { diagnostic: true });
+}
+
+export function formatDiagnosticJson(title, payload) {
+  return formatStatusCard(title, payload, { diagnostic: true }).embeds[0]?.description || "Diagnostic summary unavailable.";
+}
+
+function commandTitle(command) {
+  if (command === "health") return "Arrakis Control Plane — Adapter Health";
+  if (command === "status") return "Arrakis Control Plane — Server Status";
+  if (command === "statusDetail") return "Arrakis Control Plane — Detailed Status";
+  if (command === "readiness") return "Arrakis Control Plane — Readiness";
+  if (command === "services") return "Arrakis Control Plane — Services";
+  return "Arrakis Control Plane";
+}
+
+function formatHealthResponse(payload) {
+  const liveRoutes = Array.isArray(payload.liveRoutes) ? payload.liveRoutes.length : 0;
+  const plannedRoutes = Array.isArray(payload.plannedRoutes) ? payload.plannedRoutes.length : 0;
+  const policy = payload.rolePolicy || {};
+  const roleLines = [
+    roleLine("Observer", policy.observerConfigured),
+    roleLine("Moderator", policy.moderatorConfigured),
+    roleLine("Admin", policy.adminConfigured),
+    roleLine("Owner", policy.ownerConfigured)
+  ].join("\n");
+
+  return {
+    content: "",
+    embeds: [baseEmbed({
+      title: "Arrakis Control Plane — Adapter Health",
+      description: "The Discord adapter is online and operating in read-only mode.",
+      color: payload.ok ? COLORS.ready : COLORS.issue,
+      fields: compactFields([
+        field("Overall", payload.ok ? "ONLINE" : "ISSUE", true),
+        field("Mode", payload.experimental ? "EXPERIMENTAL" : "STANDARD", true),
+        field("Safety", lines([
+          statusLine("Read-only", truthLabel(payload.readOnly)),
+          statusLine("Writes", payload.writesEnabled ? "ENABLED" : "DISABLED")
+        ]), true),
+        field("Routes", `${liveRoutes} live / ${plannedRoutes} planned`, true),
+        field("Roles", roleLines || "No role policy returned.", false)
+      ])
+    })]
+  };
+}
+
+function formatReadinessResponse(payload) {
+  const data = resultData(payload);
+  const ready = data.ready ?? data.ok ?? payload.ok;
+  const overall = ready ? "READY" : inferOverall(data, payload);
+  const services = serviceRows(data);
+  const issues = issueLines(data, overall);
+
+  return {
+    content: "",
+    embeds: [baseEmbed({
+      title: "Arrakis Control Plane — Readiness",
+      description: ready ? "Server readiness checks are passing." : "Server readiness has one or more blocking issues.",
+      color: colorForStatus(overall),
+      fields: compactFields([
+        field("Overall", statusText(overall), true),
+        field("Issues", bulletList(issues, "No issues reported."), false),
+        services.length ? field("Services", namedStatusList(services), false) : null,
+        field("Checks", namedStatusList(checkRows(data)), false)
+      ])
+    })]
+  };
+}
+
+function formatServicesResponse(payload) {
+  return formatStatusCard("Arrakis Control Plane — Services", payload, { servicesOnly: true });
+}
+
+function formatStatusCard(title, payload, _options = {}) {
+  const data = resultData(payload);
+  const overall = inferOverall(data, payload);
+  const services = serviceRows(data);
+  const listeners = listenerRows(data, services);
+  const checks = checkRows(data);
+  const issues = issueLines(data, overall).filter((issue) => !/^Overall status is /i.test(issue) || issueLines(data, overall).length === 1);
+  const serviceSummary = services.length ? serviceHealthSummary(services) : null;
+
+  return {
+    content: "",
+    embeds: [baseEmbed({
+      title: data.title || title,
+      description: cardDescription(overall, issues, services),
+      color: colorForStatus(overall),
+      fields: compactFields([
+        field("Overall", statusText(overall), true),
+        optionalField("Region", data.region || data.shardRegion, true),
+        optionalField("Population", data.population ?? data.playerCount, true),
+        serviceSummary ? field("Summary", serviceSummary, false) : null,
+        issues.length ? field("Issues", bulletList(issues, "No issues reported."), false) : null,
+        services.length ? field("Services", namedStatusList(services), false) : null,
+        listeners.length ? field("Listeners", namedStatusList(listeners), false) : null,
+        checks.length ? field("Checks", namedStatusList(checks), false) : null
+      ])
+    })]
+  };
+}
+
+function cardDescription(overall, issues, services) {
+  if (issues.length) return `${issues.length} issue${issues.length === 1 ? "" : "s"} detected.`;
+  if (services.length && services.every((service) => /^(UP|READY|OK|ONLINE|HEALTHY)$/i.test(service.status))) {
+    return "All monitored services are online.";
+  }
+  if (/^(OK|READY|UP|ONLINE|HEALTHY)$/i.test(statusText(overall))) return "No issues reported.";
+  return "Status requires review.";
+}
+
+function serviceHealthSummary(services) {
+  const up = services.filter((service) => /^(UP|READY|OK|ONLINE|HEALTHY)$/i.test(service.status)).length;
+  return `${up} / ${services.length} services reporting UP`;
+}
+
+function formatErrorResponse(title, payload) {
+  const error = payload.payload?.error || payload.error || payload.message || "Command failed.";
+  const code = payload.payload?.code || payload.code || "unknown";
+  const status = payload.status ?? "unknown";
+
+  return {
+    content: "",
+    embeds: [baseEmbed({
+      title: `${title} — Command Failed`,
+      description: safeValue(error),
+      color: status === 403 || code === "not_authorized" ? COLORS.issue : COLORS.down,
+      fields: compactFields([
+        field("Status", String(status), true),
+        field("Code", safeValue(code), true)
+      ])
+    })]
+  };
+}
+
+function resultData(payload) {
+  return payload?.result || payload?.payload?.result || payload || {};
+}
+
+function inferOverall(data, payload) {
+  return data.overall || data.status || data.state || (payload?.ok ? "READY" : "ISSUE");
+}
+
+function serviceRows(data) {
+  return asArray(data.services || data.maps || data.instances).map((item) => normalizeRow(item, "Service"));
+}
+
+function listenerRows(data, services = []) {
+  const direct = asArray(data.listeners).map((item) => normalizeRow(item, "Listener"));
+  const nested = services.flatMap((service) => asArray(service.raw?.listeners).map((listener) => normalizeRow(listener, `${service.name} listener`)));
+  return [...direct, ...nested];
+}
+
+function checkRows(data) {
+  return asArray(data.checks || data.readiness || data.healthChecks).map((item) => normalizeRow(item, "Check"));
+}
+
+function normalizeRow(item, fallbackName) {
+  if (typeof item === "string") return { name: item, status: "UNKNOWN", raw: item };
+  const raw = item || {};
+  return {
+    name: raw.name || raw.service || raw.map || raw.id || raw.check || fallbackName,
+    status: statusText(raw.status || raw.state || raw.overall || raw.ok === true && "READY" || raw.ok === false && "ISSUE" || "UNKNOWN"),
+    raw
+  };
+}
+
+function issueLines(data, overall) {
+  const explicit = asArray(data.issues || data.errors || data.failures || data.blockingIssues).map((item) => {
+    if (typeof item === "string") return item;
+    return item.message || item.error || item.name || JSON.stringify(item);
+  });
+  const derived = deriveIssues(data, overall);
+  return dedupe([...explicit, ...derived]).slice(0, 12);
+}
+
+function deriveIssues(data, overall) {
+  const rows = [];
+  if (BAD_STATES.test(statusText(overall))) rows.push(`Overall status is ${statusText(overall)}`);
+  collectBadStateIssues(data, [], "", rows);
+  return rows;
+}
+
+function collectBadStateIssues(value, path, parentName, rows) {
+  if (value === null || value === undefined) return;
+
+  if (typeof value !== "object") {
+    const leaf = path[path.length - 1] || "";
+    const isTopLevelStatus = path.length <= 1 && /^(overall|state|status)$/i.test(leaf);
+    if (isTopLevelStatus) return;
+
+    const state = statusText(value);
+    if (BAD_STATES.test(state)) rows.push(`${pathLabel(path, parentName)} is ${state}`);
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => collectBadStateIssues(item, [...path, String(index)], parentName, rows));
+    return;
+  }
+
+  const contextName = value.name || value.service || value.map || value.id || value.check || parentName;
+  for (const [key, item] of Object.entries(value)) {
+    collectBadStateIssues(item, [...path, key], contextName, rows);
+  }
+}
+
+function pathLabel(path, parentName) {
+  const parts = path
+    .filter((part) => !/^\d+$/.test(part))
+    .filter((part) => !/^(result|payload|services|maps|instances|checks|listeners|state|status|overall)$/i.test(part));
+
+  const tail = labelCase(parts.slice(-1).join(" ") || "Status");
+  return labelCase([parentName, tail].filter(Boolean).join(" "));
+}
+
+function namedStatusList(rows) {
+  const lines = rows.map((row) => `**${escapeMarkdown(row.name)}** : ${escapeMarkdown(row.status)}`);
+  return truncateEmbedText(lines.length ? lines.join("\n") : "None reported.", 1024);
+}
+
+function bulletList(rows, fallback) {
+  return truncateEmbedText(rows.length ? rows.map((row) => `• ${escapeMarkdown(row)}`).join("\n") : fallback, 1024);
+}
+
+function baseEmbed({ title, description, color, fields }) {
+  return {
+    title: truncateEmbedText(title, 256),
+    description: truncateEmbedText(description || "", 4096),
+    color: color || COLORS.neutral,
+    fields: compactFields(fields).slice(0, 25),
+    footer: FOOTER,
+    timestamp: new Date().toISOString()
+  };
+}
+
+function field(name, value, inline = false) {
+  if (value === null || value === undefined || value === "") return null;
+  return {
+    name: truncateEmbedText(name, 256),
+    value: truncateEmbedText(String(value), 1024),
+    inline
+  };
+}
+
+function optionalField(name, value, inline = false) {
+  return value === null || value === undefined || value === "" ? null : field(name, safeValue(value), inline);
+}
+
+function compactFields(fields) {
+  return (fields || []).filter(Boolean);
+}
+
+function statusLine(label, value) {
+  return `**${escapeMarkdown(label)}:** ${escapeMarkdown(value)}`;
+}
+
+function roleLine(label, configured) {
+  return `${configured ? "Configured" : "Missing"} — ${escapeMarkdown(label)}`;
+}
+
+function truthLabel(value) {
+  return value ? "YES" : "NO";
+}
+
+function statusText(value) {
+  return String(value || "UNKNOWN").toUpperCase();
+}
+
+function colorForStatus(value) {
+  const text = statusText(value);
+  if (/ready|online|ok|healthy|pass/.test(text.toLowerCase())) return COLORS.ready;
+  if (/down|failed|error|offline|stopped/.test(text.toLowerCase())) return COLORS.down;
+  if (/issue|degraded|missing|warn|unknown/.test(text.toLowerCase())) return COLORS.issue;
+  return COLORS.neutral;
+}
+
+function isFailure(payload) {
+  return payload?.ok === false || (Number(payload?.status) >= 400);
+}
+
+function asArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value === "object") return Object.entries(value).map(([name, item]) => ({ name, ...(typeof item === "object" && item !== null ? item : { status: item }) }));
+  return [value];
+}
+
+function lines(values) {
+  return values.filter(Boolean).join("\n");
+}
+
+function safeValue(value) {
+  return escapeMarkdown(String(value ?? "Unknown"));
+}
+
+function labelCase(value) {
+  return String(value || "")
+    .replace(/[_-]+/g, " ")
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+    .replace(/\bS2s\b/g, "S2S")
+    .replace(/\bApi\b/g, "API")
+    .replace(/\bDb\b/g, "DB")
+    .replace(/\bCpu\b/g, "CPU")
+    .replace(/\bRam\b/g, "RAM");
+}
+
+function dedupe(values) {
+  return [...new Set(values.filter(Boolean).map((value) => String(value)))];
+}
+
+function escapeMarkdown(value) {
+  return String(value ?? "")
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\*/g, "\\*")
+    .replace(/_/g, "\\_")
+    .replace(/~/g, "\\~")
+    .replace(/\|/g, "\\|")
+    .replace(/>/g, "\\>");
+}
+
+function truncateEmbedText(value, max) {
+  const text = String(value || "");
+  return text.length > max ? `${text.slice(0, Math.max(0, max - 12))}\n…truncated` : text;
+}
+
+function redact(value) {
+  return JSON.parse(JSON.stringify(value, (key, item) => {
+    if (/token|secret|password|authorization|cookie|api[-_]?key/i.test(key)) return "[REDACTED]";
+    if (typeof item === "string" && /(Bearer\s+|Bot\s+|[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,})/.test(item)) return "[REDACTED]";
+    return item;
+  }));
+}

--- a/discord-bot/scripts/discord-install-url.mjs
+++ b/discord-bot/scripts/discord-install-url.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+
+const DISCORD_API = "https://discord.com/api/v10";
+const DEFAULT_PERMISSIONS = String((1n << 10n) + (1n << 11n) + (1n << 14n) + (1n << 31n));
+const DEFAULT_SCOPES = "bot applications.commands";
+
+const args = parseArgs(process.argv.slice(2));
+
+main().catch((error) => {
+  console.error(`Discord install URL helper failed: ${safeErrorMessage(error)}`);
+  process.exit(1);
+});
+
+async function main() {
+  const token = readOptionalBotToken(args.tokenFile || process.env.DISCORD_BOT_TOKEN_FILE);
+  const app = token ? await discordGet(token, "/oauth2/applications/@me") : null;
+  const bot = token ? await discordGet(token, "/users/@me") : null;
+  const clientId = args.clientId || process.env.DISCORD_CLIENT_ID || app?.id;
+
+  if (!clientId || !/^\d{15,25}$/.test(clientId)) {
+    throw new Error("Missing Discord application/client ID. Set DISCORD_CLIENT_ID, pass --client-id, or provide DISCORD_BOT_TOKEN_FILE so the helper can discover it.");
+  }
+
+  const scopes = args.scopes || DEFAULT_SCOPES;
+  const permissions = String(args.permissions || DEFAULT_PERMISSIONS);
+  const url = new URL("https://discord.com/oauth2/authorize");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("scope", scopes);
+  url.searchParams.set("permissions", permissions);
+
+  if (args.guildId) {
+    url.searchParams.set("guild_id", args.guildId);
+    url.searchParams.set("disable_guild_select", "true");
+  }
+
+  console.log("Discord bot install URL");
+  console.log("=======================");
+  if (app) console.log(`Application: ${app.name || "unknown"} (${app.id})`);
+  if (bot) console.log(`Bot user:    ${bot.username || "unknown"} (${bot.id})`);
+  console.log(`Scopes:      ${scopes}`);
+  console.log(`Permissions: ${permissions}`);
+  console.log("");
+  console.log(String(url));
+  console.log("");
+  console.log("Use this URL when the bot is usable through slash commands but is not visible as a guild/channel member. Installing with both 'bot' and 'applications.commands' scopes creates the bot guild member.");
+
+  if (app && !app.icon) {
+    console.log("");
+    console.log("Warning: the Discord application has no app icon. Upload an icon in Discord Developer Portal > Applications > General Information.");
+  }
+  if (bot && !bot.avatar) {
+    console.log("Warning: the bot user has no avatar. Upload an avatar in Discord Developer Portal > Applications > Bot.");
+  }
+}
+
+function readOptionalBotToken(path) {
+  if (!path) return "";
+  if (!existsSync(path)) throw new Error(`DISCORD_BOT_TOKEN_FILE does not exist: ${path}`);
+  const token = readFileSync(path, "utf8").trim();
+  if (!token) throw new Error(`DISCORD_BOT_TOKEN_FILE is empty: ${path}`);
+  return token;
+}
+
+async function discordGet(token, path) {
+  const response = await fetch(`${DISCORD_API}${path}`, {
+    headers: { authorization: `Bot ${token}` }
+  });
+  if (!response.ok) throw new Error(`Discord API request failed: ${response.status} ${await response.text()}`);
+  return response.json();
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--client-id") parsed.clientId = requireValue(argv, ++index, arg);
+    else if (arg === "--guild-id") parsed.guildId = requireValue(argv, ++index, arg);
+    else if (arg === "--permissions") parsed.permissions = requireValue(argv, ++index, arg);
+    else if (arg === "--scopes") parsed.scopes = requireValue(argv, ++index, arg);
+    else if (arg === "--token-file") parsed.tokenFile = requireValue(argv, ++index, arg);
+    else if (arg === "-h" || arg === "--help") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return parsed;
+}
+
+function requireValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value.`);
+  return value;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/discord-install-url.mjs [options]\n\nOptions:\n  --token-file PATH      Discord bot token file. Defaults to DISCORD_BOT_TOKEN_FILE.\n  --client-id ID        Discord application/client ID. Auto-discovered from bot token when possible.\n  --guild-id ID         Optional guild ID to preselect in the OAuth flow.\n  --permissions BITS    Discord permission bitset. Defaults to minimal read-only command permissions.\n  --scopes TEXT         OAuth scopes. Defaults to "bot applications.commands".\n`);
+}
+
+function safeErrorMessage(error) {
+  return String(error?.message || error || "Unknown error").replace(/(Bot|Bearer)\s+\S+/g, "$1 [REDACTED]");
+}

--- a/discord-bot/scripts/discord-runtime.mjs
+++ b/discord-bot/scripts/discord-runtime.mjs
@@ -1,0 +1,364 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+import { formatCommandResponse } from "./discord-formatters.mjs";
+
+const DISCORD_API = "https://discord.com/api/v10";
+const EPHEMERAL = 1 << 6;
+
+const config = loadConfig();
+const discordToken = readSecret(config.discordBotTokenFile, "DISCORD_BOT_TOKEN_FILE");
+const duneApiToken = readSecret(config.duneBotApiTokenFile, "DUNE_BOT_API_TOKEN_FILE");
+validateRuntimeConfig(config, discordToken, duneApiToken);
+
+await registerGuildCommands();
+await startGateway();
+
+async function registerGuildCommands() {
+  const url = `${DISCORD_API}/applications/${encodeURIComponent(config.discordClientId)}/guilds/${encodeURIComponent(config.discordGuildId)}/commands`;
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: discordHeaders(),
+    body: JSON.stringify(duneCommandDefinition())
+  });
+  if (!response.ok) {
+    throw new Error(`Discord command registration failed: ${response.status} ${await response.text()}`);
+  }
+  const body = await response.json();
+  console.log(JSON.stringify({ service: "dune-discord-companion-bot", event: "slash_commands_registered", count: body.length }));
+}
+
+async function startGateway() {
+  const gateway = await discordGet("/gateway/bot");
+  const gatewayUrl = `${gateway.url}/?v=10&encoding=json`;
+  const socket = new WebSocket(gatewayUrl);
+  let heartbeatTimer = null;
+  let sequence = null;
+
+  socket.addEventListener("open", () => {
+    console.log(JSON.stringify({ service: "dune-discord-companion-bot", event: "gateway_open" }));
+  });
+
+  socket.addEventListener("message", async (event) => {
+    const packet = JSON.parse(String(event.data));
+    if (packet.s !== null && packet.s !== undefined) sequence = packet.s;
+
+    if (packet.op === 10) {
+      heartbeatTimer = startHeartbeat(socket, packet.d.heartbeat_interval, () => sequence);
+      socket.send(JSON.stringify({
+        op: 2,
+        d: {
+          token: discordToken,
+          intents: 0,
+          properties: {
+            os: process.platform,
+            browser: "dune-discord-companion-bot",
+            device: "dune-discord-companion-bot"
+          },
+          presence: {
+            status: "online",
+            since: null,
+            afk: false,
+            activities: [{ name: "Arrakis status", type: 3 }]
+          }
+        }
+      }));
+      return;
+    }
+
+    if (packet.op === 11) return;
+
+    if (packet.t === "READY") {
+      console.log(JSON.stringify({ service: "dune-discord-companion-bot", event: "gateway_ready", user: packet.d?.user?.username || "unknown" }));
+      return;
+    }
+
+    if (packet.t === "INTERACTION_CREATE") {
+      await handleInteraction(packet.d).catch(async (error) => {
+        console.error(JSON.stringify({ service: "dune-discord-companion-bot", event: "interaction_error", error: safeErrorMessage(error) }));
+        const failure = { content: "Dune command failed. Check Console adapter logs for details.", ephemeral: true };
+        await editDeferredInteraction(packet.d, failure).catch(async () => {
+          await replyToInteraction(packet.d, failure).catch(() => undefined);
+        });
+      });
+    }
+  });
+
+  socket.addEventListener("close", (event) => {
+    if (heartbeatTimer) clearInterval(heartbeatTimer);
+    console.error(JSON.stringify({ service: "dune-discord-companion-bot", event: "gateway_closed", code: event.code, reason: event.reason }));
+    process.exitCode = 1;
+  });
+
+  socket.addEventListener("error", () => {
+    console.error(JSON.stringify({ service: "dune-discord-companion-bot", event: "gateway_error" }));
+  });
+}
+
+function startHeartbeat(socket, intervalMs, sequenceProvider) {
+  const sendHeartbeat = () => {
+    if (socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify({ op: 1, d: sequenceProvider() }));
+    }
+  };
+  sendHeartbeat();
+  return setInterval(sendHeartbeat, intervalMs);
+}
+
+async function handleInteraction(interaction) {
+  if (interaction.type !== 2 || interaction.data?.name !== "dune") return;
+  const parsed = parseDuneInteraction(interaction);
+  const actor = actorFromInteraction(interaction, parsed.commandLabel);
+  await deferInteraction(interaction, { ephemeral: commandStartsEphemeral(parsed.command) });
+
+  if (parsed.command === "help") {
+    await editDeferredInteraction(interaction, {
+      ephemeral: true,
+      content: "**Dune bot help**\n`/dune health` - adapter health\n`/dune status public` - public redacted status\n`/dune status detail` - admin-only diagnostics\n`/dune readiness` - readiness summary\n`/dune services` - service summary\n`/dune version` - bot/runtime version"
+    });
+    return;
+  }
+
+  if (parsed.command === "version") {
+    await editDeferredInteraction(interaction, {
+      ephemeral: true,
+      content: "**Dune bot version**\n`0.1.0`\nRead-only Discord companion runtime."
+    });
+    return;
+  }
+
+  const result = await callDuneCommand(parsed.command, actor);
+  await editDeferredInteraction(interaction, result);
+}
+
+function commandStartsEphemeral(command) {
+  return command !== "status";
+}
+
+function parseDuneInteraction(interaction) {
+  const first = interaction.data?.options?.[0];
+  if (!first) return { command: "help", commandLabel: "/dune help" };
+
+  if (first.name === "health") return { command: "health", commandLabel: "/dune health" };
+  if (first.name === "readiness") return { command: "readiness", commandLabel: "/dune readiness" };
+  if (first.name === "services") return { command: "services", commandLabel: "/dune services" };
+  if (first.name === "help") return { command: "help", commandLabel: "/dune help" };
+  if (first.name === "version") return { command: "version", commandLabel: "/dune version" };
+
+  if (first.name === "status") {
+    const second = first.options?.[0];
+    if (second?.name === "detail") return { command: "statusDetail", commandLabel: "/dune status detail" };
+    return { command: "status", commandLabel: "/dune status public" };
+  }
+
+  return { command: "help", commandLabel: "/dune help" };
+}
+
+function actorFromInteraction(interaction, commandName) {
+  const member = interaction.member || {};
+  const user = member.user || interaction.user || {};
+  return {
+    guildId: interaction.guild_id || config.discordGuildId,
+    channelId: interaction.channel_id || "unknown-channel",
+    userId: user.id || "unknown-user",
+    username: user.username || user.global_name || "unknown-user",
+    roleIds: Array.isArray(member.roles) ? member.roles : [],
+    interactionId: interaction.id,
+    commandName
+  };
+}
+
+async function callDuneCommand(command, actor) {
+  if (command === "health") {
+    const response = await callConsole("GET", "/api/integrations/discord/health");
+    return { ephemeral: true, ...formatCommandResponse("health", response) };
+  }
+  if (command === "status") {
+    const response = await callConsole("POST", "/api/integrations/discord/status", { actor, diagnostic: false });
+    return { ephemeral: false, ...formatCommandResponse("status", response) };
+  }
+  if (command === "statusDetail") {
+    const response = await callConsole("POST", "/api/integrations/discord/status", { actor, diagnostic: true });
+    return { ephemeral: true, ...formatCommandResponse("statusDetail", response) };
+  }
+  if (command === "readiness") {
+    const response = await callConsole("POST", "/api/integrations/discord/readiness", { actor });
+    return { ephemeral: true, ...formatCommandResponse("readiness", response) };
+  }
+  if (command === "services") {
+    const response = await callConsole("POST", "/api/integrations/discord/services", { actor });
+    return { ephemeral: true, ...formatCommandResponse("services", response) };
+  }
+  throw new Error(`Unsupported Dune command: ${command}`);
+}
+
+async function callConsole(method, path, body) {
+  const url = `${config.duneConsoleApiUrl.replace(/\/$/, "")}${path}`;
+  let response;
+  try {
+    response = await fetch(url, {
+      method,
+      headers: {
+        authorization: `Bearer ${duneApiToken}`,
+        ...(body ? { "content-type": "application/json" } : {})
+      },
+      body: body ? JSON.stringify(body) : undefined
+    });
+  } catch (error) {
+    return {
+      ok: false,
+      status: 0,
+      payload: {
+        code: "console_unreachable",
+        error: "Discord bot could not reach the Console adapter URL.",
+        url,
+        cause: safeErrorMessage(error)
+      }
+    };
+  }
+  const payload = await response.json().catch(() => ({ ok: false, code: "invalid_response", error: "Console returned non-JSON output." }));
+  if (!response.ok) {
+    return { ok: false, status: response.status, payload };
+  }
+  return payload;
+}
+
+async function deferInteraction(interaction, result) {
+  const response = await fetch(`${DISCORD_API}/interactions/${interaction.id}/${interaction.token}/callback`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      type: 5,
+      data: {
+        flags: result.ephemeral ? EPHEMERAL : undefined
+      }
+    })
+  });
+  if (!response.ok) {
+    throw new Error(`Discord interaction defer failed: ${response.status} ${await response.text()}`);
+  }
+}
+
+async function editDeferredInteraction(interaction, result) {
+  const applicationId = interaction.application_id || config.discordClientId;
+  const response = await fetch(`${DISCORD_API}/webhooks/${applicationId}/${interaction.token}/messages/@original`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(discordMessagePayload(result))
+  });
+  if (!response.ok) {
+    throw new Error(`Discord deferred interaction edit failed: ${response.status} ${await response.text()}`);
+  }
+}
+
+async function replyToInteraction(interaction, result) {
+  const response = await fetch(`${DISCORD_API}/interactions/${interaction.id}/${interaction.token}/callback`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      type: 4,
+      data: {
+        ...discordMessagePayload(result),
+        flags: result.ephemeral ? EPHEMERAL : undefined
+      }
+    })
+  });
+  if (!response.ok) {
+    throw new Error(`Discord interaction reply failed: ${response.status} ${await response.text()}`);
+  }
+}
+
+function discordMessagePayload(result) {
+  return {
+    content: truncateDiscordMessage(result.content || ""),
+    embeds: Array.isArray(result.embeds) ? result.embeds.slice(0, 10) : [],
+    allowed_mentions: { parse: [] }
+  };
+}
+
+async function discordGet(path) {
+  const response = await fetch(`${DISCORD_API}${path}`, { headers: discordHeaders() });
+  if (!response.ok) throw new Error(`Discord API request failed: ${response.status} ${await response.text()}`);
+  return response.json();
+}
+
+function discordHeaders() {
+  return {
+    authorization: `Bot ${discordToken}`,
+    "content-type": "application/json"
+  };
+}
+
+function duneCommandDefinition() {
+  return [{
+    name: "dune",
+    description: "Read-only Dune server visibility commands.",
+    dm_permission: false,
+    options: [
+      { type: 1, name: "health", description: "Show Discord adapter health." },
+      {
+        type: 2,
+        name: "status",
+        description: "Show server status.",
+        options: [
+          { type: 1, name: "public", description: "Show public redacted server status." },
+          { type: 1, name: "detail", description: "Show admin-only detailed status." }
+        ]
+      },
+      { type: 1, name: "readiness", description: "Show server readiness summary." },
+      { type: 1, name: "services", description: "Show service summary." },
+      { type: 1, name: "help", description: "Show safe command help." },
+      { type: 1, name: "version", description: "Show bot version." }
+    ]
+  }];
+}
+
+function truncateDiscordMessage(value) {
+  const text = String(value || "");
+  return text.length > 1900 ? `${text.slice(0, 1880)}\n…truncated` : text;
+}
+
+function loadConfig() {
+  return {
+    discordBotTokenFile: requiredEnv("DISCORD_BOT_TOKEN_FILE"),
+    duneBotApiTokenFile: requiredEnv("DUNE_BOT_API_TOKEN_FILE"),
+    duneConsoleApiUrl: requiredEnv("DUNE_CONSOLE_API_URL"),
+    discordClientId: requiredDiscordSnowflakeEnv("DISCORD_CLIENT_ID"),
+    discordGuildId: requiredDiscordSnowflakeEnv("DISCORD_GUILD_ID")
+  };
+}
+
+function validateRuntimeConfig(config, discordToken, duneApiToken) {
+  const url = new URL(config.duneConsoleApiUrl);
+  if (!/^https?:$/.test(url.protocol)) throw new Error("DUNE_CONSOLE_API_URL must use http or https.");
+  if (!looksLikeDiscordBotToken(discordToken)) throw new Error("DISCORD_BOT_TOKEN_FILE does not contain a Discord bot token-shaped value.");
+  if (!duneApiToken || duneApiToken.length < 12) throw new Error("DUNE_BOT_API_TOKEN_FILE is empty or too short.");
+}
+
+function requiredDiscordSnowflakeEnv(name) {
+  const value = requiredEnv(name);
+  if (!/^\d{15,25}$/.test(value)) {
+    throw new Error(`${name} must be a numeric Discord ID. Replace the placeholder value with the real ID from Discord.`);
+  }
+  return value;
+}
+
+function requiredEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  if (/^your-|^role-/i.test(value)) throw new Error(`${name} is still a placeholder: ${value}`);
+  return value;
+}
+
+function readSecret(path, name) {
+  if (/^your-|^role-/i.test(path)) throw new Error(`${name} points to a placeholder path: ${path}`);
+  if (!existsSync(path)) throw new Error(`${name} file does not exist: ${path}`);
+  return readFileSync(path, "utf8").trim();
+}
+
+function looksLikeDiscordBotToken(value) {
+  return /^[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}$/.test(value);
+}
+
+function safeErrorMessage(error) {
+  return String(error?.message || error || "Unknown error").replace(/(Bot|Bearer)\s+\S+/g, "$1 [REDACTED]");
+}

--- a/discord-bot/scripts/run-discord-runtime.sh
+++ b/discord-bot/scripts/run-discord-runtime.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+set -eu
+
+ENV_FILE="${DUNE_DISCORD_ENV_FILE:-$HOME/.config/dune-console/discord-bot.env}"
+
+if [ ! -f "$ENV_FILE" ]; then
+  cat >&2 <<EOF
+Missing Discord bot environment file: $ENV_FILE
+
+Create it with stable non-secret settings, for example:
+
+  mkdir -p "$HOME/.config/dune-console"
+  chmod 700 "$HOME/.config/dune-console"
+  cat > "$ENV_FILE" <<'ENVEOF'
+export DISCORD_BOT_TOKEN_FILE="$HOME/.config/dune-console/discord-bot-token.txt"
+export DUNE_BOT_API_TOKEN_FILE="$HOME/.config/dune-console/dune-bot-api-token.txt"
+export DUNE_CONSOLE_API_URL="http://127.0.0.1:8088"
+export DISCORD_CLIENT_ID="1516816812006969494"
+export DISCORD_GUILD_ID="replace-with-server-id"
+export DISCORD_OBSERVER_ROLE_IDS="replace-with-observer-role-id"
+export DISCORD_ADMIN_ROLE_IDS="replace-with-admin-role-id"
+export DISCORD_OWNER_ROLE_IDS="replace-with-owner-role-id"
+ENVEOF
+  chmod 600 "$ENV_FILE"
+EOF
+  exit 2
+fi
+
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+
+required_var() {
+  eval "value=\${$1:-}"
+  if [ -z "$value" ]; then
+    echo "Missing required environment variable after sourcing $ENV_FILE: $1" >&2
+    exit 2
+  fi
+}
+
+required_var DISCORD_BOT_TOKEN_FILE
+required_var DUNE_BOT_API_TOKEN_FILE
+required_var DUNE_CONSOLE_API_URL
+required_var DISCORD_CLIENT_ID
+required_var DISCORD_GUILD_ID
+
+exec node scripts/discord-runtime.mjs

--- a/discord-bot/scripts/run-local-discord-stack.sh
+++ b/discord-bot/scripts/run-local-discord-stack.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+BOT_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$BOT_DIR/.." && pwd)"
+API_DIR="$REPO_ROOT/console/api"
+ENV_FILE="${DUNE_DISCORD_ENV_FILE:-$HOME/.config/dune-console/discord-bot.env}"
+ADAPTER_HOST="${ADMIN_BIND_HOST:-127.0.0.1}"
+ADAPTER_PORT="${ADMIN_BIND_PORT:-8090}"
+ADAPTER_URL="http://$ADAPTER_HOST:$ADAPTER_PORT"
+LOG_DIR="${DUNE_DISCORD_LOG_DIR:-/tmp/dune-discord-stack}"
+ADAPTER_LOG="$LOG_DIR/adapter.log"
+BOT_LOG="$LOG_DIR/bot.log"
+
+mkdir -p "$LOG_DIR"
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Missing env file: $ENV_FILE" >&2
+  echo "Create it first, including DISCORD_BOT_TOKEN_FILE, DUNE_BOT_API_TOKEN_FILE, DISCORD_CLIENT_ID, and DISCORD_GUILD_ID." >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+. "$ENV_FILE"
+
+: "${DISCORD_BOT_TOKEN_FILE:?Missing DISCORD_BOT_TOKEN_FILE in $ENV_FILE}"
+: "${DUNE_BOT_API_TOKEN_FILE:?Missing DUNE_BOT_API_TOKEN_FILE in $ENV_FILE}"
+: "${DISCORD_CLIENT_ID:?Missing DISCORD_CLIENT_ID in $ENV_FILE}"
+: "${DISCORD_GUILD_ID:?Missing DISCORD_GUILD_ID in $ENV_FILE}"
+
+if [ ! -f "$DISCORD_BOT_TOKEN_FILE" ]; then
+  echo "Missing Discord bot token file: $DISCORD_BOT_TOKEN_FILE" >&2
+  exit 1
+fi
+
+if [ ! -f "$DUNE_BOT_API_TOKEN_FILE" ]; then
+  echo "Missing Console bot API token file: $DUNE_BOT_API_TOKEN_FILE" >&2
+  exit 1
+fi
+
+printf 'Stopping old Discord bot runtime if present...\n'
+pkill -f 'discord-runtime.mjs' 2>/dev/null || true
+
+printf 'Freeing adapter port %s if a stale adapter owns it...\n' "$ADAPTER_PORT"
+fuser -k "$ADAPTER_PORT/tcp" 2>/dev/null || true
+
+printf 'Starting Console adapter on %s...\n' "$ADAPTER_URL"
+(
+  cd "$API_DIR"
+  env \
+    DUNE_DOCKER_DIR="$REPO_ROOT" \
+    DUNE_BOT_API_TOKEN_FILE="$DUNE_BOT_API_TOKEN_FILE" \
+    DISCORD_OBSERVER_ROLE_IDS="${DISCORD_OBSERVER_ROLE_IDS:-role-observer}" \
+    DISCORD_MODERATOR_ROLE_IDS="${DISCORD_MODERATOR_ROLE_IDS:-role-moderator}" \
+    DISCORD_ADMIN_ROLE_IDS="${DISCORD_ADMIN_ROLE_IDS:-role-admin}" \
+    DISCORD_OWNER_ROLE_IDS="${DISCORD_OWNER_ROLE_IDS:-role-owner}" \
+    ADMIN_BIND_HOST="$ADAPTER_HOST" \
+    ADMIN_BIND_PORT="$ADAPTER_PORT" \
+    npm run start:discord-adapter
+) >"$ADAPTER_LOG" 2>&1 &
+ADAPTER_PID="$!"
+
+cleanup() {
+  kill "$ADAPTER_PID" 2>/dev/null || true
+}
+trap cleanup INT TERM EXIT
+
+printf 'Waiting for adapter health...\n'
+TOKEN="$(cat "$DUNE_BOT_API_TOKEN_FILE")"
+i=0
+while [ "$i" -lt 40 ]; do
+  if curl -fsS -H "Authorization: Bearer $TOKEN" "$ADAPTER_URL/api/integrations/discord/health" >/dev/null 2>&1; then
+    break
+  fi
+  i=$((i + 1))
+  sleep 0.5
+done
+
+if [ "$i" -ge 40 ]; then
+  echo "Adapter did not become healthy at $ADAPTER_URL" >&2
+  echo "Adapter log: $ADAPTER_LOG" >&2
+  tail -80 "$ADAPTER_LOG" >&2 || true
+  exit 1
+fi
+
+printf 'Adapter healthy: %s\n' "$ADAPTER_URL"
+printf 'Starting Discord bot. Logs: %s and %s\n' "$BOT_LOG" "$ADAPTER_LOG"
+printf 'Use Ctrl+C to stop both processes.\n'
+
+cd "$BOT_DIR"
+export DISCORD_BOT_TOKEN_FILE
+export DUNE_BOT_API_TOKEN_FILE
+export DUNE_CONSOLE_API_URL="$ADAPTER_URL"
+export DISCORD_CLIENT_ID
+export DISCORD_GUILD_ID
+export DISCORD_OBSERVER_ROLE_IDS="${DISCORD_OBSERVER_ROLE_IDS:-role-observer}"
+export DISCORD_MODERATOR_ROLE_IDS="${DISCORD_MODERATOR_ROLE_IDS:-role-moderator}"
+export DISCORD_ADMIN_ROLE_IDS="${DISCORD_ADMIN_ROLE_IDS:-role-admin}"
+export DISCORD_OWNER_ROLE_IDS="${DISCORD_OWNER_ROLE_IDS:-role-owner}"
+
+node scripts/discord-runtime.mjs 2>&1 | tee "$BOT_LOG"

--- a/discord-bot/scripts/runtime-smoke.mjs
+++ b/discord-bot/scripts/runtime-smoke.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+console.log(JSON.stringify({
+  service: "dune-discord-control-bot",
+  status: "security-scaffold-ready",
+  writesEnabledDefault: false
+}));

--- a/discord-bot/scripts/validate-scaffold.mjs
+++ b/discord-bot/scripts/validate-scaffold.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+
+const requiredFiles = [
+  "src/index.ts",
+  "src/config.ts",
+  "src/consoleApi.ts",
+  "src/commands.ts",
+  "src/security/redaction.ts",
+  "src/security/authorization.ts",
+  "scripts/command-smoke.mjs",
+  "scripts/discord-runtime.mjs",
+  "scripts/discord-formatters.mjs",
+  "scripts/discord-install-url.mjs",
+  "scripts/discord-discover.mjs",
+  "scripts/discord-channel-access.mjs",
+  "scripts/run-discord-runtime.sh",
+  "scripts/run-local-discord-stack.sh",
+  "test/redaction.test.mjs",
+  "test/discord-formatters.test.mjs",
+  "Dockerfile",
+  "package-lock.json"
+];
+
+const missing = requiredFiles.filter((path) => !existsSync(path));
+if (missing.length) {
+  console.error(`Missing required scaffold files: ${missing.join(", ")}`);
+  process.exit(1);
+}
+
+const dockerfile = readFileSync("Dockerfile", "utf8");
+if (dockerfile.includes("/var/run/docker.sock")) {
+  console.error("Docker socket mount is forbidden for the Discord bot.");
+  process.exit(1);
+}
+if (/privileged:\s*true/i.test(dockerfile)) {
+  console.error("Privileged container mode is forbidden for the Discord bot.");
+  process.exit(1);
+}
+
+const auth = readFileSync("src/security/authorization.ts", "utf8");
+const capabilityBlock = auth.match(/export\s+type\s+BotCapability\s*=([\s\S]*?);/);
+if (!capabilityBlock) {
+  console.error("BotCapability type block not found.");
+  process.exit(1);
+}
+
+const capabilityLiterals = [...capabilityBlock[1].matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+for (const capability of capabilityLiterals) {
+  if (/(^|:)write$|destructive|broadcast|admin/i.test(capability)) {
+    console.error(`Forbidden bot capability detected: ${capability}`);
+    process.exit(1);
+  }
+}
+
+for (const file of [
+  "scripts/discord-runtime.mjs",
+  "scripts/discord-formatters.mjs",
+  "scripts/discord-install-url.mjs",
+  "scripts/discord-discover.mjs",
+  "scripts/discord-channel-access.mjs"
+]) {
+  const check = spawnSync("node", ["--check", file], { encoding: "utf8", timeout: 30000 });
+  if (check.status !== 0) {
+    console.error(`Discord syntax validation failed: ${file}`);
+    if (check.stdout) console.error(check.stdout);
+    if (check.stderr) console.error(check.stderr);
+    if (check.error?.message) console.error(check.error.message);
+    process.exit(check.status || 1);
+  }
+}
+
+const runtime = readFileSync("scripts/discord-runtime.mjs", "utf8");
+for (const forbidden of ["/var/run/docker.sock", "docker compose", "docker run", "postgres", "backup restore", "backup delete"] ) {
+  if (runtime.toLowerCase().includes(forbidden.toLowerCase())) {
+    console.error(`Forbidden runtime marker detected: ${forbidden}`);
+    process.exit(1);
+  }
+}
+
+for (const required of ["formatCommandResponse", "embeds", "allowed_mentions", "parse: []", "presence", "Arrakis status"]) {
+  if (!runtime.includes(required)) {
+    console.error(`Discord runtime missing embed-response marker: ${required}`);
+    process.exit(1);
+  }
+}
+
+const formatter = readFileSync("scripts/discord-formatters.mjs", "utf8");
+for (const required of ["formatHealthResponse", "formatStatusCard", "formatReadinessResponse", "formatServicesResponse", "deriveIssues", "redact"]) {
+  if (!formatter.includes(required)) {
+    console.error(`Discord formatter missing required marker: ${required}`);
+    process.exit(1);
+  }
+}
+
+const installHelper = readFileSync("scripts/discord-install-url.mjs", "utf8");
+for (const required of ["bot applications.commands", "oauth2/authorize", "View Channel", "Use Application Commands"]) {
+  if (!installHelper.includes(required)) {
+    console.error(`Discord install helper missing required marker: ${required}`);
+    process.exit(1);
+  }
+}
+
+const channelHelper = readFileSync("scripts/discord-channel-access.mjs", "utf8");
+for (const required of ["--guild", "--channel", "--execute", "permission overwrite", "Use Application Commands"]) {
+  if (!channelHelper.includes(required)) {
+    console.error(`Discord channel helper missing required marker: ${required}`);
+    process.exit(1);
+  }
+}
+
+const launcher = readFileSync("scripts/run-discord-runtime.sh", "utf8");
+for (const required of ["DUNE_DISCORD_ENV_FILE", "discord-bot.env", "DISCORD_BOT_TOKEN_FILE", "exec node scripts/discord-runtime.mjs"]) {
+  if (!launcher.includes(required)) {
+    console.error(`Discord runtime launcher missing required marker: ${required}`);
+    process.exit(1);
+  }
+}
+
+const stackLauncher = readFileSync("scripts/run-local-discord-stack.sh", "utf8");
+for (const required of ["ADMIN_BIND_PORT", "8090", "api/integrations/discord/health", "discord-runtime.mjs"]) {
+  if (!stackLauncher.includes(required)) {
+    console.error(`Local Discord stack launcher missing required marker: ${required}`);
+    process.exit(1);
+  }
+}
+
+console.log("Discord bot scaffold validation passed.");

--- a/discord-bot/src/commands.ts
+++ b/discord-bot/src/commands.ts
@@ -1,0 +1,63 @@
+import type { BotConfig } from "./config.js";
+import { callConsoleRoute, getConsoleHealth } from "./consoleApi.js";
+import { redactValue } from "./security/redaction.js";
+import { actorTier, requireCapability, type DiscordActorContext, type RoleMapping } from "./security/authorization.js";
+
+export type DuneCommandName = "health" | "status" | "statusDetail" | "readiness" | "services";
+
+export type CommandResult = {
+  ephemeral: boolean;
+  content: string;
+};
+
+export function roleMappingFromConfig(config: BotConfig): RoleMapping {
+  return {
+    observerRoleIds: config.observerRoleIds,
+    moderatorRoleIds: config.moderatorRoleIds,
+    adminRoleIds: config.adminRoleIds,
+    ownerRoleIds: config.ownerRoleIds
+  };
+}
+
+export async function handleDuneCommand(config: BotConfig, command: DuneCommandName, actor: DiscordActorContext): Promise<CommandResult> {
+  const mapping = roleMappingFromConfig(config);
+  const tier = actorTier(actor, mapping);
+
+  if (command === "health") {
+    requireCapability(actor, mapping, "status:read");
+    const response = await getConsoleHealth(config);
+    return { ephemeral: tier !== "public", content: formatJsonBlock("Dune adapter health", response) };
+  }
+
+  if (command === "status") {
+    requireCapability(actor, mapping, "status:read");
+    const response = await callConsoleRoute(config, "status", { actor, diagnostic: false });
+    return { ephemeral: false, content: formatJsonBlock("Dune status", response) };
+  }
+
+  if (command === "statusDetail") {
+    requireCapability(actor, mapping, "logs:read");
+    const response = await callConsoleRoute(config, "status", { actor, diagnostic: true });
+    return { ephemeral: true, content: formatJsonBlock("Dune detailed status", response) };
+  }
+
+  if (command === "readiness") {
+    requireCapability(actor, mapping, "readiness:read");
+    const response = await callConsoleRoute(config, "readiness", { actor });
+    return { ephemeral: tier === "public", content: formatJsonBlock("Dune readiness", response) };
+  }
+
+  if (command === "services") {
+    requireCapability(actor, mapping, "services:read");
+    const response = await callConsoleRoute(config, "services", { actor });
+    return { ephemeral: tier === "public", content: formatJsonBlock("Dune services", response) };
+  }
+
+  throw new Error(`Unsupported command: ${command}`);
+}
+
+export function formatJsonBlock(title: string, value: unknown): string {
+  const safe = redactValue(value);
+  const body = JSON.stringify(safe, null, 2).slice(0, 1800);
+  return `**${title}**\n~~~json\n${body}\n~~~`;
+}

--- a/discord-bot/src/config.ts
+++ b/discord-bot/src/config.ts
@@ -1,0 +1,55 @@
+export type BotConfig = {
+  discordBotTokenFile: string;
+  duneBotApiTokenFile: string;
+  duneConsoleApiUrl: string;
+  discordClientId: string;
+  discordGuildId: string;
+  observerRoleIds: string[];
+  moderatorRoleIds: string[];
+  adminRoleIds: string[];
+  ownerRoleIds: string[];
+  publicStatusChannelId?: string;
+  adminAlertChannelId?: string;
+  discordWritesEnabled: false;
+};
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+function optionalCsv(name: string): string[] {
+  return String(process.env[name] || "")
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function optionalEnv(name: string): string | undefined {
+  const value = process.env[name]?.trim();
+  return value || undefined;
+}
+
+export function loadConfig(): BotConfig {
+  return {
+    discordBotTokenFile: requiredEnv("DISCORD_BOT_TOKEN_FILE"),
+    duneBotApiTokenFile: requiredEnv("DUNE_BOT_API_TOKEN_FILE"),
+    duneConsoleApiUrl: requiredEnv("DUNE_CONSOLE_API_URL"),
+    discordClientId: requiredEnv("DISCORD_CLIENT_ID"),
+    discordGuildId: requiredEnv("DISCORD_GUILD_ID"),
+    observerRoleIds: optionalCsv("DISCORD_OBSERVER_ROLE_IDS"),
+    moderatorRoleIds: optionalCsv("DISCORD_MODERATOR_ROLE_IDS"),
+    adminRoleIds: optionalCsv("DISCORD_ADMIN_ROLE_IDS"),
+    ownerRoleIds: optionalCsv("DISCORD_OWNER_ROLE_IDS"),
+    publicStatusChannelId: optionalEnv("DISCORD_PUBLIC_STATUS_CHANNEL_ID"),
+    adminAlertChannelId: optionalEnv("DISCORD_ADMIN_ALERT_CHANNEL_ID"),
+    discordWritesEnabled: false
+  };
+}
+
+export function validateConfig(config: BotConfig): void {
+  const url = new URL(config.duneConsoleApiUrl);
+  if (!/^https?:$/.test(url.protocol)) throw new Error("DUNE_CONSOLE_API_URL must use http or https.");
+  if (!config.ownerRoleIds.length) throw new Error("At least one owner role ID must be configured.");
+}

--- a/discord-bot/src/consoleApi.ts
+++ b/discord-bot/src/consoleApi.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import type { BotConfig } from "./config.js";
+import type { DiscordActorContext } from "./security/authorization.js";
+
+export type ConsoleRoute = "status" | "readiness" | "services";
+
+export type ConsoleCommandPayload = {
+  actor: DiscordActorContext;
+  diagnostic?: boolean;
+};
+
+export type ConsoleResponse = {
+  ok: boolean;
+  result?: unknown;
+  code?: string;
+  error?: string;
+};
+
+const ROUTES: Record<ConsoleRoute, string> = {
+  status: "/api/integrations/discord/status",
+  readiness: "/api/integrations/discord/readiness",
+  services: "/api/integrations/discord/services"
+};
+
+export async function callConsoleRoute(config: BotConfig, route: ConsoleRoute, payload: ConsoleCommandPayload): Promise<ConsoleResponse> {
+  const apiToken = readFileSync(config.duneBotApiTokenFile, "utf8").trim();
+  const url = new URL(ROUTES[route], config.duneConsoleApiUrl);
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiToken}`,
+      "content-type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+  const body = await response.json().catch(() => ({ ok: false, code: "invalid_response", error: "Console returned a non-JSON response." }));
+  if (!response.ok) return body as ConsoleResponse;
+  return body as ConsoleResponse;
+}
+
+export async function getConsoleHealth(config: BotConfig): Promise<ConsoleResponse> {
+  const apiToken = readFileSync(config.duneBotApiTokenFile, "utf8").trim();
+  const url = new URL("/api/integrations/discord/health", config.duneConsoleApiUrl);
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      authorization: `Bearer ${apiToken}`
+    }
+  });
+  const body = await response.json().catch(() => ({ ok: false, code: "invalid_response", error: "Console returned a non-JSON response." }));
+  return body as ConsoleResponse;
+}

--- a/discord-bot/src/index.ts
+++ b/discord-bot/src/index.ts
@@ -1,0 +1,40 @@
+import { loadConfig, validateConfig } from "./config.js";
+import { redactValue, safeErrorMessage } from "./security/redaction.js";
+import { allBotCapabilities } from "./security/authorization.js";
+
+async function main(): Promise<void> {
+  const config = loadConfig();
+  validateConfig(config);
+
+  // The network Discord client is intentionally deferred until the protected
+  // Console adapter contract is stable. Command handlers and route calls are
+  // implemented and can be exercised with scripts/command-smoke.mjs.
+  console.log(JSON.stringify({
+    service: "dune-discord-companion-bot",
+    status: "read-only-command-layer-ready",
+    commands: [
+      "/dune health",
+      "/dune status",
+      "/dune status detail",
+      "/dune readiness",
+      "/dune services"
+    ],
+    capabilities: allBotCapabilities(),
+    writesEnabled: false,
+    config: redactValue({
+      duneConsoleApiUrl: config.duneConsoleApiUrl,
+      discordGuildId: config.discordGuildId,
+      discordBotTokenFile: config.discordBotTokenFile,
+      duneBotApiTokenFile: config.duneBotApiTokenFile
+    })
+  }));
+}
+
+main().catch((error: unknown) => {
+  console.error(JSON.stringify({
+    service: "dune-discord-companion-bot",
+    status: "fatal",
+    error: safeErrorMessage(error)
+  }));
+  process.exitCode = 1;
+});

--- a/discord-bot/src/security/authorization.ts
+++ b/discord-bot/src/security/authorization.ts
@@ -1,0 +1,60 @@
+export type DiscordRoleTier = "public" | "observer" | "moderator" | "admin" | "owner";
+
+export type BotCapability =
+  | "status:read"
+  | "readiness:read"
+  | "services:read"
+  | "population:read"
+  | "logs:read"
+  | "maps:read"
+  | "backups:read";
+
+export type DiscordActorContext = {
+  guildId: string;
+  channelId: string;
+  userId: string;
+  username: string;
+  roleIds: string[];
+  interactionId?: string;
+  commandName?: string;
+};
+
+export type RoleMapping = {
+  observerRoleIds: string[];
+  moderatorRoleIds: string[];
+  adminRoleIds: string[];
+  ownerRoleIds: string[];
+};
+
+const CAPABILITIES_BY_TIER: Record<DiscordRoleTier, ReadonlySet<BotCapability>> = {
+  public: new Set(["status:read"]),
+  observer: new Set(["status:read", "readiness:read", "services:read"]),
+  moderator: new Set(["status:read", "readiness:read", "services:read", "population:read", "maps:read", "backups:read"]),
+  admin: new Set(["status:read", "readiness:read", "services:read", "population:read", "maps:read", "backups:read", "logs:read"]),
+  owner: new Set(["status:read", "readiness:read", "services:read", "population:read", "maps:read", "backups:read", "logs:read"])
+};
+
+export function actorTier(actor: DiscordActorContext, mapping: RoleMapping): DiscordRoleTier {
+  const roles = new Set(actor.roleIds);
+  if (mapping.ownerRoleIds.some((roleId) => roles.has(roleId))) return "owner";
+  if (mapping.adminRoleIds.some((roleId) => roles.has(roleId))) return "admin";
+  if (mapping.moderatorRoleIds.some((roleId) => roles.has(roleId))) return "moderator";
+  if (mapping.observerRoleIds.some((roleId) => roles.has(roleId))) return "observer";
+  return "public";
+}
+
+export function actorCan(actor: DiscordActorContext, mapping: RoleMapping, capability: BotCapability): boolean {
+  return CAPABILITIES_BY_TIER[actorTier(actor, mapping)].has(capability);
+}
+
+export function requireCapability(actor: DiscordActorContext, mapping: RoleMapping, capability: BotCapability): void {
+  if (!actorCan(actor, mapping, capability)) {
+    const error = new Error(`Discord actor ${actor.userId} is not authorized for ${capability}.`);
+    error.name = "AuthorizationError";
+    throw error;
+  }
+}
+
+export function allBotCapabilities(): BotCapability[] {
+  return ["status:read", "readiness:read", "services:read", "population:read", "logs:read", "maps:read", "backups:read"];
+}

--- a/discord-bot/src/security/redaction.ts
+++ b/discord-bot/src/security/redaction.ts
@@ -1,0 +1,42 @@
+export const REDACTION = "<redacted>";
+
+const SENSITIVE_KEY_PATTERN = /(?:token|secret|password|passwd|pwd|authorization|admin[-_]?token|discord[-_]?bot[-_]?token|funcom|database[-_]?url|db[-_]?password)/i;
+
+const TOKEN_VALUE_PATTERNS: RegExp[] = [
+  /Bot\s+[A-Za-z0-9._=-]{20,}/gi,
+  /Bearer\s+[A-Za-z0-9._=-]{20,}/gi,
+  /(?:mfa\.)[A-Za-z0-9._=-]{20,}/gi,
+  /[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}/g,
+  /(postgres(?:ql)?:\/\/[^\s"']+)/gi
+];
+
+export type Redactable = string | number | boolean | null | undefined | Redactable[] | { [key: string]: Redactable };
+
+export function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEY_PATTERN.test(key);
+}
+
+export function redactString(value: string): string {
+  let redacted = value;
+  for (const pattern of TOKEN_VALUE_PATTERNS) {
+    redacted = redacted.replace(pattern, REDACTION);
+  }
+  return redacted;
+}
+
+export function redactValue<T extends Redactable>(value: T): T | string {
+  if (typeof value === "string") return redactString(value);
+  if (Array.isArray(value)) return value.map((item) => redactValue(item)) as T;
+  if (!value || typeof value !== "object") return value;
+
+  const output: Record<string, Redactable | string> = {};
+  for (const [key, child] of Object.entries(value)) {
+    output[key] = isSensitiveKey(key) ? REDACTION : redactValue(child as Redactable);
+  }
+  return output as T;
+}
+
+export function safeErrorMessage(error: unknown): string {
+  if (error instanceof Error) return redactString(error.message);
+  return redactString(String(error));
+}

--- a/discord-bot/test/discord-formatters.test.mjs
+++ b/discord-bot/test/discord-formatters.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { formatCommandResponse } from "../scripts/discord-formatters.mjs";
+
+test("health formatter emits a Discord card", () => {
+  const response = formatCommandResponse("health", {
+    ok: true,
+    service: "dune-console-discord-adapter",
+    enabled: true,
+    experimental: true,
+    readOnly: true,
+    writesEnabled: false,
+    liveRoutes: ["/health"],
+    plannedRoutes: ["/population"],
+    rolePolicy: {
+      observerConfigured: true,
+      moderatorConfigured: false,
+      adminConfigured: true,
+      ownerConfigured: true
+    }
+  });
+
+  assert.equal(response.content, "");
+  assert.equal(response.embeds.length, 1);
+  assert.equal(response.embeds[0].title, "Arrakis Control Plane — Adapter Health");
+  assert.match(response.embeds[0].fields.find((field) => field.name === "Safety").value, /Read-only/);
+});
+
+test("public status formatter summarizes maps and issues as card fields", () => {
+  const response = formatCommandResponse("status", {
+    ok: true,
+    result: {
+      title: "My Dune Server",
+      overall: "ISSUE",
+      region: "North America",
+      population: "0/60",
+      maps: [
+        { name: "Survival_1", state: "READY", uptime: "Up 39 minutes" },
+        { name: "Overmap", state: "READY", uptime: "Up 39 minutes" }
+      ],
+      issues: ["Overmap status is ISSUE"]
+    }
+  });
+
+  const embed = response.embeds[0];
+  assert.equal(embed.title, "My Dune Server");
+  assert.equal(embed.fields.find((field) => field.name === "Population").value, "0/60");
+  assert.match(embed.fields.find((field) => field.name === "Services").value, /Survival/);
+  assert.match(embed.fields.find((field) => field.name === "Issues").value, /Overmap status/);
+});
+
+test("formatter derives missing client and S2S issues from structured status", () => {
+  const response = formatCommandResponse("services", {
+    ok: true,
+    result: {
+      overall: "ISSUE",
+      services: [
+        { name: "Overmap", status: "ISSUE", clients: "MISSING", s2s: "MISSING" },
+        { name: "Survival_1", status: "READY", clients: "MISSING", s2s: "MISSING" }
+      ]
+    }
+  });
+
+  const issues = response.embeds[0].fields.find((field) => field.name === "Issues").value;
+  const services = response.embeds[0].fields.find((field) => field.name === "Services").value;
+  assert.doesNotMatch(issues, /Overall status is ISSUE/);
+  assert.match(issues, /Overmap Clients is MISSING/);
+  assert.match(issues, /Survival 1 S2S is MISSING/);
+  assert.match(services, /Overmap/);
+  assert.match(services, /Survival/);
+});
+
+test("formatter redacts secret-shaped values inside card output", () => {
+  const secret = ["x".repeat(24), "y".repeat(6), "z".repeat(20)].join(".");
+  const response = formatCommandResponse("statusDetail", {
+    ok: true,
+    result: {
+      overall: "READY",
+      token: secret,
+      issues: [`safe issue ${secret}`]
+    }
+  });
+
+  const combined = `${response.content}\n${JSON.stringify(response.embeds)}`;
+  assert.equal(response.content, "");
+  assert.doesNotMatch(combined, /```json/);
+  assert.match(combined, /\[REDACTED\]/);
+  assert.doesNotMatch(combined, new RegExp(secret.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});

--- a/discord-bot/test/redaction.test.mjs
+++ b/discord-bot/test/redaction.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const REDACTION = "<redacted>";
+
+function redactString(value) {
+  return value
+    .replace(/Bot\s+[A-Za-z0-9._=-]{20,}/gi, REDACTION)
+    .replace(/Bearer\s+[A-Za-z0-9._=-]{20,}/gi, REDACTION)
+    .replace(/(?:mfa\.)[A-Za-z0-9._=-]{20,}/gi, REDACTION)
+    .replace(/[A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{20,}/g, REDACTION)
+    .replace(/(postgres(?:ql)?:\/\/[^\s"']+)/gi, REDACTION);
+}
+
+test("redacts Discord bot token shape", () => {
+  const token = ["MzI1NjY2Nzc4ODg5OTAwMTEy", "Gabc12", "someLongDiscordTokenValue"].join(".");
+  const value = `token=${token}`;
+  assert.equal(redactString(value), `token=${REDACTION}`);
+});
+
+test("redacts bearer token", () => {
+  const bearer = ["Bear", "er"].join("");
+  const token = ["abcdefghijkl", "mnopqrstuvwxyz", "123456"].join("");
+  const value = `Authorization: ${bearer} ${token}`;
+  assert.equal(redactString(value), `Authorization: ${REDACTION}`);
+});
+
+test("redacts postgres URLs", () => {
+  const scheme = ["postgres", "ql"].join("");
+  const value = `${scheme}://dune:sample-value@localhost:15432/dune`;
+  assert.equal(redactString(value), REDACTION);
+});

--- a/discord-bot/tsconfig.json
+++ b/discord-bot/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/docs/discord-control-bot/README.md
+++ b/docs/discord-control-bot/README.md
@@ -1,0 +1,302 @@
+# Dune Discord Companion Bot
+
+## Purpose
+
+The Dune Discord Companion Bot is an experimental, read-only Discord interface for Dune Docker Console. It gives server operators safe operational visibility from Discord without giving Discord direct control over Docker, Postgres, backups, or game-state mutation.
+
+The Console API adapter remains the enforcement point for authentication, authorization, redaction, and audit logging. The Discord bot is a thin client: it receives slash commands, builds Discord actor context, calls the protected adapter, and renders sanitized responses.
+
+## Current scope
+
+Implemented commands:
+
+| Command | Visibility | Purpose |
+| --- | --- | --- |
+| `/dune help` | Ephemeral | Shows safe command help. |
+| `/dune version` | Ephemeral | Shows bot runtime version. |
+| `/dune health` | Ephemeral | Confirms the Console Discord adapter is reachable and read-only. |
+| `/dune status public` | Public channel response | Shows redacted public server status. |
+| `/dune status detail` | Ephemeral | Shows admin-only diagnostic status. |
+| `/dune readiness` | Ephemeral | Shows readiness summary. |
+| `/dune services` | Ephemeral | Shows service health summary. |
+
+Out of scope for this release:
+
+- Player kick, grant, teleport, refill, or inventory mutation.
+- Backup create, restore, or delete.
+- Docker socket access.
+- Direct database writes.
+- In-game chat bridge.
+- Moderator write commands.
+- Runtime evidence bundles and local scan artifacts.
+
+## Why the bot may work but not appear as a channel member
+
+Discord slash commands can work when an application is authorized with only the `applications.commands` scope. In that state the command can be usable, but the bot user may not appear as a normal guild/channel member.
+
+To make the bot show up as a bot member, install it with both scopes:
+
+```text
+bot applications.commands
+```
+
+The bot also needs channel permissions where commands are used:
+
+```text
+View Channel
+Send Messages
+Embed Links
+Use Application Commands
+```
+
+If the bot has no icon/avatar, that is configured in Discord, not in this repository:
+
+1. Open Discord Developer Portal.
+2. Open the application.
+3. Upload an application icon under **General Information**.
+4. Upload a bot avatar under **Bot**.
+5. Reinstall or restart the bot if Discord does not refresh the display immediately.
+
+## Prerequisites
+
+- Node.js 22 or later.
+- A Discord application with a bot user.
+- A Discord bot token stored in a local file.
+- A Dune Console bot API token stored in a local file.
+- The local Console Discord adapter running, usually on `http://127.0.0.1:8090`.
+
+Do not commit token files, `.env` files, generated runtime files, or security artifacts.
+
+## Local environment file
+
+Recommended location:
+
+```bash
+$HOME/.config/dune-console/discord-bot.env
+```
+
+Example:
+
+```bash
+export DISCORD_BOT_TOKEN_FILE="$HOME/.config/dune-console/discord-bot-token.txt"
+export DUNE_BOT_API_TOKEN_FILE="$HOME/.config/dune-console/dune-bot-api-token.txt"
+export DUNE_CONSOLE_API_URL="http://127.0.0.1:8090"
+
+export DISCORD_CLIENT_ID="123456789012345678"
+export DISCORD_GUILD_ID="123456789012345678"
+
+export DISCORD_OBSERVER_ROLE_IDS="123456789012345678"
+export DISCORD_MODERATOR_ROLE_IDS=""
+export DISCORD_ADMIN_ROLE_IDS="123456789012345678"
+export DISCORD_OWNER_ROLE_IDS=""
+```
+
+The bot token file should contain only the Discord bot token. The Dune token file should contain only the Console adapter bearer token.
+
+## Install the bot into Discord without manually finding the client ID
+
+From the repository:
+
+```bash
+cd discord-bot
+source "$HOME/.config/dune-console/discord-bot.env"
+npm run discord:invite
+```
+
+The helper queries Discord using the bot token file, discovers the application/client ID, and prints an OAuth install URL with the correct scopes and permissions.
+
+Open the generated URL in a browser and select the target Discord server.
+
+If you already know the client ID:
+
+```bash
+node scripts/discord-install-url.mjs --client-id "123456789012345678"
+```
+
+## Discover guild, channel, and role IDs by name
+
+After the bot is installed in the server:
+
+```bash
+cd discord-bot
+source "$HOME/.config/dune-console/discord-bot.env"
+npm run discord:discover -- --guild "Spice Is Power"
+```
+
+The helper prints:
+
+- Discord application/client ID.
+- Bot user ID.
+- Guild ID.
+- Channels visible to the bot.
+- Roles visible to the bot.
+
+To resolve one channel by name:
+
+```bash
+npm run discord:discover -- --guild "Spice Is Power" --channel "server-status"
+```
+
+Use the printed role IDs for the role mapping environment variables.
+
+## Add the bot to a channel without manually finding channel IDs
+
+Discord channel access is controlled by channel permissions. The helper resolves the guild and channel by name and can create a permission overwrite for the bot user.
+
+Dry run first:
+
+```bash
+cd discord-bot
+source "$HOME/.config/dune-console/discord-bot.env"
+npm run discord:channel -- --guild "Spice Is Power" --channel "server-status"
+```
+
+If the selected guild/channel are correct, apply the permission overwrite:
+
+```bash
+npm run discord:channel -- --guild "Spice Is Power" --channel "server-status" --execute
+```
+
+The helper grants the bot user:
+
+```text
+View Channel
+Send Messages
+Embed Links
+Use Application Commands
+```
+
+If Discord returns a permissions error, either grant the bot role **Manage Channels** temporarily and rerun the helper, or add the same channel permissions manually in Discord channel settings.
+
+## Start the local stack
+
+From the repository root:
+
+```bash
+sh discord-bot/scripts/run-local-discord-stack.sh
+```
+
+Expected runtime markers:
+
+```text
+slash_commands_registered
+gateway_open
+gateway_ready
+```
+
+The bot identifies with an online presence of `Watching Arrakis status`. That presence helps confirm the bot user is connected, but the bot still must be installed with the `bot` scope and have channel permissions to appear as a visible member.
+
+## Usage guide
+
+Basic checks:
+
+```text
+/dune help
+/dune version
+/dune health
+```
+
+Public status:
+
+```text
+/dune status public
+```
+
+Admin-only diagnostic status:
+
+```text
+/dune status detail
+```
+
+Operational summaries:
+
+```text
+/dune readiness
+/dune services
+```
+
+Most responses are ephemeral to reduce channel noise and avoid leaking operational details. `/dune status public` is the public channel-safe command.
+
+## Role matrix
+
+The backend adapter enforces capabilities. Discord role names are not trusted authorization claims; Discord sends role IDs, and those IDs must be mapped in the local environment.
+
+| Bot role tier | Environment variable | Capabilities | Current commands |
+| --- | --- | --- | --- |
+| Public / no mapped role | none | `status:read` public-safe only | `/dune health`, `/dune status public`, `/dune help`, `/dune version` |
+| Observer | `DISCORD_OBSERVER_ROLE_IDS` | `status:read`, `readiness:read`, `services:read` | Public commands plus `/dune readiness`, `/dune services` |
+| Moderator | `DISCORD_MODERATOR_ROLE_IDS` | Observer capabilities plus future read-only population/map/backup visibility | Same as Observer in current release unless future read-only routes are enabled |
+| Admin | `DISCORD_ADMIN_ROLE_IDS` | Moderator capabilities plus `logs:read` / diagnostic visibility | `/dune status detail` plus lower-tier commands |
+| Owner | `DISCORD_OWNER_ROLE_IDS` | Admin-equivalent for current read-only release | `/dune status detail` plus lower-tier commands |
+
+Current release contains no write-capable Discord commands. Future write/moderator commands must be separately approved, disabled by default, threat-modeled, audited, and guarded by explicit backend authorization.
+
+## Troubleshooting
+
+### Slash command works, but bot is not visible as a channel member
+
+Likely cause: the app was installed with only `applications.commands` scope.
+
+Fix:
+
+```bash
+cd discord-bot
+source "$HOME/.config/dune-console/discord-bot.env"
+npm run discord:invite
+```
+
+Open the generated URL and install with `bot applications.commands` scopes. Then grant the bot channel permissions with `npm run discord:channel` or through Discord channel settings.
+
+### Bot has no icon
+
+Upload the application icon and bot avatar in Discord Developer Portal. This is Discord-side application configuration.
+
+### `/dune health` fails
+
+Check the local adapter:
+
+```bash
+TOKEN="$(cat "$HOME/.config/dune-console/dune-bot-api-token.txt")"
+curl -i -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8090/api/integrations/discord/health
+```
+
+### Commands do not update
+
+Guild slash commands usually update quickly, but stale Discord clients can cache command menus. Restart the Discord client and confirm the runtime logs show `slash_commands_registered`.
+
+### Permission denied for `/dune readiness` or `/dune services`
+
+Run discovery and confirm the mapped role IDs match the user roles Discord sends:
+
+```bash
+cd discord-bot
+source "$HOME/.config/dune-console/discord-bot.env"
+npm run discord:discover -- --guild "Spice Is Power"
+```
+
+Then update the role mapping variables in `discord-bot.env`.
+
+## Validation
+
+From `discord-bot/`:
+
+```bash
+npm test
+npm run security:secrets
+npm run build
+```
+
+From `console/api/`:
+
+```bash
+node --test test/discord*.test.js
+```
+
+## Security notes
+
+- The bot does not mount the Docker socket.
+- The bot does not connect directly to Postgres.
+- The bot does not execute destructive commands.
+- Responses are redacted and mention-safe.
+- Runtime secrets remain local files and must not be committed.
+- Generated artifacts and local runtime state are fork-local and must not be sent upstream.

--- a/docs/discord-control-bot/development-standards.md
+++ b/docs/discord-control-bot/development-standards.md
@@ -1,0 +1,216 @@
+# Dune Discord Control Bot - Development Standards
+
+## Purpose
+
+This document defines the engineering standards for the Discord Control Bot and its Dune Console API adapter. The upstreamable scope is a read-only Discord companion that provides safe operational visibility. Full WebUI parity, moderator write commands, evidence automation, and compliance artifact generation remain separate fork-local or future work unless explicitly approved upstream.
+
+## Core Engineering Standards
+
+1. Keep Discord client logic separate from Dune Console API adapter logic.
+2. Do not duplicate privileged WebUI backend logic inside the bot.
+3. Do not add Discord write/mutation commands in the read-only release.
+4. Prefer allowlists over denylists for service names, command names, file paths, and action types.
+5. Use structured logging with redaction.
+6. Treat all Discord inputs as untrusted.
+7. Test authorization behavior before feature completeness.
+8. Require PR review before merge.
+9. Update setup, usage, and role-matrix documentation when behavior changes.
+10. Keep generated artifacts, runtime state, passwords, tokens, and evidence bundles out of upstream PRs.
+
+## Architecture Standards
+
+### Required Separation of Concerns
+
+| Layer | Responsibility | Must Not Do |
+| --- | --- | --- |
+| Discord Bot Client | Discord connection, slash commands, interaction UX, formatting | Final authorization, direct Docker control, direct destructive DB writes |
+| Dune Console Discord API Adapter | Bot auth, server-side authorization, audit, safe read-only routing | Expose broad unauthenticated WebUI APIs |
+| Existing Console Backend | Reuse WebUI read paths and safety behavior | Trust Discord client-only checks |
+| Dune Stack | Existing Docker/Postgres/RabbitMQ/game services | Accept direct unreviewed bot mutations |
+
+## Secure Coding Standards
+
+### Input Validation
+
+All input from Discord, HTTP requests, environment variables, files, and database queries must be validated before use.
+
+Required patterns:
+
+- Validate command names against allowlists.
+- Validate role IDs and channel IDs as strings, never as trusted authorization claims.
+- Validate service names against known service allowlists.
+- Validate file paths with safe relative path helpers where file reads are required.
+- Validate numeric ranges for ports, limits, counts, and timeouts.
+
+### Output Handling
+
+1. Redact secrets before logging or sending responses.
+2. Public Discord responses must not include internal IPs, SSH hosts, DB URLs, tokens, raw `.env` values, or stack traces.
+3. Admin diagnostic output must require admin/owner capability.
+4. Large responses must be paginated or summarized.
+5. Errors must use safe messages.
+6. Discord responses must set `allowed_mentions: { parse: [] }` unless a future feature explicitly needs mentions and has a separate review.
+
+### Command Execution
+
+1. The bot must not use `child_process.exec` for Discord-originated actions.
+2. The bot must not spawn shell commands for admin actions.
+3. Backend execution must use existing Console backend wrappers.
+4. If process execution is required in backend code, use fixed command paths and argument arrays; avoid shell interpolation.
+
+### Database Access
+
+1. The bot must not connect directly to Postgres.
+2. The read-only release must not add database write behavior.
+3. Any future database write feature must be separately approved, owner-only, typed-confirmed, audited, rate-limited, and backed up first where supported.
+4. Do not concatenate user input into SQL statements.
+
+### Secrets
+
+1. Use file-based runtime secrets: `*_TOKEN_FILE`, `*_PASSWORD_FILE` where possible.
+2. Do not commit `.env` files containing secrets.
+3. Do not store the Discord bot token in addon files, static WebUI addon files, source files, tests, docs, logs, or container layers.
+4. Do not echo secrets in Discord.
+5. Do not log request bodies that may contain secrets.
+6. Do not upstream generated runtime state, local evidence bundles, vulnerability artifacts, passwords, tokens, or session secrets.
+
+## Branching and Pull Request Standards
+
+### Branch Naming
+
+Use descriptive branches:
+
+```text
+feature/discord-control-bot
+feature/discord-api-adapter
+security/discord-authz-gates
+fix/discord-redaction-leak
+```
+
+### Pull Request Requirements
+
+Every upstream PR must include:
+
+1. Purpose summary.
+2. Risk classification.
+3. Test evidence.
+4. Security impact statement.
+5. Rollback plan.
+6. Screenshots/log snippets if user-facing behavior changes.
+7. Updated docs if behavior or controls change.
+8. Confirmation that no generated runtime files, artifacts, passwords, or secrets are included.
+
+Privileged future-feature PRs must also include:
+
+1. Threat model update.
+2. Authorization matrix update.
+3. Confirmation matrix update.
+4. Audit event mapping.
+5. DAST test cases.
+6. Explicit owner approval.
+
+## Definition of Done
+
+A feature is not done until all applicable items are complete:
+
+```text
+[ ] Code is reviewed.
+[ ] Unit tests pass.
+[ ] Authorization tests pass.
+[ ] Redaction tests pass.
+[ ] Secret scan passes.
+[ ] Container checks pass if container files changed.
+[ ] Documentation is updated.
+[ ] Rollback path is documented.
+[ ] Upstream diff excludes generated artifacts, runtime state, passwords, tokens, and local evidence bundles.
+```
+
+## Testing Standards
+
+### Required Test Layers
+
+| Test Type | Required For |
+| --- | --- |
+| Unit tests | All modules |
+| Authorization matrix tests | Every command and API route |
+| Redaction tests | All logging and response formatting |
+| Integration tests | API adapter and bot client interaction |
+| Container tests | Dockerfile and Compose changes |
+| Regression tests | Every fixed security issue |
+
+### Test Naming
+
+Tests should describe policy intent:
+
+```text
+redacts postgres connection string in error output
+rejects unmapped observer command
+blocks write-capable Discord command registration
+blocks Docker socket mount in bot compose
+```
+
+## Logging Standards
+
+Use structured logs. Required fields where applicable:
+
+```json
+{
+  "service": "dune-discord-companion-bot",
+  "event": "command.received",
+  "discordGuildId": "...",
+  "discordChannelId": "...",
+  "discordUserId": "...",
+  "command": "/dune status",
+  "result": "success|failed|blocked"
+}
+```
+
+Forbidden in logs:
+
+- Discord bot token.
+- Dune bot API token.
+- Admin password.
+- Database password.
+- Funcom token.
+- Full database URL.
+- Raw `.env` file content.
+- Full request body for secret-bearing routes.
+
+## Audit Standards
+
+Every Discord-originated adapter request should emit an audit event with:
+
+1. Source: `discord`.
+2. Discord actor context.
+3. Command and normalized action.
+4. Target object, if any.
+5. Risk level.
+6. Authorization decision.
+7. Result.
+8. Error reason if blocked or failed.
+
+## Release Standards
+
+A release candidate requires:
+
+1. Passing tests.
+2. Passing secret scan.
+3. Passing container checks if container files changed.
+4. Release notes.
+5. Rollback instructions.
+6. No open critical/high security findings unless exception is approved and time-bound.
+
+## Exception Handling
+
+Security exceptions must include:
+
+1. Finding ID.
+2. Affected component.
+3. Risk rating.
+4. Reason for exception.
+5. Compensating controls.
+6. Owner.
+7. Expiration date.
+8. Review cadence.
+
+Permanent exceptions are not allowed for critical or high-risk findings.

--- a/docs/discord-control-bot/feature-priority.md
+++ b/docs/discord-control-bot/feature-priority.md
@@ -1,0 +1,100 @@
+# Dune Discord Companion Bot - Feature Priority Plan
+
+## Product Goal
+
+Build an experimental Discord companion bot for Dune Docker Console that starts read-only and provides safe operational visibility for server operators.
+
+The initial bot is not a full WebUI replacement. It is a companion interface for status, readiness, and service visibility. Dune Docker Console remains the authority for backend authorization, safety checks, redaction, audit logging, and execution.
+
+## Initial Upstream Scope
+
+| Domain | Initial Commands / Functions | Risk |
+| --- | --- | --- |
+| Status | `/dune status public`, `/dune status detail`, `/dune health`, `/dune version` | Low/Medium due diagnostic split |
+| Readiness | `/dune readiness` | Low |
+| Services | `/dune services` | Low/Medium |
+| Help | `/dune help` | Low |
+| Setup helpers | OAuth install URL, guild/channel/role discovery, channel permission helper | Medium due Discord permission changes |
+
+## Out of Scope for the Experimental Upstream Bot
+
+The following are explicitly out of scope until the read-only bot is stable, reviewed, and separately approved:
+
+1. Docker socket mounting.
+2. Direct database access from the bot process.
+3. Backup create, restore, delete, or delete-all.
+4. Player grants, teleport, kick, refill, reset progression, or inventory mutation.
+5. Broadcasts and shutdown broadcasts.
+6. Map, sietch, or deep desert mutation.
+7. Addon install, enable, disable, or remove.
+8. Credential-setting workflows.
+9. Any destructive action.
+10. Fork-local evidence automation, generated scan outputs, and local runtime state.
+
+## Priority Model
+
+| Priority | Meaning |
+| --- | --- |
+| P0 | Foundational security, protected Console API contract, redaction, and authorization tests. |
+| P1 | Experimental read-only companion bot: status, health, readiness, and services. |
+| P2 | Operational hardening: pagination, redaction tuning, rate limits, audit review, role/channel mapping UI, alerting. |
+| P3 | Separately approved non-destructive admin conveniences, if any, after a security review. |
+| P4 | Future platform evolution. Full WebUI parity remains a long-term option, not the current delivery target. |
+
+## P0 - Security Foundation and Delivery Gates
+
+These must be implemented before connecting the bot to Discord or exposing adapter routes.
+
+1. Dedicated branch and isolated bot workspace.
+2. Secure configuration contract for Discord and Console credentials.
+3. Redaction library for sensitive output, connection strings, host paths, and sensitive headers.
+4. Discord actor context model: guild ID, channel ID, user ID, username, roles, command, interaction ID.
+5. Role-to-capability authorization model.
+6. Read-only capability enforcement for experimental routes.
+7. Audit event schema for Discord-originated adapter requests.
+8. Rate-limit and idempotency design for slash commands.
+9. Architecture documentation that prohibits Docker socket access and direct database writes from the bot.
+10. Setup helpers that avoid manual ID hunting.
+
+## P1 - Experimental Read-Only Bot
+
+The first working bot release should expose only read-only commands.
+
+| Domain | Commands / Functions | Required Control |
+| --- | --- | --- |
+| Health | `/dune health`, `/dune version` | Public-safe sanitized output |
+| Status | `/dune status public`, `/dune status detail` | Public/admin response split |
+| Readiness | `/dune readiness` | Observer capability |
+| Services | `/dune services` | Observer capability, no raw Docker access |
+| Setup | `discord:invite`, `discord:discover`, `discord:channel` | Local operator execution only; no credential output |
+
+## P2 - Operational Hardening
+
+1. Public/admin channel classification.
+2. Response pagination and message-size enforcement.
+3. Per-command rate limits.
+4. Audit review command or export.
+5. Bot heartbeat and health dashboard.
+6. Role/channel mapping management in WebUI.
+7. Alerting for status changes, backup failures, and readiness degradation.
+8. Emergency disable flag for all Discord-originated calls.
+
+## P3 - Separately Approved Non-Destructive Enhancements
+
+These require explicit approval and updated threat modeling:
+
+1. Scheduled status posts.
+2. Maintenance notice posts to Discord only, not in-game broadcast.
+3. Owner-only diagnostic bundles with strict redaction.
+
+## Non-Negotiable Security Requirements
+
+1. The bot container must not mount `/var/run/docker.sock`.
+2. The bot must not execute destructive actions.
+3. The bot must not directly write to the database.
+4. The bot must not store credentials in addon files, browser-delivered files, source control, logs, or container layers.
+5. Backend authorization must be enforced server-side, not only in the Discord client.
+6. The Console API must remain responsible for final authorization and safety checks.
+7. Public Discord responses must not expose internal IPs, SSH targets, database URLs, raw environment files, stack traces, or host paths.
+8. Logs must be capped, redacted, and role-gated if log visibility is added later.
+9. Generated artifacts and local runtime state must not be included in upstream PRs.


### PR DESCRIPTION
## Summary

Adds an experimental read-only Discord companion bot and protected Console API adapter for status, readiness, service health, and related operational visibility.

## Scope

This PR is intentionally scoped as one upstreamable Discord bot integration change from the fork. The bot and adapter are read-only.

## Validation

Run Console adapter tests, Discord bot tests, secret scan, and build. Confirm no write-capable Discord commands are included.

## Notes

- This PR avoids generated artifacts, runtime state, local secrets, and fork-only evidence automation.
- No passwords or runtime files are included.
- Discord write/moderator actions are not included.
