### PR TITLE
Feature/Add sortable headers to Database Browser tables

### DIFF
--- a/console/web/src/components/common/DataTable.tsx
+++ b/console/web/src/components/common/DataTable.tsx
@@ -13,6 +13,9 @@ type DataTableProps = {
   tableClassName?: string;
   renderCell?: (row: Record<string, unknown>, column: string) => ReactNode;
   emptyMessage?: string;
+  sortColumn?: string;
+  sortDirection?: "asc" | "desc";
+  onSort?: (column: string) => void;
 };
 
 export function DataTable({
@@ -26,9 +29,12 @@ export function DataTable({
   secondaryActionClassName = "",
   tableClassName = "",
   renderCell,
-  emptyMessage = "No rows."
+  emptyMessage = "No rows.",
+  sortColumn,
+  sortDirection,
+  onSort
 }: DataTableProps) {
   const cols = columns?.length ? columns : Array.from(new Set(rows.flatMap((row) => Object.keys(row)))).slice(0, 8);
   if (!rows.length) return <div className="empty">{emptyMessage}</div>;
-  return <div className="table-wrap"><table className={tableClassName}><thead><tr>{cols.map((col) => <th key={col}>{friendlyColumnName(col)}</th>)}{action && <th className={actionClassName}>Actions</th>}{secondaryAction && <th className={secondaryActionClassName}>{secondaryActionLabel}</th>}</tr></thead><tbody>{rows.map((row, index) => <tr key={index} onClick={() => onRowClick?.(row)} className={onRowClick ? "clickable" : ""}>{cols.map((col) => <td key={col}>{renderCell ? renderCell(row, col) : formatCell(row[col])}</td>)}{action && <td className={actionClassName}>{action(row)}</td>}{secondaryAction && <td className={secondaryActionClassName}>{secondaryAction(row)}</td>}</tr>)}</tbody></table></div>;
+  return <div className="table-wrap"><table className={tableClassName}><thead><tr>{cols.map((col) => <th key={col} className={onSort ? "sortable" : ""} onClick={onSort ? () => onSort(col) : undefined}>{friendlyColumnName(col)}{onSort && sortColumn === col && <span className="sort-indicator">{sortDirection === "desc" ? " ↓" : " ↑"}</span>}</th>)}{action && <th className={actionClassName}>Actions</th>}{secondaryAction && <th className={secondaryActionClassName}>{secondaryActionLabel}</th>}</tr></thead><tbody>{rows.map((row, index) => <tr key={index} onClick={() => onRowClick?.(row)} className={onRowClick ? "clickable" : ""}>{cols.map((col) => <td key={col}>{renderCell ? renderCell(row, col) : formatCell(row[col])}</td>)}{action && <td className={actionClassName}>{action(row)}</td>}{secondaryAction && <td className={secondaryActionClassName}>{secondaryAction(row)}</td>}</tr>)}</tbody></table></div>;
 }

--- a/console/web/src/features/database/DatabasePanel.tsx
+++ b/console/web/src/features/database/DatabasePanel.tsx
@@ -36,6 +36,17 @@ function isTerminalTask(status: string) {
   return ["succeeded", "failed", "cancelled"].includes(status);
 }
 
+type SortState = { column: string; direction: "asc" | "desc" };
+
+function useSortableRows<T extends Record<string, unknown>>(rows: T[]) {
+  const [sort, setSort] = useState<SortState | null>(null);
+  const sortedRows = sort ? [...rows].sort((a, b) => compareTableValues(a[sort.column], b[sort.column], sort.direction)) : rows;
+  function onSort(column: string) {
+    setSort((current) => (current?.column === column ? { column, direction: current.direction === "asc" ? "desc" : "asc" } : { column, direction: "asc" }));
+  }
+  return { sortedRows, sortColumn: sort?.column, sortDirection: sort?.direction, onSort, reset: () => setSort(null) };
+}
+
 function loadDatabasePasswordState(): DatabasePasswordState {
   if (typeof window === "undefined") return { result: null };
   try {
@@ -168,6 +179,8 @@ export function DatabasePanel() {
     setColumns([]);
     setCount("");
     setPreviewError("");
+    columnsSort.reset();
+    previewSort.reset();
     await refreshTablePreview(table);
     window.setTimeout(() => previewRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }), 50);
   }
@@ -289,6 +302,11 @@ export function DatabasePanel() {
   const filteredTables = tableSearchTerm
     ? tables.filter((table) => `${String(table.schema || "")}.${String(table.name || "")}`.toLowerCase().includes(tableSearchTerm))
     : tables;
+  const tablesSort = useSortableRows(filteredTables);
+  const columnsSort = useSortableRows(columns);
+  const previewSort = useSortableRows(previewRows);
+  const searchSort = useSortableRows(searchRows);
+  const querySort = useSortableRows(queryRows);
   return <section className="panel">
     <h2>Database Browser</h2>
     <p className="database-browser-note">
@@ -326,7 +344,7 @@ export function DatabasePanel() {
       {tableSearch && <button onClick={() => setTableSearch("")}>Clear</button>}
     </div>
     {filteredTables.length
-      ? <DataTable rows={filteredTables} columns={["schema", "name", "row_count"]} onRowClick={(row) => open(String(row.name))} />
+      ? <DataTable rows={tablesSort.sortedRows} columns={["schema", "name", "row_count"]} onRowClick={(row) => open(String(row.name))} sortColumn={tablesSort.sortColumn} sortDirection={tablesSort.sortDirection} onSort={tablesSort.onSort} />
       : <div className="empty database-empty">No matching tables found.</div>}
     <h3 ref={previewRef}>{selected ? `${schema}.${selected} (${count} rows)` : "Table Preview"}</h3>
     {!selected && <div className="empty database-empty">No table selected. Select a table to preview and edit rows.</div>}
@@ -339,9 +357,9 @@ export function DatabasePanel() {
       </p>}
       <details className="technical-details">
         <summary>Columns</summary>
-        <DataTable rows={columns} />
+        <DataTable rows={columnsSort.sortedRows} sortColumn={columnsSort.sortColumn} sortDirection={columnsSort.sortDirection} onSort={columnsSort.onSort} />
       </details>
-      {!previewLoading && !previewError && (previewRows.length ? <DataTable rows={previewRows} columns={previewColumns} action={(row) => <button onClick={(event) => { event.stopPropagation(); startEdit(row); }}>Edit</button>} actionClassName="backup-table-actions" tableClassName="backup-table" /> : <div className="empty database-empty">This table has no rows to preview.</div>)}
+      {!previewLoading && !previewError && (previewRows.length ? <DataTable rows={previewSort.sortedRows} columns={previewColumns} action={(row) => <button onClick={(event) => { event.stopPropagation(); startEdit(row); }}>Edit</button>} actionClassName="backup-table-actions" tableClassName="backup-table" sortColumn={previewSort.sortColumn} sortDirection={previewSort.sortDirection} onSort={previewSort.onSort} /> : <div className="empty database-empty">This table has no rows to preview.</div>)}
       {!editRow && editResult && <section className={`result-panel ${editResult.status === "running" ? "" : "transient-result"} ${editResult.status === "succeeded" ? "result-ok" : editResult.status === "failed" ? "result-fail" : "result-running"}`}>
         <div className="panel-title"><strong>{formatResultTitle(editResult.title, editResult.status === "running")}</strong><StatusPill value={editResult.status === "succeeded" ? "Saved" : editResult.status === "failed" ? "Failed" : "Saving"} /></div>
         {editResult.message && <p>{formatResultMessage(editResult.message)}</p>}
@@ -363,7 +381,7 @@ export function DatabasePanel() {
     </section>}
     <h3>Search Tables and Columns</h3>
     <div className="action-row"><input value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Search tables or columns" /><button onClick={searchColumns}>Search</button></div>
-    {searchRan && (searchRows.length ? <DataTable rows={searchRows} /> : <div className="empty database-empty">No matching tables or columns found.</div>)}
+    {searchRan && (searchRows.length ? <DataTable rows={searchSort.sortedRows} sortColumn={searchSort.sortColumn} sortDirection={searchSort.sortDirection} onSort={searchSort.onSort} /> : <div className="empty database-empty">No matching tables or columns found.</div>)}
     <div className={`playerAdmin_toggle database-advanced-section ${advancedSqlOpen ? "open" : ""}`}>
       <button className="playerAdmin_toggleHeader" aria-label={advancedSqlOpen ? "Collapse Advanced SQL Console" : "Expand Advanced SQL Console"} onClick={() => setAdvancedSqlOpen(!advancedSqlOpen)}>{advancedSqlOpen ? <ChevronUp size={18} /> : <ChevronDown size={18} />}<span>Advanced SQL Console</span></button>
       {advancedSqlOpen && <div className="playerAdmin_toggleBody">
@@ -371,11 +389,19 @@ export function DatabasePanel() {
         <div className="action-row"><button onClick={runQuery}>Run Query</button><button onClick={exportQueryJson}>Export Query JSON</button></div>
         {queryRan && queryError && <div className="empty database-empty danger-note">{formatResultMessage(`Query failed: ${queryError}`)}</div>}
         {queryRan && !queryError && queryResult && (queryRows.length
-          ? <DataTable rows={queryRows} columns={queryColumns} />
+          ? <DataTable rows={querySort.sortedRows} columns={queryColumns} sortColumn={querySort.sortColumn} sortDirection={querySort.sortDirection} onSort={querySort.onSort} />
           : <div className="result-panel transient-result result-ok database-query-result">Query completed. Rows affected: {queryAffectedRows}.</div>)}
       </div>}
     </div>
   </section>;
+}
+
+function compareTableValues(a: unknown, b: unknown, direction: "asc" | "desc") {
+  const aNum = Number(a);
+  const bNum = Number(b);
+  const bothNumeric = a !== null && a !== undefined && a !== "" && b !== null && b !== undefined && b !== "" && !Number.isNaN(aNum) && !Number.isNaN(bNum);
+  const result = bothNumeric ? aNum - bNum : String(a ?? "").localeCompare(String(b ?? ""), undefined, { sensitivity: "base" });
+  return direction === "asc" ? result : -result;
 }
 
 function databasePreviewColumns(preview: { columns?: { name: string }[] } | null) {

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1046,6 +1046,9 @@ body.debug .technical-details { display: block; }
 table { width: max-content; min-width: 100%; border-collapse: collapse; }
 th, td { border-bottom: 1px solid #302b25; padding: 9px 10px; text-align: left; vertical-align: middle; max-width: 360px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 th { color: #ffd08a; background: #171a1d; position: sticky; top: 0; z-index: 1; }
+th.sortable { cursor: pointer; user-select: none; }
+th.sortable:hover { color: #ffe0a8; }
+.sort-indicator { color: #cbbd9f; }
 tr.clickable { cursor: pointer; }
 tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 .actions-column { text-align: center; }


### PR DESCRIPTION
## 🚀 Summary
Adds interactive, click-to-sort column headers to all tables within the **Database Browser** tab.

## ✨ Key Features
* **Universal Support:** Enabled across all five browser tables:
  * Table List
  * Columns Detail
  * Table Preview
  * Search Results
  * Query Results
* **Smart Sorting:** Toggles between ascending/descending order and uses numeric-aware comparison for accurate data ordering.
* **Local & Independent:** Sorting is processed entirely in the browser. Each table tracks its own sort state independently.

## 📸 Screenshots / GIFs
<img width="2210" height="577" alt="image" src="https://github.com/user-attachments/assets/0af3ab8d-785f-423d-9214-2d8327f715dc" />

## 🧪 Testing Steps
<details>
<summary>Click to expand testing checklist</summary>

1. Navigate to the **Database Browser** tab.
2. Click any column header to toggle between **Ascending** and **Descending** sort.
3. Verify that numeric columns (e.g., IDs, counts) sort by value size rather than string order.
4. Switch between different tables to ensure each table **retains its own unique sort state**.
</details>