### PR TITLE
security: generate command auth tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,8 +64,8 @@ ADMIN_MOCK_MODE=0
 # DUNE_DB_USER=dune
 # DUNE_DB_PASSWORD=dune
 
-# Optional RabbitMQ/server-command override. Normally the web admin reads
-# runtime/secrets/command-auth-token.txt or uses the RedBlink built-in token.
+# Optional RabbitMQ/server-command override. Normally the web admin reads or
+# creates runtime/secrets/command-auth-token.txt with local 0600 permissions.
 # DUNE_COMMAND_AUTH_TOKEN=
 
 # Optional runtime path override when the web admin is run outside this repo.

--- a/console/api/src/rmq.js
+++ b/console/api/src/rmq.js
@@ -1,11 +1,11 @@
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
-import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { randomBytes, randomUUID } from "node:crypto";
 import { redact } from "./redact.js";
 
-const BUILTIN_COMMAND_AUTH_TOKEN = "Nu6VmPWUMvdPMeB7qErr";
 const RMQ_CONTAINER = "dune-rmq-game";
+const COMMAND_AUTH_TOKEN_BYTES = 32;
 
 export function validateBroadcastMessage(message) {
   const raw = String(message || "").trim();
@@ -226,14 +226,22 @@ export function validatePublishLabel(value) {
   throw new Error("Invalid RabbitMQ publish label");
 }
 
-function commandAuthToken(repoRoot) {
+export function commandAuthToken(repoRoot) {
   const file = resolve(repoRoot, "runtime/secrets/command-auth-token.txt");
   if (process.env.DUNE_COMMAND_AUTH_TOKEN) return process.env.DUNE_COMMAND_AUTH_TOKEN;
   if (existsSync(file)) {
     const raw = readFileSync(file, "utf8").trim();
     if (raw) return raw;
   }
-  return BUILTIN_COMMAND_AUTH_TOKEN;
+  const token = randomBytes(COMMAND_AUTH_TOKEN_BYTES).toString("base64url");
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, `${token}\n`, { mode: 0o600 });
+  try {
+    chmodSync(file, 0o600);
+  } catch {
+    // Best effort on non-POSIX development hosts.
+  }
+  return token;
 }
 
 function dockerExec(args, timeoutMs = 30000) {

--- a/console/api/test/rmq.test.js
+++ b/console/api/test/rmq.test.js
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildBroadcastCommand, buildCarePackageWhisperPayload, buildMapChatPayload, buildShutdownBroadcastCommand, publishCarePackageWhisper, publishMapChat, validateBroadcastMessage, validateLocalizedTexts, validatePublishLabel } from "../src/rmq.js";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { buildBroadcastCommand, buildCarePackageWhisperPayload, buildMapChatPayload, buildShutdownBroadcastCommand, commandAuthToken, publishCarePackageWhisper, publishMapChat, validateBroadcastMessage, validateLocalizedTexts, validatePublishLabel } from "../src/rmq.js";
 
 test("builds verified ServiceBroadcast generic command payload", () => {
   const command = buildBroadcastCommand({ message: "Server event starts soon", durationSec: 45, title: "Event" });
@@ -105,6 +108,46 @@ test("validates RabbitMQ publish labels before eval construction", () => {
   assert.equal(validatePublishLabel("web_shutdown_1"), "web_shutdown_1");
   assert.throws(() => validatePublishLabel("bad label"));
   assert.throws(() => validatePublishLabel("bad\"), halt(). %"));
+});
+
+test("command auth token generates and reuses a local secret file", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-rmq-token-"));
+  const previous = process.env.DUNE_COMMAND_AUTH_TOKEN;
+  delete process.env.DUNE_COMMAND_AUTH_TOKEN;
+  try {
+    const tokenFile = resolve(repoRoot, "runtime/secrets/command-auth-token.txt");
+    const token = commandAuthToken(repoRoot);
+    assert.match(token, /^[A-Za-z0-9_-]{40,}$/);
+    assert.equal(existsSync(tokenFile), true);
+    assert.equal(readFileSync(tokenFile, "utf8").trim(), token);
+    assert.equal(statSync(tokenFile).mode & 0o777, 0o600);
+    assert.equal(commandAuthToken(repoRoot), token);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.DUNE_COMMAND_AUTH_TOKEN;
+    } else {
+      process.env.DUNE_COMMAND_AUTH_TOKEN = previous;
+    }
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("command auth token honors explicit environment override", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-rmq-token-env-"));
+  const previous = process.env.DUNE_COMMAND_AUTH_TOKEN;
+  process.env.DUNE_COMMAND_AUTH_TOKEN = "explicit-token";
+  try {
+    const tokenFile = resolve(repoRoot, "runtime/secrets/command-auth-token.txt");
+    assert.equal(commandAuthToken(repoRoot), "explicit-token");
+    assert.equal(existsSync(tokenFile), false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.DUNE_COMMAND_AUTH_TOKEN;
+    } else {
+      process.env.DUNE_COMMAND_AUTH_TOKEN = previous;
+    }
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
 });
 
 test("publishes map chat to chat.map routing key", async () => {

--- a/docs/security/generated-command-auth-token.md
+++ b/docs/security/generated-command-auth-token.md
@@ -1,0 +1,103 @@
+# Generated Command Auth Token
+
+Branch: `security/generated-command-auth-token`
+
+## Purpose
+
+Remove the shared built-in RabbitMQ server-command auth token and generate a deployment-local secret on first use.
+
+This keeps the existing command channel behavior but changes the default secret source from public source code to `runtime/secrets/command-auth-token.txt`.
+
+## Source Findings
+
+Primary source: `C:/Users/ronal/OneDrive/Downloads/security_report.pdf`
+
+Related finding:
+
+- SAST-H3: Hardcoded built-in RabbitMQ command auth token.
+
+Related low-severity context:
+
+- SAST-L4 notes that command publishing paths should share the same hardening direction.
+
+## Architecture Before
+
+- `console/api/src/rmq.js` contained a public built-in token constant.
+- `runtime/scripts/admin-tools.sh` contained the same public built-in token constant.
+- If `DUNE_COMMAND_AUTH_TOKEN` and `runtime/secrets/command-auth-token.txt` were absent, both paths used the source-controlled fallback.
+- Every deployment without an override therefore shared the same command-channel secret.
+
+## Architecture After
+
+- `DUNE_COMMAND_AUTH_TOKEN` remains the highest-precedence explicit override.
+- If `runtime/secrets/command-auth-token.txt` exists and is non-empty, both Node and shell paths reuse it.
+- If no token exists, the Node path creates a random 32-byte base64url token and writes it with `0600` permissions.
+- If no token exists, the shell path creates a random 32-byte hex token with `openssl rand -hex 32` and writes it with `0600` permissions.
+- The public built-in token constant is removed from source.
+
+## Minimal Impact
+
+- Existing deployments with `DUNE_COMMAND_AUTH_TOKEN` keep working.
+- Existing deployments with `runtime/secrets/command-auth-token.txt` keep working.
+- New deployments generate a local secret automatically instead of failing closed or requiring extra setup.
+- RabbitMQ publish payload shape and routing are unchanged.
+
+## Code Evidence
+
+- `console/api/src/rmq.js:7-8` defines the container name and token byte count without a built-in token value.
+- `console/api/src/rmq.js:229-245` resolves env override, reuses the secret file, or creates a new `0600` secret.
+- `runtime/scripts/admin-tools.sh:10-11` keeps the same shared token file path.
+- `runtime/scripts/admin-tools.sh:133-149` resolves env override and secret-file reuse before generation.
+- `runtime/scripts/admin-tools.sh:152-162` generates a local token with `openssl rand -hex 32` and writes it with `0600` permissions.
+- `.env.example:67-69` documents that the file is read or created locally.
+
+## Test Evidence
+
+Targeted shell assertion:
+
+```bash
+cd /home/ronal/dune-awakening-selfhost-docker-WSL
+bash runtime/tests/test-command-auth-token.sh
+```
+
+Result:
+
+```text
+PASS: command auth token is generated instead of built in
+```
+
+Syntax checks:
+
+```bash
+bash -n runtime/scripts/admin-tools.sh runtime/tests/test-command-auth-token.sh
+```
+
+Result: passed.
+
+API unit tests:
+
+```bash
+cd /home/ronal/dune-awakening-selfhost-docker-WSL/console/api
+npm test
+```
+
+Result: 145 tests passed.
+
+Unit coverage added:
+
+- `console/api/test/rmq.test.js:113-133` verifies the Node path generates, stores, chmods, and reuses a local token.
+- `console/api/test/rmq.test.js:135-150` verifies `DUNE_COMMAND_AUTH_TOKEN` remains an explicit override and does not create a file.
+
+Static source check:
+
+```bash
+grep -RIn -- 'Nu6VmPWUMvdPMeB7qErr\|BUILTIN_COMMAND_AUTH_TOKEN' console/api/src runtime/scripts .env.example
+```
+
+Result: no matches.
+
+## Follow-ups
+
+- Consider adding a rotation command that regenerates the token and restarts dependent services.
+- Continue hardening RabbitMQ TLS and management exposure in separate PRs.
+

--- a/runtime/scripts/admin-tools.sh
+++ b/runtime/scripts/admin-tools.sh
@@ -9,7 +9,6 @@ SKILL_MODULES_FILE="runtime/data/admin-skill-modules.json"
 XP_EVENT_TAGS_FILE="runtime/data/admin-xp-event-tags.json"
 TOKEN_FILE="runtime/secrets/funcom-token.txt"
 COMMAND_TOKEN_FILE="runtime/secrets/command-auth-token.txt"
-BUILTIN_COMMAND_AUTH_TOKEN="Nu6VmPWUMvdPMeB7qErr"
 RMQ_CONTAINER="dune-rmq-game"
 POSTGRES_CONTAINER="dune-postgres"
 ADMIN_HISTORY_TSV="runtime/generated/admin-command-history.tsv"
@@ -147,8 +146,20 @@ command_auth_token() {
     fi
   fi
 
-  # Matches the working upstream manager's command-auth fallback.
-  printf '%s' "$BUILTIN_COMMAND_AUTH_TOKEN"
+  generate_command_auth_token
+}
+
+generate_command_auth_token() {
+  local token
+
+  mkdir -p "$(dirname "$COMMAND_TOKEN_FILE")"
+  token="$(openssl rand -hex 32)"
+  (
+    umask 077
+    printf '%s\n' "$token" > "$COMMAND_TOKEN_FILE"
+  )
+  chmod 600 "$COMMAND_TOKEN_FILE" 2>/dev/null || true
+  printf '%s' "$token"
 }
 
 require_rmq_game_running() {

--- a/runtime/tests/test-command-auth-token.sh
+++ b/runtime/tests/test-command-auth-token.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+
+  grep -Fq -- "$pattern" "$file" || fail "$file missing: $pattern"
+}
+
+assert_not_contains_anywhere() {
+  local pattern="$1"
+  local output
+  shift
+  output="$(mktemp)"
+
+  if grep -RIn -- "$pattern" "$@" >"$output"; then
+    cat "$output" >&2
+    rm -f "$output"
+    fail "unexpected source match: $pattern"
+  fi
+  rm -f "$output"
+}
+
+assert_not_contains_anywhere 'Nu6VmPWUMvdPMeB7qErr' console/api/src runtime/scripts .env.example
+assert_not_contains_anywhere 'BUILTIN_COMMAND_AUTH_TOKEN' console/api/src runtime/scripts
+assert_contains runtime/scripts/admin-tools.sh 'generate_command_auth_token'
+assert_contains runtime/scripts/admin-tools.sh 'openssl rand -hex 32'
+assert_contains console/api/src/rmq.js 'randomBytes(COMMAND_AUTH_TOKEN_BYTES).toString("base64url")'
+assert_contains .env.example 'creates runtime/secrets/command-auth-token.txt'
+
+echo "PASS: command auth token is generated instead of built in"


### PR DESCRIPTION
## Summary
- Remove the shared built-in RabbitMQ command auth token from Node and shell sources.
- Generate `runtime/secrets/command-auth-token.txt` on first use with local `0600` permissions.
- Preserve `DUNE_COMMAND_AUTH_TOKEN` as the explicit override.
- Add unit/static tests and a design/security evidence document.

## Findings Addressed
- SAST-H3: hardcoded built-in RabbitMQ command auth token.
- SAST-L4, partial: align command-publish hardening around generated local secrets.

## Minimal Impact
- Existing `DUNE_COMMAND_AUTH_TOKEN` deployments keep working.
- Existing `runtime/secrets/command-auth-token.txt` deployments keep working.
- New installs automatically create a local token instead of using a public fallback.
- RabbitMQ payload shape and routing are unchanged.

## Design / Architecture Evidence
- See `docs/security/generated-command-auth-token.md`.

## Tests
- `bash runtime/tests/test-command-auth-token.sh` -> passing
- `bash -n runtime/scripts/admin-tools.sh runtime/tests/test-command-auth-token.sh` -> passing
- `cd console/api && npm test` -> 145 passing
- Static source grep for the old public token and `BUILTIN_COMMAND_AUTH_TOKEN` -> no matches

## Follow-ups
- A token rotation command can be added separately.
- RabbitMQ TLS and management-auth hardening should stay separate.