### PR TITLE
[Fix] the text cutoff in <select> element

### DIFF
--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1441,7 +1441,7 @@ td .inline-action-result-wrap { flex: 1 0 100%; justify-content: flex-start; min
 .landsraad-persistent-status .inline-action-result { display: inline-flex; align-items: center; min-height: 24px; line-height: 1.2; white-space: nowrap; }
 .landsraad-persistent-controls { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; justify-content: flex-end; min-width: min(100%, 460px); }
 .landsraad-persistent-controls label { display: inline-flex; flex-direction: row; gap: 8px; align-items: center; min-width: 0; color: #ceb894; font-size: 1rem; font-weight: 400; }
-.landsraad-persistent-controls select { width: 150px; height: 38px; font-size: 1rem; }
+.landsraad-persistent-controls select { width: 150px; height: auto; font-size: 1rem; }
 .landsraad-persistent-controls button { height: 38px; }
 .landsraad-section-divider { margin-top: 2px; }
 .landsraad-task-table th, .landsraad-task-table td,

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1441,8 +1441,8 @@ td .inline-action-result-wrap { flex: 1 0 100%; justify-content: flex-start; min
 .landsraad-persistent-status .inline-action-result { display: inline-flex; align-items: center; min-height: 24px; line-height: 1.2; white-space: nowrap; }
 .landsraad-persistent-controls { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; justify-content: flex-end; min-width: min(100%, 460px); }
 .landsraad-persistent-controls label { display: inline-flex; flex-direction: row; gap: 8px; align-items: center; min-width: 0; color: #ceb894; font-size: 1rem; font-weight: 400; }
-.landsraad-persistent-controls select { width: 150px; height: auto; font-size: 1rem; }
-.landsraad-persistent-controls button { height: 38px; }
+.landsraad-persistent-controls select { flex: 0 1 180px; height: auto; }
+.landsraad-persistent-controls button { height: auto; }
 .landsraad-section-divider { margin-top: 2px; }
 .landsraad-task-table th, .landsraad-task-table td,
 .landsraad-reward-table th, .landsraad-reward-table td { vertical-align: middle; }


### PR DESCRIPTION
This fixes #51 [Bug] - Landsraad Page - Select Box - Text Cut off.

## Changes

- Removed fixed height (38px) from the "Save Rules" button, allowing it to size naturally off padding
- Replaced hardcoded width (150px) on the select with proportional flex-basis sizing (`flex: 0 1 180px`), matching the pattern used by other selects in the panel (Player, Task)
- Both elements now size uniformly without visual gaps; select and button align at approximately 43-45px height

This resolves the visual un-uniformity that occurred when the select was changed from a fixed height to auto. The select now matches the styling pattern of the bottom selects (Contribution row), ensuring consistency across the Landsraad panel.

Verified: No text clipping regression; build passes (`npm run build`).

<img width="504" height="102" alt="image" src="https://github.com/user-attachments/assets/7cb47aac-7636-4e23-b93f-777a454a2c09" />

