### PR TITLE
Add OPS health addon bridge actions

### DIFF
--- a/console/api/src/addons.js
+++ b/console/api/src/addons.js
@@ -13,6 +13,7 @@ const ADDON_LIFECYCLE_STATES = new Set(["active", "deprecated", "unsupported", "
 const INSTALL_BLOCKED_LIFECYCLES = new Set(["unsupported", "removed", "blocked"]);
 const ALLOWED_ADDON_PERMISSIONS = new Set([
   "players:read",
+  "ops:read",
   "database:read",
   "database:write",
   "server:status",

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3015,3 +3015,105 @@ function unsupported(feature, requiredTables) {
     reason: `Unsupported by detected schema. Missing required table(s): ${requiredTables.join(", ")}`
   };
 }
+
+function emptyAddonOpsHealthPlayers() {
+  return {
+    total: 0,
+    onlineStatus: {},
+    lifeState: {},
+    characterState: {},
+    combinations: []
+  };
+}
+
+function emptyAddonOpsHealthFarms() {
+  return {
+    total: 0,
+    ready: 0,
+    alive: 0,
+    connectedPlayers: 0,
+    incomingS2SConnections: 0,
+    outgoingS2SConnections: 0
+  };
+}
+
+function addCount(target, key, count) {
+  target[String(key || "Unknown")] = (target[String(key || "Unknown")] || 0) + count;
+}
+
+export async function addonOpsHealthPlayers(db) {
+  if (!(await tableExists(db, "player_state"))) return emptyAddonOpsHealthPlayers();
+
+  const columns = await columnsFor(db, "player_state");
+  const required = ["online_status", "life_state", "character_state"];
+  if (!required.every((column) => columns.has(column))) return emptyAddonOpsHealthPlayers();
+
+  const result = await db.query(`
+    select coalesce(online_status::text, 'Unknown') as online_status,
+           coalesce(life_state::text, 'Unknown') as life_state,
+           coalesce(character_state::text, 'Unknown') as character_state,
+           count(*)::int as players
+    from dune.player_state
+    group by 1, 2, 3
+    order by 1, 2, 3`);
+
+  const out = emptyAddonOpsHealthPlayers();
+  for (const row of result.rows || []) {
+    const players = Number(row.players || 0);
+    const onlineStatus = String(row.online_status || "Unknown");
+    const lifeState = String(row.life_state || "Unknown");
+    const characterState = String(row.character_state || "Unknown");
+
+    out.total += players;
+    addCount(out.onlineStatus, onlineStatus, players);
+    addCount(out.lifeState, lifeState, players);
+    addCount(out.characterState, characterState, players);
+    out.combinations.push({ onlineStatus, lifeState, characterState, players });
+  }
+
+  return out;
+}
+
+export async function addonOpsHealthFarms(db) {
+  if (!(await tableExists(db, "farm_state"))) return emptyAddonOpsHealthFarms();
+
+  const columns = await columnsFor(db, "farm_state");
+  const boolCount = (column) => columns.has(column)
+    ? `sum(case when coalesce(${quoteIdentifier(column)}, false) then 1 else 0 end)::int`
+    : "0::int";
+  const intSum = (column) => columns.has(column)
+    ? `coalesce(sum(coalesce(${quoteIdentifier(column)}, 0)), 0)::int`
+    : "0::int";
+
+  const result = await db.query(`
+    select count(*)::int as total,
+           ${boolCount("ready")} as ready,
+           ${boolCount("alive")} as alive,
+           ${intSum("connected_players")} as connected_players,
+           ${intSum("incoming_s2s_connections")} as incoming_s2s_connections,
+           ${intSum("outgoing_s2s_connections")} as outgoing_s2s_connections
+    from dune.farm_state`);
+
+  const row = result.rows?.[0] || {};
+  return {
+    total: Number(row.total || 0),
+    ready: Number(row.ready || 0),
+    alive: Number(row.alive || 0),
+    connectedPlayers: Number(row.connected_players || 0),
+    incomingS2SConnections: Number(row.incoming_s2s_connections || 0),
+    outgoingS2SConnections: Number(row.outgoing_s2s_connections || 0)
+  };
+}
+
+export async function addonOpsHealthSummaryV2(db) {
+  const [players, farms] = await Promise.all([
+    addonOpsHealthPlayers(db),
+    addonOpsHealthFarms(db)
+  ]);
+
+  return { players, farms };
+}
+
+export async function addonOpsHealthSummary(db) {
+  return addonOpsHealthSummaryV2(db);
+}

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -509,6 +509,16 @@ async function addonBridgeRoute(req, res, path) {
     audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
     return json(res, 200, { ok: true, result });
   }
+  if (action === "ops.health.summary" || action === "ops.health.players" || action === "ops.health.farms" || action === "ops.health.summary.v2") {
+    const addon = assertInstalledAddonPermission(config, id, "ops:read");
+    const result = action === "ops.health.players"
+      ? await duneDb.addonOpsHealthPlayers(db)
+      : action === "ops.health.farms"
+        ? await duneDb.addonOpsHealthFarms(db)
+        : await duneDb.addonOpsHealthSummary(db);
+    audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
+    return json(res, 200, { ok: true, result });
+  }
   if (action === "database.query" || action === "database.execute") {
     const query = String(body.query || "");
     const readOnly = isReadOnlySql(query);

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { assertIdentifier, discoverDbConfig, isReadOnlySql, quoteQualified, redactDbError, rowsResult } from "../src/db.js";
-import { addCurrency, addFactionReputation, addIntel, addonLeadershipPlayers, completeJourneyNode, completeTutorial, deleteInventoryItem, giveItemToPlayer, giveItemToStorage, landsraadOverview, listPlayers, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerJourney, playerPosition, playerResearchItems, repairVehicleDecay, resetJourneyNode, resetTutorial, runSql, setLandsraadPlayerContribution, tablePreview, unlockCraftingRecipe, unlockResearchItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError } from "../src/duneDb.js";
+import { addCurrency, addFactionReputation, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, completeJourneyNode, completeTutorial, deleteInventoryItem, giveItemToPlayer, giveItemToStorage, landsraadOverview, listPlayers, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerJourney, playerPosition, playerResearchItems, repairVehicleDecay, resetJourneyNode, resetTutorial, runSql, setLandsraadPlayerContribution, tablePreview, unlockCraftingRecipe, unlockResearchItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError } from "../src/duneDb.js";
 
 test("discovers RedBlink Postgres defaults and env overrides", () => {
   assert.deepEqual(discoverDbConfig({}), {
@@ -1071,6 +1071,160 @@ test("tutorial complete and reset use player controller tutorial records", async
   const reset = await resetTutorial(resetDb, 123, { tutorialId: 7 });
   assert.equal(reset.deletedRows, 1);
   assert.ok(resetCalls.some((call) => call.text.includes("delete from dune.tutorial_per_player") && call.values[0] === 55 && call.values[1] === 7));
+});
+
+
+test("OPS health players returns aggregate counts only", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("information_schema.columns")) {
+        return { rows: ["online_status", "life_state", "character_state"].map((column_name) => ({ column_name })) };
+      }
+      if (text.includes("from dune.player_state") && text.includes("group by 1, 2, 3")) {
+        return { rows: [
+          { online_status: "Online", life_state: "Alive", character_state: "Active", players: 2 },
+          { online_status: "Offline", life_state: "Alive", character_state: "Active", players: 1 }
+        ] };
+      }
+      return { rows: [] };
+    }
+  };
+
+  const result = await addonOpsHealthPlayers(db);
+  assert.deepEqual(result, {
+    total: 3,
+    onlineStatus: { Online: 2, Offline: 1 },
+    lifeState: { Alive: 3 },
+    characterState: { Active: 3 },
+    combinations: [
+      { onlineStatus: "Online", lifeState: "Alive", characterState: "Active", players: 2 },
+      { onlineStatus: "Offline", lifeState: "Alive", characterState: "Active", players: 1 }
+    ]
+  });
+  assert.equal(Object.hasOwn(result, "rows"), false);
+  assert.ok(calls.some((call) => String(call.text).includes("count(*)::int as players")));
+});
+
+test("OPS health players falls back to empty aggregate shape when source is missing", async () => {
+  const db = {
+    query: async () => ({ rows: [{ exists: false }] })
+  };
+
+  assert.deepEqual(await addonOpsHealthPlayers(db), {
+    total: 0,
+    onlineStatus: {},
+    lifeState: {},
+    characterState: {},
+    combinations: []
+  });
+});
+
+test("OPS health farms returns aggregate counters only", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("information_schema.columns")) {
+        return { rows: [
+          "ready",
+          "alive",
+          "connected_players",
+          "incoming_s2s_connections",
+          "outgoing_s2s_connections"
+        ].map((column_name) => ({ column_name })) };
+      }
+      if (text.includes("from dune.farm_state")) {
+        return { rows: [{
+          total: 2,
+          ready: 2,
+          alive: 1,
+          connected_players: 7,
+          incoming_s2s_connections: 3,
+          outgoing_s2s_connections: 4
+        }] };
+      }
+      return { rows: [] };
+    }
+  };
+
+  assert.deepEqual(await addonOpsHealthFarms(db), {
+    total: 2,
+    ready: 2,
+    alive: 1,
+    connectedPlayers: 7,
+    incomingS2SConnections: 3,
+    outgoingS2SConnections: 4
+  });
+  assert.ok(calls.some((call) => String(call.text).includes("count(*)::int as total")));
+});
+
+test("OPS health farms falls back to empty aggregate shape when source is missing", async () => {
+  const db = {
+    query: async () => ({ rows: [{ exists: false }] })
+  };
+
+  assert.deepEqual(await addonOpsHealthFarms(db), {
+    total: 0,
+    ready: 0,
+    alive: 0,
+    connectedPlayers: 0,
+    incomingS2SConnections: 0,
+    outgoingS2SConnections: 0
+  });
+});
+
+test("OPS health summary compatibility action matches summary v2 shape", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("information_schema.columns")) {
+        const table = values[1];
+        const columns = table === "player_state"
+          ? ["online_status", "life_state", "character_state"]
+          : ["ready", "alive", "connected_players", "incoming_s2s_connections", "outgoing_s2s_connections"];
+        return { rows: columns.map((column_name) => ({ column_name })) };
+      }
+      if (text.includes("from dune.player_state")) {
+        return { rows: [{ online_status: "Online", life_state: "Alive", character_state: "Active", players: 1 }] };
+      }
+      if (text.includes("from dune.farm_state")) {
+        return { rows: [{ total: 1, ready: 1, alive: 1, connected_players: 1, incoming_s2s_connections: 1, outgoing_s2s_connections: 1 }] };
+      }
+      return { rows: [] };
+    }
+  };
+
+  assert.deepEqual(await addonOpsHealthSummary(db), await addonOpsHealthSummaryV2(db));
+});
+
+test("OPS health summary v2 combines player and farm aggregate health", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("information_schema.columns")) {
+        const table = values[1];
+        const columns = table === "player_state"
+          ? ["online_status", "life_state", "character_state"]
+          : ["ready", "alive", "connected_players", "incoming_s2s_connections", "outgoing_s2s_connections"];
+        return { rows: columns.map((column_name) => ({ column_name })) };
+      }
+      if (text.includes("from dune.player_state")) {
+        return { rows: [{ online_status: "Online", life_state: "Alive", character_state: "Active", players: 1 }] };
+      }
+      if (text.includes("from dune.farm_state")) {
+        return { rows: [{ total: 1, ready: 1, alive: 1, connected_players: 1, incoming_s2s_connections: 1, outgoing_s2s_connections: 1 }] };
+      }
+      return { rows: [] };
+    }
+  };
+
+  const result = await addonOpsHealthSummaryV2(db);
+  assert.equal(result.players.total, 1);
+  assert.equal(result.farms.total, 1);
 });
 
 function fakeMutationDb(calls, fixtures = {}) {


### PR DESCRIPTION
## Summary

Adds read-only OPS health aggregate addon bridge actions for Dune Docker Console addons.

## Changes

- Add ops:read as an allowed addon permission.
- Add ops.health.summary.
- Add ops.health.players.
- Add ops.health.farms.
- Add ops.health.summary.v2.
- Add unit coverage for aggregate player and farm health helpers.

## Scope

Changed files:

- console/api/src/addons.js
- console/api/src/duneDb.js
- console/api/src/server.js
- console/api/test/db.test.js

## Validation state

Current branch state after upstream refresh:

- Branch synced onto current Red-Blink/main: passed.
- PR delta limited to expected Core bridge files: passed.
- Local console/api tests after latest upstream sync: passed.
- Local bridge/WebUI E2E after latest upstream sync: pending rerun or pending evidence.

Older E2E output from prior Core bases should not be treated as final validation for this PR. E2E must be rerun against the current PR head after the latest upstream Core release/base update.

## Compatibility

Dune Ops Observability v0.3.0 uses the ops:read permission and these ops.health.* bridge actions. The addon catalog PR should wait until this Core bridge dependency is accepted or the catalog entry clearly states the Core compatibility requirement.