### PR TITLE
Fix Console Update release source for forks

### DIFF
--- a/console/api/test/selfUpdateScript.test.js
+++ b/console/api/test/selfUpdateScript.test.js
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { createServer } from "node:http";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+test("self-update check prefers the official upstream release repo in fork checkouts", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "arrakis-self-update-"));
+  mkdirSync(join(dir, "runtime", "scripts"), { recursive: true });
+  copyFileSync(join(repoRoot, "runtime", "scripts", "self-update.sh"), join(dir, "runtime", "scripts", "self-update.sh"));
+  chmodSync(join(dir, "runtime", "scripts", "self-update.sh"), 0o700);
+  writeFileSync(join(dir, "VERSION"), "v1.3.37\n");
+
+  assert.equal(spawnSync("git", ["init", "-q"], { cwd: dir }).status, 0);
+  assert.equal(spawnSync("git", ["remote", "add", "origin", "git@github.com:yacketrj/dune-awakening-selfhost-docker-WSL.git"], { cwd: dir }).status, 0);
+  assert.equal(spawnSync("git", ["remote", "add", "upstream", "https://github.com/Red-Blink/dune-awakening-selfhost-docker.git"], { cwd: dir }).status, 0);
+
+  const requests = [];
+  const server = createServer((req, res) => {
+    requests.push(req.url || "");
+    if (req.url === "/repos/Red-Blink/dune-awakening-selfhost-docker/releases/latest") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ tag_name: "v1.3.37" }));
+      return;
+    }
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ message: "not found" }));
+  });
+  await new Promise((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+
+  try {
+    const address = server.address();
+    const apiBase = `http://127.0.0.1:${address.port}`;
+    const result = await runProcess("bash", ["runtime/scripts/self-update.sh", "check"], {
+      cwd: dir,
+      timeout: 15000,
+      env: { ...process.env, DUNE_SELF_UPDATE_API_BASE: apiBase, NO_PROXY: "127.0.0.1,localhost", no_proxy: "127.0.0.1,localhost" }
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /GitHub repo:\s+Red-Blink\/dune-awakening-selfhost-docker/);
+    assert(!result.stdout.includes("yacketrj/dune-awakening-selfhost-docker-WSL"));
+    assert.deepEqual(requests, ["/repos/Red-Blink/dune-awakening-selfhost-docker/releases/latest"]);
+  } finally {
+    server.closeAllConnections();
+    await new Promise((resolveClose) => server.close(resolveClose));
+  }
+});
+
+function runProcess(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const { timeout = 15000, ...spawnOptions } = options;
+    const child = spawn(command, args, spawnOptions);
+    let stdout = "";
+    let stderr = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error(`${command} ${args.join(" ")} timed out\n${stdout}\n${stderr}`));
+    }, timeout);
+
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (status, signal) => {
+      clearTimeout(timer);
+      resolve({ status, signal, stdout, stderr });
+    });
+  });
+}

--- a/runtime/scripts/self-update.sh
+++ b/runtime/scripts/self-update.sh
@@ -6,9 +6,43 @@ ROOT_DIR="$(pwd)"
 
 CURRENT_VERSION="dev"
 [ -f VERSION ] && CURRENT_VERSION="$(tr -d '[:space:]' < VERSION)"
+DEFAULT_SELF_UPDATE_REPO="Red-Blink/dune-awakening-selfhost-docker"
+
+normalize_github_remote_repo() {
+  local remote="$1"
+
+  case "$remote" in
+    https://github.com/*)
+      remote="${remote#https://github.com/}"
+      ;;
+    git@github.com:*)
+      remote="${remote#git@github.com:}"
+      ;;
+    ssh://git@github.com/*)
+      remote="${remote#ssh://git@github.com/}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  remote="${remote%.git}"
+  remote="${remote%/}"
+  [ -n "$remote" ] || return 1
+  printf '%s\n' "$remote"
+}
+
+github_repo_from_git_remote() {
+  local remote_name="$1"
+  local remote
+
+  remote="$(git remote get-url "$remote_name" 2>/dev/null || true)"
+  [ -n "$remote" ] || return 1
+  normalize_github_remote_repo "$remote"
+}
 
 detect_github_repo() {
-  local remote
+  local remote_name repo
 
   if [ -n "${DUNE_SELF_UPDATE_REPO:-}" ]; then
     printf '%s\n' "$DUNE_SELF_UPDATE_REPO"
@@ -16,27 +50,49 @@ detect_github_repo() {
   fi
 
   if command -v git >/dev/null 2>&1; then
-    remote="$(git remote get-url origin 2>/dev/null || true)"
-    case "$remote" in
-      https://github.com/*)
-        remote="${remote#https://github.com/}"
-        remote="${remote%.git}"
-        printf '%s\n' "$remote"
+    for remote_name in upstream origin; do
+      repo="$(github_repo_from_git_remote "$remote_name" 2>/dev/null || true)"
+      if [ "$repo" = "$DEFAULT_SELF_UPDATE_REPO" ]; then
+        printf '%s\n' "$repo"
         return 0
-        ;;
-      git@github.com:*)
-        remote="${remote#git@github.com:}"
-        remote="${remote%.git}"
-        printf '%s\n' "$remote"
-        return 0
-        ;;
-    esac
+      fi
+    done
+
+    repo="$(github_repo_from_git_remote upstream 2>/dev/null || true)"
+    if [ -n "$repo" ]; then
+      printf '%s\n' "$repo"
+      return 0
+    fi
+
+    repo="$(github_repo_from_git_remote origin 2>/dev/null || true)"
+    if [ -n "$repo" ]; then
+      printf '%s\n' "$repo"
+      return 0
+    fi
   fi
 
-  printf '%s\n' "Red-Blink/dune-awakening-selfhost-docker"
+  printf '%s\n' "$DEFAULT_SELF_UPDATE_REPO"
+}
+
+detect_github_fetch_remote() {
+  local repo="$1"
+  local remote_name remote_repo
+
+  if command -v git >/dev/null 2>&1; then
+    for remote_name in upstream origin; do
+      remote_repo="$(github_repo_from_git_remote "$remote_name" 2>/dev/null || true)"
+      if [ "$remote_repo" = "$repo" ]; then
+        printf '%s\n' "$remote_name"
+        return 0
+      fi
+    done
+  fi
+
+  printf '%s\n' "https://github.com/${repo}.git"
 }
 
 GITHUB_REPO="$(detect_github_repo)"
+GITHUB_FETCH_REMOTE="$(detect_github_fetch_remote "$GITHUB_REPO")"
 GITHUB_API_BASE="${DUNE_SELF_UPDATE_API_BASE:-https://api.github.com}"
 GITHUB_TOKEN="${DUNE_SELF_UPDATE_TOKEN:-}"
 LATEST_TAG_CACHE_FILE="runtime/generated/self-update-latest-tag.txt"
@@ -840,12 +896,12 @@ install_release_tag_with_git() {
     exit 2
   }
 
-  remote="$(git remote get-url origin 2>/dev/null || true)"
+  remote="$GITHUB_FETCH_REMOTE"
   echo "Updating stack Git checkout from:"
   echo "  $remote"
   echo "Fetching release tag: $tag"
-  git fetch --force --tags origin
-  git fetch --force origin "refs/tags/${tag}:refs/tags/${tag}" >/dev/null 2>&1 || true
+  git fetch --force --tags "$remote"
+  git fetch --force "$remote" "refs/tags/${tag}:refs/tags/${tag}" >/dev/null 2>&1 || true
 
   target="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null || true)"
   if [ -z "$target" ]; then
@@ -939,13 +995,13 @@ case "$cmd" in
     ;;
 
   check|status)
-    echo "Current stack version: $CURRENT_VERSION"
     set +e
     latest="$(latest_release_tag)"
     rc=$?
     set -e
 
     if [ "$rc" -ne 0 ] || [ -z "${latest:-}" ]; then
+      echo "Current stack version: $CURRENT_VERSION"
       echo "Latest release:        unknown"
       echo "GitHub repo:           $GITHUB_REPO"
       echo


### PR DESCRIPTION
## Summary

Fixes a Console Update failure in forked/self-hosted checkouts where `origin` is not the canonical Red-Blink repository.

The Updates tab calls `runtime/scripts/dune self-update check` and `runtime/scripts/dune self-update install latest`. The self-update script detected its GitHub release source from `origin`, then used `origin` again when fetching update tags. That works in a direct Red-Blink clone, but fails in fork-based installs because `origin` points at the fork, which may not publish the upstream release feed or tags.

This PR keeps the explicit `DUNE_SELF_UPDATE_REPO` override, but makes fork checkouts prefer the official Red-Blink release repo when an `upstream` remote is available.

## How It Was Identified

In the WSL fork checkout, Console Update failed because release lookup targeted the fork:

```text
runtime/scripts/dune self-update check
Current stack version: v1.3.37
Latest release:        unknown
GitHub repo:           yacketrj/dune-awakening-selfhost-docker-WSL
```

Pointing the same command at the canonical release repo succeeded:

```text
DUNE_SELF_UPDATE_REPO=Red-Blink/dune-awakening-selfhost-docker runtime/scripts/dune self-update check
Latest release:        v1.3.37
GitHub repo:           Red-Blink/dune-awakening-selfhost-docker
You are already on the latest stack version.
```

Upstream `main` contains the same origin-only detection logic, so this is a latent upstream bug for forked installs even though a direct Red-Blink clone does not hit it.

## Evidence Synced With Upstream

This branch is based directly on upstream `main` at:

```text
1bb72c5 Release v1.3.37
```

The branch contains one commit:

```text
28cbaaf Fix console update release source for forks
```

Files changed:

```text
console/api/test/selfUpdateScript.test.js
runtime/scripts/self-update.sh
```

## Resolution

- Adds GitHub remote normalization for HTTPS, SSH shorthand, and `ssh://git@github.com/...` remotes.
- Keeps `DUNE_SELF_UPDATE_REPO` as the explicit release-source override.
- Prefers `Red-Blink/dune-awakening-selfhost-docker` when either `upstream` or `origin` points at the official repo.
- Falls back to `upstream`, then `origin`, then the official Red-Blink repo.
- Fetches install tags from the selected release repo/remote instead of always fetching from `origin`.
- Removes the duplicate `Current stack version` line from successful self-update checks while preserving it on failures.
- Adds a regression test that simulates a fork checkout and verifies the script calls the Red-Blink releases endpoint rather than the fork endpoint.

## Regression Testing Output

Upstream-based branch validation:

```text
npm ci --prefix console/api
# added 14 packages; found 0 vulnerabilities

npm test --prefix console/api
# tests 181
# pass 181
# fail 0

npm audit --prefix console/api --audit-level=moderate
# found 0 vulnerabilities

npm ci --prefix console/web
# added 26 packages; found 0 vulnerabilities

npm run build --prefix console/web
# Vite v8.0.16 build passed

npm audit --prefix console/web --audit-level=moderate
# found 0 vulnerabilities

git diff --check HEAD~1..HEAD
# passed

bash -n runtime/scripts/self-update.sh
# passed

runtime/scripts/dune self-update check
# Current stack version: v1.3.37
# Latest release:        v1.3.37
# GitHub repo:           Red-Blink/dune-awakening-selfhost-docker
# You are already on the latest stack version.
```

Non-destructive Updates tab runtime checks from the active WSL clone:

```text
runtime/scripts/dune update check
# Steam app id: 4754530
# Local build: 23894313
# Remote build: 23894313
# No update available.

runtime/scripts/dune update auto status
# Auto updates enabled: 0
# Systemd timer: active
```

## Security Checks

Changed-file secret scans:

```text
semgrep --config p/secrets --error --metrics=off --no-git-ignore runtime/scripts/self-update.sh
# 0 findings

trivy fs --scanners secret --exit-code 1 runtime/scripts/self-update.sh
# No issues detected with scanner(s): secret

docker run --rm -v /tmp/dune-console-update-upstream/runtime/scripts/self-update.sh:/repo/self-update.sh:ro zricethezav/gitleaks:latest detect --source=/repo --no-git --redact --verbose
# no leaks found
```
