### PR TITLE
feat(wsl): add Windows WSL installer and operations docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Keep database and internal admin ports private.
 
 ## Getting Started
 
+### Linux server
+
 Copy and paste this on a fresh Linux server:
 
 ```bash
@@ -73,6 +75,40 @@ bash -c 'set -euo pipefail; if ! command -v curl >/dev/null 2>&1; then sudo apt-
 ```
 
 The installer downloads the latest release, prepares the server, starts the Web UI, and tells you what address to open in your browser. If you are on the same network as the server, use the same-network address. If you are connecting over the internet, use the public address and allow TCP `8088` in your firewall.
+
+### Windows 11 Home / WSL2 / Ubuntu 26.04
+
+Windows users can install through WSL2 without replacing the Linux installer. Start with the Windows quick-start so WSL2 and Ubuntu 26.04 are installed, Ubuntu is launched once, and the Linux username/password are created before the Dune installer runs.
+
+Windows setup order:
+
+1. Confirm virtualization is enabled.
+2. Open PowerShell as Administrator.
+3. Install WSL2.
+4. Install Ubuntu 26.04.
+5. Launch Ubuntu once and create the Linux user.
+6. Run the Dune Windows / WSL installer.
+
+Documentation:
+
+- How to open Administrator PowerShell: [docs/ADMIN-POWERSHELL.md](docs/ADMIN-POWERSHELL.md)
+- Windows quick install, including WSL and Ubuntu setup: [docs/WINDOWS-WSL-QUICKSTART.md](docs/WINDOWS-WSL-QUICKSTART.md)
+- Full Windows guide: [docs/WINDOWS-WSL-INSTALL.md](docs/WINDOWS-WSL-INSTALL.md)
+- WSL mirrored networking and Web UI Docker socket access: [docs/WINDOWS-WSL-NETWORKING-AND-DOCKER-SOCKET.md](docs/WINDOWS-WSL-NETWORKING-AND-DOCKER-SOCKET.md)
+- Maintainer security checks: [docs/WINDOWS-WSL-SECURITY-REGRESSION.md](docs/WINDOWS-WSL-SECURITY-REGRESSION.md)
+
+If you already cloned this repository locally after completing WSL and Ubuntu first-run setup, open Administrator PowerShell in the repo folder and run:
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass -Force
+.\install.ps1
+```
+
+Then open the Web UI from Windows:
+
+```text
+http://localhost:8088
+```
 
 ## Community Addons
 

--- a/console/api/src/auth.js
+++ b/console/api/src/auth.js
@@ -1,4 +1,5 @@
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { readFileSync } from "node:fs";
 
 const sessions = new Map();
 
@@ -50,9 +51,19 @@ export function createAuth(config) {
     return session;
   }
 
+  function currentAdminPassword() {
+    if (config.adminPasswordEnvManaged) return config.adminPassword;
+    if (!config.adminPasswordFile) return config.adminPassword;
+    try {
+      return readFileSync(config.adminPasswordFile, "utf8").trim() || config.adminPassword;
+    } catch {
+      return config.adminPassword;
+    }
+  }
+
   function passwordMatches(value) {
     const left = Buffer.from(String(value || ""));
-    const right = Buffer.from(config.adminPassword);
+    const right = Buffer.from(currentAdminPassword());
     return left.length === right.length && timingSafeEqual(left, right);
   }
 

--- a/console/api/src/httpSafety.js
+++ b/console/api/src/httpSafety.js
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 
 export async function readJsonBody(req, maxBytes) {
   const chunks = [];
@@ -75,6 +75,7 @@ export function safeStaticTarget(staticDir, requestPath) {
   const normalizedPath = requestPath === "/" ? "/index.html" : requestPath;
   const file = resolve(dist, `.${normalizedPath}`);
   const fallback = resolve(dist, "index.html");
-  const safeFile = file.startsWith(`${dist}/`) ? file : fallback;
+  const relativePath = relative(dist, file);
+  const safeFile = relativePath && !relativePath.startsWith("..") && !isAbsolute(relativePath) ? file : fallback;
   return existsSync(safeFile) ? safeFile : fallback;
 }

--- a/docs/ADMIN-POWERSHELL.md
+++ b/docs/ADMIN-POWERSHELL.md
@@ -1,0 +1,23 @@
+# Open PowerShell as Administrator
+
+The Windows / WSL installer must be run from an **Administrative PowerShell** window.
+
+## Windows 11 steps
+
+1. Press the **Windows** key.
+2. Type `PowerShell`.
+3. Right-click **Windows PowerShell**.
+4. Select **Run as administrator**.
+5. Click **Yes** on the Windows security prompt.
+6. Confirm the PowerShell window title starts with **Administrator:**.
+
+## Why this is required
+
+The installer may need administrative rights to:
+
+- install or enable WSL components;
+- restart WSL;
+- configure Ubuntu for `systemd`;
+- prepare Docker and networking prerequisites.
+
+After PowerShell opens with Administrator rights, follow the command in [WINDOWS-WSL-QUICKSTART.md](WINDOWS-WSL-QUICKSTART.md).

--- a/docs/WINDOWS-WSL-INSTALL.md
+++ b/docs/WINDOWS-WSL-INSTALL.md
@@ -76,9 +76,12 @@ Paste this example, then adjust `memory` and `processors` for your machine:
 
 ```ini
 [wsl2]
+networkingMode=mirrored
 localhostForwarding=true
+firewall=true
 memory=32GB
 processors=8
+
 ```
 
 Save the file, close Notepad, then fully restart WSL:

--- a/docs/WINDOWS-WSL-INSTALL.md
+++ b/docs/WINDOWS-WSL-INSTALL.md
@@ -1,0 +1,708 @@
+# Windows 11 Home + WSL2 + Ubuntu 26.04 Install Guide
+
+This guide explains how to install Dune Docker Console on a fresh **Windows 11 Home** machine using **WSL2**, **Ubuntu 26.04**, and **Docker Engine inside Ubuntu**.
+
+Windows 11 Home can run WSL2. Windows Pro is not required.
+
+The Windows path is:
+
+1. Confirm virtualization is enabled.
+2. Install WSL2 on Windows.
+3. Apply recommended WSL resource and localhost-forwarding settings.
+4. Install Ubuntu 26.04 as the WSL distribution.
+5. Launch Ubuntu once and create the Linux username/password.
+6. Enable `systemd` in Ubuntu.
+7. Install Docker Engine and Docker Compose inside Ubuntu.
+8. Clone this repository inside Ubuntu.
+9. Run the existing Linux `install.sh` from inside Ubuntu.
+10. Open the Web UI from Windows at `http://localhost:8088`.
+
+The repository's Linux installer remains the source of truth for starting Dune Docker Console. The PowerShell script prepares Windows/WSL and then delegates to `install.sh`.
+
+For exact steps to launch PowerShell with admin rights, see [ADMIN-POWERSHELL.md](ADMIN-POWERSHELL.md).
+
+---
+
+## What this installs
+
+| Component | Location | Purpose |
+|---|---|---|
+| WSL2 | Windows | Runs Linux on Windows 11 Home |
+| Ubuntu 26.04 | WSL distribution | Linux environment for the server tooling |
+| Docker Engine | Inside Ubuntu | Runs the Dune Docker Console containers |
+| Docker Compose plugin | Inside Ubuntu | Starts the compose stacks |
+| Dune Docker Console | Inside Ubuntu home directory | Web console and server management tools |
+
+This guide intentionally avoids Docker Desktop as the default path. Docker is installed **inside Ubuntu** so the Linux `install.sh` can run the same way it does on a normal Ubuntu host.
+
+---
+
+## Requirements
+
+| Requirement | Plain explanation |
+|---|---|
+| Windows 11 Home | Supported for WSL2 |
+| Virtualization enabled | Required for WSL2; check Task Manager > Performance > CPU |
+| 200 GB+ free disk space | Recommended for game server files, images, generated data, and backups |
+| 20 GB+ RAM | Minimum starting point; more maps require more memory |
+| AVX/AVX2 CPU support | Required by the game server |
+| Funcom self-host token | Entered during the Web UI setup wizard |
+| Router access | Required only for public/internet hosting |
+
+Recommended WSL memory allocation:
+
+| Physical RAM | Suggested WSL memory |
+|---:|---:|
+| 32 GB | 24 GB |
+| 48 GB | 36 GB |
+| 64 GB | 48 GB |
+| 96 GB+ | 64 GB |
+
+Do not allocate all system memory to WSL. Leave enough RAM for Windows, browser sessions, antivirus, Discord, and remote administration tools.
+
+---
+
+## Recommended `.wslconfig`
+
+For the first end-to-end install test, use the default WSL localhost-forwarding path. This is the simplest path for opening the Web UI from Windows at `http://localhost:8088`.
+
+Open the WSL config file from PowerShell:
+
+```powershell
+notepad "$env:USERPROFILE\.wslconfig"
+```
+
+Paste this example, then adjust `memory` and `processors` for your machine:
+
+```ini
+[wsl2]
+localhostForwarding=true
+memory=32GB
+processors=8
+```
+
+Save the file, close Notepad, then fully restart WSL:
+
+```powershell
+wsl --shutdown
+```
+
+If you later need LAN-focused networking, see [Advanced WSL networking](#advanced-wsl-networking). Do not use mirrored networking for the first validation pass unless you are specifically testing LAN routing.
+
+---
+
+## Installation option A: Windows quick path
+
+Use this option if you want the script to prepare Docker and the repository after you install WSL2 and Ubuntu.
+
+### 1. Confirm virtualization is enabled
+
+1. Press `Ctrl` + `Shift` + `Esc` to open **Task Manager**.
+2. Select **Performance**.
+3. Select **CPU**.
+4. Confirm **Virtualization: Enabled**.
+
+If virtualization is disabled, enable it in BIOS/UEFI first, then return to this guide.
+
+### 2. Open PowerShell as Administrator
+
+The Windows / WSL installer must be run from an **Administrative PowerShell** window.
+
+To open PowerShell as Administrator:
+
+1. Press the **Windows** key.
+2. Type `PowerShell`.
+3. Right-click **Windows PowerShell**.
+4. Select **Run as administrator**.
+5. Click **Yes** on the Windows security prompt.
+6. Confirm the window title starts with **Administrator:**.
+
+### 3. Install WSL2
+
+In Administrator PowerShell:
+
+```powershell
+wsl --install --no-distribution
+```
+
+If Windows asks you to restart, restart the PC. After the restart, open **PowerShell as Administrator** again and run:
+
+```powershell
+wsl --update
+wsl --set-default-version 2
+wsl --status
+```
+
+### 4. Apply recommended WSL settings
+
+Open:
+
+```powershell
+notepad "$env:USERPROFILE\.wslconfig"
+```
+
+Paste this default same-PC config:
+
+```ini
+[wsl2]
+localhostForwarding=true
+memory=32GB
+processors=8
+```
+
+Adjust `memory` and `processors`, save the file, then run:
+
+```powershell
+wsl --shutdown
+```
+
+### 5. Install Ubuntu 26.04
+
+List available WSL distributions:
+
+```powershell
+wsl --list --online
+```
+
+Install Ubuntu 26.04:
+
+```powershell
+wsl --install --distribution Ubuntu-26.04
+```
+
+If `Ubuntu-26.04` is not listed, install the closest available official Ubuntu 26.04 entry shown by `wsl --list --online`, then pass that exact distribution name to `install.ps1` with `-WslDistro`.
+
+### 6. Launch Ubuntu once and create the Linux user
+
+Start Ubuntu:
+
+```powershell
+wsl -d Ubuntu-26.04
+```
+
+Ubuntu may ask you to create a Linux username and password. Complete that setup. The password will not show characters while you type; that is normal.
+
+Inside Ubuntu, verify the user exists:
+
+```bash
+whoami
+exit
+```
+
+If `whoami` prints your Linux username, continue.
+
+### 7. Run the Windows installer
+
+If you cloned the repository on Windows, go to that folder:
+
+```powershell
+cd C:\path\to\dune-awakening-selfhost-docker
+```
+
+Run:
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass -Force
+.\install.ps1
+```
+
+The script will:
+
+- validate WSL and the Ubuntu distribution;
+- enable `systemd`;
+- install Docker Engine inside Ubuntu using Docker's official apt repository;
+- install the Docker Compose plugin;
+- clone or update this repository inside Ubuntu;
+- run `install.sh` inside Ubuntu;
+- print the Web UI address.
+
+### 8. Open the Web UI
+
+From Windows, open:
+
+```text
+http://localhost:8088
+```
+
+If that does not work, see [FAQ / troubleshooting](#faq--troubleshooting).
+
+---
+
+## Installation option B: manual Windows + Ubuntu setup
+
+Use this path if you prefer to see each step or if the PowerShell helper stops and asks you to finish something manually.
+
+### 1. Install WSL
+
+Open **PowerShell as Administrator** using the steps above, then run:
+
+```powershell
+wsl --install --no-distribution
+```
+
+Restart Windows if asked.
+
+After restart, open **PowerShell as Administrator** again and run:
+
+```powershell
+wsl --update
+wsl --set-default-version 2
+wsl --status
+```
+
+### 2. Apply recommended WSL settings
+
+Open:
+
+```powershell
+notepad "$env:USERPROFILE\.wslconfig"
+```
+
+Paste:
+
+```ini
+[wsl2]
+localhostForwarding=true
+memory=32GB
+processors=8
+```
+
+Adjust `memory` and `processors`, save the file, then run:
+
+```powershell
+wsl --shutdown
+```
+
+### 3. Install Ubuntu 26.04
+
+Check the exact distro name available on your machine:
+
+```powershell
+wsl --list --online
+```
+
+If `Ubuntu-26.04` is listed:
+
+```powershell
+wsl --install --distribution Ubuntu-26.04
+```
+
+If it is not listed, install the closest available official Ubuntu 26.04 entry shown by `wsl --list --online`, then use that exact distribution name when running the installer.
+
+### 4. Open Ubuntu and create your Linux user
+
+Start Ubuntu from the Start Menu or run:
+
+```powershell
+wsl -d Ubuntu-26.04
+```
+
+Create the Ubuntu username and password when asked.
+
+When typing the password, the screen may not show dots or characters. That is normal.
+
+### 5. Keep the server inside the Linux filesystem
+
+Inside Ubuntu:
+
+```bash
+cd ~
+pwd
+```
+
+The path should look like:
+
+```text
+/home/your-user-name
+```
+
+Do not install the server under `/mnt/c/Users/...`. Keep it under `/home/...` for Linux filesystem performance and to avoid Windows file-locking behavior.
+
+### 6. Enable systemd
+
+Inside Ubuntu:
+
+```bash
+ps -p 1 -o comm=
+```
+
+If the output is not `systemd`, run:
+
+```bash
+sudo nano /etc/wsl.conf
+```
+
+Paste:
+
+```ini
+[boot]
+systemd=true
+```
+
+Save with `CTRL+O`, press `Enter`, then exit with `CTRL+X`.
+
+Back in PowerShell:
+
+```powershell
+wsl --shutdown
+wsl -d Ubuntu-26.04
+```
+
+### 7. Install Docker Engine inside Ubuntu
+
+Inside Ubuntu:
+
+```bash
+sudo apt update
+sudo apt upgrade -y
+sudo apt install -y ca-certificates curl gnupg lsb-release git nano iproute2 apt-transport-https
+```
+
+Remove conflicting old packages if present:
+
+```bash
+sudo apt remove -y docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc || true
+```
+
+Add Docker's official apt repository:
+
+```bash
+sudo install -m 0755 -d /etc/apt/keyrings
+
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
+  -o /etc/apt/keyrings/docker.asc
+
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+sudo tee /etc/apt/sources.list.d/docker.sources > /dev/null <<EOF
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}")
+Components: stable
+Architectures: $(dpkg --print-architecture)
+Signed-By: /etc/apt/keyrings/docker.asc
+EOF
+
+sudo apt update
+```
+
+Install Docker:
+
+```bash
+sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+```
+
+Start Docker:
+
+```bash
+sudo systemctl enable --now docker
+sudo systemctl status docker --no-pager
+```
+
+Allow your Ubuntu user to run Docker:
+
+```bash
+sudo usermod -aG docker $USER
+newgrp docker
+```
+
+Test Docker:
+
+```bash
+docker run hello-world
+```
+
+### 8. Clone the repository inside Ubuntu
+
+Inside Ubuntu:
+
+```bash
+cd ~
+git clone https://github.com/Red-Blink/dune-awakening-selfhost-docker.git
+cd dune-awakening-selfhost-docker
+```
+
+If you are testing a fork, use the fork URL instead:
+
+```bash
+git clone https://github.com/yacketrj/dune-awakening-selfhost-docker-WSL.git
+cd dune-awakening-selfhost-docker-WSL
+```
+
+### 9. Run the Linux installer
+
+```bash
+chmod +x install.sh
+./install.sh
+```
+
+Press `Enter` when asked for the Web UI port to use the default `8088`.
+
+At the end, copy the generated admin password and open the Web UI.
+
+---
+
+## Public hosting ports
+
+Forward these ports only if players outside your PC or home network need to connect:
+
+| Port | Protocol | Purpose |
+|---|---:|---|
+| `8088` | TCP | Web admin setup panel |
+| `31982` | TCP | Game messaging |
+| `7777-7810` | UDP | Game traffic |
+
+Security recommendation:
+
+- Do not expose `8088` to the public internet unless you fully understand the risk.
+- Forward the game ports publicly only when needed.
+- Keep database and internal admin ports private.
+
+---
+
+## Windows Firewall rules
+
+If hosting for LAN or internet players, open PowerShell as Administrator and run:
+
+```powershell
+New-NetFirewallRule -DisplayName "Dune Admin Web 8088 TCP" `
+  -Direction Inbound `
+  -Protocol TCP `
+  -LocalPort 8088 `
+  -Action Allow
+
+New-NetFirewallRule -DisplayName "Dune Game Messaging 31982 TCP" `
+  -Direction Inbound `
+  -Protocol TCP `
+  -LocalPort 31982 `
+  -Action Allow
+
+New-NetFirewallRule -DisplayName "Dune Game UDP 7777-7810" `
+  -Direction Inbound `
+  -Protocol UDP `
+  -LocalPort 7777-7810 `
+  -Action Allow
+```
+
+---
+
+## Advanced WSL networking
+
+For the first same-PC install test, use the recommended localhost-forwarding config:
+
+```ini
+[wsl2]
+localhostForwarding=true
+memory=32GB
+processors=8
+```
+
+For LAN or internet hosting, WSL mirrored networking may be useful on Windows 11. Mirrored networking changes how WSL services are exposed and can require Windows Firewall rules. Use it only when you are specifically testing LAN reachability.
+
+Advanced mirrored example:
+
+```ini
+[wsl2]
+networkingMode=mirrored
+dnsTunneling=true
+autoProxy=true
+firewall=true
+memory=32GB
+processors=8
+```
+
+Do not combine `networkingMode=mirrored` with an expectation that `localhostForwarding` controls access. In mirrored mode, WSL may warn that `localhostForwarding` has no effect.
+
+After changing `.wslconfig`, always restart WSL:
+
+```powershell
+wsl --shutdown
+```
+
+---
+
+## Daily commands
+
+Inside Ubuntu:
+
+```bash
+cd ~/dune-awakening-selfhost-docker
+```
+
+If you cloned the fork:
+
+```bash
+cd ~/dune-awakening-selfhost-docker-WSL
+```
+
+Useful commands:
+
+```bash
+dune --help
+dune status
+dune start
+dune stop
+dune web
+dune logs redblink-dune-docker-console
+```
+
+---
+
+## FAQ / troubleshooting
+
+### `Ubuntu-26.04` is not listed
+
+Run:
+
+```powershell
+wsl --list --online
+```
+
+Use the exact Ubuntu 26.04 name that Microsoft lists. If Ubuntu 26.04 is not listed, install the closest available official Ubuntu 26.04 entry, then pass that exact name to `install.ps1` with `-WslDistro`.
+
+### Could not determine the default Linux user
+
+Open Ubuntu once and finish first-run setup:
+
+```powershell
+wsl --shutdown
+wsl -d Ubuntu-26.04
+```
+
+Create the Linux username/password if prompted, then run:
+
+```bash
+whoami
+exit
+```
+
+After `whoami` prints your Linux username, re-run the installer.
+
+### `docker: permission denied`
+
+Inside Ubuntu:
+
+```bash
+sudo usermod -aG docker $USER
+newgrp docker
+docker run hello-world
+```
+
+If it still fails:
+
+```powershell
+wsl --shutdown
+wsl -d Ubuntu-26.04
+```
+
+### Docker service is not running
+
+Inside Ubuntu:
+
+```bash
+sudo systemctl status docker --no-pager
+sudo systemctl enable --now docker
+```
+
+If `systemctl` fails, verify `systemd`:
+
+```bash
+ps -p 1 -o comm=
+```
+
+### Web UI does not open from Windows
+
+First verify that the console container exists:
+
+```powershell
+wsl -d Ubuntu-26.04 -- bash -lc 'docker ps --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"'
+```
+
+Look for:
+
+```text
+redblink-dune-docker-console
+```
+
+If the container is missing, start it from Ubuntu:
+
+```powershell
+wsl -d Ubuntu-26.04 -- bash -lc 'cd ~/dune-awakening-selfhost-docker && docker compose -f docker-compose.web.yml up -d redblink-dune-docker-console'
+```
+
+Then verify the Web UI is listening inside Ubuntu:
+
+```powershell
+wsl -d Ubuntu-26.04 -- bash -lc 'ss -ltnp | grep 8088 || true'
+wsl -d Ubuntu-26.04 -- bash -lc 'curl -I http://127.0.0.1:8088 || true'
+```
+
+If Ubuntu returns `HTTP/1.1 200 OK` but Windows still cannot connect to `localhost:8088`, check the Windows-side WSL config:
+
+```powershell
+Get-Content "$env:USERPROFILE\.wslconfig" -ErrorAction SilentlyContinue
+```
+
+For the default same-PC setup, use:
+
+```ini
+[wsl2]
+localhostForwarding=true
+memory=32GB
+processors=8
+```
+
+Then fully restart WSL and start the console again:
+
+```powershell
+wsl --shutdown
+wsl -d Ubuntu-26.04 -- bash -lc 'cd ~/dune-awakening-selfhost-docker && docker compose -f docker-compose.web.yml up -d redblink-dune-docker-console'
+```
+
+Test from Windows:
+
+```powershell
+Test-NetConnection localhost -Port 8088
+```
+
+If you intentionally use mirrored networking, test the LAN address instead of assuming localhost forwarding:
+
+```powershell
+$wslIps = (wsl -d Ubuntu-26.04 -- bash -lc "hostname -I").Trim().Split(" ", [System.StringSplitOptions]::RemoveEmptyEntries)
+$wslIp = $wslIps | Where-Object { $_ -notlike "172.*" } | Select-Object -First 1
+$wslIp
+Test-NetConnection $wslIp -Port 8088
+```
+
+If the container keeps restarting, inspect the logs:
+
+```powershell
+wsl -d Ubuntu-26.04 -- bash -lc 'docker logs --tail=200 redblink-dune-docker-console'
+```
+
+Redact passwords, tokens, and secrets before sharing logs.
+
+### Players cannot connect from outside the house
+
+Check:
+
+1. Router forwards `31982/TCP` and `7777-7810/UDP` to the Windows PC.
+2. Windows Firewall allows those ports.
+3. The server advertises the correct public IP.
+4. Your ISP is not using CGNAT.
+5. WSL networking mode allows LAN/internet traffic to reach Ubuntu.
+
+---
+
+## Security checklist
+
+Before opening the server to the internet:
+
+- Change or store the generated admin password securely.
+- Do not commit `.env`, `runtime/secrets`, generated files, or backups.
+- Do not expose the Web UI to untrusted users.
+- Do not expose `8088` to the public internet unless you intentionally need remote administration.
+- Forward only the ports you need.
+- Keep Windows, WSL, Ubuntu packages, and Docker patched.
+- Treat `/var/run/docker.sock` as privileged host access.
+- Back up the database before updates or major configuration changes.

--- a/docs/WINDOWS-WSL-NETWORKING-AND-DOCKER-SOCKET.md
+++ b/docs/WINDOWS-WSL-NETWORKING-AND-DOCKER-SOCKET.md
@@ -1,0 +1,244 @@
+# Windows / WSL networking and Docker socket access
+
+This guide covers two Windows / WSL issues that can make a healthy Dune stack look broken:
+
+1. the game client hangs on **Connecting** because WSL is not using mirrored networking; and
+2. the Web UI shows Docker permission errors because the console container cannot access `/var/run/docker.sock`.
+
+Use this guide after the first install is complete, especially for LAN or public hosting from Windows 11 + WSL2.
+
+---
+
+## Required WSL networking for LAN or public game hosting
+
+For same-PC Web UI validation, `localhostForwarding=true` may be enough. For actual LAN or public Dune game traffic, use WSL mirrored networking so the Linux/Docker server path can behave like the Windows host network endpoint.
+
+Open `.wslconfig` from **PowerShell**:
+
+```powershell
+notepad "$env:USERPROFILE\.wslconfig"
+```
+
+Use this baseline:
+
+```ini
+[wsl2]
+networkingMode=mirrored
+localhostForwarding=true
+firewall=true
+memory=32GB
+processors=8
+
+[experimental]
+hostAddressLoopback=true
+```
+
+Adjust `memory` and `processors` for the host. Do not allocate all system RAM to WSL; leave enough for Windows, the game client, browser, Discord, antivirus, and remote administration tools.
+
+After saving `.wslconfig`, fully restart WSL from **PowerShell**:
+
+```powershell
+wsl --shutdown
+```
+
+Then reopen Ubuntu and verify the network view:
+
+```bash
+ip -4 addr show
+ip route
+hostname -I
+```
+
+For LAN testing, players should reach the Windows host LAN IP, for example:
+
+```text
+192.168.x.x
+```
+
+If the server advertises a WAN address while the client is on the same LAN, the router must support NAT hairpin/loopback. If it does not, the client may hang on **Connecting** even though `dune ready` is healthy.
+
+---
+
+## Quick symptom check: Connecting hang
+
+If `dune ready` is healthy but the game client hangs on **Connecting**, confirm whether client UDP traffic reaches the game ports:
+
+```bash
+sudo timeout 75 tcpdump -ni any 'udp port 7777 or udp port 7778'
+```
+
+During a real client attempt, you should see packets to the client game ports. If you only see internal `172.x.x.x` traffic on `7888/7889`, that is server-to-server traffic, not client entry traffic.
+
+Useful state checks:
+
+```bash
+dune ready
+
+docker exec dune-postgres psql -U postgres -d dune -P pager=off -c "
+select server_id, map, game_addr, game_port, igw_addr, igw_port, ready, alive, connected_players
+from dune.farm_state
+where map in ('Overmap','Survival_1','DeepDesert_1')
+order by map, server_id;
+"
+```
+
+If `connected_players` stays `0` during a connection attempt, the client did not complete entry into the game server.
+
+---
+
+## Docker socket access for the Web UI
+
+The Web UI console container uses the host Docker socket to inspect and control the Dune containers. The compose file passes the host UID/GID and Docker socket GID into the container. If those values are stale after a WSL or Docker restart, the Web UI may show errors like:
+
+```text
+permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock
+```
+
+This is not a Dune server failure. It means the Web UI process cannot access `/var/run/docker.sock`.
+
+### Verify host Docker access
+
+Inside Ubuntu:
+
+```bash
+docker ps >/dev/null && echo "host docker OK" || echo "host docker FAIL"
+```
+
+If host Docker fails, add the Ubuntu user to the `docker` group and restart the login/session:
+
+```bash
+sudo usermod -aG docker "$USER"
+newgrp docker
+docker ps
+```
+
+If it still fails after `newgrp docker`, restart WSL from **PowerShell**:
+
+```powershell
+wsl --shutdown
+```
+
+Then reopen Ubuntu and test `docker ps` again.
+
+### Refresh Web UI UID/GID and Docker socket GID
+
+Run this from the repository root inside Ubuntu:
+
+```bash
+cd ~/dune-awakening-selfhost-docker
+
+HOST_UID="$(id -u)"
+HOST_GID="$(id -g)"
+SOCKET_GID="$(stat -c '%g' /var/run/docker.sock)"
+
+cp .env ".env.bak.$(date +%Y%m%d-%H%M%S)"
+
+grep -v -E '^(DUNE_HOST_UID|DUNE_HOST_GID|DOCKER_SOCKET_GID)=' .env > /tmp/dune-env.$$
+{
+  cat /tmp/dune-env.$$
+  echo "DUNE_HOST_UID=$HOST_UID"
+  echo "DUNE_HOST_GID=$HOST_GID"
+  echo "DOCKER_SOCKET_GID=$SOCKET_GID"
+} > .env
+rm -f /tmp/dune-env.$$
+
+grep -E '^(DUNE_HOST_UID|DUNE_HOST_GID|DOCKER_SOCKET_GID)=' .env
+```
+
+If you cloned the WSL fork instead, use that repository path:
+
+```bash
+cd ~/dune-awakening-selfhost-docker-WSL
+```
+
+Recreate the Web UI container so the new group settings apply:
+
+```bash
+docker compose -f docker-compose.web.yml up -d --force-recreate redblink-dune-docker-console
+```
+
+Then verify inside the container:
+
+```bash
+docker exec redblink-dune-docker-console sh -lc '
+echo "===== container id ====="
+id
+
+echo "===== docker socket ====="
+ls -l /var/run/docker.sock
+stat -c "socket uid=%u gid=%g mode=%A path=%n" /var/run/docker.sock
+'
+```
+
+Expected pattern:
+
+```text
+uid=<your Linux uid>
+groups=<socket gid included>
+srw-rw---- 1 root <socket gid> ... /var/run/docker.sock
+```
+
+The container must either run as a user/group that can access the socket or have the socket GID in its supplemental groups.
+
+### Test Docker socket access from inside the Web UI container
+
+```bash
+docker exec redblink-dune-docker-console sh -lc '
+node - <<'"'"'NODE'"'"'
+const http = require("http");
+
+const req = http.request({
+  socketPath: "/var/run/docker.sock",
+  path: "/v1.47/_ping",
+  method: "GET"
+}, res => {
+  let body = "";
+  res.on("data", chunk => body += chunk);
+  res.on("end", () => {
+    console.log("status=" + res.statusCode);
+    console.log("body=" + body.trim());
+  });
+});
+
+req.on("error", err => {
+  console.error("ERROR:", err.message);
+  process.exit(1);
+});
+
+req.end();
+NODE
+'
+```
+
+Expected result:
+
+```text
+status=200
+body=OK
+```
+
+If the socket test succeeds but the browser still shows an old Docker permission error, restart the Web UI container and hard-refresh the browser:
+
+```bash
+docker restart redblink-dune-docker-console
+```
+
+Then press `Ctrl+F5` in the browser.
+
+---
+
+## Do not use world-writable Docker socket permissions
+
+Do not fix this with:
+
+```bash
+sudo chmod 666 /var/run/docker.sock
+```
+
+The Docker socket is privileged host access. Making it world-writable gives broad Docker control to any local process and can be reverted by Docker after restart anyway.
+
+---
+
+## After WSL or Docker restarts
+
+A WSL shutdown, Windows restart, Docker service restart, or `.wslconfig` change can recreate `/var/run/docker.sock`. If the Web UI loses Docker access afterward, repeat the UID/GID refresh and Web UI container recreation steps above.

--- a/docs/WINDOWS-WSL-QUICKSTART.md
+++ b/docs/WINDOWS-WSL-QUICKSTART.md
@@ -1,0 +1,220 @@
+# Windows / WSL Quick Install
+
+This path is for **Windows 11 Home** users who want to run the Linux server through **WSL2** and **Ubuntu 26.04**.
+
+## 1. Confirm firmware virtualization is enabled
+
+Before installing WSL, confirm CPU virtualization is enabled in firmware. This is usually shown as **Virtualization**, **Intel VT-x**, **Intel Virtualization Technology**, **AMD-V**, or **SVM Mode** in BIOS/UEFI.
+
+This is **not** the same thing as installing the Hyper-V management feature. Windows 11 Home can use WSL2 through the Windows Subsystem for Linux and Virtual Machine Platform components installed by `wsl --install`. Do not follow unofficial Hyper-V-on-Home workarounds for this installer.
+
+Check from Task Manager:
+
+1. Press `Ctrl` + `Shift` + `Esc` to open **Task Manager**.
+2. Select **Performance**.
+3. Select **CPU**.
+4. Confirm **Virtualization: Enabled**.
+
+You can also check from PowerShell:
+
+```powershell
+Get-CimInstance Win32_Processor | Select-Object Name, VirtualizationFirmwareEnabled
+```
+
+Expected result:
+
+```text
+VirtualizationFirmwareEnabled : True
+```
+
+If virtualization is disabled, enable it in BIOS/UEFI first, then return to this guide.
+
+## 2. Open PowerShell as Administrator
+
+The Windows / WSL installer must be run from an **Administrative PowerShell** window.
+
+To open PowerShell as Administrator:
+
+1. Press the **Windows** key.
+2. Type `PowerShell`.
+3. Right-click **Windows PowerShell**.
+4. Select **Run as administrator**.
+5. Click **Yes** on the Windows security prompt.
+6. Confirm the window title starts with **Administrator:**.
+
+## 3. Install WSL2
+
+In the Administrator PowerShell window, run:
+
+```powershell
+wsl --install --no-distribution
+```
+
+If Windows asks you to restart, restart the PC. After the restart, open **PowerShell as Administrator** again and run:
+
+```powershell
+wsl --update
+wsl --set-default-version 2
+wsl --status
+```
+
+## 4. Apply recommended WSL settings
+
+These settings are recommended for the first install and same-PC Web UI access. They keep WSL in the default localhost-forwarding path so `http://localhost:8088` works from Windows after the Web console starts.
+
+Recommended memory values:
+
+| Physical RAM | Suggested WSL memory |
+|---:|---:|
+| 32 GB | 24 GB |
+| 48 GB | 36 GB |
+| 64 GB | 48 GB |
+| 96 GB+ | 64 GB |
+
+Open the WSL config file:
+
+```powershell
+notepad "$env:USERPROFILE\.wslconfig"
+```
+
+Paste this example, then adjust `memory` and `processors` for your machine:
+
+```ini
+[wsl2]
+localhostForwarding=true
+memory=32GB
+processors=8
+```
+
+Save the file, close Notepad, then fully restart WSL:
+
+```powershell
+wsl --shutdown
+```
+
+If your PC has less than 48 GB RAM, lower `memory` before continuing. Do not allocate all system memory to WSL; leave enough RAM for Windows.
+
+Do not add `networkingMode=mirrored` for the first end-to-end install test. Mirrored networking is useful for some LAN setups, but it changes how Windows reaches WSL services and can make `localhost:8088` troubleshooting harder.
+
+## 5. Install Ubuntu 26.04
+
+List the available WSL distributions:
+
+```powershell
+wsl --list --online
+```
+
+Install Ubuntu 26.04:
+
+```powershell
+wsl --install --distribution Ubuntu-26.04
+```
+
+If `Ubuntu-26.04` is not listed, install the closest available official Ubuntu 26.04 entry shown by `wsl --list --online`, then use that exact distribution name when running `install.ps1`.
+
+## 6. Launch Ubuntu once and create the Linux user
+
+Before running the Dune installer, start Ubuntu once:
+
+```powershell
+wsl -d Ubuntu-26.04
+```
+
+Ubuntu may ask you to create a Linux username and password. Complete that setup. The password will not show characters while you type; that is normal.
+
+Inside Ubuntu, verify the user exists:
+
+```bash
+whoami
+exit
+```
+
+If `whoami` prints your Linux username, continue.
+
+## 7. Run the Dune Windows / WSL installer
+
+Paste this command into the same Administrator PowerShell window:
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass -Force; $ErrorActionPreference='Stop'; $ProgressPreference='SilentlyContinue'; $root=Join-Path $env:USERPROFILE 'dune-awakening-selfhost-docker'; New-Item -ItemType Directory -Force -Path $root | Out-Null; Set-Location $root; $installer=Join-Path $root 'install.ps1'; Invoke-WebRequest -UseBasicParsing -Uri 'https://raw.githubusercontent.com/Red-Blink/dune-awakening-selfhost-docker/main/install.ps1' -OutFile $installer; powershell -NoProfile -ExecutionPolicy Bypass -File $installer -RepoUrl 'https://github.com/Red-Blink/dune-awakening-selfhost-docker.git' -RepoRef 'main'
+```
+
+Do not wrap this command in another `powershell -Command "..."` call. It is meant to be pasted directly into an already-open Administrator PowerShell window.
+
+This command:
+
+1. Creates `%USERPROFILE%\dune-awakening-selfhost-docker`.
+2. Downloads `install.ps1` directly.
+3. Runs the downloaded `install.ps1`.
+4. The installer prepares WSL2, Ubuntu 26.04, Docker Engine inside Ubuntu, and delegates final server startup to the existing Linux `install.sh`.
+
+## 8. Get the Web UI admin password
+
+The Web UI admin password is stored in persistent Ubuntu host storage:
+
+```text
+~/dune-awakening-selfhost-docker/runtime/secrets/admin-web-password.txt
+```
+
+Docker image rebuilds, container recreates, and `docker compose down` do not delete this file. That is intentional so normal restarts do not rotate the admin password.
+
+The password printed by the installer is the current password in this file at install time. If you later change the Web UI password from the browser, the installer-printed password is no longer valid; the same file will contain the new current password.
+
+To print the current password from PowerShell:
+
+```powershell
+Write-Host "Admin Web UI password:"
+wsl -d Ubuntu-26.04 -- bash -lc "cat ~/dune-awakening-selfhost-docker/runtime/secrets/admin-web-password.txt"
+```
+
+If you intentionally need to rotate the Web UI admin password, move aside only `admin-web-password.txt`, then recreate the Web UI container so a new file is generated. Do not remove the whole `runtime/secrets` directory, because it may contain other secrets, including the Funcom token.
+
+## 9. If `localhost:8088` does not open
+
+First verify the Web console is running inside Ubuntu:
+
+```powershell
+wsl -d Ubuntu-26.04 -- bash -lc 'ss -ltnp | grep 8088 || true'
+wsl -d Ubuntu-26.04 -- bash -lc 'curl -i http://127.0.0.1:8088/api/health || true'
+```
+
+If Ubuntu returns `HTTP/1.1 200 OK` but Windows cannot connect to `localhost:8088`, the Web UI is healthy and Windows localhost forwarding is the broken layer. Confirm from Windows:
+
+```powershell
+Test-NetConnection localhost -Port 8088
+Invoke-WebRequest -UseBasicParsing http://127.0.0.1:8088/api/health
+```
+
+If those Windows tests fail while the WSL health check passes, refresh Windows' explicit forwarding rule to the current WSL IP. Run this from **PowerShell as Administrator**:
+
+```powershell
+$wslIp = (wsl -d Ubuntu-26.04 -- bash -lc "hostname -I").Trim().Split(" ", [System.StringSplitOptions]::RemoveEmptyEntries)[0]
+
+netsh interface portproxy delete v4tov4 listenaddress=127.0.0.1 listenport=8088 2>$null
+netsh interface portproxy add v4tov4 listenaddress=127.0.0.1 listenport=8088 connectaddress=$wslIp connectport=8088
+
+netsh interface portproxy show all
+Test-NetConnection 127.0.0.1 -Port 8088
+```
+
+Then open:
+
+```text
+http://127.0.0.1:8088
+```
+
+WSL IP addresses can change after `wsl --shutdown` or a Windows restart. If the Web UI works inside Ubuntu but stops loading from Windows again, re-run the portproxy block above.
+
+If the WSL health check fails too, restart only the Web UI container before recreating anything:
+
+```powershell
+wsl -d Ubuntu-26.04 -- bash -lc 'docker restart redblink-dune-docker-console && sleep 5 && curl -i http://127.0.0.1:8088/api/health'
+```
+
+Only recreate the Web UI container if the restart still fails:
+
+```powershell
+wsl -d Ubuntu-26.04 -- bash -lc 'cd ~/dune-awakening-selfhost-docker && ADMIN_BIND_PORT=8088 docker compose -f docker-compose.web.yml up -d --force-recreate --build redblink-dune-docker-console && sleep 5 && curl -i http://127.0.0.1:8088/api/health'
+```
+
+For the full guide and advanced LAN notes, see [WINDOWS-WSL-INSTALL.md](WINDOWS-WSL-INSTALL.md).

--- a/docs/WINDOWS-WSL-SECURITY-REGRESSION.md
+++ b/docs/WINDOWS-WSL-SECURITY-REGRESSION.md
@@ -1,0 +1,115 @@
+# Windows / WSL Security Regression Checklist
+
+This checklist covers the Windows `install.ps1` helper and the Windows / WSL documentation. It is intended for maintainers reviewing changes that affect WSL setup, Docker installation, or Web UI exposure.
+
+## Scope
+
+| Area | Regression concern |
+|---|---|
+| `install.ps1` | Unsafe PowerShell execution, secret leakage, destructive filesystem changes, wrong repository bootstrap |
+| WSL setup | Root-only operations limited to OS/package setup |
+| Docker setup | Docker installed from official apt repository; no unreviewed shell piping in the Windows helper |
+| README | Linux `install.sh` path remains intact; Windows path is additive |
+| Documentation | Web UI exposure warnings, secret handling, firewall/port guidance |
+
+## Static security checks
+
+Run these from the repository root:
+
+```bash
+python3 - <<'PY'
+from pathlib import Path
+import re
+
+checks = []
+
+def add(name, ok, detail=''):
+    checks.append((name, bool(ok), detail))
+
+install = Path('install.ps1').read_text(encoding='utf-8')
+readme = Path('README.md').read_text(encoding='utf-8')
+guide = Path('docs/WINDOWS-WSL-INSTALL.md').read_text(encoding='utf-8')
+quickstart = Path('docs/WINDOWS-WSL-QUICKSTART.md').read_text(encoding='utf-8')
+admin = Path('docs/ADMIN-POWERSHELL.md').read_text(encoding='utf-8')
+
+lower_install = install.lower()
+
+add('install.ps1 exists', Path('install.ps1').is_file())
+add('install.ps1 avoids dynamic-expression execution', 'invoke-expression' not in lower_install and re.search(r'\biex\b', lower_install) is None)
+add('install.ps1 avoids direct remote-download-to-shell pattern', not re.search(r'(curl|irm|iwr|wget).{0,80}\|.{0,40}(bash|sh|pwsh|powershell)', lower_install, re.S))
+add('install.ps1 keeps admin authentication enabled by default', 'admin_auth_disabled=1' not in lower_install)
+add('install.ps1 does not embed Funcom token values', 'funcom-token' not in lower_install and 'funcom_token=' not in lower_install)
+add('install.ps1 removes only temporary helper scripts', 'Remove-Item -LiteralPath $scriptPath -Force' in install)
+add('install.ps1 calls wsl.exe with explicit distro flag arrays', '@("-d", $WslDistro' in install)
+add('install.ps1 converts Windows temp paths to WSL /mnt paths', 'return "/mnt/$drive/$rest"' in install and "-replace '\\\\', '/'" in install)
+add('install.ps1 writes temp shell scripts without UTF-8 BOM', 'Set-Content -LiteralPath $scriptPath -Value $ScriptText -Encoding ASCII -NoNewline' in install)
+add('README preserves Linux install.sh path', './install.sh' in readme and 'Copy and paste this on a fresh Linux server' in readme)
+add('README adds Windows WSL option', 'Windows 11 Home / WSL2 / Ubuntu 26.04' in readme)
+add('README links Windows quickstart', 'WINDOWS-WSL-QUICKSTART.md' in readme)
+add('README links Administrator PowerShell instructions', 'ADMIN-POWERSHELL.md' in readme)
+add('Quickstart downloads install.ps1 directly', 'raw.githubusercontent.com/Red-Blink/dune-awakening-selfhost-docker/main/install.ps1' in quickstart)
+add('Quickstart passes explicit repo URL and ref', '-RepoUrl' in quickstart and '-RepoRef' in quickstart)
+add('Quickstart explains Administrator PowerShell launch steps', 'Run as administrator' in quickstart and 'Administrator:' in quickstart)
+add('Quickstart warns not to nest powershell command wrapper', 'Do not wrap this command' in quickstart)
+add('Admin doc explains Run as administrator', 'Run as administrator' in admin and 'Administrator:' in admin)
+add('WSL guide warns not to expose Web UI publicly', 'Do not expose `8088`' in guide or 'Do not expose the Web UI' in guide)
+add('WSL guide tells users not to commit secrets', 'Do not commit `.env`' in guide and 'runtime/secrets' in guide)
+add('WSL guide documents Docker socket risk', '/var/run/docker.sock' in guide and 'privileged' in guide)
+add('WSL guide documents required public ports', '`31982`' in guide and '`7777-7810`' in guide and '`8088`' in guide)
+
+failed = [c for c in checks if not c[1]]
+for name, ok, detail in checks:
+    print(f"{'PASS' if ok else 'FAIL'} {name}{': ' + detail if detail else ''}")
+
+if failed:
+    raise SystemExit(1)
+print(f"PASS security regression checks completed: {len(checks)} checks")
+PY
+```
+
+Expected result: all checks pass.
+
+## Manual review checks
+
+- Confirm `install.ps1` is additive and does not replace or modify `install.sh`.
+- Confirm Linux users can still use the original README Linux installer.
+- Confirm Windows users can either use the direct `install.ps1` bootstrap command or run the helper from a trusted local checkout.
+- Confirm the direct bootstrap downloads `install.ps1` and runs it as a file, not through a nested command string.
+- Confirm WSL subprocess calls include `-d <distro>` and do not rely on PowerShell argument passthrough.
+- Confirm Windows temporary script paths are converted to `/mnt/<drive>/...` paths before WSL execution.
+- Confirm temporary shell scripts are written without a UTF-8 BOM so Bash reads the first command correctly.
+- Confirm Windows documentation tells users how to launch Administrator PowerShell.
+- Confirm the helper delegates to `install.sh` after preparing WSL and Docker.
+- Confirm the helper does not store Windows, Ubuntu, Funcom, or Web UI passwords.
+- Confirm public port guidance distinguishes game ports from the admin Web UI.
+- Confirm documentation tells users to keep database and internal admin ports private.
+- Confirm the Web UI remains protected by the generated admin password unless the user explicitly changes configuration.
+
+## Runtime smoke checks
+
+On a Windows 11 Home host with virtualization enabled:
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass -Force
+.\install.ps1 -NoStart
+```
+
+Then inside Ubuntu:
+
+```bash
+docker version
+docker compose version
+cd ~/dune-awakening-selfhost-docker
+chmod +x install.sh
+./install.sh
+```
+
+Expected result:
+
+- WSL2 is available.
+- Ubuntu 26.04 starts.
+- `systemd` is enabled.
+- Docker Engine starts inside Ubuntu.
+- Docker Compose plugin is available.
+- Repository is present inside Ubuntu.
+- `install.sh` starts the Web UI and prints the generated admin password.

--- a/docs/WINDOWS-WSL-SECURITY-REGRESSION.md
+++ b/docs/WINDOWS-WSL-SECURITY-REGRESSION.md
@@ -39,10 +39,10 @@ add('install.ps1 avoids dynamic-expression execution', 'invoke-expression' not i
 add('install.ps1 avoids direct remote-download-to-shell pattern', not re.search(r'(curl|irm|iwr|wget).{0,80}\|.{0,40}(bash|sh|pwsh|powershell)', lower_install, re.S))
 add('install.ps1 keeps admin authentication enabled by default', 'admin_auth_disabled=1' not in lower_install)
 add('install.ps1 does not embed Funcom token values', 'funcom-token' not in lower_install and 'funcom_token=' not in lower_install)
-add('install.ps1 removes only temporary helper scripts', 'Remove-Item -LiteralPath $scriptPath -Force' in install)
+add('install.ps1 transports WSL scripts with base64 instead of temp files', 'ToBase64String' in install and "base64 -d | bash" in install)
 add('install.ps1 calls wsl.exe with explicit distro flag arrays', '@("-d", $WslDistro' in install)
-add('install.ps1 converts Windows temp paths to WSL /mnt paths', 'return "/mnt/$drive/$rest"' in install and "-replace '\\\\', '/'" in install)
-add('install.ps1 writes temp shell scripts without UTF-8 BOM', 'Set-Content -LiteralPath $scriptPath -Value $ScriptText -Encoding ASCII -NoNewline' in install)
+add('install.ps1 shell-quotes user controlled Bash literals', 'function ConvertTo-ShellSingleQuotedString' in install and 'install_dir="$HOME"/__INSTALL_DIR__' in install)
+add('install.ps1 avoids double-quoted user controlled install dir interpolation', 'install_dir="$HOME/__INSTALL_DIR__"' not in install)
 add('README preserves Linux install.sh path', './install.sh' in readme and 'Copy and paste this on a fresh Linux server' in readme)
 add('README adds Windows WSL option', 'Windows 11 Home / WSL2 / Ubuntu 26.04' in readme)
 add('README links Windows quickstart', 'WINDOWS-WSL-QUICKSTART.md' in readme)
@@ -76,14 +76,37 @@ Expected result: all checks pass.
 - Confirm Windows users can either use the direct `install.ps1` bootstrap command or run the helper from a trusted local checkout.
 - Confirm the direct bootstrap downloads `install.ps1` and runs it as a file, not through a nested command string.
 - Confirm WSL subprocess calls include `-d <distro>` and do not rely on PowerShell argument passthrough.
-- Confirm Windows temporary script paths are converted to `/mnt/<drive>/...` paths before WSL execution.
-- Confirm temporary shell scripts are written without a UTF-8 BOM so Bash reads the first command correctly.
+- Confirm WSL script bodies are base64 transported through `bash -lc` without temporary helper files.
+- Confirm user-controlled Bash literals such as repository archive URL, Linux user, and install directory are shell-quoted before interpolation.
 - Confirm Windows documentation tells users how to launch Administrator PowerShell.
 - Confirm the helper delegates to `install.sh` after preparing WSL and Docker.
 - Confirm the helper does not store Windows, Ubuntu, Funcom, or Web UI passwords.
 - Confirm public port guidance distinguishes game ports from the admin Web UI.
 - Confirm documentation tells users to keep database and internal admin ports private.
 - Confirm the Web UI remains protected by the generated admin password unless the user explicitly changes configuration.
+
+## Security review findings
+
+Latest review result for PR #42:
+
+| Finding | Resolution |
+|---|---|
+| The checklist still expected the older temporary WSL helper script implementation. | Updated the static checks and manual review checklist for the current base64-to-`bash` transport. |
+| `-InstallDir` was interpolated inside a double-quoted Bash string, allowing command substitution if a malicious install directory was supplied. | Added `ConvertTo-ShellSingleQuotedString` and now inject repository URL, Linux user, and install directory as shell-quoted literals. |
+| `safeStaticTarget` used `/` string-prefix checks, which do not behave correctly under Windows path separators during regression tests. | Switched to `path.relative` and `path.isAbsolute` containment checks so static file traversal protection is cross-platform. |
+
+Validation completed:
+
+```text
+PASS security regression checklist: 22 checks
+PASS npm audit --prefix console/api --audit-level=moderate: 0 vulnerabilities
+PASS npm audit --prefix console/web --audit-level=moderate: 0 vulnerabilities
+PASS install.ps1 PowerShell parser syntax check
+PASS bash -n install.sh
+PASS python3 -m py_compile orchestrator/dune_orchestrator.py
+PASS npm test --prefix console/api: 189 passed, 0 failed
+PASS npm run build --prefix console/web
+```
 
 ## Runtime smoke checks
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,398 @@
+#Requires -Version 5.1
+[CmdletBinding()]
+param(
+    [string]$WslDistro = "Ubuntu-26.04",
+    [string]$InstallDir = "dune-awakening-selfhost-docker",
+    [string]$RepoUrl = "",
+    [string]$RepoRef = "main",
+    [int]$AdminPort = 8088,
+    [switch]$SkipWslInstall,
+    [switch]$SkipDockerInstall,
+    [switch]$NoStart
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Script:RepoRoot = $PSScriptRoot
+if ([string]::IsNullOrWhiteSpace($Script:RepoRoot)) {
+    $Script:RepoRoot = (Get-Location).Path
+}
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host ""
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function Write-Info {
+    param([string]$Message)
+    Write-Host "    $Message"
+}
+
+function Test-CommandAvailable {
+    param([string]$CommandName)
+    return $null -ne (Get-Command $CommandName -ErrorAction SilentlyContinue)
+}
+
+function Invoke-External {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [string[]]$Arguments = @()
+    )
+
+    & $FilePath @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code ${LASTEXITCODE}: $FilePath $($Arguments -join ' ')"
+    }
+}
+
+function Invoke-WslScript {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ScriptText,
+        [string]$User = "",
+        [switch]$Root
+    )
+
+    $scriptBase64 = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($ScriptText))
+    $bashCommand = "printf '%s' '$scriptBase64' | base64 -d | bash"
+
+    if ($Root) {
+        Invoke-External -FilePath "wsl.exe" -Arguments @("-d", $WslDistro, "-u", "root", "--", "bash", "-lc", $bashCommand)
+    } elseif (-not [string]::IsNullOrWhiteSpace($User)) {
+        Invoke-External -FilePath "wsl.exe" -Arguments @("-d", $WslDistro, "-u", $User, "--", "bash", "-lc", $bashCommand)
+    } else {
+        Invoke-External -FilePath "wsl.exe" -Arguments @("-d", $WslDistro, "--", "bash", "-lc", $bashCommand)
+    }
+}
+
+function Get-RegisteredWslDistros {
+    if (-not (Test-CommandAvailable "wsl.exe")) {
+        return @()
+    }
+
+    $output = & wsl.exe --list --quiet 2>$null
+    if ($LASTEXITCODE -ne 0 -or $null -eq $output) {
+        return @()
+    }
+
+    return @($output | ForEach-Object { ($_ -replace "`0", "").Trim() } | Where-Object { $_ })
+}
+
+function Test-WslDistroRegistered {
+    param([string]$Name)
+    return (Get-RegisteredWslDistros) -contains $Name
+}
+
+function Ensure-WslInstalled {
+    Write-Step "Checking WSL"
+
+    if (-not (Test-CommandAvailable "wsl.exe")) {
+        throw "wsl.exe was not found. Use Windows 11 Home or later with WSL enabled, then run this script again."
+    }
+
+    if (-not $SkipWslInstall) {
+        & wsl.exe --status 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            Write-Info "WSL is not fully installed. Starting Microsoft WSL installation."
+            Write-Info "Windows may ask you to reboot. If it does, reboot and run this script again."
+            Invoke-External -FilePath "wsl.exe" -Arguments @("--install", "--no-distribution")
+        }
+    }
+
+    & wsl.exe --set-default-version 2 2>$null | Out-Null
+    Write-Info "WSL is available."
+}
+
+function Ensure-UbuntuDistro {
+    Write-Step "Checking $WslDistro"
+
+    if (Test-WslDistroRegistered -Name $WslDistro) {
+        Write-Info "$WslDistro is already installed."
+        return
+    }
+
+    if ($SkipWslInstall) {
+        throw "$WslDistro is not registered, and -SkipWslInstall was used. Install the distro first or remove -SkipWslInstall."
+    }
+
+    Write-Info "Installing $WslDistro."
+    Write-Info "If Ubuntu opens a first-run setup window, create the Ubuntu username and password, then exit Ubuntu and re-run this script."
+    & wsl.exe --install --distribution $WslDistro
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host ""
+        Write-Host "$WslDistro was not available from 'wsl --install --distribution'." -ForegroundColor Yellow
+        Write-Host "Run this command to see exact available names:"
+        Write-Host "  wsl --list --online"
+        Write-Host "If Ubuntu 26.04 is not listed, install it from the official .wsl image, then re-run this script."
+        throw "Failed to install $WslDistro."
+    }
+
+    Write-Info "Starting $WslDistro once so Ubuntu can finish first-run setup."
+    & wsl.exe -d $WslDistro -- echo ready | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host ""
+        Write-Host "Ubuntu likely still needs first-run username setup." -ForegroundColor Yellow
+        Write-Host "Open Ubuntu from the Start Menu, create the username/password, exit Ubuntu, then run this script again."
+        throw "$WslDistro first-run setup is not complete."
+    }
+}
+
+function Get-UbuntuDefaultUser {
+    param([int]$Retries = 5)
+
+    for ($attempt = 1; $attempt -le $Retries; $attempt++) {
+        $userOutput = @(& wsl.exe -d $WslDistro -- sh -lc "id -un 2>/dev/null || whoami 2>/dev/null" 2>$null)
+        $user = ($userOutput | ForEach-Object { ($_ -replace "`0", "").Trim() } | Where-Object { $_ } | Select-Object -First 1)
+        if (-not [string]::IsNullOrWhiteSpace($user)) {
+            return $user
+        }
+
+        if ($attempt -lt $Retries) {
+            Start-Sleep -Seconds 3
+        }
+    }
+
+    throw "Could not determine the default Linux user for $WslDistro. Open Ubuntu once with 'wsl -d $WslDistro', create the Linux username/password if prompted, verify with 'whoami', then re-run this script."
+}
+
+function Enable-Systemd {
+    Write-Step "Ensuring systemd is enabled in $WslDistro"
+
+    $script = @'
+set -euo pipefail
+if ! grep -q '^\[boot\]' /etc/wsl.conf 2>/dev/null || ! grep -q '^systemd=true' /etc/wsl.conf 2>/dev/null; then
+  cat >/etc/wsl.conf <<'WSLCONF'
+[boot]
+systemd=true
+WSLCONF
+fi
+'@
+
+    Invoke-WslScript -ScriptText $script -Root
+    Write-Info "Restarting WSL so systemd settings apply."
+    & wsl.exe --shutdown
+    Start-Sleep -Seconds 5
+}
+
+function Resolve-RepoUrl {
+    if (-not [string]::IsNullOrWhiteSpace($RepoUrl)) {
+        return $RepoUrl
+    }
+
+    if (Test-CommandAvailable "git.exe") {
+        Push-Location $Script:RepoRoot
+        try {
+            $origin = (& git.exe config --get remote.origin.url 2>$null | Select-Object -First 1)
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($origin)) {
+                return $origin.Trim()
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    }
+
+    return "https://github.com/Red-Blink/dune-awakening-selfhost-docker.git"
+}
+
+function Resolve-SourceArchiveUrl {
+    param([string]$ResolvedRepoUrl)
+
+    $repo = $ResolvedRepoUrl.Trim()
+    $owner = ""
+    $name = ""
+
+    if ($repo -match '^https://github\.com/([^/]+)/([^/?#]+?)(\.git)?/?$') {
+        $owner = $Matches[1]
+        $name = $Matches[2]
+    } elseif ($repo -match '^git@github\.com:([^/]+)/(.+?)(\.git)?$') {
+        $owner = $Matches[1]
+        $name = $Matches[2]
+    } else {
+        throw "Only GitHub repository URLs are supported by the Windows end-user installer. Use a URL like https://github.com/owner/repo.git."
+    }
+
+    $encodedRef = [System.Uri]::EscapeDataString($RepoRef)
+    return "https://api.github.com/repos/$owner/$name/tarball/$encodedRef"
+}
+
+function Install-DockerEngineInUbuntu {
+    param([string]$LinuxUser)
+
+    if ($SkipDockerInstall) {
+        Write-Step "Skipping Docker installation because -SkipDockerInstall was used"
+        return
+    }
+
+    Write-Step "Installing Docker Engine inside Ubuntu"
+
+    $escapedUser = $LinuxUser.Replace("'", "'\''")
+    $script = @'
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y ca-certificates curl gnupg lsb-release nano iproute2 apt-transport-https tar gzip
+for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do
+  apt-get remove -y "$pkg" >/dev/null 2>&1 || true
+done
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+. /etc/os-release
+codename="${UBUNTU_CODENAME:-$VERSION_CODENAME}"
+arch="$(dpkg --print-architecture)"
+cat >/etc/apt/sources.list.d/docker.sources <<EOFDOCKER
+Types: deb
+URIs: https://download.docker.com/linux/ubuntu
+Suites: $codename
+Components: stable
+Architectures: $arch
+Signed-By: /etc/apt/keyrings/docker.asc
+EOFDOCKER
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
+  systemctl enable --now docker
+else
+  service docker start || true
+fi
+usermod -aG docker '__LINUX_USER__' || true
+docker version >/dev/null
+docker compose version >/dev/null
+'@
+
+    $script = $script.Replace("__LINUX_USER__", $escapedUser)
+    Invoke-WslScript -ScriptText $script -Root
+    Write-Info "Docker Engine and Docker Compose plugin are installed."
+}
+
+function Install-RepositoryAndRunInstaller {
+    param(
+        [string]$LinuxUser,
+        [string]$SourceArchiveUrl
+    )
+
+    Write-Step "Installing Dune Docker Console source archive inside Ubuntu"
+
+    $safeArchiveUrl = $SourceArchiveUrl.Replace("'", "'\''")
+    $safeInstallDir = $InstallDir.Replace("'", "'\''")
+    $safeAdminPort = [string]$AdminPort
+    $startFlag = if ($NoStart) { "1" } else { "0" }
+
+    $script = @'
+set -euo pipefail
+cd "$HOME"
+archive_url='__SOURCE_ARCHIVE_URL__'
+install_dir="$HOME/__INSTALL_DIR__"
+
+case "$install_dir" in
+  "$HOME"/*) ;;
+  *) echo "Refusing to install outside HOME: $install_dir"; exit 1 ;;
+esac
+
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+mkdir -p "$work_dir/source"
+
+echo "Downloading source archive."
+curl -fsSL "$archive_url" -o "$work_dir/source.tar.gz"
+tar -xzf "$work_dir/source.tar.gz" -C "$work_dir/source" --strip-components=1
+
+preserve_dir="$work_dir/preserve"
+mkdir -p "$preserve_dir"
+
+if [ -d "$install_dir/runtime" ]; then
+  mv "$install_dir/runtime" "$preserve_dir/runtime"
+fi
+if [ -f "$install_dir/.env" ]; then
+  mv "$install_dir/.env" "$preserve_dir/.env"
+fi
+
+rm -rf "$install_dir"
+mkdir -p "$install_dir"
+cp -a "$work_dir/source/." "$install_dir/"
+
+if [ -d "$preserve_dir/runtime" ]; then
+  rm -rf "$install_dir/runtime"
+  mv "$preserve_dir/runtime" "$install_dir/runtime"
+fi
+if [ -f "$preserve_dir/.env" ]; then
+  mv "$preserve_dir/.env" "$install_dir/.env"
+fi
+
+cd "$install_dir"
+chmod +x install.sh
+if [ '__START_FLAG__' = '1' ]; then
+  echo "Source is ready at $(pwd). -NoStart was used, so install.sh was not run."
+else
+  ADMIN_BIND_PORT='__ADMIN_PORT__' ./install.sh
+fi
+'@
+
+    $script = $script.Replace("__SOURCE_ARCHIVE_URL__", $safeArchiveUrl)
+    $script = $script.Replace("__INSTALL_DIR__", $safeInstallDir)
+    $script = $script.Replace("__START_FLAG__", $startFlag)
+    $script = $script.Replace("__ADMIN_PORT__", $safeAdminPort)
+
+    Invoke-WslScript -ScriptText $script -User $LinuxUser
+}
+
+function Show-Finish {
+    param(
+        [string]$LinuxUser,
+        [string]$SourceArchiveUrl
+    )
+
+    Write-Host ""
+    Write-Host "Windows / WSL setup finished." -ForegroundColor Green
+    Write-Host ""
+    Write-Host "Open the Web UI from Windows:"
+    Write-Host "  http://localhost:$AdminPort"
+    Write-Host ""
+    Write-Host "Useful commands:"
+    Write-Host "  wsl -d $WslDistro"
+    Write-Host "  cd ~/$InstallDir"
+    Write-Host "  dune --help"
+    Write-Host "  dune status"
+    Write-Host "  dune start"
+    Write-Host "  dune stop"
+    Write-Host ""
+    Write-Host "Install details:"
+    Write-Host "  WSL distro: $WslDistro"
+    Write-Host "  Linux user: $LinuxUser"
+    Write-Host "  Source archive: $SourceArchiveUrl"
+    Write-Host "  Ubuntu path: ~/$InstallDir"
+}
+
+try {
+    Write-Host "Dune Docker Console Windows / WSL installer" -ForegroundColor Green
+    Write-Host "This script prepares Ubuntu on WSL2, installs Docker Engine inside Ubuntu, then runs install.sh."
+
+    Ensure-WslInstalled
+    Ensure-UbuntuDistro
+
+    $linuxUser = Get-UbuntuDefaultUser -Retries 5
+    Write-Step "Using Ubuntu user '$linuxUser'"
+
+    Enable-Systemd
+    Install-DockerEngineInUbuntu -LinuxUser $linuxUser
+
+    $resolvedRepoUrl = Resolve-RepoUrl
+    $sourceArchiveUrl = Resolve-SourceArchiveUrl -ResolvedRepoUrl $resolvedRepoUrl
+    Write-Step "Using source archive $sourceArchiveUrl"
+
+    Install-RepositoryAndRunInstaller -LinuxUser $linuxUser -SourceArchiveUrl $sourceArchiveUrl
+    Show-Finish -LinuxUser $linuxUser -SourceArchiveUrl $sourceArchiveUrl
+}
+catch {
+    Write-Host ""
+    Write-Host "Installation stopped." -ForegroundColor Red
+    Write-Host $_.Exception.Message -ForegroundColor Red
+    Write-Host ""
+    Write-Host "See docs/WINDOWS-WSL-INSTALL.md for the manual path and troubleshooting."
+    exit 1
+}

--- a/install.ps1
+++ b/install.ps1
@@ -69,6 +69,11 @@ function Invoke-WslScript {
     }
 }
 
+function ConvertTo-ShellSingleQuotedString {
+    param([string]$Value)
+    return "'" + $Value.Replace("'", "'\''") + "'"
+}
+
 function Get-RegisteredWslDistros {
     if (-not (Test-CommandAvailable "wsl.exe")) {
         return @()
@@ -230,7 +235,7 @@ function Install-DockerEngineInUbuntu {
 
     Write-Step "Installing Docker Engine inside Ubuntu"
 
-    $escapedUser = $LinuxUser.Replace("'", "'\''")
+    $escapedUser = ConvertTo-ShellSingleQuotedString -Value $LinuxUser
     $script = @'
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
@@ -260,7 +265,7 @@ if command -v systemctl >/dev/null 2>&1 && [ -d /run/systemd/system ]; then
 else
   service docker start || true
 fi
-usermod -aG docker '__LINUX_USER__' || true
+usermod -aG docker __LINUX_USER__ || true
 docker version >/dev/null
 docker compose version >/dev/null
 '@
@@ -278,16 +283,16 @@ function Install-RepositoryAndRunInstaller {
 
     Write-Step "Installing Dune Docker Console source archive inside Ubuntu"
 
-    $safeArchiveUrl = $SourceArchiveUrl.Replace("'", "'\''")
-    $safeInstallDir = $InstallDir.Replace("'", "'\''")
+    $safeArchiveUrl = ConvertTo-ShellSingleQuotedString -Value $SourceArchiveUrl
+    $safeInstallDir = ConvertTo-ShellSingleQuotedString -Value $InstallDir
     $safeAdminPort = [string]$AdminPort
     $startFlag = if ($NoStart) { "1" } else { "0" }
 
     $script = @'
 set -euo pipefail
 cd "$HOME"
-archive_url='__SOURCE_ARCHIVE_URL__'
-install_dir="$HOME/__INSTALL_DIR__"
+archive_url=__SOURCE_ARCHIVE_URL__
+install_dir="$HOME"/__INSTALL_DIR__
 
 case "$install_dir" in
   "$HOME"/*) ;;

--- a/install.sh
+++ b/install.sh
@@ -228,17 +228,26 @@ next_available_port() {
 
 existing_web_port() {
   if [ -f .env ]; then
-    awk -F= '/^ADMIN_BIND_PORT=/ {print $2; exit}' .env | sed 's/[[:space:]"'\'']//g'
+    awk -F= '/^ADMIN_BIND_PORT=/ { gsub(/[[:space:]\042\047]/, "", $2); print $2; exit }' .env
+  fi
+}
+
+persist_env_var() {
+  local key="$1"
+  local value="$2"
+  local env_file=".env"
+  local escaped_value
+
+  escaped_value="$(printf '%s' "$value" | sed 's/[\/&]/\\&/g')"
+  if [ -f "$env_file" ] && grep -q "^${key}=" "$env_file"; then
+    sed -i "s/^${key}=.*/${key}=${escaped_value}/" "$env_file"
+  else
+    printf '%s=%s\n' "$key" "$value" >> "$env_file"
   fi
 }
 
 persist_web_port() {
-  local env_file=".env"
-  if [ -f "$env_file" ] && grep -q '^ADMIN_BIND_PORT=' "$env_file"; then
-    sed -i "s/^ADMIN_BIND_PORT=.*/ADMIN_BIND_PORT=$WEB_PORT/" "$env_file"
-  else
-    printf '\nADMIN_BIND_PORT=%s\n' "$WEB_PORT" >> "$env_file"
-  fi
+  persist_env_var "ADMIN_BIND_PORT" "$WEB_PORT"
 }
 
 prepare_docker_socket_gid() {
@@ -319,6 +328,14 @@ start_console() {
   export DUNE_HOST_GID="${DUNE_HOST_GID:-$(id -g)}"
   export COMPOSE_PROJECT_NAME="${DUNE_COMPOSE_PROJECT_NAME:-dune-awakening-selfhost-docker}"
   prepare_docker_socket_gid
+
+  persist_env_var "ADMIN_BIND_PORT" "$ADMIN_BIND_PORT"
+  persist_env_var "DUNE_HOST_REPO_ROOT" "$DUNE_HOST_REPO_ROOT"
+  persist_env_var "DUNE_HOST_UID" "$DUNE_HOST_UID"
+  persist_env_var "DUNE_HOST_GID" "$DUNE_HOST_GID"
+  persist_env_var "DOCKER_SOCKET_GID" "$DOCKER_SOCKET_GID"
+  persist_env_var "COMPOSE_PROJECT_NAME" "$COMPOSE_PROJECT_NAME"
+
   if [ "${DOCKER[0]}" = "sudo" ]; then
     need_sudo env \
       "ADMIN_BIND_PORT=$ADMIN_BIND_PORT" \
@@ -327,9 +344,18 @@ start_console() {
       "DUNE_HOST_GID=$DUNE_HOST_GID" \
       "DOCKER_SOCKET_GID=$DOCKER_SOCKET_GID" \
       "COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME" \
-      docker compose -f "$WEB_COMPOSE" up -d --build "$WEB_SERVICE"
+      docker compose -f "$WEB_COMPOSE" down --remove-orphans || true
+    need_sudo env \
+      "ADMIN_BIND_PORT=$ADMIN_BIND_PORT" \
+      "DUNE_HOST_REPO_ROOT=$DUNE_HOST_REPO_ROOT" \
+      "DUNE_HOST_UID=$DUNE_HOST_UID" \
+      "DUNE_HOST_GID=$DUNE_HOST_GID" \
+      "DOCKER_SOCKET_GID=$DOCKER_SOCKET_GID" \
+      "COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME" \
+      docker compose -f "$WEB_COMPOSE" up -d --force-recreate --build "$WEB_SERVICE"
   else
-    "${DOCKER[@]}" compose -f "$WEB_COMPOSE" up -d --build "$WEB_SERVICE"
+    "${DOCKER[@]}" compose -f "$WEB_COMPOSE" down --remove-orphans || true
+    "${DOCKER[@]}" compose -f "$WEB_COMPOSE" up -d --force-recreate --build "$WEB_SERVICE"
   fi
 }
 
@@ -373,10 +399,13 @@ show_finish() {
     echo "Docker is ready. Setup can continue."
   fi
   echo
-  echo "Your first admin password was generated automatically."
+  echo "Current Web UI admin password file:"
+  echo "  $password_file"
   if [ -n "$admin_password" ]; then
-    echo "Use this password to sign in:"
+    echo "Use this current password to sign in:"
     echo "  $admin_password"
+    echo "If you later change the Web UI password, this printed password becomes obsolete."
+    echo "The password file above will then contain the new current password."
   else
     echo "The password was not ready yet. Wait a few seconds and run ./install.sh again to show it."
   fi


### PR DESCRIPTION
## Summary

Adds a Windows / WSL install and operations path while preserving the existing Linux-first install flow.

Included changes:

- Add `install.ps1` as an additive Windows / WSL bootstrapper.
- Add Windows / WSL quickstart and full install documentation.
- Add Administrator PowerShell guidance.
- Add Windows / WSL security regression checklist.
- Add WSL mirrored networking and Docker socket repair guide.
- Update `README.md` to link the Windows / WSL path without replacing the Linux install path.
- Harden Web UI admin password handling so file-managed admin passwords are re-read from the password file instead of relying only on startup state.
- Clarify installer output so the printed admin password is treated as the current password from `runtime/secrets/admin-web-password.txt`, not a permanent password if the user later changes it in the Web UI.
- Harden Windows installer Bash literal interpolation for repository URL, Linux user, and install directory values.
- Make static file traversal protection cross-platform by using path-relative containment checks.

## Why

Windows 11 Home users can run the stack through WSL2, but setup is easy to get wrong: firmware virtualization, WSL installation, Ubuntu user creation, Docker Engine setup, localhost forwarding, mirrored networking for UDP game traffic, and Docker socket permissions are all common failure points.

This PR gives those users a documented path while keeping the standard Linux installer intact.

## Security notes

- Does not disable admin authentication.
- Does not embed Funcom tokens, passwords, real public IPs, or credentials.
- Does not weaken Docker socket permissions.
- Documents that Docker socket access is privileged host access.
- Documents that the Web UI should remain private/trusted-admin only.
- Shell-quotes user-controlled Bash literals before injecting them into WSL script bodies.
- Keeps WSL script transport in memory through base64-to-`bash` instead of temporary helper files.
- Uses cross-platform static path containment checks to preserve traversal protection on Windows and Linux paths.

## Security findings and resolutions

```text
RESOLVED Checklist drift: docs still expected the older temporary WSL helper-script flow. Updated the checklist for the current base64-to-bash WSL script transport.
RESOLVED Installer shell interpolation: -InstallDir was embedded inside a double-quoted Bash string. Added ConvertTo-ShellSingleQuotedString and now injects repository URL, Linux user, and install directory as shell-quoted literals.
RESOLVED Cross-platform static path guard: safeStaticTarget used a forward-slash prefix check. Switched to path.relative/path.isAbsolute containment checks so traversal protection passes on Windows and Linux path separators.
```

## Regression / validation

```text
PASS README links Windows / WSL docs.
PASS Windows quickstart downloads install.ps1 directly and runs it as a local file.
PASS Windows docs explain Administrator PowerShell launch.
PASS WSL docs warn against exposing Web UI publicly.
PASS WSL docs document Docker socket risk.
PASS WSL networking guide includes mirrored networking and hostAddressLoopback guidance.
PASS WSL networking guide includes UDP game traffic verification.
PASS Docker socket repair guide refreshes UID/GID/socket-GID instead of using unsafe world-writable socket permissions.
PASS security regression checklist: 22 checks.
PASS npm audit --prefix console/api --audit-level=moderate: 0 vulnerabilities.
PASS npm audit --prefix console/web --audit-level=moderate: 0 vulnerabilities.
PASS install.ps1 PowerShell parser syntax check.
PASS bash -n install.sh.
PASS python3 -m py_compile orchestrator/dune_orchestrator.py.
PASS npm test --prefix console/api: 189 passed, 0 failed.
PASS npm run build --prefix console/web.
```

Test environment:

```text
Ubuntu 26.04 WSL checkout: /home/darkdante/dune-pr42-e2e
Branch: upstream-wsl-install-networking-prep
Node: v26.4.0 local workspace runtime
npm: 11.17.0
```

Limitations:

```text
Live Windows + WSL + Dune client runtime validation must be performed on a Windows host. The documented WSL networking/socket guide is based on live troubleshooting where mirrored networking resolved the client hang and UID/GID/socket-GID refresh resolved Web UI Docker socket access.
```
