### PR TITLE
[Feature] Database column filter

### DIFF
--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -99,13 +99,62 @@ async function tablePrimaryKeyColumns(db, schema, table) {
   return result.rows.map((row) => row.name).filter(Boolean);
 }
 
-export async function tableCount(db, schema, table) {
+const MAX_FILTER_TERMS = 20;
+
+function validateFilterTree(tree) {
+  if (tree === null || tree === undefined) return null;
+  if (!Array.isArray(tree) || !tree.length) throw new Error("Invalid filter");
+  let totalTerms = 0;
+  for (const group of tree) {
+    if (!Array.isArray(group) || !group.length) throw new Error("Invalid filter");
+    for (const term of group) {
+      if (!term || (term.type !== "text" && term.type !== "column")) throw new Error("Invalid filter");
+      if (term.type === "column" && !String(term.column || "")) throw new Error("Invalid filter");
+      if (typeof term.value !== "string") throw new Error("Invalid filter");
+      totalTerms += 1;
+    }
+  }
+  if (totalTerms > MAX_FILTER_TERMS) throw new Error("Too many filter conditions");
+  return tree;
+}
+
+function escapeLikeValue(value) {
+  return String(value).replace(/[\\%_]/g, (ch) => `\\${ch}`);
+}
+
+async function buildFilterWhereClause(db, schema, table, filterTree) {
+  const validated = validateFilterTree(filterTree);
+  if (!validated) return { sql: "", params: [] };
+  const columnNames = (await tableColumns(db, schema, table)).map((column) => column.name);
+  const params = [];
+  const orGroups = validated.map((group) => {
+    const andTerms = group.map((term) => {
+      if (term.type === "column") {
+        const matched = columnNames.find((name) => name.toLowerCase() === String(term.column).toLowerCase());
+        if (!matched) return "false";
+        params.push(term.value);
+        return `lower(${quoteIdentifier(matched)}::text) = lower($${params.length})`;
+      }
+      const likeValue = `%${escapeLikeValue(term.value)}%`;
+      const conditions = columnNames.map((name) => {
+        params.push(likeValue);
+        return `${quoteIdentifier(name)}::text ILIKE $${params.length}`;
+      });
+      return conditions.length ? `(${conditions.join(" or ")})` : "false";
+    });
+    return `(${andTerms.join(" and ")})`;
+  });
+  return { sql: ` where ${orGroups.join(" or ")}`, params };
+}
+
+export async function tableCount(db, schema, table, filterTree = null) {
   const safe = quoteQualified(schema, table);
-  const result = await db.query(`select count(*)::bigint as count from ${safe}`);
+  const { sql: whereSql, params } = await buildFilterWhereClause(db, schema, table, filterTree);
+  const result = await db.query(`select count(*)::bigint as count from ${safe}${whereSql}`, params);
   return { schema, table, count: result.rows[0]?.count ?? "0" };
 }
 
-export async function tablePreview(db, schema, table, limit = 50, offset = 0) {
+export async function tablePreview(db, schema, table, limit = 50, offset = 0, filterTree = null) {
   const safe = quoteQualified(schema, table);
   const maxLimit = intParam(limit, "limit", 1, MAX_TABLE_PREVIEW_ROWS);
   const safeOffset = intParam(offset, "offset", 0);
@@ -116,7 +165,8 @@ export async function tablePreview(db, schema, table, limit = 50, offset = 0) {
   const orderSql = primaryKeys.length
     ? ` order by ${primaryKeys.map((key) => quoteIdentifier(key)).join(", ")}`
     : " order by ctid";
-  const result = await db.query(`select ${rowIdSql} as __rowid, * from ${safe}${orderSql} limit $1 offset $2`, [maxLimit, safeOffset]);
+  const { sql: whereSql, params: whereParams } = await buildFilterWhereClause(db, schema, table, filterTree);
+  const result = await db.query(`select ${rowIdSql} as __rowid, * from ${safe}${whereSql}${orderSql} limit $${whereParams.length + 1} offset $${whereParams.length + 2}`, [...whereParams, maxLimit, safeOffset]);
   return { schema, table, limit: maxLimit, offset: safeOffset, ...rowsResult(result) };
 }
 

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -1006,13 +1006,23 @@ async function exportJson(res, filename, fn) {
   }
 }
 
+function parseDatabaseFilterParam(url) {
+  const raw = url.searchParams.get("filter");
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    throw new Error("Invalid filter parameter");
+  }
+}
+
 function databaseTableRoute(req, res, path, action, url) {
   const parts = path.split("/");
   const schema = decodeURIComponent(parts[4]);
   const table = decodeURIComponent(parts[5]);
   if (action === "columns") return dbJson(res, () => duneDb.tableColumns(db, schema, table));
-  if (action === "count") return dbJson(res, () => duneDb.tableCount(db, schema, table));
-  return dbJson(res, () => duneDb.tablePreview(db, schema, table, url.searchParams.get("limit") || 50, url.searchParams.get("offset") || 0));
+  if (action === "count") return dbJson(res, () => duneDb.tableCount(db, schema, table, parseDatabaseFilterParam(url)));
+  return dbJson(res, () => duneDb.tablePreview(db, schema, table, url.searchParams.get("limit") || 50, url.searchParams.get("offset") || 0, parseDatabaseFilterParam(url)));
 }
 
 function dbPlayerRoute(res, path, fn) {

--- a/console/web/src/api/database.ts
+++ b/console/web/src/api/database.ts
@@ -1,14 +1,21 @@
 import { api, post } from "./client";
 import type { Task } from "./setup";
 
+export type ColumnFilterTerm = { type: "text"; value: string } | { type: "column"; column: string; value: string };
+export type ColumnFilterTree = ColumnFilterTerm[][];
+
+function filterQueryParam(filter: ColumnFilterTree | null, prefix: "?" | "&") {
+  return filter ? `${prefix}filter=${encodeURIComponent(JSON.stringify(filter))}` : "";
+}
+
 export const databaseApi = {
   status: () => api<Record<string, unknown>>("/api/database/status"),
   changePassword: (password: string) => post<{ ok: boolean; user: string; task: Task }>("/api/database/password", { password }),
   schemas: () => api<string[]>("/api/database/schemas"),
   tables: (schema = "dune") => api<{ schema: string; name: string; row_count: string }[]>(`/api/database/tables?schema=${encodeURIComponent(schema)}`),
   columns: (schema: string, table: string) => api<Record<string, unknown>[]>(`/api/database/tables/${encodeURIComponent(schema)}/${encodeURIComponent(table)}/columns`),
-  count: (schema: string, table: string) => api<{ count: string }>(`/api/database/tables/${encodeURIComponent(schema)}/${encodeURIComponent(table)}/count`),
-  preview: (schema: string, table: string, limit = 50, offset = 0) => api<{ columns: { name: string }[]; rows: Record<string, unknown>[] }>(`/api/database/tables/${encodeURIComponent(schema)}/${encodeURIComponent(table)}/preview?limit=${limit}&offset=${offset}`),
+  count: (schema: string, table: string, filter: ColumnFilterTree | null = null) => api<{ count: string }>(`/api/database/tables/${encodeURIComponent(schema)}/${encodeURIComponent(table)}/count${filterQueryParam(filter, "?")}`),
+  preview: (schema: string, table: string, limit = 50, offset = 0, filter: ColumnFilterTree | null = null) => api<{ columns: { name: string }[]; rows: Record<string, unknown>[] }>(`/api/database/tables/${encodeURIComponent(schema)}/${encodeURIComponent(table)}/preview?limit=${limit}&offset=${offset}${filterQueryParam(filter, "&")}`),
   updateRow: (schema: string, table: string, rowId: string, values: Record<string, unknown>) => api<{ ok: boolean; updatedRows: number; schema: string; table: string; message?: string }>(`/api/database/tables/${encodeURIComponent(schema)}/${encodeURIComponent(table)}/row`, { method: "PATCH", body: JSON.stringify({ rowId, values }) }),
   search: (q: string) => api<Record<string, unknown>[]>(`/api/database/search?q=${encodeURIComponent(q)}`),
   query: (query: string) => post<{ columns: { name: string }[]; rows: Record<string, unknown>[]; rowCount?: number; command?: string }>("/api/database/query", { query }),

--- a/console/web/src/features/database/DatabasePanel.tsx
+++ b/console/web/src/features/database/DatabasePanel.tsx
@@ -53,6 +53,62 @@ function parseColumnEqualityFilter(term: string): { column: string; value: strin
   return match ? { column: match[1], value: match[2] } : null;
 }
 
+function stripOuterQuotes(term: string): string {
+  const match = term.match(/^(['"])([\s\S]*)\1$/);
+  return match ? match[2] : term;
+}
+
+function splitTopLevelKeyword(term: string, keyword: string): string[] {
+  const parts: string[] = [];
+  let current = "";
+  let quote: string | null = null;
+  let i = 0;
+  while (i < term.length) {
+    const ch = term[i];
+    if (quote) {
+      current += ch;
+      if (ch === quote) quote = null;
+      i += 1;
+      continue;
+    }
+    if (ch === "'" || ch === "\"") {
+      quote = ch;
+      current += ch;
+      i += 1;
+      continue;
+    }
+    const slice = term.slice(i, i + keyword.length).toLowerCase();
+    const before = i === 0 ? " " : term[i - 1];
+    const after = term[i + keyword.length] || " ";
+    if (slice === keyword && /\s/.test(before) && /\s/.test(after)) {
+      parts.push(current.trim());
+      current = "";
+      i += keyword.length;
+      continue;
+    }
+    current += ch;
+    i += 1;
+  }
+  parts.push(current.trim());
+  return parts.filter((part) => part.length > 0);
+}
+
+function rowMatchesColumnQuery(row: Record<string, unknown>, previewColumns: string[], query: string): boolean {
+  const orGroups = splitTopLevelKeyword(query, "or");
+  return orGroups.some((group) => {
+    const andTerms = splitTopLevelKeyword(group, "and");
+    return andTerms.every((rawTerm) => {
+      const filter = parseColumnEqualityFilter(rawTerm);
+      if (filter) {
+        const matchedColumn = previewColumns.find((column) => column.toLowerCase() === filter.column.toLowerCase());
+        return matchedColumn ? String(row[matchedColumn] ?? "").toLowerCase() === filter.value.toLowerCase() : false;
+      }
+      const needle = stripOuterQuotes(rawTerm).toLowerCase();
+      return previewColumns.some((column) => String(row[column] ?? "").toLowerCase().includes(needle));
+    });
+  });
+}
+
 function loadDatabasePasswordState(): DatabasePasswordState {
   if (typeof window === "undefined") return { result: null };
   try {
@@ -337,15 +393,10 @@ await refreshTablePreview(table, 0, previewPageSize);
   const filteredColumnsMeta = columnSearchTerm
     ? columns.filter((column) => String(column.name || "").toLowerCase().includes(columnSearchTerm))
     : columns;
-  const columnEqualityFilter = columnSearch.trim() ? parseColumnEqualityFilter(columnSearch.trim()) : null;
-  const filteredPreviewRows = columnEqualityFilter
-    ? previewRows.filter((row) => {
-        const matchedColumn = previewColumns.find((column) => column.toLowerCase() === columnEqualityFilter.column.toLowerCase());
-        return matchedColumn ? String(row[matchedColumn] ?? "").toLowerCase() === columnEqualityFilter.value.toLowerCase() : false;
-      })
-    : columnSearchTerm
-      ? previewRows.filter((row) => previewColumns.some((column) => String(row[column] ?? "").toLowerCase().includes(columnSearchTerm)))
-      : previewRows;
+  const columnSearchQuery = columnSearch.trim();
+  const filteredPreviewRows = columnSearchQuery
+    ? previewRows.filter((row) => rowMatchesColumnQuery(row, previewColumns, columnSearchQuery))
+    : previewRows;
   const tablesSort = useSortableRows(filteredTables);
   const columnsSort = useSortableRows(filteredColumnsMeta);
   const previewSort = useSortableRows(filteredPreviewRows);
@@ -396,7 +447,7 @@ await refreshTablePreview(table, 0, previewPageSize);
       {previewLoading && <div className="empty database-empty">Loading table page...</div>}
       {previewError && <div className="empty database-empty danger-note">Preview failed: {formatResultMessage(previewError)}</div>}
 {!previewLoading && !previewError && <div className="action-row database-table-search-row">
-  <input value={columnSearch} onChange={(event) => setColumnSearch(event.target.value)} placeholder="Search columns, or column='value'" />
+  <input value={columnSearch} onChange={(event) => setColumnSearch(event.target.value)} placeholder="Search columns, or column='value' and/or ..." />
   {columnSearch && <button onClick={() => setColumnSearch("")}>Clear</button>}
 </div>}
 {!previewLoading && !previewError && <div className="database-preview-toolbar">

--- a/console/web/src/features/database/DatabasePanel.tsx
+++ b/console/web/src/features/database/DatabasePanel.tsx
@@ -48,6 +48,11 @@ function useSortableRows<T extends Record<string, unknown>>(rows: T[]) {
   return { sortedRows, sortColumn: sort?.column, sortDirection: sort?.direction, onSort, reset: () => setSort(null) };
 }
 
+function parseColumnEqualityFilter(term: string): { column: string; value: string } | null {
+  const match = term.match(/^['"]?([^'"=\s]+)['"]?\s*=\s*['"]?(.*?)['"]?$/);
+  return match ? { column: match[1], value: match[2] } : null;
+}
+
 function loadDatabasePasswordState(): DatabasePasswordState {
   if (typeof window === "undefined") return { result: null };
   try {
@@ -121,6 +126,7 @@ export function DatabasePanel() {
   const [databasePasswordConfirm, setDatabasePasswordConfirm] = useState("");
   const [databasePasswordState, setDatabasePasswordState] = useState<DatabasePasswordState>(() => loadDatabasePasswordState());
   const [tableSearch, setTableSearch] = useState("");
+  const [columnSearch, setColumnSearch] = useState("");
   const [search, setSearch] = useState("");
   const [searchRows, setSearchRows] = useState<Record<string, unknown>[]>([]);
   const [searchRan, setSearchRan] = useState(false);
@@ -185,7 +191,8 @@ export function DatabasePanel() {
     setPreviewError("");
     columnsSort.reset();
     previewSort.reset();
-    await refreshTablePreview(table, 0, previewPageSize);
+setColumnSearch("");
+await refreshTablePreview(table, 0, previewPageSize);
     window.setTimeout(() => previewRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }), 50);
   }
   async function refreshTablePreview(table: string, page = previewPage, pageSize = previewPageSize) {
@@ -326,9 +333,22 @@ export function DatabasePanel() {
   const filteredTables = tableSearchTerm
     ? tables.filter((table) => `${String(table.schema || "")}.${String(table.name || "")}`.toLowerCase().includes(tableSearchTerm))
     : tables;
+  const columnSearchTerm = columnSearch.trim().toLowerCase();
+  const filteredColumnsMeta = columnSearchTerm
+    ? columns.filter((column) => String(column.name || "").toLowerCase().includes(columnSearchTerm))
+    : columns;
+  const columnEqualityFilter = columnSearch.trim() ? parseColumnEqualityFilter(columnSearch.trim()) : null;
+  const filteredPreviewRows = columnEqualityFilter
+    ? previewRows.filter((row) => {
+        const matchedColumn = previewColumns.find((column) => column.toLowerCase() === columnEqualityFilter.column.toLowerCase());
+        return matchedColumn ? String(row[matchedColumn] ?? "").toLowerCase() === columnEqualityFilter.value.toLowerCase() : false;
+      })
+    : columnSearchTerm
+      ? previewRows.filter((row) => previewColumns.some((column) => String(row[column] ?? "").toLowerCase().includes(columnSearchTerm)))
+      : previewRows;
   const tablesSort = useSortableRows(filteredTables);
-  const columnsSort = useSortableRows(columns);
-  const previewSort = useSortableRows(previewRows);
+  const columnsSort = useSortableRows(filteredColumnsMeta);
+  const previewSort = useSortableRows(filteredPreviewRows);
   const searchSort = useSortableRows(searchRows);
   const querySort = useSortableRows(queryRows);
   return <section className="panel">
@@ -375,26 +395,36 @@ export function DatabasePanel() {
     {selected && <section className="database-table-panel">
       {previewLoading && <div className="empty database-empty">Loading table page...</div>}
       {previewError && <div className="empty database-empty danger-note">Preview failed: {formatResultMessage(previewError)}</div>}
-      {!previewLoading && !previewError && <div className="database-preview-toolbar">
-        <p className="muted database-preview-count">
-          Showing {previewStartRow.toLocaleString()}-{previewEndRow.toLocaleString()} of {previewRowCount.toLocaleString()} rows.
-        </p>
-        <div className="database-pagination-controls">
-          <label className="compact-select">Rows<select value={String(previewPageSize)} onChange={(event) => { void changePreviewPageSize(event.target.value); }}>
-            {DATABASE_PREVIEW_PAGE_SIZES.map((size) => <option key={size} value={size}>{size}</option>)}
-          </select></label>
-          <button disabled={!previewHasPreviousPage || previewLoading} onClick={() => void goToPreviewPage(0)}>First</button>
-          <button disabled={!previewHasPreviousPage || previewLoading} onClick={() => void goToPreviewPage(previewPage - 1)}>Previous</button>
-          <span className="muted database-page-indicator">Page {(previewPage + 1).toLocaleString()} of {previewTotalPages.toLocaleString()}</span>
-          <button disabled={!previewHasNextPage || previewLoading} onClick={() => void goToPreviewPage(previewPage + 1)}>Next</button>
-          <button disabled={!previewHasNextPage || previewLoading} onClick={() => void goToPreviewPage(previewTotalPages - 1)}>Last</button>
-        </div>
+{!previewLoading && !previewError && <div className="action-row database-table-search-row">
+  <input value={columnSearch} onChange={(event) => setColumnSearch(event.target.value)} placeholder="Search columns, or column='value'" />
+  {columnSearch && <button onClick={() => setColumnSearch("")}>Clear</button>}
+</div>}
+{!previewLoading && !previewError && <div className="database-preview-toolbar">
+  <p className="muted database-preview-count">
+    Showing {previewStartRow.toLocaleString()}-{previewEndRow.toLocaleString()} of {previewRowCount.toLocaleString()} rows.
+    {previewIsTruncated ? ` Full preview is capped at ${DATABASE_PREVIEW_MAX_ROWS.toLocaleString()} rows to keep the browser responsive.` : ""}
+  </p>
+  <div className="database-pagination-controls">
+    <label className="compact-select">Rows<select value={String(previewPageSize)} onChange={(event) => { void changePreviewPageSize(event.target.value); }}>
+      {DATABASE_PREVIEW_PAGE_SIZES.map((size) => <option key={size} value={size}>{size}</option>)}
+    </select></label>
+    <button disabled={!previewHasPreviousPage || previewLoading} onClick={() => void goToPreviewPage(0)}>First</button>
+    <button disabled={!previewHasPreviousPage || previewLoading} onClick={() => void goToPreviewPage(previewPage - 1)}>Previous</button>
+    <span className="muted database-page-indicator">Page {(previewPage + 1).toLocaleString()} of {previewTotalPages.toLocaleString()}</span>
+    <button disabled={!previewHasNextPage || previewLoading} onClick={() => void goToPreviewPage(previewPage + 1)}>Next</button>
+    <button disabled={!previewHasNextPage || previewLoading} onClick={() => void goToPreviewPage(previewTotalPages - 1)}>Last</button>
+  </div>
+</div>}
       </div>}
       <details className="technical-details">
         <summary>Columns</summary>
-        <DataTable rows={columnsSort.sortedRows} sortColumn={columnsSort.sortColumn} sortDirection={columnsSort.sortDirection} onSort={columnsSort.onSort} />
+        <DataTable rows={columnsSort.sortedRows} emptyMessage={columnSearchTerm ? "No matching columns found." : "No columns found."} sortColumn={columnsSort.sortColumn} sortDirection={columnsSort.sortDirection} onSort={columnsSort.onSort} />
       </details>
-      {!previewLoading && !previewError && (previewRows.length ? <DataTable rows={previewSort.sortedRows} columns={previewColumns} action={(row) => <button onClick={(event) => { event.stopPropagation(); startEdit(row); }}>Edit</button>} actionClassName="backup-table-actions" tableClassName="backup-table" sortColumn={previewSort.sortColumn} sortDirection={previewSort.sortDirection} onSort={previewSort.onSort} /> : <div className="empty database-empty">This table has no rows to preview.</div>)}
+      {!previewLoading && !previewError && (previewRows.length
+        ? (previewSort.sortedRows.length
+            ? <DataTable rows={previewSort.sortedRows} columns={previewColumns} action={(row) => <button onClick={(event) => { event.stopPropagation(); startEdit(row); }}>Edit</button>} actionClassName="backup-table-actions" tableClassName="backup-table" sortColumn={previewSort.sortColumn} sortDirection={previewSort.sortDirection} onSort={previewSort.onSort} />
+            : <div className="empty database-empty">No matching rows found.</div>)
+        : <div className="empty database-empty">This table has no rows to preview.</div>)}
       {!editRow && editResult && <section className={`result-panel ${editResult.status === "running" ? "" : "transient-result"} ${editResult.status === "succeeded" ? "result-ok" : editResult.status === "failed" ? "result-fail" : "result-running"}`}>
         <div className="panel-title"><strong>{formatResultTitle(editResult.title, editResult.status === "running")}</strong><StatusPill value={editResult.status === "succeeded" ? "Saved" : editResult.status === "failed" ? "Failed" : "Saving"} /></div>
         {editResult.message && <p>{formatResultMessage(editResult.message)}</p>}

--- a/console/web/src/features/database/DatabasePanel.tsx
+++ b/console/web/src/features/database/DatabasePanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
-import { databaseApi } from "../../api/database";
+import { databaseApi, type ColumnFilterTerm, type ColumnFilterTree } from "../../api/database";
 import { setupApi, type Task } from "../../api/setup";
 import { SecretInput } from "../../components/SecretInput";
 import { DataTable } from "../../components/common/DataTable";
@@ -93,18 +93,16 @@ function splitTopLevelKeyword(term: string, keyword: string): string[] {
   return parts.filter((part) => part.length > 0);
 }
 
-function rowMatchesColumnQuery(row: Record<string, unknown>, previewColumns: string[], query: string): boolean {
-  const orGroups = splitTopLevelKeyword(query, "or");
-  return orGroups.some((group) => {
+function buildColumnFilterTree(query: string): ColumnFilterTree | null {
+  const trimmed = query.trim();
+  if (!trimmed) return null;
+  const orGroups = splitTopLevelKeyword(trimmed, "or");
+  return orGroups.map((group) => {
     const andTerms = splitTopLevelKeyword(group, "and");
-    return andTerms.every((rawTerm) => {
+    return andTerms.map((rawTerm): ColumnFilterTerm => {
       const filter = parseColumnEqualityFilter(rawTerm);
-      if (filter) {
-        const matchedColumn = previewColumns.find((column) => column.toLowerCase() === filter.column.toLowerCase());
-        return matchedColumn ? String(row[matchedColumn] ?? "").toLowerCase() === filter.value.toLowerCase() : false;
-      }
-      const needle = stripOuterQuotes(rawTerm).toLowerCase();
-      return previewColumns.some((column) => String(row[column] ?? "").toLowerCase().includes(needle));
+      if (filter) return { type: "column", column: filter.column, value: filter.value };
+      return { type: "text", value: stripOuterQuotes(rawTerm) };
     });
   });
 }
@@ -166,6 +164,7 @@ export function DatabasePanel() {
   const [preview, setPreview] = useState<{ columns?: { name: string }[]; rows?: Record<string, unknown>[] } | null>(null);
   const [columns, setColumns] = useState<Record<string, unknown>[]>([]);
   const [count, setCount] = useState("");
+  const [tableTotalCount, setTableTotalCount] = useState("");
   const [previewPage, setPreviewPage] = useState(0);
   const [previewPageSize, setPreviewPageSize] = useState(DATABASE_PREVIEW_DEFAULT_PAGE_SIZE);
   const [previewError, setPreviewError] = useState("");
@@ -183,6 +182,7 @@ export function DatabasePanel() {
   const [databasePasswordState, setDatabasePasswordState] = useState<DatabasePasswordState>(() => loadDatabasePasswordState());
   const [tableSearch, setTableSearch] = useState("");
   const [columnSearch, setColumnSearch] = useState("");
+  const [previewFilter, setPreviewFilter] = useState<ColumnFilterTree | null>(null);
   const [search, setSearch] = useState("");
   const [searchRows, setSearchRows] = useState<Record<string, unknown>[]>([]);
   const [searchRan, setSearchRan] = useState(false);
@@ -243,27 +243,30 @@ export function DatabasePanel() {
     setPreview(null);
     setColumns([]);
     setCount("");
+    setTableTotalCount("");
     setPreviewPage(0);
     setPreviewError("");
     columnsSort.reset();
     previewSort.reset();
-setColumnSearch("");
-await refreshTablePreview(table, 0, previewPageSize);
+    setColumnSearch("");
+    setPreviewFilter(null);
+    void databaseApi.count(schema, table).then((result) => setTableTotalCount(String(result.count))).catch(() => undefined);
+    await refreshTablePreview(table, 0, previewPageSize, null);
     window.setTimeout(() => previewRef.current?.scrollIntoView({ behavior: "smooth", block: "start" }), 50);
   }
-  async function refreshTablePreview(table: string, page = previewPage, pageSize = previewPageSize) {
+  async function refreshTablePreview(table: string, page = previewPage, pageSize = previewPageSize, filter = previewFilter) {
     setPreviewLoading(true);
     setPreviewError("");
     try {
       const [nextColumns, nextCount] = await Promise.all([
         databaseApi.columns(schema, table),
-        databaseApi.count(schema, table)
+        databaseApi.count(schema, table, filter)
       ]);
       const rowCount = Math.max(0, Number(nextCount.count) || 0);
       const safePageSize = normalizeDatabasePreviewPageSize(pageSize);
       const totalPages = Math.max(1, Math.ceil(rowCount / safePageSize));
       const safePage = Math.max(0, Math.min(page, totalPages - 1));
-      const nextPreview = rowCount > 0 ? await databaseApi.preview(schema, table, safePageSize, safePage * safePageSize) : { columns: [], rows: [] };
+      const nextPreview = rowCount > 0 ? await databaseApi.preview(schema, table, safePageSize, safePage * safePageSize, filter) : { columns: [], rows: [] };
       setPreview(nextPreview);
       setColumns(nextColumns);
       setCount(String(nextCount.count));
@@ -288,6 +291,22 @@ await refreshTablePreview(table, 0, previewPageSize);
     setPreviewPage(0);
     previewSort.reset();
     if (selected) await refreshTablePreview(selected, 0, nextPageSize);
+  }
+  async function runColumnSearch() {
+    if (!selected || previewLoading) return;
+    const nextFilter = buildColumnFilterTree(columnSearch);
+    setPreviewFilter(nextFilter);
+    setPreviewPage(0);
+    previewSort.reset();
+    await refreshTablePreview(selected, 0, previewPageSize, nextFilter);
+  }
+  async function clearColumnSearch() {
+    setColumnSearch("");
+    if (!previewFilter) return;
+    setPreviewFilter(null);
+    setPreviewPage(0);
+    previewSort.reset();
+    if (selected) await refreshTablePreview(selected, 0, previewPageSize, null);
   }
   async function loadDatabaseStatus() {
     setDatabaseStatusLoading(true);
@@ -393,13 +412,9 @@ await refreshTablePreview(table, 0, previewPageSize);
   const filteredColumnsMeta = columnSearchTerm
     ? columns.filter((column) => String(column.name || "").toLowerCase().includes(columnSearchTerm))
     : columns;
-  const columnSearchQuery = columnSearch.trim();
-  const filteredPreviewRows = columnSearchQuery
-    ? previewRows.filter((row) => rowMatchesColumnQuery(row, previewColumns, columnSearchQuery))
-    : previewRows;
   const tablesSort = useSortableRows(filteredTables);
   const columnsSort = useSortableRows(filteredColumnsMeta);
-  const previewSort = useSortableRows(filteredPreviewRows);
+  const previewSort = useSortableRows(previewRows);
   const searchSort = useSortableRows(searchRows);
   const querySort = useSortableRows(queryRows);
   return <section className="panel">
@@ -441,19 +456,19 @@ await refreshTablePreview(table, 0, previewPageSize);
     {filteredTables.length
       ? <DataTable rows={tablesSort.sortedRows} columns={["schema", "name", "row_count"]} onRowClick={(row) => open(String(row.name))} sortColumn={tablesSort.sortColumn} sortDirection={tablesSort.sortDirection} onSort={tablesSort.onSort} />
       : <div className="empty database-empty">No matching tables found.</div>}
-    <h3 ref={previewRef}>{selected ? `${schema}.${selected} (${count} rows)` : "Table Preview"}</h3>
+    <h3 ref={previewRef}>{selected ? `${schema}.${selected} (${tableTotalCount} rows)` : "Table Preview"}</h3>
     {!selected && <div className="empty database-empty">No table selected. Select a table to preview and edit rows.</div>}
     {selected && <section className="database-table-panel">
       {previewLoading && <div className="empty database-empty">Loading table page...</div>}
       {previewError && <div className="empty database-empty danger-note">Preview failed: {formatResultMessage(previewError)}</div>}
 {!previewLoading && !previewError && <div className="action-row database-table-search-row">
-  <input value={columnSearch} onChange={(event) => setColumnSearch(event.target.value)} placeholder="Search columns, or column='value' and/or ..." />
-  {columnSearch && <button onClick={() => setColumnSearch("")}>Clear</button>}
+  <input value={columnSearch} onChange={(event) => setColumnSearch(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter") void runColumnSearch(); }} placeholder="Search columns, or column='value' and/or ..." />
+  <button disabled={previewLoading} onClick={() => void runColumnSearch()}>Search</button>
+  {columnSearch && <button onClick={() => void clearColumnSearch()}>Clear</button>}
 </div>}
 {!previewLoading && !previewError && <div className="database-preview-toolbar">
   <p className="muted database-preview-count">
     Showing {previewStartRow.toLocaleString()}-{previewEndRow.toLocaleString()} of {previewRowCount.toLocaleString()} rows.
-    {previewIsTruncated ? ` Full preview is capped at ${DATABASE_PREVIEW_MAX_ROWS.toLocaleString()} rows to keep the browser responsive.` : ""}
   </p>
   <div className="database-pagination-controls">
     <label className="compact-select">Rows<select value={String(previewPageSize)} onChange={(event) => { void changePreviewPageSize(event.target.value); }}>
@@ -466,16 +481,13 @@ await refreshTablePreview(table, 0, previewPageSize);
     <button disabled={!previewHasNextPage || previewLoading} onClick={() => void goToPreviewPage(previewTotalPages - 1)}>Last</button>
   </div>
 </div>}
-      </div>}
       <details className="technical-details">
         <summary>Columns</summary>
         <DataTable rows={columnsSort.sortedRows} emptyMessage={columnSearchTerm ? "No matching columns found." : "No columns found."} sortColumn={columnsSort.sortColumn} sortDirection={columnsSort.sortDirection} onSort={columnsSort.onSort} />
       </details>
       {!previewLoading && !previewError && (previewRows.length
-        ? (previewSort.sortedRows.length
-            ? <DataTable rows={previewSort.sortedRows} columns={previewColumns} action={(row) => <button onClick={(event) => { event.stopPropagation(); startEdit(row); }}>Edit</button>} actionClassName="backup-table-actions" tableClassName="backup-table" sortColumn={previewSort.sortColumn} sortDirection={previewSort.sortDirection} onSort={previewSort.onSort} />
-            : <div className="empty database-empty">No matching rows found.</div>)
-        : <div className="empty database-empty">This table has no rows to preview.</div>)}
+        ? <DataTable rows={previewSort.sortedRows} columns={previewColumns} action={(row) => <button onClick={(event) => { event.stopPropagation(); startEdit(row); }}>Edit</button>} actionClassName="backup-table-actions" tableClassName="backup-table" sortColumn={previewSort.sortColumn} sortDirection={previewSort.sortDirection} onSort={previewSort.onSort} />
+        : <div className="empty database-empty">{previewFilter ? "No matching rows found." : "This table has no rows to preview."}</div>)}
       {!editRow && editResult && <section className={`result-panel ${editResult.status === "running" ? "" : "transient-result"} ${editResult.status === "succeeded" ? "result-ok" : editResult.status === "failed" ? "result-fail" : "result-running"}`}>
         <div className="panel-title"><strong>{formatResultTitle(editResult.title, editResult.status === "running")}</strong><StatusPill value={editResult.status === "succeeded" ? "Saved" : editResult.status === "failed" ? "Failed" : "Saving"} /></div>
         {editResult.message && <p>{formatResultMessage(editResult.message)}</p>}


### PR DESCRIPTION
## 🚀 Summary
Adds a row-search box to the **Database Browser's Table Preview** tab, allowing users to narrow down rows while maintaining full visibility into all columns.

## ✨ Key Features
* **Free-Text Search:** Matches substrings against **any cell value** in the row (case-insensitive).
* **Column-Specific Search:** Uses `column='value'` syntax for exact matches (quotes are optional on either side, e.g., `Character_ID=2` or `'Character_ID'='2'`).
* **Logical Operators:** Supports case-insensitive `AND` / `OR` logic. `AND` binds tighter than `OR` (e.g., `a AND b OR c` evaluates as `(a AND b) OR c`).
* **Quote-Aware Parsing:** Keyword splitting respects quotes so that `AND`/`OR` inside a quoted value are not mis-split.
* **Smart Isolation:** 
  * The **Columns** detail table (schema/data-type listing) continues to filter its own rows by column name, completely unchanged.
  * Search states reset automatically whenever a different table is opened.

## 💡 Example Syntax
```text
DA_MQ_FindTheFremen and Character_ID=2
```
*Result: Returns rows where any column contains `DA_MQ_FindTheFremen` **and** the `Character_ID` column is exactly `2`.*

## 📸 Screenshots / GIFs
<img width="2228" height="580" alt="image" src="https://github.com/user-attachments/assets/25ad4f7c-5734-4bfe-b4bb-a867ee612f5d" />


## 🧪 Testing Steps
<details>
<summary>Click to expand testing checklist</summary>

### Automated Quality Checks
- [x] Run `tsc --noEmit` to ensure it passes with zero TypeScript errors.

### Manual Verification (Browser/Mocked Backend via `console/web`)
- [x] Verify free-text search narrows preview rows without hiding any columns.
- [x] Verify `column='value'` matches exact values on the specified column.
- [x] Verify `AND` successfully combines a free-text term with a column condition.
- [x] Verify `OR` successfully combines two distinct column conditions.
- [x] Verify the "No matching rows found." UI state displays correctly on zero matches.
- [x] Verify the search box completely resets when switching to a different table.
- [x] Verify the **Edit Row** form still shows all fields regardless of the active filter.
</details>
