### PR TITLE
Generate command auth tokens locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,8 +73,8 @@ DUNE_DISCORD_ADAPTER_ENABLED=false
 # DUNE_DB_USER=dune
 # DUNE_DB_PASSWORD=dune
 
-# Optional RabbitMQ/server-command override. Normally the web admin reads
-# runtime/secrets/command-auth-token.txt or uses the RedBlink built-in token.
+# Optional RabbitMQ/server-command override. Normally the web admin reads or
+# creates runtime/secrets/command-auth-token.txt with local 0600 permissions.
 # DUNE_COMMAND_AUTH_TOKEN=
 
 # Optional runtime path override when the web admin is run outside this repo.

--- a/console/api/src/rmq.js
+++ b/console/api/src/rmq.js
@@ -1,11 +1,11 @@
 import { spawn } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
-import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { randomBytes, randomUUID } from "node:crypto";
 import { redact } from "./redact.js";
 
-const BUILTIN_COMMAND_AUTH_TOKEN = "Nu6VmPWUMvdPMeB7qErr";
 const RMQ_CONTAINER = "dune-rmq-game";
+const COMMAND_AUTH_TOKEN_BYTES = 32;
 
 export function validateBroadcastMessage(message) {
   const raw = String(message || "").trim();
@@ -226,14 +226,38 @@ export function validatePublishLabel(value) {
   throw new Error("Invalid RabbitMQ publish label");
 }
 
-function commandAuthToken(repoRoot) {
+export function commandAuthToken(repoRoot) {
   const file = resolve(repoRoot, "runtime/secrets/command-auth-token.txt");
   if (process.env.DUNE_COMMAND_AUTH_TOKEN) return process.env.DUNE_COMMAND_AUTH_TOKEN;
-  if (existsSync(file)) {
-    const raw = readFileSync(file, "utf8").trim();
-    if (raw) return raw;
+  const existing = readCommandAuthTokenFile(file);
+  if (existing) return existing;
+  return generateCommandAuthTokenFile(file);
+}
+
+function readCommandAuthTokenFile(file) {
+  if (!existsSync(file)) return "";
+  return readFileSync(file, "utf8").trim();
+}
+
+function generateCommandAuthTokenFile(file) {
+  const token = randomBytes(COMMAND_AUTH_TOKEN_BYTES).toString("base64url");
+  mkdirSync(dirname(file), { recursive: true });
+  const writeFlag = existsSync(file) ? "w" : "wx";
+  try {
+    writeFileSync(file, `${token}\n`, { mode: 0o600, flag: writeFlag });
+  } catch (error) {
+    if (error?.code === "EEXIST") {
+      const existing = readCommandAuthTokenFile(file);
+      if (existing) return existing;
+    }
+    throw error;
   }
-  return BUILTIN_COMMAND_AUTH_TOKEN;
+  try {
+    chmodSync(file, 0o600);
+  } catch {
+    // Best effort on non-POSIX development hosts.
+  }
+  return token;
 }
 
 function dockerExec(args, timeoutMs = 30000) {

--- a/console/api/test/rmq.test.js
+++ b/console/api/test/rmq.test.js
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { buildBroadcastCommand, buildCarePackageWhisperPayload, buildMapChatPayload, buildShutdownBroadcastCommand, publishCarePackageWhisper, publishMapChat, validateBroadcastMessage, validateLocalizedTexts, validatePublishLabel } from "../src/rmq.js";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { buildBroadcastCommand, buildCarePackageWhisperPayload, buildMapChatPayload, buildShutdownBroadcastCommand, commandAuthToken, publishCarePackageWhisper, publishMapChat, validateBroadcastMessage, validateLocalizedTexts, validatePublishLabel } from "../src/rmq.js";
 
 test("builds verified ServiceBroadcast generic command payload", () => {
   const command = buildBroadcastCommand({ message: "Server event starts soon", durationSec: 45, title: "Event" });
@@ -105,6 +108,66 @@ test("validates RabbitMQ publish labels before eval construction", () => {
   assert.equal(validatePublishLabel("web_shutdown_1"), "web_shutdown_1");
   assert.throws(() => validatePublishLabel("bad label"));
   assert.throws(() => validatePublishLabel("bad\"), halt(). %"));
+});
+
+test("command auth token generates and reuses a local secret file", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-rmq-token-"));
+  const previous = process.env.DUNE_COMMAND_AUTH_TOKEN;
+  delete process.env.DUNE_COMMAND_AUTH_TOKEN;
+  try {
+    const tokenFile = resolve(repoRoot, "runtime/secrets/command-auth-token.txt");
+    const token = commandAuthToken(repoRoot);
+    assert.match(token, /^[A-Za-z0-9_-]{40,}$/);
+    assert.equal(existsSync(tokenFile), true);
+    assert.equal(readFileSync(tokenFile, "utf8").trim(), token);
+    assert.equal(statSync(tokenFile).mode & 0o777, 0o600);
+    assert.equal(commandAuthToken(repoRoot), token);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.DUNE_COMMAND_AUTH_TOKEN;
+    } else {
+      process.env.DUNE_COMMAND_AUTH_TOKEN = previous;
+    }
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("command auth token honors explicit environment override", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-rmq-token-env-"));
+  const previous = process.env.DUNE_COMMAND_AUTH_TOKEN;
+  process.env.DUNE_COMMAND_AUTH_TOKEN = "explicit-token";
+  try {
+    const tokenFile = resolve(repoRoot, "runtime/secrets/command-auth-token.txt");
+    assert.equal(commandAuthToken(repoRoot), "explicit-token");
+    assert.equal(existsSync(tokenFile), false);
+  } finally {
+    if (previous === undefined) {
+      delete process.env.DUNE_COMMAND_AUTH_TOKEN;
+    } else {
+      process.env.DUNE_COMMAND_AUTH_TOKEN = previous;
+    }
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("command auth token reuses an existing local secret file", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-rmq-token-existing-"));
+  const previous = process.env.DUNE_COMMAND_AUTH_TOKEN;
+  delete process.env.DUNE_COMMAND_AUTH_TOKEN;
+  try {
+    const tokenFile = resolve(repoRoot, "runtime/secrets/command-auth-token.txt");
+    mkdirSync(resolve(repoRoot, "runtime/secrets"), { recursive: true });
+    writeFileSync(tokenFile, "existing-local-token\n", { mode: 0o600 });
+    assert.equal(commandAuthToken(repoRoot), "existing-local-token");
+    assert.equal(readFileSync(tokenFile, "utf8"), "existing-local-token\n");
+  } finally {
+    if (previous === undefined) {
+      delete process.env.DUNE_COMMAND_AUTH_TOKEN;
+    } else {
+      process.env.DUNE_COMMAND_AUTH_TOKEN = previous;
+    }
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
 });
 
 test("publishes map chat to chat.map routing key", async () => {

--- a/docs/security/generated-command-auth-token.md
+++ b/docs/security/generated-command-auth-token.md
@@ -1,0 +1,92 @@
+# Generated Command Auth Token
+
+Branch: `security/generated-command-auth-token-fix`
+
+## Purpose
+
+Remove the shared built-in RabbitMQ server-command auth token and generate a deployment-local secret on first use.
+
+The command channel behavior stays the same: admin tools and the WebUI still send the `Version`, `AuthToken`, and `MessageContent` envelope to the existing RabbitMQ route. The default token source changes from public source code to `runtime/secrets/command-auth-token.txt`.
+
+## Source Findings
+
+- Upstream `Red-Blink/dune-awakening-selfhost-docker` `main` at `1bb72c5027b5fbab4cbf4ae7d0328a8793539a0a` still contains the static fallback in `console/api/src/rmq.js` and `runtime/scripts/admin-tools.sh`.
+- Fork tracking issue: `yacketrj/dune-awakening-selfhost-docker-WSL#66`.
+- Related upstream history: `Red-Blink/dune-awakening-selfhost-docker#22` attempted this class of fix but was closed unmerged.
+
+## Architecture Before
+
+- `console/api/src/rmq.js` contained a public built-in token constant.
+- `runtime/scripts/admin-tools.sh` contained the same public built-in token constant.
+- If `DUNE_COMMAND_AUTH_TOKEN` and `runtime/secrets/command-auth-token.txt` were absent, both paths used the source-controlled fallback.
+- Every deployment without an override therefore shared the same command-channel secret.
+
+## Architecture After
+
+- `DUNE_COMMAND_AUTH_TOKEN` remains the highest-precedence explicit override.
+- If `runtime/secrets/command-auth-token.txt` exists and is non-empty, both Node and shell paths reuse it.
+- If no token exists, the Node path creates a random 32-byte base64url token and writes it with `0600` permissions.
+- If no token exists, the shell path creates a random 32-byte hex token with `openssl rand -hex 32`, falling back to Python `secrets.token_hex(32)` when OpenSSL is unavailable.
+- The public built-in token constant is removed from source.
+
+## STRIDE Notes
+
+- Spoofing: deployment-local tokens remove a public shared credential that could authenticate forged server-command payloads.
+- Tampering: generated files use `0600` permissions to limit local modification to the owning user.
+- Repudiation: existing admin audit and history output stay unchanged.
+- Information disclosure: the token is not printed in command output; RabbitMQ error output continues to redact `AuthToken`.
+- Denial of service: no routing or payload schema changes are introduced.
+- Elevation of privilege: explicit `DUNE_COMMAND_AUTH_TOKEN` override remains available for operators who manage secrets externally.
+
+## Minimal Impact
+
+- Existing deployments with `DUNE_COMMAND_AUTH_TOKEN` keep working.
+- Existing deployments with `runtime/secrets/command-auth-token.txt` keep working.
+- New deployments generate a local secret automatically instead of requiring extra setup.
+- RabbitMQ publish payload shape and routing are unchanged.
+
+## Verification Plan
+
+Run from the repository root:
+
+```bash
+bash -n runtime/scripts/admin-tools.sh runtime/tests/test-command-auth-token.sh
+bash runtime/tests/test-command-auth-token.sh
+npm test --prefix console/api
+npm audit --prefix console/api --audit-level=moderate
+npm run build --prefix console/web
+git diff --check
+```
+
+Run a source secret scan after committing or from a clean export so dependency folders and local runtime secrets are excluded:
+
+```bash
+git archive --format=tar HEAD | tar -xf - -C /tmp/dune-gitleaks-source
+gitleaks detect --no-git --source /tmp/dune-gitleaks-source --redact
+```
+
+## Verification Results
+
+Validation was run from the staged source tree for this branch.
+
+- `bash -n runtime/scripts/admin-tools.sh runtime/tests/test-command-auth-token.sh`: passed.
+- `bash runtime/tests/test-command-auth-token.sh`: passed.
+- `npm test --prefix console/api`: 183 tests passed.
+- `npm audit --prefix console/api --audit-level=moderate`: 0 vulnerabilities.
+- `npm audit --prefix console/web --audit-level=moderate`: 0 vulnerabilities.
+- `npm run build --prefix console/web`: passed.
+- `git diff --cached --check`: passed.
+- `gitleaks detect --no-git --source <staged export> --redact --exit-code 1`: no leaks found.
+- `trivy fs --scanners secret --exit-code 1 --severity HIGH,CRITICAL <staged export>`: passed.
+- `semgrep --config p/secrets` on changed files: 0 findings.
+- `semgrep --config p/security-audit` on changed runtime command files: 0 findings.
+
+Full Trivy misconfiguration scanning still reports pre-existing Dockerfile HIGH findings outside this PR:
+
+- `DS-0002` non-root container users in `console/api/Dockerfile` and `orchestrator/Dockerfile`; tracked in fork issues `#34`, `#36`, and open upstream PR `Red-Blink/dune-awakening-selfhost-docker#13`.
+- `DS-0029` missing `--no-install-recommends` in `orchestrator/Dockerfile`; tracked in fork issue `#67`.
+
+## Review Notes
+
+- This change does not rotate existing deployment secrets. Operators who already created `runtime/secrets/command-auth-token.txt` or set `DUNE_COMMAND_AUTH_TOKEN` should rotate them through their normal secret management process if exposure is suspected.
+- This change does not claim SOC 2 certification. It provides evidence useful for secret-management and change-control review.

--- a/runtime/scripts/admin-tools.sh
+++ b/runtime/scripts/admin-tools.sh
@@ -9,7 +9,6 @@ SKILL_MODULES_FILE="runtime/data/admin-skill-modules.json"
 XP_EVENT_TAGS_FILE="runtime/data/admin-xp-event-tags.json"
 TOKEN_FILE="runtime/secrets/funcom-token.txt"
 COMMAND_TOKEN_FILE="runtime/secrets/command-auth-token.txt"
-BUILTIN_COMMAND_AUTH_TOKEN="Nu6VmPWUMvdPMeB7qErr"
 RMQ_CONTAINER="dune-rmq-game"
 POSTGRES_CONTAINER="dune-postgres"
 ADMIN_HISTORY_TSV="runtime/generated/admin-command-history.tsv"
@@ -149,8 +148,31 @@ command_auth_token() {
     fi
   fi
 
-  # Matches the working upstream manager's command-auth fallback.
-  printf '%s' "$BUILTIN_COMMAND_AUTH_TOKEN"
+  generate_command_auth_token
+}
+
+generate_command_auth_token() {
+  local token
+
+  mkdir -p "$(dirname "$COMMAND_TOKEN_FILE")"
+  if command -v openssl >/dev/null 2>&1; then
+    token="$(openssl rand -hex 32)"
+  elif command -v python3 >/dev/null 2>&1; then
+    token="$(python3 - <<'PY'
+import secrets
+print(secrets.token_hex(32))
+PY
+)"
+  else
+    echo "Missing openssl or python3; cannot generate $COMMAND_TOKEN_FILE" >&2
+    return 1
+  fi
+  (
+    umask 077
+    printf '%s\n' "$token" > "$COMMAND_TOKEN_FILE"
+  )
+  chmod 600 "$COMMAND_TOKEN_FILE" 2>/dev/null || true
+  printf '%s' "$token"
 }
 
 require_rmq_game_running() {

--- a/runtime/tests/test-command-auth-token.sh
+++ b/runtime/tests/test-command-auth-token.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+
+  grep -Fq -- "$pattern" "$file" || fail "$file missing: $pattern"
+}
+
+assert_not_contains_anywhere() {
+  local pattern="$1"
+  local output
+  shift
+  output="$(mktemp)"
+
+  if grep -RIn -- "$pattern" "$@" >"$output"; then
+    cat "$output" >&2
+    rm -f "$output"
+    fail "unexpected source match: $pattern"
+  fi
+  rm -f "$output"
+}
+
+assert_not_contains_anywhere 'BUILTIN_COMMAND_AUTH_TOKEN' console/api/src runtime/scripts
+assert_contains runtime/scripts/admin-tools.sh 'generate_command_auth_token'
+assert_contains runtime/scripts/admin-tools.sh 'openssl rand -hex 32'
+assert_contains console/api/src/rmq.js 'randomBytes(COMMAND_AUTH_TOKEN_BYTES).toString("base64url")'
+assert_contains .env.example 'creates runtime/secrets/command-auth-token.txt'
+
+echo "PASS: command auth token is generated instead of built in"


### PR DESCRIPTION
## Issue Summary

This PR removes a source-controlled built-in RabbitMQ server-command auth token fallback from the WebUI API and admin shell tooling.

The issue was identified during the Gitleaks follow-up for the WSL fork security workstream. I checked current upstream `Red-Blink/dune-awakening-selfhost-docker` `main` before opening this PR and confirmed that commit `1bb72c5027b5fbab4cbf4ae7d0328a8793539a0a` still contained the static fallback in:

- `console/api/src/rmq.js`
- `runtime/scripts/admin-tools.sh`

The token value is intentionally not repeated in this PR body.

Fork tracking:

- `yacketrj/dune-awakening-selfhost-docker-WSL#66`
- Local validation PR: `yacketrj/dune-awakening-selfhost-docker-WSL#68`

## Evidence

Before this change, both command publishing paths used the same public fallback when neither an explicit environment override nor `runtime/secrets/command-auth-token.txt` existed:

- WebUI API command publishing read `DUNE_COMMAND_AUTH_TOKEN`, then `runtime/secrets/command-auth-token.txt`, then the built-in fallback.
- Runtime admin tooling followed the same order and fell back to the built-in value.

That meant deployments without a local override shared a command-channel secret from public source code.

Related upstream context:

- Upstream `main` affected at `1bb72c5027b5fbab4cbf4ae7d0328a8793539a0a`.
- Closed upstream PR #22 attempted this class of fix but was not merged.

## Resolution

- Removed the built-in token constant from both Node and shell command publishers.
- Preserved operator override precedence:
  1. `DUNE_COMMAND_AUTH_TOKEN`
  2. Existing non-empty `runtime/secrets/command-auth-token.txt`
  3. First-use generated local token file
- Node generates a 32-byte base64url token and writes it with `0600` permissions.
- Shell tooling generates a 32-byte hex token with `openssl rand -hex 32`, with a Python `secrets.token_hex(32)` fallback.
- Existing deployments with an env override or existing token file keep working.
- Added API tests, a runtime shell source assertion, `.env.example` guidance, and `docs/security/generated-command-auth-token.md`.

## Test Output

```text
$ bash -n runtime/scripts/admin-tools.sh runtime/tests/test-command-auth-token.sh
passed

$ bash runtime/tests/test-command-auth-token.sh
PASS: command auth token is generated instead of built in

$ npm test --prefix console/api
# tests 183
# pass 183
# fail 0

$ npm audit --prefix console/api --audit-level=moderate
found 0 vulnerabilities

$ npm audit --prefix console/web --audit-level=moderate
found 0 vulnerabilities

$ npm run build --prefix console/web
✓ built in 7.66s

$ git diff --cached --check
passed

$ gitleaks detect --no-git --source <HEAD export> --redact --exit-code 1
no leaks found

$ trivy fs --scanners secret --exit-code 1 --severity HIGH,CRITICAL <staged export>
passed

$ semgrep --config p/secrets <changed files>
0 findings

$ semgrep --config p/security-audit console/api/src/rmq.js runtime/scripts/admin-tools.sh
0 findings
```

Fork validation checks also passed before opening this upstream PR:

```text
Analyze (javascript-typescript): pass
Analyze (python): pass
CodeQL: pass
```

## Security Notes

Full Trivy misconfiguration scanning still reports pre-existing Dockerfile HIGH findings outside this PR:

- `DS-0002` non-root container users in `console/api/Dockerfile` and `orchestrator/Dockerfile`; covered by open upstream PR #13.
- `DS-0029` missing `--no-install-recommends` in `orchestrator/Dockerfile`; tracked in fork issue `yacketrj/dune-awakening-selfhost-docker-WSL#67`.

This change does not rotate existing deployment secrets. Operators who suspect exposure should rotate `runtime/secrets/command-auth-token.txt` or their externally managed `DUNE_COMMAND_AUTH_TOKEN` value through their normal secret process.