### PR TITLE
Make first-online care packages durable per player

### DIFF
--- a/console/api/src/carePackage.js
+++ b/console/api/src/carePackage.js
@@ -33,6 +33,8 @@ const DEFAULT_KIT = {
   sendMessage: ""
 };
 
+const firstOnlineClaimLocks = new Set();
+
 const DEFAULT_CONFIG = {
   enabled: true,
   version: DEFAULT_KIT_ID,
@@ -109,7 +111,7 @@ export function clearCarePackageHistory(config) {
   mkdirSync(dirname(file), { recursive: true });
   writeFileSync(file, "", { mode: 0o600 });
   try { chmodSync(file, 0o600); } catch {}
-  return { ok: true, removed, rows: [] };
+  return { ok: true, removed, rows: [], firstOnlineClaimsPreserved: true };
 }
 
 function normalizeHistoryRow(row = {}) {
@@ -146,7 +148,8 @@ export function carePackageEligiblePlayers(config, players = [], options = {}) {
   const rule = options.ruleId ? kitConfig.autoGrantRules.find((entry) => entry.id === options.ruleId) : null;
   const kit = rule ? selectedKit(kitConfig, rule.kitId, rule.grantWhen, rule.lastSeenDays) : selectedKit(kitConfig, kitConfig.autoGrantKitId);
   const history = carePackageHistory(config, 500).rows;
-  const rows = players.map((player) => eligibilityForPlayer(kit, history, normalizePlayer(player)));
+  const firstOnlineClaims = readFirstOnlineClaims(config);
+  const rows = players.map((player) => eligibilityForPlayer(kit, history, normalizePlayer(player), { firstOnlineClaims }));
   return {
     config: kitConfig,
     kit,
@@ -204,10 +207,11 @@ export async function runCarePackageAutoScan(config, players = [], source = "aut
       continue;
     }
     const history = carePackageHistory(config, 500).rows;
+    const firstOnlineClaims = readFirstOnlineClaims(config);
     const rows = players.map((player) => {
       const normalized = normalizePlayer(player);
-      if (kit.grantWhen !== "last_seen") return eligibilityForPlayer(kit, history, normalized, { requireOnline: true });
-      return lastSeenReturnEligibility(config, pendingReturns, kit, rule, history, normalized);
+      if (kit.grantWhen !== "last_seen") return eligibilityForPlayer(kit, history, normalized, { requireOnline: true, firstOnlineClaims });
+      return lastSeenReturnEligibility(config, pendingReturns, kit, rule, history, normalized, { firstOnlineClaims });
     });
     for (const player of rows) {
       if (!player.eligible) {
@@ -247,15 +251,25 @@ export async function grantCarePackage(config, playerId, body = {}, context = {}
   const kit = selectedKit(kitConfig, body.kitId || (source === "manual" ? kitConfig.activeKitId : kitConfig.autoGrantKitId));
   validatePlayerTarget(playerId);
   if (!kit.items.length && !kit.xp) throw new Error("Care Package has no configured items or XP");
-  if (source !== "manual" && body.grantWhen === "first_online" && hasSuccessfulFirstOnlineGrant(carePackageHistory(config, 500).rows, {
+
+  const grantIdentity = {
+    playerId,
     action_player_id: playerId,
     actor_id: body.actorId || "",
     account_id: body.accountId || body.account_id || "",
     funcom_id: body.funcomId || body.funcom_id || "",
-    fls_id: body.flsId || body.fls_id || ""
-  })) {
-    throw new Error(`A first-online Care Package was already granted to ${playerId}`);
+    fls_id: body.flsId || body.fls_id || "",
+    character_name: body.characterName || ""
+  };
+  const firstOnlineGrant = shouldUseFirstOnlineClaim(kitConfig, kit, source, body);
+  let firstOnlineClaim = null;
+  if (firstOnlineGrant) {
+    firstOnlineClaim = claimFirstOnlineGrant(config, kit, grantIdentity, source);
+    if (firstOnlineClaim.alreadyClaimed && source !== "manual") {
+      throw new Error(`A first-online Care Package was already granted to ${playerId}`);
+    }
   }
+
   if (source !== "manual" && hasSuccessfulGrant(config, playerId, kit.id, body.actorId, body)) {
     throw new Error(`Care Package ${kit.name} was already granted to ${playerId}`);
   }
@@ -353,6 +367,9 @@ export async function grantCarePackage(config, playerId, body = {}, context = {}
     results
   };
   appendGrant(config, row);
+  if (firstOnlineClaim?.claimed && !hasDeliveredCarePackageContent(row)) {
+    releaseFirstOnlineClaim(config, firstOnlineClaim.primaryKey);
+  }
   return row;
 }
 
@@ -394,7 +411,7 @@ function eligibilityForPlayer(kit, history, player, options = {}) {
   if (kit.grantWhen === "first_online" && String(player.online_status || "").toLowerCase() !== "online") {
     return { ...player, eligible: false, reason: "Not currently online" };
   }
-  if (kit.grantWhen === "first_online" && hasSuccessfulFirstOnlineGrant(history, player)) {
+  if (kit.grantWhen === "first_online" && (hasSuccessfulFirstOnlineGrant(history, player) || hasFirstOnlineClaim(options.firstOnlineClaims, player))) {
     return { ...player, eligible: false, reason: "Already received first-online Care Package" };
   }
   if (kit.grantWhen === "last_seen") {
@@ -415,8 +432,8 @@ function eligibilityForPlayer(kit, history, player, options = {}) {
   return { ...player, eligible: true, reason: "" };
 }
 
-function lastSeenReturnEligibility(config, pendingReturns, kit, rule, history, player) {
-  const staleEligibility = eligibilityForPlayer(kit, history, player);
+function lastSeenReturnEligibility(config, pendingReturns, kit, rule, history, player, options = {}) {
+  const staleEligibility = eligibilityForPlayer(kit, history, player, options);
   const online = String(player.online_status || "").toLowerCase() === "online";
   const key = pendingReturnKey(kit, rule, player);
   const pending = Boolean(pendingReturns[key]);
@@ -431,6 +448,106 @@ function lastSeenReturnEligibility(config, pendingReturns, kit, rule, history, p
   }
   if (online && staleEligibility.eligible) return staleEligibility;
   return staleEligibility;
+}
+
+
+function shouldUseFirstOnlineClaim(kitConfig, kit, source, body = {}) {
+  const grantWhen = body.grantWhen || kit.grantWhen || kitConfig.grantWhen;
+  if (grantWhen === "first_online") return true;
+  if (source !== "manual") return false;
+  return kitConfig.autoGrantRules.some((rule) => rule.enabled && rule.grantWhen === "first_online" && rule.kitId === kit.id);
+}
+
+function claimFirstOnlineGrant(config, kit, identity, source) {
+  const keys = firstOnlineIdentityKeys(identity);
+  if (!keys.length) return { claimed: false, alreadyClaimed: false, primaryKey: "" };
+  const primaryKey = keys[0];
+  const lockKey = `first_online:${primaryKey}`;
+  if (firstOnlineClaimLocks.has(lockKey)) return { claimed: false, alreadyClaimed: true, primaryKey };
+  firstOnlineClaimLocks.add(lockKey);
+  try {
+    const claims = readFirstOnlineClaims(config);
+    if (hasFirstOnlineClaim(claims, identity)) return { claimed: false, alreadyClaimed: true, primaryKey };
+    const now = new Date().toISOString();
+    const claim = {
+      claimedAt: now,
+      source,
+      kitId: kit.id,
+      kitName: kit.name,
+      characterName: identity.character_name || "",
+      identities: firstOnlineIdentityMap(identity)
+    };
+    claims.players[primaryKey] = claim;
+    for (const key of keys) claims.aliases[key] = primaryKey;
+    writeFirstOnlineClaims(config, claims);
+    return { claimed: true, alreadyClaimed: false, primaryKey };
+  } finally {
+    firstOnlineClaimLocks.delete(lockKey);
+  }
+}
+
+function releaseFirstOnlineClaim(config, primaryKey) {
+  if (!primaryKey) return;
+  const claims = readFirstOnlineClaims(config);
+  if (!claims.players[primaryKey]) return;
+  delete claims.players[primaryKey];
+  for (const [key, value] of Object.entries(claims.aliases || {})) {
+    if (value === primaryKey) delete claims.aliases[key];
+  }
+  writeFirstOnlineClaims(config, claims);
+}
+
+function hasFirstOnlineClaim(claims, identity) {
+  if (!claims || typeof claims !== "object") return false;
+  const players = claims.players || {};
+  const aliases = claims.aliases || {};
+  return firstOnlineIdentityKeys(identity).some((key) => Boolean(players[key] || aliases[key]));
+}
+
+function firstOnlineIdentityMap(entity = {}) {
+  return {
+    account_id: String(entity.account_id || entity.accountId || "").trim(),
+    funcom_id: String(entity.funcom_id || entity.funcomId || "").trim(),
+    fls_id: String(entity.fls_id || entity.flsId || "").trim(),
+    action_player_id: String(entity.action_player_id || entity.actionPlayerId || entity.playerId || "").trim(),
+    actor_id: String(entity.actor_id || entity.actorId || entity.player_pawn_id || "").trim()
+  };
+}
+
+function firstOnlineIdentityKeys(entity = {}) {
+  const identities = firstOnlineIdentityMap(entity);
+  return [
+    ["account_id", identities.account_id],
+    ["funcom_id", identities.funcom_id],
+    ["fls_id", identities.fls_id],
+    ["action_player_id", identities.action_player_id],
+    ["actor_id", identities.actor_id]
+  ]
+    .map(([name, value]) => [name, String(value || "").trim().toLowerCase()])
+    .filter(([, value]) => value)
+    .map(([name, value]) => `${name}:${value}`);
+}
+
+function readFirstOnlineClaims(config) {
+  const file = firstOnlineClaimsPath(config);
+  if (!existsSync(file)) return { version: 1, players: {}, aliases: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    return {
+      version: 1,
+      players: parsed?.players && typeof parsed.players === "object" && !Array.isArray(parsed.players) ? parsed.players : {},
+      aliases: parsed?.aliases && typeof parsed.aliases === "object" && !Array.isArray(parsed.aliases) ? parsed.aliases : {}
+    };
+  } catch {
+    return { version: 1, players: {}, aliases: {} };
+  }
+}
+
+function writeFirstOnlineClaims(config, value) {
+  const file = firstOnlineClaimsPath(config);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, `${JSON.stringify({ version: 1, players: value.players || {}, aliases: value.aliases || {} }, null, 2)}\n`, { mode: 0o600 });
+  try { chmodSync(file, 0o600); } catch {}
 }
 
 function pendingReturnKey(kit, rule, player) {
@@ -911,6 +1028,10 @@ function configPath(config) {
 
 function grantsPath(config) {
   return resolve(config.generatedDir, "care-package-grants.jsonl");
+}
+
+function firstOnlineClaimsPath(config) {
+  return resolve(config.generatedDir, "care-package-first-online-claims.json");
 }
 
 function pendingReturnsPath(config) {

--- a/console/api/test/carePackage.test.js
+++ b/console/api/test/carePackage.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { clearCarePackageHistory, enableCarePackage, grantEligibleCarePackages, grantCarePackage, runCarePackageAutoScan, saveCarePackageConfig, carePackageCapabilities, carePackageConfig, carePackageEligiblePlayers, carePackageHistory, validateCarePackageConfig } from "../src/carePackage.js";
@@ -262,6 +262,131 @@ test("care package first-online does not repeat after many skipped scans", async
     assert.equal(repeat.granted, 0);
     assert.equal(repeat.skipped, 1);
     assert.match(repeat.results[0].reason, /Already received first-online Care Package/);
+  } finally {
+    rmSync(config.repoRoot, { recursive: true, force: true });
+  }
+});
+
+
+test("care package manual grant satisfies first-online claim even after visible history is cleared", async () => {
+  const config = tempConfig();
+  try {
+    saveCarePackageConfig(config, {
+      enabled: true,
+      activeKitId: "starter-kit",
+      autoGrantKitId: "starter-kit",
+      kits: [{ id: "starter-kit", name: "Starter Kit", xp: 10, items: [] }],
+      autoGrantRules: [{ id: "first-online-rule", enabled: true, kitId: "starter-kit", grantWhen: "first_online" }]
+    });
+
+    const manual = await grantCarePackage(config, "Player#1", {
+      confirmation: "GRANT CARE PACKAGE",
+      kitId: "starter-kit",
+      accountId: "account-1",
+      funcomId: "Player#1",
+      flsId: "Player#1",
+      characterName: "Player",
+      onlineStatus: "Online"
+    });
+
+    assert.equal(manual.status, "granted");
+    const claimsFile = resolve(config.generatedDir, "care-package-first-online-claims.json");
+    assert.equal(existsSync(claimsFile), true);
+
+    clearCarePackageHistory(config);
+    assert.deepEqual(carePackageHistory(config).rows, []);
+
+    const repeat = await runCarePackageAutoScan(config, [{
+      actor_id: 2,
+      account_id: "account-1",
+      funcom_id: "Player#1",
+      fls_id: "Player#1",
+      character_name: "Player Again",
+      action_player_id: "Player#1",
+      online_status: "Online"
+    }]);
+
+    assert.equal(repeat.granted, 0);
+    assert.equal(repeat.skipped, 1);
+    assert.match(repeat.results[0].reason, /Already received first-online Care Package/);
+  } finally {
+    rmSync(config.repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("care package first-online manual and auto race is blocked by pre-delivery claim", async () => {
+  const config = tempConfig();
+  config.mockMode = false;
+  try {
+    writeCatalog(config);
+    saveCarePackageConfig(config, {
+      enabled: true,
+      activeKitId: "starter-kit",
+      autoGrantKitId: "starter-kit",
+      kits: [{
+        id: "starter-kit",
+        name: "Starter Kit",
+        xp: 0,
+        items: [{ itemName: "Plant Fiber", quantity: 1, quality: 1 }]
+      }],
+      autoGrantRules: [{ id: "first-online-rule", enabled: true, kitId: "starter-kit", grantWhen: "first_online" }]
+    });
+
+    let releaseGrant;
+    const grantStarted = new Promise((resolveStarted) => {
+      releaseGrant = resolveStarted;
+    });
+    let itemGrantEntered;
+    const itemGrantStarted = new Promise((resolveStarted) => {
+      itemGrantEntered = resolveStarted;
+    });
+
+    const manualGrant = grantCarePackage(config, "Player#1", {
+      confirmation: "GRANT CARE PACKAGE",
+      kitId: "starter-kit",
+      actorId: 1,
+      accountId: "account-1",
+      funcomId: "Player#1",
+      flsId: "Player#1",
+      characterName: "Player",
+      onlineStatus: "Online"
+    }, {
+      db: {},
+      dbGiveItemToPlayer: async (_actorId, item) => {
+        itemGrantEntered();
+        await grantStarted;
+        return { ok: true, inserted: { template_id: item.templateId, stack_size: item.quantity, quality_level: item.quality } };
+      }
+    });
+
+    await itemGrantStarted;
+
+    const auto = await runCarePackageAutoScan(config, [{
+      actor_id: 2,
+      account_id: "account-1",
+      funcom_id: "Player#1",
+      fls_id: "Player#1",
+      character_name: "Player Again",
+      action_player_id: "Player#1",
+      online_status: "Online"
+    }], "auto", {
+      db: {},
+      dbGiveItemToPlayer: async () => {
+        throw new Error("auto path should not deliver package content");
+      }
+    });
+
+    assert.equal(auto.granted, 0);
+    assert.equal(auto.skipped, 1);
+    assert.match(auto.results[0].reason, /Already received first-online Care Package/);
+
+    releaseGrant();
+    const manual = await manualGrant;
+    assert.equal(manual.status, "granted");
+
+    const claimsFile = resolve(config.generatedDir, "care-package-first-online-claims.json");
+    const claims = JSON.parse(readFileSync(claimsFile, "utf8"));
+    assert.ok(claims.players["account_id:account-1"]);
   } finally {
     rmSync(config.repoRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes #26

## Summary

This PR makes Care Package `first_online` grants durable per player identity instead of relying only on visible Grant History.

The fix adds a durable first-online claim ledger:

```text
runtime/generated/care-package-first-online-claims.json
```

The claim is written before package delivery begins, so a manual grant and background auto scan cannot both pass eligibility before either writes Grant History.

## Why

Issue #26 reports that manual and auto Care Package grants can both deliver the same first-online package when they happen close together.

The previous behavior used Grant History as both audit log and idempotency source. Because Grant History is appended after delivery completes, it is not safe as a pre-delivery claim mechanism.

## Changes

- Add durable first-online claim ledger.
- Preserve first-online claims when visible Grant History is cleared.
- Check first-online claims during eligibility.
- Claim first-online identity before package delivery.
- Keep manual repeat grants allowed while letting manual starter grants satisfy first-online auto eligibility.
- Release a newly-created claim only if no package content was delivered.
- Add regression coverage for visible-history clear and manual/auto race behavior.

## Tests

```text
node --test console/api/test/carePackage.test.js
```
