### PR TITLE
Add addon-supporting operational metrics stack

### DIFF
--- a/docker-compose.metrics.yml
+++ b/docker-compose.metrics.yml
@@ -1,0 +1,80 @@
+services:
+  dune-prometheus:
+    image: ${METRICS_PROMETHEUS_IMAGE:-prom/prometheus:latest}
+    container_name: dune-prometheus
+    restart: unless-stopped
+    networks:
+      - dune-net
+    ports:
+      - "127.0.0.1:${METRICS_PROMETHEUS_PORT:-9090}:9090"
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=${METRICS_RETENTION_TIME:-7d}
+      - --storage.tsdb.retention.size=${METRICS_RETENTION_SIZE:-2GB}
+      - --web.console.libraries=/usr/share/prometheus/console_libraries
+      - --web.console.templates=/usr/share/prometheus/consoles
+      - --web.enable-lifecycle
+    volumes:
+      - ./runtime/metrics/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./runtime/metrics/rules:/etc/prometheus/rules:ro
+      - dune-prometheus-data:/prometheus
+    security_opt:
+      - no-new-privileges:true
+
+  dune-node-exporter:
+    image: ${METRICS_NODE_EXPORTER_IMAGE:-quay.io/prometheus/node-exporter:latest}
+    container_name: dune-node-exporter
+    restart: unless-stopped
+    networks:
+      - dune-net
+    command:
+      - --path.rootfs=/host
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/docker/netns|var/lib/docker/.+)($$|/)
+      - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$$
+    pid: host
+    volumes:
+      # Avoid :rslave by default because WSL/Docker Desktop root mounts may not be shared/slave mounts.
+      - /:/host:ro
+    security_opt:
+      - no-new-privileges:true
+
+  dune-cadvisor:
+    image: ${METRICS_CADVISOR_IMAGE:-gcr.io/cadvisor/cadvisor:latest}
+    container_name: dune-cadvisor
+    restart: unless-stopped
+    networks:
+      - dune-net
+    privileged: true
+    command:
+      - --docker_only=true
+      - --housekeeping_interval=10s
+      - --store_container_labels=false
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /dev/disk:/dev/disk:ro
+
+  dune-postgres-exporter:
+    image: ${METRICS_POSTGRES_EXPORTER_IMAGE:-quay.io/prometheuscommunity/postgres-exporter:latest}
+    container_name: dune-postgres-exporter
+    restart: unless-stopped
+    networks:
+      - dune-net
+    environment:
+      DATA_SOURCE_URI: dune-postgres:5432/dune?sslmode=disable
+      DATA_SOURCE_USER: ${DUNE_DB_USER:-dune}
+      DATA_SOURCE_PASS: ${DUNE_DB_PASSWORD:-dune}
+      PG_EXPORTER_DISABLE_DEFAULT_METRICS: "false"
+      PG_EXPORTER_DISABLE_SETTINGS_METRICS: "false"
+    security_opt:
+      - no-new-privileges:true
+
+networks:
+  dune-net:
+    external: true
+
+volumes:
+  dune-prometheus-data:

--- a/docs/E2E-METRICS-TESTING.md
+++ b/docs/E2E-METRICS-TESTING.md
@@ -1,0 +1,398 @@
+# E2E Metrics Stack Testing
+
+This document describes the end-to-end validation procedure for the addon-supporting operational metrics stack.
+
+The goal is to verify that the opt-in metrics stack can be started, scraped, validated, inspected, and stopped without changing the normal Dune server startup path.
+
+## Scope
+
+This test covers:
+
+* metrics compose configuration
+* Prometheus startup
+* Prometheus scrape target health
+* Prometheus rule loading
+* Postgres exporter connectivity
+* RabbitMQ metrics scrape reachability
+* cAdvisor availability
+* node exporter availability
+* `dune metrics` command wiring
+* `dune metrics validate`
+* clean shutdown of the metrics stack
+
+This test does not cover:
+
+* WSL installer behavior
+* Windows-specific setup
+* admin tooling
+* self-update behavior
+* gameplay KPI analytics
+* Grafana
+* addon UI rendering
+* player-level or gameplay-labeled metrics
+
+## Prerequisites
+
+Run from the repository root.
+
+Required tools:
+
+```bash
+docker version
+docker compose version
+bash --version
+```
+
+The normal Dune Docker stack should already be configured.
+
+The metrics stack is opt-in and should not start unless explicitly requested.
+
+## Files Under Test
+
+```text
+docker-compose.metrics.yml
+runtime/metrics/prometheus.yml
+runtime/metrics/rules/containers.yml
+runtime/metrics/rules/dune-stack.yml
+runtime/metrics/rules/host.yml
+runtime/metrics/rules/postgres.yml
+runtime/metrics/rules/rabbitmq.yml
+runtime/scripts/dune
+runtime/scripts/metrics-stack.sh
+runtime/scripts/metrics-status.sh
+tests/metrics-stack-unit.sh
+```
+
+## Static Validation
+
+Render the metrics compose file:
+
+```bash
+docker compose -f docker-compose.metrics.yml config
+```
+
+Expected result:
+
+```text
+Compose config renders successfully.
+No YAML parse errors.
+No missing required service references.
+```
+
+Run shell checks if ShellCheck is available:
+
+```bash
+shellcheck runtime/scripts/dune runtime/scripts/metrics-stack.sh runtime/scripts/metrics-status.sh tests/metrics-stack-unit.sh
+```
+
+Expected result:
+
+```text
+No ShellCheck findings.
+```
+
+Run the metrics unit tests:
+
+```bash
+bash tests/metrics-stack-unit.sh
+```
+
+Expected result:
+
+```text
+All unit tests pass.
+```
+
+## Start Metrics Stack
+
+Start the metrics stack:
+
+```bash
+bash runtime/scripts/dune metrics start
+```
+
+Expected result:
+
+```text
+Metrics stack starts successfully.
+Prometheus is available on 127.0.0.1:9090 by default.
+Exporters are not exposed publicly by default.
+```
+
+Check status:
+
+```bash
+bash runtime/scripts/dune metrics status
+```
+
+Expected result:
+
+```text
+Prometheus container is running.
+Configured exporters are running or reachable.
+No failed metrics services are reported.
+```
+
+## Prometheus Health Check
+
+Check Prometheus health:
+
+```bash
+curl -fsS http://127.0.0.1:9090/-/healthy
+```
+
+Expected result:
+
+```text
+Prometheus Server is Healthy.
+```
+
+Check Prometheus readiness:
+
+```bash
+curl -fsS http://127.0.0.1:9090/-/ready
+```
+
+Expected result:
+
+```text
+Prometheus Server is Ready.
+```
+
+## Target Scrape Validation
+
+Query active Prometheus targets:
+
+```bash
+curl -fsS http://127.0.0.1:9090/api/v1/targets
+```
+
+Expected result:
+
+```text
+Prometheus returns target metadata.
+Expected targets are present.
+Expected active targets report health as up.
+```
+
+Run the built-in validator:
+
+```bash
+bash runtime/scripts/dune metrics validate
+```
+
+Expected result:
+
+```text
+READY: metrics validation passed.
+```
+
+The validator should confirm:
+
+```text
+Prometheus is reachable.
+Scrape targets are loaded.
+Rules are loaded.
+Configured targets are healthy.
+Postgres exporter reports pg_up == 1.
+RabbitMQ metrics are reachable.
+Container metrics are reachable.
+Host metrics are reachable.
+```
+
+## Rule Loading Validation
+
+Check loaded rules:
+
+```bash
+curl -fsS http://127.0.0.1:9090/api/v1/rules
+```
+
+Expected result:
+
+```text
+Prometheus returns rule groups.
+Host, container, Postgres, RabbitMQ, and Dune stack rule groups are loaded.
+```
+
+## Metrics Query Validation
+
+Check generic target health:
+
+```bash
+curl -fsS 'http://127.0.0.1:9090/api/v1/query?query=up'
+```
+
+Expected result:
+
+```text
+The query succeeds.
+Configured scrape targets report up == 1.
+```
+
+Check Postgres exporter connectivity:
+
+```bash
+curl -fsS 'http://127.0.0.1:9090/api/v1/query?query=pg_up'
+```
+
+Expected result:
+
+```text
+The query succeeds.
+pg_up reports 1 for the configured Postgres target.
+```
+
+## Logs
+
+Inspect all metrics stack logs:
+
+```bash
+bash runtime/scripts/dune metrics logs
+```
+
+Inspect a specific service log:
+
+```bash
+bash runtime/scripts/dune metrics logs prometheus
+```
+
+Expected result:
+
+```text
+Logs are available.
+No repeated crash loop is present.
+No authentication secret is printed.
+No database password is printed.
+```
+
+## Restart Validation
+
+Restart the metrics stack:
+
+```bash
+bash runtime/scripts/dune metrics restart
+```
+
+Then validate again:
+
+```bash
+bash runtime/scripts/dune metrics validate
+```
+
+Expected result:
+
+```text
+Restart succeeds.
+Validation passes after restart.
+```
+
+## Stop Validation
+
+Stop the metrics stack:
+
+```bash
+bash runtime/scripts/dune metrics stop
+```
+
+Expected result:
+
+```text
+Metrics stack stops cleanly.
+Normal Dune stack remains unaffected.
+```
+
+Confirm status:
+
+```bash
+bash runtime/scripts/dune metrics status
+```
+
+Expected result:
+
+```text
+Metrics services are stopped or unavailable as expected.
+No normal Dune game services are stopped by the metrics stop command.
+```
+
+## Pass Criteria
+
+The E2E test passes when all of the following are true:
+
+```text
+docker compose -f docker-compose.metrics.yml config passes.
+tests/metrics-stack-unit.sh passes.
+dune metrics start succeeds.
+Prometheus health endpoint succeeds.
+Prometheus readiness endpoint succeeds.
+Prometheus targets endpoint succeeds.
+Prometheus rules endpoint succeeds.
+dune metrics validate returns READY.
+pg_up reports 1.
+Configured scrape targets report up == 1.
+dune metrics restart succeeds.
+dune metrics stop succeeds.
+Normal Dune stack behavior is not changed by metrics commands.
+```
+
+## Failure Criteria
+
+The E2E test fails if any of the following occur:
+
+```text
+Metrics compose file does not render.
+Prometheus does not start.
+Prometheus binds publicly by default.
+Required scrape targets are missing.
+Configured scrape targets remain down.
+Rules do not load.
+pg_up does not report 1 when Postgres is running.
+dune metrics validate fails.
+Metrics logs expose secrets.
+Metrics commands stop or modify normal Dune services unexpectedly.
+```
+
+## Evidence to Include in PR
+
+Attach or paste the following validation output in the pull request:
+
+```bash
+docker compose -f docker-compose.metrics.yml config >/tmp/metrics-compose-config.txt
+bash tests/metrics-stack-unit.sh | tee /tmp/metrics-unit-tests.txt
+bash runtime/scripts/dune metrics start
+bash runtime/scripts/dune metrics status | tee /tmp/metrics-status.txt
+bash runtime/scripts/dune metrics validate | tee /tmp/metrics-validate.txt
+curl -fsS http://127.0.0.1:9090/-/healthy
+curl -fsS http://127.0.0.1:9090/-/ready
+bash runtime/scripts/dune metrics stop
+```
+
+Minimum PR evidence:
+
+```text
+Compose config rendered successfully.
+Metrics unit tests passed.
+Metrics stack started.
+Prometheus health passed.
+Prometheus readiness passed.
+dune metrics validate passed.
+Metrics stack stopped cleanly.
+```
+
+## Rollback
+
+The metrics stack is opt-in.
+
+To stop it:
+
+```bash
+bash runtime/scripts/dune metrics stop
+```
+
+If needed, remove metrics containers and volumes using Docker Compose directly:
+
+```bash
+docker compose -f docker-compose.metrics.yml down
+```
+
+Normal Dune game services should not require rollback unless they were changed independently of the metrics stack.

--- a/docs/PR-EVIDENCE-ADDON-METRICS-SUPPORT.md
+++ b/docs/PR-EVIDENCE-ADDON-METRICS-SUPPORT.md
@@ -1,0 +1,173 @@
+## Summary
+
+Adds an opt-in operational metrics stack intended to support Dune Ops Observability addon work without changing the default runtime path.
+
+This PR adds:
+- `docker-compose.metrics.yml`
+- Prometheus scrape configuration
+- Prometheus alert/rule groups for containers, host, Postgres, RabbitMQ, and the Dune stack
+- `dune metrics` CLI support
+- metrics stack/status helper scripts
+- unit and validation tests
+- reusable changed-file security checks
+- R1 implementation notes
+- E2E metrics testing documentation
+- PR evidence documentation
+
+## Why this is needed
+
+The addon needs a supported operational metrics foundation before real dashboard data can be wired safely. This PR provides that foundation while keeping metrics opt-in and local by default.
+
+It also separates infrastructure support from the later bridge/API work needed for browser-safe addon consumption.
+
+## Scope
+
+In scope:
+- Opt-in metrics compose stack
+- Prometheus configuration
+- Prometheus rule files
+- CLI entrypoints for metrics start/stop/restart/status/validate/logs
+- Metrics validation tests
+- Security validation script for changed files
+- Implementation, E2E, and PR evidence docs
+
+## Out of scope
+
+Out of scope:
+- WSL installer changes
+- Windows/WSL docs
+- Admin PowerShell docs
+- `install.ps1`
+- General admin/self-update work
+- General command-auth-token changes
+- Browser-side Prometheus access
+- Browser-side Prometheus tokens
+- Direct addon access to exporters
+- `ops.health.summary` bridge implementation
+- `metrics.query` or arbitrary PromQL exposed to addons
+
+## Implementation details
+
+Default posture:
+- Metrics stack is opt-in.
+- Prometheus binds to `127.0.0.1:9090` by default.
+- Exporters are not public by default.
+- No gameplay/player labels are emitted in R1.
+- The addon should not query Prometheus directly.
+- Future addon consumption should go through a permissioned Console/backend bridge or API action.
+
+Added operational commands:
+- `dune metrics start`
+- `dune metrics stop`
+- `dune metrics restart`
+- `dune metrics status`
+- `dune metrics validate`
+- `dune metrics logs`
+
+## Regression test results
+
+Validated locally:
+- `docker compose -f docker-compose.metrics.yml config`
+- `shellcheck runtime/scripts/dune runtime/scripts/metrics-stack.sh runtime/scripts/metrics-status.sh tests/metrics-stack-unit.sh tests/security-pr-checks.sh`
+- `git diff --check upstream/main...HEAD`
+- `bash tests/metrics-stack-unit.sh`
+
+Result: passed.
+
+## Security check results
+
+Validated locally with reusable changed-file security checks:
+- Git whitespace/conflict check
+- Changed-file inventory
+- Changed-file secret keyword review
+- ShellCheck
+- Gitleaks changed-file scan
+- Trivy filesystem scan against changed-file staging directory when available
+
+Command used:
+- `BASE_REF=upstream/main REPORT_DIR=.security-reports ./tests/security-pr-checks.sh`
+
+Result: passed cleanly.
+
+The security script stages only files changed by this PR, which separates inherited repository/history findings from new PR findings.
+
+## E2E test results
+
+Validated locally:
+- `bash runtime/scripts/dune metrics start`
+- `bash runtime/scripts/dune metrics status`
+- `curl -fsS http://127.0.0.1:9090/-/healthy`
+- `curl -fsS http://127.0.0.1:9090/-/ready`
+- `bash runtime/scripts/dune metrics validate`
+- `bash runtime/scripts/dune metrics stop`
+
+Result: passed.
+
+Observed validation outcome:
+- Prometheus healthy
+- Prometheus ready
+- Six active targets discovered
+- All configured targets returned `up=1` during validation
+- Postgres exporter returned `pg_up=1`
+- Four Prometheus rule groups loaded
+- Validator returned `READY: metrics validation passed`
+- Metrics stack stopped cleanly
+
+Startup note:
+- Initial `metrics status` may show target health as `unknown` immediately after startup while Prometheus scrape pools settle.
+- Follow-up validation confirmed final scrape health with all targets returning `up=1`.
+
+## WebUI test results
+
+Validated manually:
+- Dune Docker Console loaded normally.
+- Addons panel loaded normally.
+- Dune Ops Observability could be launched when locally installed.
+- Browser network inspection did not show direct calls from the addon to Prometheus or exporters.
+- No browser console errors were observed from this metrics-support change set.
+
+Result: passed.
+
+## Documentation
+
+Added or updated:
+- `docs/R1-METRICS-STACK-IMPLEMENTATION-NOTES.md`
+- `docs/E2E-METRICS-TESTING.md`
+- `docs/PR-EVIDENCE-ADDON-METRICS-SUPPORT.md`
+
+The evidence document contains the detailed validation trail for local testing, security, E2E, and WebUI checks.
+
+## Risks
+
+Primary risks:
+- Prometheus startup status may briefly report `unknown` targets before the first scrape completes.
+- Metrics stack adds optional local containers when enabled.
+- Operators may need Docker resources available for Prometheus/exporters.
+
+Mitigations:
+- Stack is opt-in.
+- Validation command confirms target health after startup.
+- Prometheus binds locally by default.
+- Exporters are not exposed publicly by default.
+
+## Rollback
+
+Rollback path:
+- Do not start the metrics stack.
+- Run `dune metrics stop` if it was started.
+- Revert this PR to remove the metrics compose file, Prometheus config/rules, CLI entrypoints, helper scripts, tests, and docs.
+
+No database migrations are included.
+
+## Related issues / PRs
+
+- RFC issue: https://github.com/Red-Blink/dune-awakening-selfhost-docker/issues/43
+- Follow-up real-data bridge issue: https://github.com/Red-Blink/dune-awakening-selfhost-docker/issues/44
+- Source fork PR: https://github.com/yacketrj/dune-awakening-selfhost-docker-WSL/pull/83
+
+## Follow-up
+
+Next focused work item after this PR:
+- Add a read-only, permissioned Console/backend bridge action for aggregate OPS health data, scoped to issue #44.
+- Proposed action: `ops.health.summary`.
+- Addon UI consumption should be implemented only after the Core bridge exists.

--- a/docs/R1-METRICS-STACK-IMPLEMENTATION-NOTES.md
+++ b/docs/R1-METRICS-STACK-IMPLEMENTATION-NOTES.md
@@ -1,0 +1,353 @@
+# R1 Metrics Stack MVP Implementation Notes
+
+Tracking issue: #82
+Branch: `feature/metrics`
+PR: #83
+
+## Summary
+
+R1 adds the first opt-in operational metrics stack for Dune Docker Console.
+
+Implemented components:
+
+- `docker-compose.metrics.yml`
+- `runtime/metrics/prometheus.yml`
+- `runtime/metrics/rules/host.yml`
+- `runtime/metrics/rules/containers.yml`
+- `runtime/metrics/rules/postgres.yml`
+- `runtime/metrics/rules/rabbitmq.yml`
+- `runtime/metrics/rules/dune-stack.yml`
+- `runtime/scripts/metrics-stack.sh`
+- `runtime/scripts/metrics-status.sh`
+- `dune metrics ...` CLI dispatch in `runtime/scripts/dune`
+
+## Why
+
+The project needs industry-standard operational metrics for host, container, RabbitMQ, and Postgres health without forcing gameplay KPI analytics into Prometheus.
+
+This first release phase creates the independent metrics control plane while keeping the Dune game stack unchanged.
+
+## Operational Design
+
+The metrics stack is opt-in and starts separately from the game stack:
+
+```text
+dune metrics start
+dune metrics stop
+dune metrics restart
+dune metrics status
+dune metrics logs [service]
+dune metrics config
+dune metrics pull
+```
+
+Prometheus binds to localhost only by default:
+
+```text
+127.0.0.1:9090
+```
+
+Exporters are attached to the existing internal `dune-net` network and are not published publicly by default.
+
+Metrics compose now uses a separate project name by default:
+
+```text
+${DUNE_COMPOSE_PROJECT_NAME:-dune-awakening-selfhost-docker}-metrics
+```
+
+This prevents metrics compose operations from warning that the main game/web containers are orphaned.
+
+## Metrics Stack Components
+
+```text
+dune-prometheus
+dune-node-exporter
+dune-cadvisor
+dune-postgres-exporter
+```
+
+Prometheus also scrapes existing RabbitMQ containers when they are running:
+
+```text
+dune-rmq-admin:15692
+dune-rmq-game:15692
+```
+
+## Prometheus Jobs
+
+```text
+dune-prometheus
+dune-node
+dune-cadvisor
+dune-postgres
+dune-rabbitmq-admin
+dune-rabbitmq-game
+```
+
+## Alert Rule Groups
+
+```text
+dune-host
+dune-containers
+dune-postgres
+dune-rabbitmq
+dune-stack
+```
+
+The `dune-stack` rule file is currently a valid empty rule group. It is reserved for R2 console-exporter metrics.
+
+## Security Notes
+
+Security posture for R1:
+
+- Metrics stack remains opt-in.
+- Prometheus binds to `127.0.0.1` by default.
+- node_exporter is not public.
+- cAdvisor is not public.
+- postgres_exporter is not public.
+- RabbitMQ metrics are scraped on the internal Docker network.
+- No passwords or tokens are committed.
+- postgres_exporter uses environment-derived credentials, not Git-tracked literal secrets.
+- No player identifiers or gameplay labels are emitted in R1.
+
+## Validation Result: 2026-06-30, initial run
+
+Local validation was run from:
+
+```text
+/home/darkdante/dune-clean-repro
+```
+
+Commands run:
+
+```bash
+docker compose -f docker-compose.metrics.yml config
+bash runtime/scripts/metrics-stack.sh config
+bash runtime/scripts/metrics-stack.sh start
+bash runtime/scripts/metrics-stack.sh status
+bash runtime/scripts/metrics-stack.sh stop
+bash runtime/scripts/dune metrics status
+```
+
+Observed results:
+
+- Compose config rendered successfully.
+- Prometheus started and reported healthy on `127.0.0.1:9090`.
+- cAdvisor started.
+- postgres_exporter started.
+- node_exporter failed to start under WSL/Docker mount propagation.
+- Stack stopped cleanly afterward.
+- Post-stop status correctly reported Prometheus unreachable.
+
+Failure:
+
+```text
+Error response from daemon: path / is mounted on / but it is not a shared or slave mount
+```
+
+Root cause:
+
+`dune-node-exporter` originally mounted the host root as:
+
+```text
+/:/host:ro,rslave
+```
+
+That propagation mode is common in Linux host examples, but it fails when the Docker host root mount is not configured as shared/slave. This is common in WSL/Docker Desktop environments.
+
+Fix applied:
+
+```text
+/:/host:ro
+```
+
+The node exporter host root mount is still read-only, but no longer requires `rslave` propagation by default.
+
+## Validation Result: 2026-06-30, retest after mount fix
+
+Command run:
+
+```bash
+bash runtime/scripts/metrics-stack.sh start
+```
+
+Observed results:
+
+- Metrics compose started all four containers.
+- Prometheus started and exposed `127.0.0.1:9090`.
+- cAdvisor started.
+- node_exporter started.
+- postgres_exporter started.
+- Prometheus health reported `healthy`.
+
+Container status:
+
+```text
+dune-prometheus          Up 2 seconds                      127.0.0.1:9090->9090/tcp
+dune-cadvisor            Up 2 seconds (health: starting)   8080/tcp
+dune-node-exporter       Up 2 seconds                      9100/tcp
+dune-postgres-exporter   Up 2 seconds                      9187/tcp
+```
+
+Remaining issue observed:
+
+- The status command printed the `=== Prometheus targets ===` header but no target rows.
+
+Conclusion:
+
+- Container startup and Prometheus health are now passing.
+- Empty target output is not a complete validation pass. Prometheus should report active scrape targets for the configured jobs.
+
+Fix applied after this observation:
+
+- `metrics-stack.sh` now waits briefly for Prometheus targets after `start` and `restart`.
+- `metrics-stack.sh status` now prints `active_targets=<count>`.
+- Empty target output now renders an explicit message instead of silently passing.
+- Metrics compose now uses a separate project name and ignores orphan warnings from the main game/web stack.
+
+## Validation Result: 2026-06-30, retest after target reporting fix
+
+User-reported local result:
+
+- Metrics stack is running.
+- Prometheus shows configured targets.
+- Prometheus shows loaded rules.
+
+Conclusion:
+
+- Prometheus startup is validated.
+- Compose service startup is validated after the node exporter mount fix.
+- Prometheus scrape target loading is validated.
+- Prometheus rule loading is validated.
+- The previous blank target output issue is resolved.
+
+## Validation Result: 2026-06-30, metric query pass
+
+Commands run:
+
+```bash
+curl -fsS 'http://127.0.0.1:9090/api/v1/query?query=up'
+curl -fsS 'http://127.0.0.1:9090/api/v1/query?query=pg_up'
+```
+
+Observed `up == 1` targets:
+
+```text
+dune-postgres-exporter:9187  job=dune-postgres       service=postgres-exporter
+dune-cadvisor:8080           job=dune-cadvisor       service=cadvisor
+dune-rmq-admin:15692         job=dune-rabbitmq-admin service=rabbitmq-admin
+dune-rmq-game:15692          job=dune-rabbitmq-game  service=rabbitmq-game
+dune-prometheus:9090         job=dune-prometheus     service=prometheus
+dune-node-exporter:9100      job=dune-node           service=node-exporter
+```
+
+Observed `pg_up == 1` target:
+
+```text
+dune-postgres-exporter:9187 job=dune-postgres service=postgres-exporter
+```
+
+Conclusion:
+
+- All configured Prometheus scrape targets are reachable and healthy.
+- RabbitMQ admin and game metrics endpoints are reachable from Prometheus on `dune-net`.
+- postgres_exporter is connected successfully to Postgres.
+- R1 metrics startup, target loading, rule loading, RabbitMQ scrape reachability, and Postgres exporter connectivity are validated.
+
+PromQL selector curl note:
+
+`curl` can return HTTP 400 when a PromQL selector is passed directly in the URL without URL encoding. Use `--data-urlencode` or an encoded URL for selector queries.
+
+Correct examples:
+
+```bash
+curl -fsS -G 'http://127.0.0.1:9090/api/v1/query' --data-urlencode 'query=up{job=~"dune-rabbitmq-.*"}'
+curl -fsS 'http://127.0.0.1:9090/api/v1/query?query=up%7Bjob%3D~%22dune-rabbitmq-.*%22%7D'
+```
+
+## Validation Result: 2026-06-30, game-stack regression pass
+
+Commands run:
+
+```bash
+bash runtime/scripts/dune --help
+bash runtime/scripts/dune status
+bash runtime/scripts/dune ready
+bash runtime/scripts/dune ps
+```
+
+Observed results:
+
+- CLI help renders and includes `dune metrics [start|stop|restart|status|logs|config|pull]`.
+- `dune status` reports `Overall: READY`.
+- `dune status` reports RabbitMQ admin listener OK.
+- `dune status` reports RabbitMQ game listener OK.
+- `dune ready` reports all core container checks OK.
+- `dune ready` reports all listener checks OK.
+- `dune ready` reports RabbitMQ game user connections OK.
+- `dune ready` reports the stack as READY.
+- `dune ps` shows metrics containers and game containers running.
+- `dune ps` shows `dune-cadvisor` healthy after the initial startup period.
+
+Conclusion:
+
+- R1 did not break normal game-stack CLI status, readiness, or process listing checks.
+- cAdvisor health settles to healthy under the tested WSL/Docker Desktop environment.
+- Game/admin RabbitMQ runtime checks pass through existing CLI readiness and listener checks.
+
+## Validation Result: 2026-06-30, unit and live metrics validator pass
+
+Commands run:
+
+```bash
+git pull
+bash tests/metrics-stack-unit.sh
+bash runtime/scripts/dune metrics validate
+```
+
+Observed unit test result:
+
+- TAP output rendered visibly.
+- Test harness created isolated fake command directory.
+- Fake Docker command installed.
+- Fake curl/Prometheus command installed.
+- Happy-path validation printed full metrics validator output.
+- Happy-path assertions passed for Prometheus health, six targets, RabbitMQ admin/game targets, rule groups, `pg_up`, READY summary, and URL-encoded `up` / `pg_up` queries.
+- Failure-path validation intentionally removed the required `dune-node` target.
+- Failure-path assertions passed for missing target detection and failure summary.
+- Final TAP plan reported `1..16`.
+
+Observed live validator result:
+
+- Prometheus health passed.
+- Active targets reported: `6`.
+- Live targets up: `dune-cadvisor`, `dune-node`, `dune-postgres`, `dune-prometheus`, `dune-rabbitmq-admin`, `dune-rabbitmq-game`.
+- Rule groups reported: `4`.
+- `up == 1` for all six live targets.
+- `pg_up == 1` for `dune-postgres-exporter:9187`.
+- Live validator ended with `READY: metrics validation passed.`
+
+Conclusion:
+
+- Metrics unit coverage is now visible and useful in local and CI logs.
+- The live metrics validator passes against the running stack.
+- The metrics validation command and unit harness are ready to be used as PR gates.
+
+## Regression Expectations
+
+R1 should not alter normal game startup behavior.
+
+Regression checks:
+
+```bash
+bash runtime/scripts/dune --help
+bash runtime/scripts/dune status
+bash runtime/scripts/dune ready
+bash runtime/scripts/dune ps
+```
+
+Current result: passed locally on 2026-06-30.
+
+## Remaining R1 Work
+
+- Run security/static checks before marking PR ready for review.

--- a/runtime/metrics/prometheus.yml
+++ b/runtime/metrics/prometheus.yml
@@ -1,0 +1,51 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  scrape_timeout: 10s
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+scrape_configs:
+  - job_name: dune-prometheus
+    static_configs:
+      - targets:
+          - dune-prometheus:9090
+        labels:
+          service: prometheus
+
+  - job_name: dune-node
+    static_configs:
+      - targets:
+          - dune-node-exporter:9100
+        labels:
+          service: node-exporter
+
+  - job_name: dune-cadvisor
+    scrape_interval: 10s
+    static_configs:
+      - targets:
+          - dune-cadvisor:8080
+        labels:
+          service: cadvisor
+
+  - job_name: dune-postgres
+    static_configs:
+      - targets:
+          - dune-postgres-exporter:9187
+        labels:
+          service: postgres-exporter
+
+  - job_name: dune-rabbitmq-admin
+    static_configs:
+      - targets:
+          - dune-rmq-admin:15692
+        labels:
+          service: rabbitmq-admin
+
+  - job_name: dune-rabbitmq-game
+    static_configs:
+      - targets:
+          - dune-rmq-game:15692
+        labels:
+          service: rabbitmq-game

--- a/runtime/metrics/rules/containers.yml
+++ b/runtime/metrics/rules/containers.yml
@@ -1,0 +1,49 @@
+groups:
+  - name: dune-containers
+    rules:
+      - alert: DuneContainerMissing
+        expr: absent(container_last_seen{name=~"dune-.*|redblink-dune-docker-console"})
+        for: 2m
+        labels:
+          severity: warning
+          service: cadvisor
+        annotations:
+          summary: Dune container metrics are missing
+          description: cAdvisor is not reporting expected Dune container metrics.
+
+      - alert: DuneContainerHighMemory
+        expr: |
+          (
+            container_memory_working_set_bytes{name=~"dune-.*|redblink-dune-docker-console"}
+            / container_spec_memory_limit_bytes{name=~"dune-.*|redblink-dune-docker-console"}
+          ) * 100 > 90
+          and container_spec_memory_limit_bytes{name=~"dune-.*|redblink-dune-docker-console"} > 0
+        for: 10m
+        labels:
+          severity: warning
+          service: cadvisor
+        annotations:
+          summary: Dune container memory usage is high
+          description: A Dune container is using more than 90% of its memory limit for 10 minutes.
+
+      - alert: DuneContainerMemoryFailures
+        expr: increase(container_memory_failcnt{name=~"dune-.*|redblink-dune-docker-console"}[10m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          service: cadvisor
+        annotations:
+          summary: Dune container memory allocation failures detected
+          description: A Dune container memory fail counter increased in the last 10 minutes.
+
+      - alert: DuneContainerNetworkErrors
+        expr: |
+          rate(container_network_receive_errors_total{name=~"dune-.*|redblink-dune-docker-console"}[5m]) > 0
+          or rate(container_network_transmit_errors_total{name=~"dune-.*|redblink-dune-docker-console"}[5m]) > 0
+        for: 10m
+        labels:
+          severity: warning
+          service: cadvisor
+        annotations:
+          summary: Dune container network errors detected
+          description: A Dune container is reporting network receive or transmit errors.

--- a/runtime/metrics/rules/dune-stack.yml
+++ b/runtime/metrics/rules/dune-stack.yml
@@ -1,0 +1,3 @@
+groups:
+  - name: dune-stack
+    rules: []

--- a/runtime/metrics/rules/host.yml
+++ b/runtime/metrics/rules/host.yml
@@ -1,0 +1,62 @@
+groups:
+  - name: dune-host
+    rules:
+      - alert: DuneHostHighCpu
+        expr: 100 * (1 - avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m]))) > 85
+        for: 10m
+        labels:
+          severity: warning
+          service: node-exporter
+        annotations:
+          summary: Dune host CPU usage is high
+          description: Host CPU usage has been above 85% for 10 minutes.
+
+      - alert: DuneHostHighMemory
+        expr: 100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) > 90
+        for: 10m
+        labels:
+          severity: warning
+          service: node-exporter
+        annotations:
+          summary: Dune host memory usage is high
+          description: Host memory usage has been above 90% for 10 minutes.
+
+      - alert: DuneHostLowAvailableMemory
+        expr: node_memory_MemAvailable_bytes < 2147483648
+        for: 5m
+        labels:
+          severity: critical
+          service: node-exporter
+        annotations:
+          summary: Dune host available memory is critically low
+          description: Host available memory has been below 2 GiB for 5 minutes.
+
+      - alert: DuneHostHighFilesystemUsage
+        expr: 100 * (1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"})) > 85
+        for: 15m
+        labels:
+          severity: warning
+          service: node-exporter
+        annotations:
+          summary: Dune host filesystem usage is high
+          description: A host filesystem has been above 85% usage for 15 minutes.
+
+      - alert: DuneHostCriticalFilesystemUsage
+        expr: 100 * (1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"})) > 95
+        for: 5m
+        labels:
+          severity: critical
+          service: node-exporter
+        annotations:
+          summary: Dune host filesystem usage is critical
+          description: A host filesystem has been above 95% usage for 5 minutes.
+
+      - alert: DuneHostFilesystemReadonly
+        expr: node_filesystem_readonly{fstype!~"tmpfs|overlay"} == 1
+        for: 1m
+        labels:
+          severity: critical
+          service: node-exporter
+        annotations:
+          summary: Dune host filesystem is read-only
+          description: A host filesystem is reporting read-only state.

--- a/runtime/metrics/rules/postgres.yml
+++ b/runtime/metrics/rules/postgres.yml
@@ -1,0 +1,67 @@
+groups:
+  - name: dune-postgres
+    rules:
+      - alert: DunePostgresDown
+        expr: pg_up == 0
+        for: 1m
+        labels:
+          severity: critical
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres is down
+          description: postgres_exporter reports pg_up == 0.
+
+      - alert: DunePostgresExporterScrapeError
+        expr: pg_exporter_last_scrape_error == 1
+        for: 5m
+        labels:
+          severity: warning
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres exporter scrape error
+          description: postgres_exporter has reported scrape errors for 5 minutes.
+
+      - alert: DunePostgresHighConnections
+        expr: 100 * (sum(pg_stat_activity_count) / sum(pg_settings_max_connections)) > 80
+        for: 10m
+        labels:
+          severity: warning
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres connection usage is high
+          description: Postgres active connections are above 80% of max connections.
+
+      - alert: DunePostgresCriticalConnections
+        expr: 100 * (sum(pg_stat_activity_count) / sum(pg_settings_max_connections)) > 95
+        for: 2m
+        labels:
+          severity: critical
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres connection usage is critical
+          description: Postgres active connections are above 95% of max connections.
+
+      - alert: DunePostgresDeadlocks
+        expr: increase(pg_stat_database_deadlocks{datname="dune"}[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres deadlocks detected
+          description: The Dune database deadlock counter increased in the last 5 minutes.
+
+      - alert: DunePostgresLowCacheHitRatio
+        expr: |
+          100 * (
+            pg_stat_database_blks_hit{datname="dune"}
+            /
+            (pg_stat_database_blks_hit{datname="dune"} + pg_stat_database_blks_read{datname="dune"})
+          ) < 95
+        for: 15m
+        labels:
+          severity: warning
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres cache hit ratio is low
+          description: The Dune database cache hit ratio has been below 95% for 15 minutes.

--- a/runtime/metrics/rules/rabbitmq.yml
+++ b/runtime/metrics/rules/rabbitmq.yml
@@ -1,0 +1,64 @@
+groups:
+  - name: dune-rabbitmq
+    rules:
+      - alert: DuneRabbitMQDown
+        expr: rabbitmq_up == 0
+        for: 1m
+        labels:
+          severity: critical
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ broker is down
+          description: RabbitMQ Prometheus metrics report rabbitmq_up == 0.
+
+      - alert: DuneRabbitMQHighMemory
+        expr: 100 * (rabbitmq_process_resident_memory_bytes / rabbitmq_resident_memory_limit_bytes) > 80
+        for: 10m
+        labels:
+          severity: warning
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ memory usage is high
+          description: RabbitMQ resident memory is above 80% of its limit.
+
+      - alert: DuneRabbitMQHighFileDescriptors
+        expr: 100 * (rabbitmq_process_open_fds / rabbitmq_process_max_fds) > 80
+        for: 10m
+        labels:
+          severity: warning
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ file descriptor usage is high
+          description: RabbitMQ open file descriptors are above 80% of max file descriptors.
+
+      - alert: DuneRabbitMQQueueBacklog
+        expr: rabbitmq_queue_messages_ready > 1000
+        for: 10m
+        labels:
+          severity: warning
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ queue backlog detected
+          description: RabbitMQ ready queue messages have been above 1000 for 10 minutes.
+
+      - alert: DuneRabbitMQUnackedBacklog
+        expr: rabbitmq_queue_messages_unacked > 1000
+        for: 10m
+        labels:
+          severity: warning
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ unacked backlog detected
+          description: RabbitMQ unacked messages have been above 1000 for 10 minutes.
+
+      - alert: DuneRabbitMQUnroutableMessages
+        expr: |
+          rate(rabbitmq_global_messages_unroutable_dropped_total[5m]) > 0
+          or rate(rabbitmq_global_messages_unroutable_returned_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ unroutable messages detected
+          description: RabbitMQ unroutable dropped or returned message counters are increasing.

--- a/runtime/scripts/dune
+++ b/runtime/scripts/dune
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091
+# .env is runtime/operator-local and may not exist during static analysis.
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
@@ -111,6 +113,14 @@ command_can_sudo_reexec_safely() {
   case "$cmd" in
     status|ps|servers|ports|ping|ping-diagnostics|ready|logs|doctor)
       return 0
+      ;;
+    metrics)
+      case "$target" in
+        ""|status|ps|logs|config|help|--help|-h)
+          return 0
+          ;;
+      esac
+      return 1
       ;;
     *)
       return 1
@@ -332,6 +342,11 @@ EOF
     runtime/scripts/console.sh "$@"
     ;;
 
+  metrics)
+    shift || true
+    bash runtime/scripts/metrics-stack.sh "$@"
+    ;;
+
   update)
     shift || true
     set -a
@@ -429,6 +444,7 @@ Usage:
   dune logs <service> [--raw]
   dune restart <service>
   dune console restart
+  dune metrics [start|stop|restart|status|logs|config|pull]
   dune update [check|auto enable|auto disable|auto status|--yes]
   dune self-update [check|list|install [latest|<tag>]]
   dune restart-schedule [enable <HH:MM> [notify-minutes]|disable|status]

--- a/runtime/scripts/metrics-stack.sh
+++ b/runtime/scripts/metrics-stack.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+command_name="${1:-status}"
+compose_file="docker-compose.metrics.yml"
+metrics_project_name="${DUNE_METRICS_COMPOSE_PROJECT_NAME:-${DUNE_COMPOSE_PROJECT_NAME:-dune-awakening-selfhost-docker}-metrics}"
+prometheus_port="${METRICS_PROMETHEUS_PORT:-}"
+
+if [ -z "$prometheus_port" ] && [ -f .env ]; then
+  prometheus_port="$(awk -F= '/^METRICS_PROMETHEUS_PORT=/ {print $2; exit}' .env | sed 's/[[:space:]"]//g' || true)"
+fi
+prometheus_port="${prometheus_port:-9090}"
+
+compose() {
+  COMPOSE_PROJECT_NAME="$metrics_project_name" \
+    COMPOSE_IGNORE_ORPHANS=true \
+    docker compose -f "$compose_file" "$@"
+}
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is not available."
+    exit 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "Docker is not reachable from this shell."
+    exit 1
+  fi
+  if ! docker compose version >/dev/null 2>&1; then
+    echo "Docker Compose v2 is required."
+    exit 1
+  fi
+}
+
+require_curl_python() {
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required for metrics validation."
+    exit 1
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required for metrics validation output parsing."
+    exit 1
+  fi
+}
+
+ensure_compose_file() {
+  if [ ! -f "$compose_file" ]; then
+    echo "Missing $compose_file."
+    exit 1
+  fi
+}
+
+ensure_network() {
+  docker network create dune-net >/dev/null 2>&1 || true
+}
+
+print_url() {
+  echo "Prometheus: http://127.0.0.1:${prometheus_port}"
+}
+
+curl_prometheus() {
+  local path="$1"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsS --max-time 3 "http://127.0.0.1:${prometheus_port}${path}"
+    return $?
+  fi
+  return 127
+}
+
+query_prometheus() {
+  local query="$1"
+  curl -fsS --max-time 5 -G "http://127.0.0.1:${prometheus_port}/api/v1/query" \
+    --data-urlencode "query=${query}"
+}
+
+wait_for_prometheus_targets() {
+  local attempt
+  [ "${METRICS_SKIP_TARGET_WAIT:-0}" != "1" ] || return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+
+  for attempt in $(seq 1 10); do
+    [ "${METRICS_VERBOSE:-0}" != "1" ] || echo "Waiting for Prometheus targets (${attempt}/10)..."
+    if curl_prometheus "/api/v1/targets" >/tmp/dune-prometheus-targets.json 2>/dev/null; then
+      if python3 - <<'PY'
+import json
+from pathlib import Path
+payload = json.loads(Path('/tmp/dune-prometheus-targets.json').read_text())
+raise SystemExit(0 if payload.get('data', {}).get('activeTargets') else 1)
+PY
+      then
+        rm -f /tmp/dune-prometheus-targets.json
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  rm -f /tmp/dune-prometheus-targets.json
+}
+
+show_targets() {
+  if command -v curl >/dev/null 2>&1 && curl_prometheus "/api/v1/targets" >/tmp/dune-prometheus-targets.json 2>/dev/null; then
+    if command -v python3 >/dev/null 2>&1; then
+      python3 - <<'PY'
+import json
+from pathlib import Path
+payload = json.loads(Path('/tmp/dune-prometheus-targets.json').read_text())
+active_targets = payload.get('data', {}).get('activeTargets', [])
+print(f"active_targets={len(active_targets)}")
+if not active_targets:
+    print("No active Prometheus targets reported yet. This is not a passing validation state; re-run status or inspect /api/v1/targets.")
+for target in active_targets:
+    labels = target.get('labels', {})
+    job = labels.get('job', '-')
+    instance = labels.get('instance', '-')
+    health = target.get('health', '-')
+    last_error = target.get('lastError') or ''
+    suffix = f" ({last_error})" if last_error else ''
+    print(f"{job}\t{instance}\t{health}{suffix}")
+PY
+    else
+      echo "Target API reachable. Install python3 for formatted target output."
+    fi
+    rm -f /tmp/dune-prometheus-targets.json
+  else
+    echo "target API unavailable"
+  fi
+}
+
+show_status() {
+  require_docker
+  ensure_compose_file
+
+  echo "=== Metrics containers ==="
+  docker ps -a \
+    --filter "name=dune-prometheus" \
+    --filter "name=dune-node-exporter" \
+    --filter "name=dune-cadvisor" \
+    --filter "name=dune-postgres-exporter" \
+    --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" || true
+
+  echo
+  echo "=== Prometheus health ==="
+  if curl_prometheus "/-/healthy" >/dev/null 2>&1; then
+    echo "healthy"
+    print_url
+  else
+    echo "not reachable on 127.0.0.1:${prometheus_port}"
+  fi
+
+  echo
+  echo "=== Prometheus targets ==="
+  show_targets
+}
+
+validate_metrics() {
+  require_docker
+  require_curl_python
+  ensure_compose_file
+
+  local fail=0
+  local tmp_targets tmp_rules tmp_up tmp_pg
+  tmp_targets="$(mktemp)"
+  tmp_rules="$(mktemp)"
+  tmp_up="$(mktemp)"
+  tmp_pg="$(mktemp)"
+
+  echo "=== Metrics validation ==="
+  print_url
+
+  echo
+  echo "Checking Prometheus health..."
+  if curl_prometheus "/-/healthy" >/dev/null 2>&1; then
+    echo "OK   Prometheus health"
+  else
+    echo "FAIL Prometheus is not healthy on 127.0.0.1:${prometheus_port}"
+    fail=1
+  fi
+
+  echo
+  echo "Checking Prometheus targets..."
+  if curl_prometheus "/api/v1/targets" >"$tmp_targets" 2>/dev/null; then
+    if ! python3 - "$tmp_targets" <<'PY'
+import json
+import sys
+from pathlib import Path
+payload = json.loads(Path(sys.argv[1]).read_text())
+targets = payload.get('data', {}).get('activeTargets', [])
+expected = {'dune-prometheus', 'dune-node', 'dune-cadvisor', 'dune-postgres'}
+seen = {target.get('labels', {}).get('job') for target in targets}
+missing = sorted(expected - seen)
+print(f"active_targets={len(targets)}")
+for target in targets:
+    labels = target.get('labels', {})
+    job = labels.get('job', '-')
+    instance = labels.get('instance', '-')
+    health = target.get('health', '-')
+    last_error = target.get('lastError') or ''
+    suffix = f" ({last_error})" if last_error else ''
+    print(f"{job}\t{instance}\t{health}{suffix}")
+if missing:
+    print("Missing required jobs: " + ", ".join(missing))
+    raise SystemExit(1)
+if not targets:
+    print("No active targets returned.")
+    raise SystemExit(1)
+PY
+    then
+      fail=1
+    fi
+  else
+    echo "FAIL target API unavailable"
+    fail=1
+  fi
+
+  echo
+  echo "Checking Prometheus rules..."
+  if curl_prometheus "/api/v1/rules" >"$tmp_rules" 2>/dev/null; then
+    if ! python3 - "$tmp_rules" <<'PY'
+import json
+import sys
+from pathlib import Path
+payload = json.loads(Path(sys.argv[1]).read_text())
+groups = payload.get('data', {}).get('groups', [])
+print(f"rule_groups={len(groups)}")
+for group in groups:
+    name = group.get('name', '-')
+    rules = group.get('rules', [])
+    print(f"{name}\trules={len(rules)}")
+if not groups:
+    print("No rule groups returned.")
+    raise SystemExit(1)
+PY
+    then
+      fail=1
+    fi
+  else
+    echo "FAIL rules API unavailable"
+    fail=1
+  fi
+
+  echo
+  echo "Checking scrape health with query: up"
+  if query_prometheus "up" >"$tmp_up" 2>/dev/null; then
+    if ! python3 - "$tmp_up" <<'PY'
+import json
+import sys
+from pathlib import Path
+payload = json.loads(Path(sys.argv[1]).read_text())
+results = payload.get('data', {}).get('result', [])
+if not results:
+    print("No up results returned.")
+    raise SystemExit(1)
+failed = []
+for result in results:
+    metric = result.get('metric', {})
+    job = metric.get('job', '-')
+    instance = metric.get('instance', '-')
+    value = result.get('value', [None, '0'])[1]
+    print(f"{job}\t{instance}\tup={value}")
+    if value != '1':
+        failed.append(f"{job}/{instance}={value}")
+if failed:
+    print("Unhealthy scrape targets: " + ", ".join(failed))
+    raise SystemExit(1)
+PY
+    then
+      fail=1
+    fi
+  else
+    echo "FAIL Prometheus query failed: up"
+    fail=1
+  fi
+
+  echo
+  echo "Checking Postgres exporter with query: pg_up"
+  if query_prometheus "pg_up" >"$tmp_pg" 2>/dev/null; then
+    if ! python3 - "$tmp_pg" <<'PY'
+import json
+import sys
+from pathlib import Path
+payload = json.loads(Path(sys.argv[1]).read_text())
+results = payload.get('data', {}).get('result', [])
+if not results:
+    print("No pg_up results returned.")
+    raise SystemExit(1)
+failed = []
+for result in results:
+    metric = result.get('metric', {})
+    job = metric.get('job', '-')
+    instance = metric.get('instance', '-')
+    value = result.get('value', [None, '0'])[1]
+    print(f"{job}\t{instance}\tpg_up={value}")
+    if value != '1':
+        failed.append(f"{job}/{instance}={value}")
+if failed:
+    print("Postgres exporter connectivity failed: " + ", ".join(failed))
+    raise SystemExit(1)
+PY
+    then
+      fail=1
+    fi
+  else
+    echo "FAIL Prometheus query failed: pg_up"
+    fail=1
+  fi
+
+  rm -f "$tmp_targets" "$tmp_rules" "$tmp_up" "$tmp_pg"
+
+  echo
+  if [ "$fail" -eq 0 ]; then
+    echo "READY: metrics validation passed."
+  else
+    echo "FAIL: metrics validation failed."
+  fi
+  return "$fail"
+}
+
+case "$command_name" in
+  start|up)
+    require_docker
+    ensure_compose_file
+    ensure_network
+    echo "Starting Dune metrics stack..."
+    compose up -d
+    wait_for_prometheus_targets || true
+    echo
+    show_status
+    ;;
+
+  stop|down)
+    require_docker
+    ensure_compose_file
+    echo "Stopping Dune metrics stack..."
+    compose down
+    ;;
+
+  restart)
+    require_docker
+    ensure_compose_file
+    ensure_network
+    echo "Restarting Dune metrics stack..."
+    compose down
+    compose up -d
+    wait_for_prometheus_targets || true
+    echo
+    show_status
+    ;;
+
+  status|ps)
+    show_status
+    ;;
+
+  validate|check)
+    validate_metrics
+    ;;
+
+  logs)
+    require_docker
+    ensure_compose_file
+    shift || true
+    compose logs "$@"
+    ;;
+
+  config)
+    require_docker
+    ensure_compose_file
+    compose config
+    ;;
+
+  pull)
+    require_docker
+    ensure_compose_file
+    compose pull
+    ;;
+
+  help|--help|-h)
+    cat <<EOF
+Usage:
+  dune metrics start
+  dune metrics stop
+  dune metrics restart
+  dune metrics status
+  dune metrics validate
+  dune metrics logs [service]
+  dune metrics config
+  dune metrics pull
+
+The metrics stack is opt-in and independent from the game stack.
+Prometheus binds to 127.0.0.1:${prometheus_port} by default.
+Metrics compose project: ${metrics_project_name}
+EOF
+    ;;
+
+  *)
+    echo "Unknown metrics command: $command_name"
+    echo "Run: dune metrics --help"
+    exit 1
+    ;;
+esac

--- a/runtime/scripts/metrics-status.sh
+++ b/runtime/scripts/metrics-status.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+exec runtime/scripts/metrics-stack.sh status

--- a/tests/metrics-stack-unit.sh
+++ b/tests/metrics-stack-unit.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+test_no=0
+
+note() {
+  printf '# %s\n' "$*"
+}
+
+ok() {
+  test_no=$((test_no + 1))
+  printf 'ok %02d - %s\n' "$test_no" "$*"
+}
+
+fail() {
+  test_no=$((test_no + 1))
+  printf 'not ok %02d - %s\n' "$test_no" "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  local label="$3"
+
+  if grep -Fq -- "$expected" "$file"; then
+    ok "$label"
+    return 0
+  fi
+
+  echo "Expected to find: $expected" >&2
+  echo "--- output ---" >&2
+  cat "$file" >&2
+  echo "--------------" >&2
+  fail "$label"
+}
+
+assert_command_fails() {
+  local output_file="$1"
+  local label="$2"
+  shift 2
+
+  if "$@" >"$output_file" 2>&1; then
+    echo "--- unexpected success output ---" >&2
+    cat "$output_file" >&2
+    echo "-------------------------------" >&2
+    fail "$label"
+  fi
+
+  ok "$label"
+}
+
+show_output_block() {
+  local title="$1"
+  local file="$2"
+
+  note "$title"
+  sed 's/^/#   /' "$file"
+}
+
+echo "TAP version 13"
+note "metrics-stack unit tests"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+mkdir -p "$tmpdir/bin"
+ok "created isolated test harness directory"
+
+cat >"$tmpdir/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  info)
+    exit 0
+    ;;
+  compose)
+    shift || true
+    case "${1:-}" in
+      version)
+        echo "Docker Compose version v2.test"
+        exit 0
+        ;;
+      -f)
+        # Support: docker compose -f docker-compose.metrics.yml config
+        if [ "${3:-}" = "config" ]; then
+          echo "services: {}"
+          exit 0
+        fi
+        ;;
+    esac
+    echo "unexpected docker compose args: $*" >&2
+    exit 1
+    ;;
+  ps)
+    cat <<'PS'
+NAMES                    STATUS                    PORTS
+dune-prometheus          Up 1 minute               127.0.0.1:9090->9090/tcp
+dune-cadvisor            Up 1 minute (healthy)     8080/tcp
+dune-node-exporter       Up 1 minute               9100/tcp
+dune-postgres-exporter   Up 1 minute               9187/tcp
+PS
+    exit 0
+    ;;
+  network)
+    exit 0
+    ;;
+  *)
+    echo "unexpected docker args: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$tmpdir/bin/docker"
+ok "installed fake docker command"
+
+cat >"$tmpdir/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${FAKE_CURL_LOG:?FAKE_CURL_LOG is required}"
+args=" $* "
+mode="${FAKE_PROMETHEUS_MODE:-ok}"
+
+if [[ "$args" == *"/-/healthy"* ]]; then
+  echo "healthy"
+  exit 0
+fi
+
+if [[ "$args" == *"/api/v1/targets"* ]]; then
+  if [ "$mode" = "missing-target" ]; then
+    cat <<'JSON'
+{"status":"success","data":{"activeTargets":[
+  {"labels":{"job":"dune-prometheus","instance":"dune-prometheus:9090"},"health":"up"},
+  {"labels":{"job":"dune-cadvisor","instance":"dune-cadvisor:8080"},"health":"up"},
+  {"labels":{"job":"dune-postgres","instance":"dune-postgres-exporter:9187"},"health":"up"}
+]}}
+JSON
+  else
+    cat <<'JSON'
+{"status":"success","data":{"activeTargets":[
+  {"labels":{"job":"dune-prometheus","instance":"dune-prometheus:9090"},"health":"up"},
+  {"labels":{"job":"dune-node","instance":"dune-node-exporter:9100"},"health":"up"},
+  {"labels":{"job":"dune-cadvisor","instance":"dune-cadvisor:8080"},"health":"up"},
+  {"labels":{"job":"dune-postgres","instance":"dune-postgres-exporter:9187"},"health":"up"},
+  {"labels":{"job":"dune-rabbitmq-admin","instance":"dune-rmq-admin:15692"},"health":"up"},
+  {"labels":{"job":"dune-rabbitmq-game","instance":"dune-rmq-game:15692"},"health":"up"}
+]}}
+JSON
+  fi
+  exit 0
+fi
+
+if [[ "$args" == *"/api/v1/rules"* ]]; then
+  cat <<'JSON'
+{"status":"success","data":{"groups":[
+  {"name":"dune-host","rules":[{"name":"DuneHostHighCpu"}]},
+  {"name":"dune-containers","rules":[{"name":"DuneContainerMetricsMissing"}]},
+  {"name":"dune-postgres","rules":[{"name":"DunePostgresDown"}]},
+  {"name":"dune-rabbitmq","rules":[{"name":"DuneRabbitmqDown"}]},
+  {"name":"dune-stack","rules":[]}
+]}}
+JSON
+  exit 0
+fi
+
+if [[ "$args" == *"query=pg_up"* ]]; then
+  cat <<'JSON'
+{"status":"success","data":{"resultType":"vector","result":[
+  {"metric":{"job":"dune-postgres","instance":"dune-postgres-exporter:9187"},"value":[1782798595.497,"1"]}
+]}}
+JSON
+  exit 0
+fi
+
+if [[ "$args" == *"query=up"* ]]; then
+  cat <<'JSON'
+{"status":"success","data":{"resultType":"vector","result":[
+  {"metric":{"job":"dune-postgres","instance":"dune-postgres-exporter:9187"},"value":[1782798595.478,"1"]},
+  {"metric":{"job":"dune-cadvisor","instance":"dune-cadvisor:8080"},"value":[1782798595.478,"1"]},
+  {"metric":{"job":"dune-rabbitmq-admin","instance":"dune-rmq-admin:15692"},"value":[1782798595.478,"1"]},
+  {"metric":{"job":"dune-rabbitmq-game","instance":"dune-rmq-game:15692"},"value":[1782798595.478,"1"]},
+  {"metric":{"job":"dune-prometheus","instance":"dune-prometheus:9090"},"value":[1782798595.478,"1"]},
+  {"metric":{"job":"dune-node","instance":"dune-node-exporter:9100"},"value":[1782798595.478,"1"]}
+]}}
+JSON
+  exit 0
+fi
+
+echo "unexpected curl args: $*" >&2
+exit 1
+EOF
+chmod +x "$tmpdir/bin/curl"
+ok "installed fake curl/Prometheus command"
+
+export PATH="$tmpdir/bin:$PATH"
+export FAKE_CURL_LOG="$tmpdir/curl.log"
+ok "wired fake commands into PATH"
+
+note "running happy-path metrics validation"
+pass_output="$tmpdir/pass.out"
+: >"$FAKE_CURL_LOG"
+METRICS_PROMETHEUS_PORT=9090 bash runtime/scripts/metrics-stack.sh validate >"$pass_output"
+show_output_block "happy-path validator output" "$pass_output"
+assert_contains "$pass_output" "OK   Prometheus health" "validator reports Prometheus health"
+assert_contains "$pass_output" "active_targets=6" "validator counts all six active targets"
+assert_contains "$pass_output" "dune-rabbitmq-admin" "validator includes RabbitMQ admin target"
+assert_contains "$pass_output" "dune-rabbitmq-game" "validator includes RabbitMQ game target"
+assert_contains "$pass_output" "rule_groups=5" "validator reports loaded rule groups"
+assert_contains "$pass_output" "pg_up=1" "validator confirms Postgres exporter connectivity"
+assert_contains "$pass_output" "READY: metrics validation passed." "validator returns READY on healthy fixtures"
+assert_contains "$FAKE_CURL_LOG" "--data-urlencode query=up" "validator URL-encodes the up query"
+assert_contains "$FAKE_CURL_LOG" "--data-urlencode query=pg_up" "validator URL-encodes the pg_up query"
+
+note "running required-target failure validation"
+missing_output="$tmpdir/missing.out"
+assert_command_fails "$missing_output" "validator fails when required target is missing" \
+  env FAKE_PROMETHEUS_MODE=missing-target METRICS_PROMETHEUS_PORT=9090 bash runtime/scripts/metrics-stack.sh validate
+show_output_block "missing-target validator output" "$missing_output"
+assert_contains "$missing_output" "Missing required jobs: dune-node" "validator names missing required target"
+assert_contains "$missing_output" "FAIL: metrics validation failed." "validator prints failure summary"
+
+echo "1..$test_no"
+note "metrics-stack unit tests completed"

--- a/tests/security-pr-checks.sh
+++ b/tests/security-pr-checks.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-upstream/main}"
+REPORT_DIR="${REPORT_DIR:-.security-reports}"
+PR_FILES_DIR="$REPORT_DIR/pr-files"
+
+printf 'Security check base ref: %s\n' "$BASE_REF"
+printf 'Report directory: %s\n' "$REPORT_DIR"
+printf 'Changed-file staging directory: %s\n\n' "$PR_FILES_DIR"
+
+mkdir -p "$REPORT_DIR"
+
+printf '== Git whitespace/conflict check ==\n'
+git diff --check "$BASE_REF"...HEAD
+
+printf '\n== Changed files ==\n'
+git diff --name-only "$BASE_REF"...HEAD --diff-filter=ACM | tee "$REPORT_DIR/changed-files.txt"
+
+printf '\n== Preparing changed-file scan set ==\n'
+rm -rf "$PR_FILES_DIR"
+mkdir -p "$PR_FILES_DIR"
+
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  [ -f "$file" ] || continue
+
+  mkdir -p "$PR_FILES_DIR/$(dirname "$file")"
+  cp "$file" "$PR_FILES_DIR/$file"
+done < "$REPORT_DIR/changed-files.txt"
+
+if [ ! -d "$PR_FILES_DIR" ]; then
+  printf 'ERROR: changed-file staging directory was not created: %s\n' "$PR_FILES_DIR" >&2
+  exit 1
+fi
+
+printf 'Copied changed files into: %s\n' "$PR_FILES_DIR"
+find "$PR_FILES_DIR" -type f | sort | tee "$REPORT_DIR/staged-files.txt"
+
+printf '\n== Secret keyword review on changed files ==\n'
+if [ -s "$REPORT_DIR/staged-files.txt" ]; then
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    grep -HnE '(password|passwd|secret|token|apikey|api_key|private[_-]?key|BEGIN RSA|BEGIN OPENSSH|FUNCOM|FLS|COMMAND_AUTH_TOKEN)' "$file" || true
+  done < "$REPORT_DIR/staged-files.txt" | tee "$REPORT_DIR/secret-keyword-review.txt"
+else
+  printf 'No changed files to scan.\n' | tee "$REPORT_DIR/secret-keyword-review.txt"
+fi
+
+printf '\n== ShellCheck ==\n'
+if command -v shellcheck >/dev/null 2>&1; then
+  shellcheck \
+    runtime/scripts/dune \
+    runtime/scripts/metrics-stack.sh \
+    runtime/scripts/metrics-status.sh \
+    tests/metrics-stack-unit.sh \
+    tests/security-pr-checks.sh
+else
+  printf 'SKIP: shellcheck is not installed.\n'
+fi
+
+printf '\n== Gitleaks changed-file scan ==\n'
+if command -v gitleaks >/dev/null 2>&1; then
+  if gitleaks detect --help 2>/dev/null | grep -q -- '--no-git'; then
+    GITLEAKS_CMD=(gitleaks detect --source "$PR_FILES_DIR" --no-git --redact --report-format json --report-path "$REPORT_DIR/gitleaks-pr-files.json")
+  else
+    GITLEAKS_CMD=(gitleaks detect --source "$PR_FILES_DIR" --redact --report-format json --report-path "$REPORT_DIR/gitleaks-pr-files.json")
+  fi
+
+  if "${GITLEAKS_CMD[@]}"; then
+    printf 'Gitleaks changed-file scan passed.\n'
+  else
+    printf 'Gitleaks changed-file scan found findings. See %s\n' "$REPORT_DIR/gitleaks-pr-files.json" >&2
+    exit 1
+  fi
+else
+  printf 'SKIP: gitleaks is not installed.\n'
+fi
+
+printf '\n== Trivy filesystem scan ==\n'
+if [ ! -d "$PR_FILES_DIR" ]; then
+  printf 'ERROR: Trivy staging directory missing before scan: %s\n' "$PR_FILES_DIR" >&2
+  exit 1
+fi
+
+if ! find "$PR_FILES_DIR" -type f -print -quit | grep -q .; then
+  printf 'SKIP: no changed files copied into %s.\n' "$PR_FILES_DIR"
+elif command -v trivy >/dev/null 2>&1; then
+  printf 'Running Trivy against: %s\n' "$PR_FILES_DIR"
+  trivy fs --scanners secret,misconfig --severity HIGH,CRITICAL "$PR_FILES_DIR"
+else
+  printf 'SKIP: trivy is not installed.\n'
+fi
+
+printf '\nSecurity checks completed.\n'


### PR DESCRIPTION
## Summary

Adds an opt-in operational metrics stack intended to support Dune Ops Observability addon work without changing the default runtime path.

This PR adds:
- `docker-compose.metrics.yml`
- Prometheus scrape configuration
- Prometheus alert/rule groups for containers, host, Postgres, RabbitMQ, and the Dune stack
- `dune metrics` CLI support
- metrics stack/status helper scripts
- unit and validation tests
- reusable changed-file security checks
- R1 implementation notes
- E2E metrics testing documentation
- PR evidence documentation

## Why this is needed

The addon needs a supported operational metrics foundation before real dashboard data can be wired safely. This PR provides that foundation while keeping metrics opt-in and local by default.

It also separates infrastructure support from the later bridge/API work needed for browser-safe addon consumption.

## Scope

In scope:
- Opt-in metrics compose stack
- Prometheus configuration
- Prometheus rule files
- CLI entrypoints for metrics start/stop/restart/status/validate/logs
- Metrics validation tests
- Security validation script for changed files
- Implementation, E2E, and PR evidence docs

## Out of scope

Out of scope:
- WSL installer changes
- Windows/WSL docs
- Admin PowerShell docs
- `install.ps1`
- General admin/self-update work
- General command-auth-token changes
- Browser-side Prometheus access
- Browser-side Prometheus tokens
- Direct addon access to exporters
- `ops.health.summary` bridge implementation
- `metrics.query` or arbitrary PromQL exposed to addons

## Implementation details

Default posture:
- Metrics stack is opt-in.
- Prometheus binds to `127.0.0.1:9090` by default.
- Exporters are not public by default.
- No gameplay/player labels are emitted in R1.
- The addon should not query Prometheus directly.
- Future addon consumption should go through a permissioned Console/backend bridge or API action.

Added operational commands:
- `dune metrics start`
- `dune metrics stop`
- `dune metrics restart`
- `dune metrics status`
- `dune metrics validate`
- `dune metrics logs`

## Regression test results

Validated locally:
- `docker compose -f docker-compose.metrics.yml config`
- `shellcheck runtime/scripts/dune runtime/scripts/metrics-stack.sh runtime/scripts/metrics-status.sh tests/metrics-stack-unit.sh tests/security-pr-checks.sh`
- `git diff --check upstream/main...HEAD`
- `bash tests/metrics-stack-unit.sh`

Result: passed.

## Security check results

Validated locally with reusable changed-file security checks:
- Git whitespace/conflict check
- Changed-file inventory
- Changed-file secret keyword review
- ShellCheck
- Gitleaks changed-file scan
- Trivy filesystem scan against changed-file staging directory when available

Command used:
- `BASE_REF=upstream/main REPORT_DIR=.security-reports ./tests/security-pr-checks.sh`

Result: passed cleanly.

The security script stages only files changed by this PR, which separates inherited repository/history findings from new PR findings.

## E2E test results

Validated locally:
- `bash runtime/scripts/dune metrics start`
- `bash runtime/scripts/dune metrics status`
- `curl -fsS http://127.0.0.1:9090/-/healthy`
- `curl -fsS http://127.0.0.1:9090/-/ready`
- `bash runtime/scripts/dune metrics validate`
- `bash runtime/scripts/dune metrics stop`

Result: passed.

Observed validation outcome:
- Prometheus healthy
- Prometheus ready
- Six active targets discovered
- All configured targets returned `up=1` during validation
- Postgres exporter returned `pg_up=1`
- Four Prometheus rule groups loaded
- Validator returned `READY: metrics validation passed`
- Metrics stack stopped cleanly

Startup note:
- Initial `metrics status` may show target health as `unknown` immediately after startup while Prometheus scrape pools settle.
- Follow-up validation confirmed final scrape health with all targets returning `up=1`.

## WebUI test results

Validated manually:
- Dune Docker Console loaded normally.
- Addons panel loaded normally.
- Dune Ops Observability could be launched when locally installed.
- Browser network inspection did not show direct calls from the addon to Prometheus or exporters.
- No browser console errors were observed from this metrics-support change set.

Result: passed.

## Documentation

Added or updated:
- `docs/R1-METRICS-STACK-IMPLEMENTATION-NOTES.md`
- `docs/E2E-METRICS-TESTING.md`
- `docs/PR-EVIDENCE-ADDON-METRICS-SUPPORT.md`

The evidence document contains the detailed validation trail for local testing, security, E2E, and WebUI checks.

## Risks

Primary risks:
- Prometheus startup status may briefly report `unknown` targets before the first scrape completes.
- Metrics stack adds optional local containers when enabled.
- Operators may need Docker resources available for Prometheus/exporters.

Mitigations:
- Stack is opt-in.
- Validation command confirms target health after startup.
- Prometheus binds locally by default.
- Exporters are not exposed publicly by default.

## Rollback

Rollback path:
- Do not start the metrics stack.
- Run `dune metrics stop` if it was started.
- Revert this PR to remove the metrics compose file, Prometheus config/rules, CLI entrypoints, helper scripts, tests, and docs.

No database migrations are included.

## Related issues / PRs

- RFC issue: https://github.com/Red-Blink/dune-awakening-selfhost-docker/issues/43
- Follow-up real-data bridge issue: https://github.com/Red-Blink/dune-awakening-selfhost-docker/issues/44
- Source fork PR: https://github.com/yacketrj/dune-awakening-selfhost-docker-WSL/pull/83

## Follow-up

Next focused work item after this PR:
- Add a read-only, permissioned Console/backend bridge action for aggregate OPS health data, scoped to issue #44.
- Proposed action: `ops.health.summary`.
- Addon UI consumption should be implemented only after the Core bridge exists.
