### PR TITLE
security: bind admin console locally by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,7 +41,10 @@ BATTLEGROUP_ID=
 # runtime/secrets/funcom-token.txt
 
 # Optional Dune Docker Console web UI.
-ADMIN_BIND_HOST=auto
+# Bind locally by default because the web console can control the Docker daemon.
+# Set ADMIN_BIND_HOST=auto or a specific trusted interface only when protected by
+# a firewall, VPN, or TLS-terminating reverse proxy.
+ADMIN_BIND_HOST=127.0.0.1
 ADMIN_BIND_PORT=8088
 ADMIN_AUTH_DISABLED=0
 ADMIN_SECURE_COOKIES=0

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You do not need to be a Linux expert. Start with a fresh server and the installe
 | Funcom token | You will paste this into the browser setup wizard. |
 | CPU support | The game server needs AVX/AVX2. Most modern dedicated servers and VPS plans expose this. |
 | Disk space | 100 GB or more is recommended. |
-| Web access | Open the Web UI on port `8088` from your browser. You can use the public address or the same-network/local address shown by the installer. |
+| Web access | Open the Web UI on port `8088` from your browser. The console binds to `127.0.0.1` by default; opt into LAN/public binding only when protected by a firewall, VPN, or TLS reverse proxy. |
 
 Memory Guide:
 
@@ -58,7 +58,7 @@ Forward these ports for public/internet hosting:
 
 | Port | Protocol | Purpose |
 |---|---|---|
-| `8088` | TCP | Web admin setup panel |
+| `8088` | TCP | Web admin setup panel. Keep local-only unless access is protected for trusted admins. |
 | `31982` | TCP | Game messaging |
 | `7777-7810` | UDP | Game traffic |
 
@@ -72,7 +72,7 @@ Copy and paste this on a fresh Linux server:
 bash -c 'set -euo pipefail; if ! command -v curl >/dev/null 2>&1; then sudo apt-get update && sudo apt-get install -y ca-certificates curl tar; fi; mkdir -p "$HOME/dune-awakening-selfhost-docker"; cd "$HOME/dune-awakening-selfhost-docker"; latest_url="$(curl -fsSLI -o /dev/null -w "%{url_effective}" https://github.com/Red-Blink/dune-awakening-selfhost-docker/releases/latest)"; version="${latest_url##*/}"; curl -fsSL "https://github.com/Red-Blink/dune-awakening-selfhost-docker/archive/refs/tags/${version}.tar.gz" | tar -xz --strip-components=1; chmod +x install.sh; ./install.sh'
 ```
 
-The installer downloads the latest release, prepares the server, starts the Web UI, and tells you what address to open in your browser. If you are on the same network as the server, use the same-network address. If you are connecting over the internet, use the public address and allow TCP `8088` in your firewall.
+The installer downloads the latest release, prepares the server, starts the Web UI, and tells you what address to open in your browser. The Web UI controls the Docker daemon, so it defaults to local access on `127.0.0.1`. To expose it beyond the host, explicitly set `ADMIN_BIND_HOST=auto` or a trusted interface and protect access with a firewall, VPN, or TLS-terminating reverse proxy. Do not directly expose TCP `8088` to the public internet.
 
 ## Community Addons
 

--- a/console/api/src/config.js
+++ b/console/api/src/config.js
@@ -15,13 +15,16 @@ export function loadConfig() {
 
   const adminPasswordFile = resolve(secretsDir, "admin-web-password.txt");
   const adminPasswordEnvManaged = Boolean(process.env.ADMIN_PASSWORD);
+  const host = resolveAdminBindHost(process.env.ADMIN_BIND_HOST);
+  const authDisabled = process.env.ADMIN_AUTH_DISABLED === "1";
+  assertSafeAuthDisabledMode({ host, authDisabled });
   return {
     appName: APP_NAME,
     repoRoot,
     duneScript: resolve(repoRoot, "runtime/scripts/dune"),
-    host: resolveAdminBindHost(process.env.ADMIN_BIND_HOST),
+    host,
     port: Number(process.env.ADMIN_BIND_PORT || 8088),
-    authDisabled: process.env.ADMIN_AUTH_DISABLED === "1",
+    authDisabled,
     secureCookies: secureCookieEnv === undefined ? process.env.NODE_ENV === "production" : secureCookieEnv === "1",
     allowHostBootstrap: process.env.ALLOW_HOST_BOOTSTRAP === "true",
     mockMode: process.env.ADMIN_MOCK_MODE === "1",
@@ -41,9 +44,19 @@ export function loadConfig() {
 }
 
 function resolveAdminBindHost(value) {
-  const raw = String(value || "0.0.0.0").trim();
+  const raw = String(value || "127.0.0.1").trim();
   if (raw && raw !== "auto") return raw;
   return detectPrivateIpv4() || "127.0.0.1";
+}
+
+function assertSafeAuthDisabledMode({ host, authDisabled }) {
+  if (!authDisabled || isLoopbackHost(host)) return;
+  throw new Error("ADMIN_AUTH_DISABLED=1 is only allowed when ADMIN_BIND_HOST resolves to localhost or loopback.");
+}
+
+function isLoopbackHost(value) {
+  const host = String(value || "").trim().toLowerCase();
+  return host === "localhost" || host === "::1" || host === "[::1]" || host.startsWith("127.");
 }
 
 function detectPrivateIpv4() {

--- a/console/api/test/config.test.js
+++ b/console/api/test/config.test.js
@@ -13,6 +13,7 @@ test("web config exposes safe deployment flags and JSON body limit", () => {
   process.env.ADMIN_MAX_JSON_BYTES = "12345";
   try {
     const config = loadConfig();
+    assert.equal(config.host, "127.0.0.1");
     assert.equal(config.secureCookies, true);
     assert.equal(config.maxJsonBytes, 12345);
     const exposed = publicConfig(config);
@@ -24,6 +25,48 @@ test("web config exposes safe deployment flags and JSON body limit", () => {
 
     process.env.ADMIN_SECURE_COOKIES = "0";
     assert.equal(loadConfig().secureCookies, false);
+  } finally {
+    process.env = previous;
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("web config allows explicit bind hosts when authentication remains enabled", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-bind-"));
+  const previous = { ...process.env };
+  process.env = {
+    ...previous,
+    DUNE_DOCKER_DIR: repoRoot,
+    ADMIN_BIND_HOST: "0.0.0.0",
+    ADMIN_AUTH_DISABLED: "0"
+  };
+  try {
+    assert.equal(loadConfig().host, "0.0.0.0");
+  } finally {
+    process.env = previous;
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("web config refuses auth-disabled mode on non-loopback bind hosts", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-auth-disabled-"));
+  const previous = { ...process.env };
+  process.env = {
+    ...previous,
+    DUNE_DOCKER_DIR: repoRoot,
+    ADMIN_BIND_HOST: "0.0.0.0",
+    ADMIN_AUTH_DISABLED: "1"
+  };
+  try {
+    assert.throws(
+      () => loadConfig(),
+      /ADMIN_AUTH_DISABLED=1 is only allowed/
+    );
+
+    process.env.ADMIN_BIND_HOST = "127.0.0.1";
+    const config = loadConfig();
+    assert.equal(config.host, "127.0.0.1");
+    assert.equal(config.authDisabled, true);
   } finally {
     process.env = previous;
     rmSync(repoRoot, { recursive: true, force: true });

--- a/docker-compose.web.yml
+++ b/docker-compose.web.yml
@@ -17,7 +17,7 @@ services:
       DUNE_HOST_REPO_ROOT: "${DUNE_HOST_REPO_ROOT:-${PWD}}"
       # Make RedBlink dune scripts target the main Dune stack, not this web-only compose project.
       COMPOSE_PROJECT_NAME: "${DUNE_COMPOSE_PROJECT_NAME:-dune-awakening-selfhost-docker}"
-      ADMIN_BIND_HOST: "${ADMIN_BIND_HOST:-0.0.0.0}"
+      ADMIN_BIND_HOST: "${ADMIN_BIND_HOST:-127.0.0.1}"
       ADMIN_BIND_PORT: "${ADMIN_BIND_PORT:-8088}"
       ADMIN_AUTH_DISABLED: "${ADMIN_AUTH_DISABLED:-0}"
       ADMIN_SECURE_COOKIES: "${ADMIN_SECURE_COOKIES:-0}"

--- a/docs/security/admin-safe-defaults.md
+++ b/docs/security/admin-safe-defaults.md
@@ -1,0 +1,100 @@
+# Admin Console Safe Defaults
+
+Branch: `security/admin-safe-defaults`
+
+## Purpose
+
+Reduce the default remote attack surface of the Dune Docker Console while preserving explicit operator opt-in for LAN or public administration.
+
+This change addresses the first remediation slice for the security report findings related to the web admin console binding broadly while holding Docker daemon access.
+
+## Source Findings
+
+Primary source: `C:/Users/ronal/OneDrive/Downloads/security_report.pdf`
+
+Related findings:
+
+- SAST-C1: Docker socket mounted into a host-networked, internet-reachable admin container.
+- DAST-C1: Web admin binds to all interfaces by default while holding the host Docker socket.
+- DAST-C2: Authentication can be disabled and TLS/secure cookies are off by default.
+- SAST-H1: Admin web console defaults to binding all interfaces.
+- SAST-H2: Authentication can be fully disabled while the console controls Docker/DB.
+
+## Architecture Before
+
+- `docker-compose.web.yml` defaulted `ADMIN_BIND_HOST` to `0.0.0.0`.
+- `console/api/src/config.js` also resolved an unset bind host to `0.0.0.0`.
+- `ADMIN_AUTH_DISABLED=1` could be combined with a non-loopback bind host.
+- README guidance allowed opening the web UI through public addresses and firewalling TCP `8088`.
+
+Because the console uses host networking and mounts `/var/run/docker.sock`, a broadly reachable console greatly increases the impact of weak credentials, disabled auth, or any future web/API flaw.
+
+## Architecture After
+
+- Compose defaults `ADMIN_BIND_HOST` to `127.0.0.1`.
+- API config resolves an unset bind host to `127.0.0.1`.
+- Explicit bind hosts still work when authentication remains enabled.
+- `ADMIN_AUTH_DISABLED=1` now fails configuration unless the resolved host is loopback.
+- `.env.example` and README describe `ADMIN_BIND_HOST=auto` or explicit interface binding as an intentional opt-in that should be protected by a firewall, VPN, or TLS reverse proxy.
+
+## Minimal Impact
+
+- No Docker socket behavior changes.
+- No route, API, or UI workflow changes.
+- Existing operators who already set `ADMIN_BIND_HOST` keep their selected binding when authentication is enabled.
+- Local development can still disable auth when binding to `127.0.0.1`, `localhost`, or `::1`.
+
+## Code Evidence
+
+- `console/api/src/config.js:18-20` resolves host and auth state before building the config object.
+- `console/api/src/config.js:46-54` changes the unset bind-host fallback to `127.0.0.1` and rejects auth-disabled non-loopback binding.
+- `console/api/src/config.js:57-59` treats `localhost`, `::1`, `[::1]`, and `127.*` as loopback.
+- `docker-compose.web.yml:20` defaults `ADMIN_BIND_HOST` to `127.0.0.1`.
+- `.env.example` documents local binding as the example default.
+- `README.md:44`, `README.md:61`, and `README.md:75` document local-only default behavior and protected opt-in exposure.
+
+## Test Evidence
+
+Automated:
+
+```bash
+cd /home/ronal/dune-awakening-selfhost-docker-WSL/console/api
+npm ci
+npm test
+```
+
+Result: 145 tests passed.
+
+Compose validation:
+
+```bash
+cd /home/ronal/dune-awakening-selfhost-docker-WSL
+docker compose -f docker-compose.web.yml config >/tmp/dune-compose-web-pr1.yml
+grep -n 'ADMIN_BIND_HOST' /tmp/dune-compose-web-pr1.yml
+```
+
+Result:
+
+```text
+10:      ADMIN_BIND_HOST: 127.0.0.1
+```
+
+Guard smoke:
+
+```bash
+ADMIN_AUTH_DISABLED=1 ADMIN_BIND_HOST=0.0.0.0 DUNE_DOCKER_DIR="$(mktemp -d)" \
+  node --input-type=module -e 'import { loadConfig } from "./console/api/src/config.js"; loadConfig();'
+```
+
+Result: the command exits non-zero with `ADMIN_AUTH_DISABLED=1 is only allowed when ADMIN_BIND_HOST resolves to localhost or loopback.`
+
+Unit coverage added:
+
+- `console/api/test/config.test.js:15-17` verifies the default host is `127.0.0.1`.
+- `console/api/test/config.test.js:34-49` verifies explicit `0.0.0.0` remains allowed when auth is enabled.
+- `console/api/test/config.test.js:51-74` verifies auth-disabled mode rejects non-loopback hosts and remains available on loopback.
+
+## Follow-ups
+
+- Add HTTPS-aware secure-cookie and security-header hardening in a separate PR.
+- Evaluate Docker socket proxy or non-root container changes separately because those are architectural changes with higher compatibility risk.


### PR DESCRIPTION
## Summary
- Bind the web admin console to `127.0.0.1` by default in Compose and API config.
- Reject `ADMIN_AUTH_DISABLED=1` when the resolved bind host is not loopback.
- Update `.env.example`, README guidance, and add a design/security evidence document.

## Findings Addressed
- SAST-C1 / DAST-C1, partial mitigation: reduce default remote exposure while the console has Docker daemon access.
- DAST-C2 / SAST-H2, partial mitigation: prevent auth-disabled mode on non-loopback binds.
- SAST-H1: replace all-interface default bind with localhost.

## Minimal Impact
- Existing explicit `ADMIN_BIND_HOST` values continue to work when auth is enabled.
- Local development can still use `ADMIN_AUTH_DISABLED=1` on loopback.
- No Docker socket, API route, or UI behavior changes beyond safer startup config.

## Design / Architecture Evidence
- See `docs/security/admin-safe-defaults.md`.

## Tests
- `cd console/api && npm ci && npm test` -> 145 passing
- `docker compose -f docker-compose.web.yml config` confirms `ADMIN_BIND_HOST: 127.0.0.1`
- Manual guard smoke confirms `ADMIN_AUTH_DISABLED=1 ADMIN_BIND_HOST=0.0.0.0` exits with a configuration error

## Follow-ups
- HTTPS-aware secure-cookie/security-header hardening should remain separate.
- Docker socket proxy or non-root architecture should remain separate because it has higher compatibility risk.