### PR TITLE
feat: OPS observability roadmap - full bridge action suite (v0.3.0-v1.0.0)

### DIFF
--- a/console/api/src/addons.js
+++ b/console/api/src/addons.js
@@ -13,6 +13,7 @@ const ADDON_LIFECYCLE_STATES = new Set(["active", "deprecated", "unsupported", "
 const INSTALL_BLOCKED_LIFECYCLES = new Set(["unsupported", "removed", "blocked"]);
 const ALLOWED_ADDON_PERMISSIONS = new Set([
   "players:read",
+  "ops:read",
   "database:read",
   "database:write",
   "server:status",

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2968,3 +2968,530 @@ export async function addonOpsHealthSummaryV2(db) {
 export async function addonOpsHealthSummary(db) {
   return addonOpsHealthSummaryV2(db);
 }
+
+// v0.4.0 Player Activity Foundation
+function emptyAddonActivity() {
+  return {
+    totalPlayers: 0,
+    onlinePlayers: 0,
+    offlinePlayers: 0,
+    activeLast1h: 0,
+    activeLast24h: 0,
+    activeLast7d: 0,
+    sessionCount: 0,
+    returningPlayers: 0,
+    newPlayers: 0,
+    guildActivity: [],
+    factionActivity: [],
+    mapActivity: [],
+    inactivePlayers: 0
+  };
+}
+
+export async function addonOpsActivitySummary(db) {
+  if (!(await tableExists(db, "player_state"))) return emptyAddonActivity();
+
+  const psColumns = await columnsFor(db, "player_state");
+  const hasOnlineStatus = psColumns.has("online_status");
+  const hasLastSeen = psColumns.has("last_seen_time") || psColumns.has("last_seen") || psColumns.has("last_login_time");
+  const lastSeenCol = hasLastSeen
+    ? firstExistingColumn(psColumns, ["last_seen_time", "last_seen", "last_login_time"])
+    : "";
+
+  const onlineCount = hasOnlineStatus
+    ? await db.query(`select count(*)::int as c from dune.player_state where online_status::text = 'Online'`)
+    : { rows: [{ c: 0 }] };
+
+  const totalResult = await db.query("select count(*)::int as c from dune.player_state");
+
+  let active1h = 0, active24h = 0, active7d = 0;
+  if (lastSeenCol) {
+    const active = await db.query(`
+      select
+        count(*) filter (where ${quoteIdentifier(lastSeenCol)} >= (current_timestamp at time zone 'UTC') - interval '1 hour')::int as active_1h,
+        count(*) filter (where ${quoteIdentifier(lastSeenCol)} >= (current_timestamp at time zone 'UTC') - interval '24 hours')::int as active_24h,
+        count(*) filter (where ${quoteIdentifier(lastSeenCol)} >= (current_timestamp at time zone 'UTC') - interval '7 days')::int as active_7d
+      from dune.player_state`);
+    active1h = Number(active.rows[0]?.active_1h || 0);
+    active24h = Number(active.rows[0]?.active_24h || 0);
+    active7d = Number(active.rows[0]?.active_7d || 0);
+  }
+
+  let guildActivity = [];
+  if (await tableExists(db, "guild_members") && await tableExists(db, "guilds")) {
+    const guildResult = await db.query(`
+      select coalesce(g.name, g.guild_name, 'Unknown') as guild_name,
+             count(gm.*)::int as members,
+             count(*) filter (where ps.online_status::text = 'Online')::int as online
+      from dune.guild_members gm
+      join dune.guilds g on g.id = gm.guild_id or g.guild_id = gm.guild_id
+      left join dune.player_state ps on ps.account_id = gm.player_id or ps.player_controller_id = gm.player_id
+      group by g.name, g.guild_name
+      order by members desc
+      limit 20`);
+    guildActivity = guildResult.rows.map((r) => ({
+      guild: String(r.guild_name || "Unknown"),
+      members: Number(r.members || 0),
+      online: Number(r.online || 0)
+    }));
+  }
+
+  let factionActivity = [];
+  if (await tableExists(db, "player_faction") && await tableExists(db, "factions")) {
+    const factionResult = await db.query(`
+      select coalesce(f.name, 'Unknown') as faction_name,
+             count(pf.*)::int as members,
+             count(*) filter (where ps.online_status::text = 'Online')::int as online
+      from dune.player_faction pf
+      left join dune.factions f on f.id = pf.faction_id
+      left join dune.player_state ps on ps.player_pawn_id = pf.actor_id or ps.player_controller_id = pf.actor_id
+      group by f.name
+      order by members desc`);
+    factionActivity = factionResult.rows.map((r) => ({
+      faction: String(r.faction_name || "Unknown"),
+      members: Number(r.members || 0),
+      online: Number(r.online || 0)
+    }));
+  }
+
+  let mapActivity = [];
+  if (await tableExists(db, "actors")) {
+    const mapResult = await db.query(`
+      select coalesce(nullif(a.map, ''), 'Unknown') as map_name,
+             count(*)::int as actors,
+             count(*) filter (where ps.online_status::text = 'Online')::int as online
+      from dune.actors a
+      left join dune.player_state ps on ps.player_pawn_id = a.id
+      where a.class ilike '%PlayerCharacter%'
+      group by a.map
+      order by actors desc
+      limit 20`);
+    mapActivity = mapResult.rows.map((r) => ({
+      map: String(r.map_name || "Unknown"),
+      actors: Number(r.actors || 0),
+      online: Number(r.online || 0)
+    }));
+  }
+
+  const totalOnline = Number(onlineCount.rows[0]?.c || 0);
+  const totalPlayers = Number(totalResult.rows[0]?.c || 0);
+  const inactivePlayers = totalPlayers - active7d;
+
+  return {
+    totalPlayers,
+    onlinePlayers: totalOnline,
+    offlinePlayers: totalPlayers - totalOnline,
+    activeLast1h: active1h,
+    activeLast24h: active24h,
+    activeLast7d: active7d,
+    sessionCount: 0,
+    returningPlayers: 0,
+    newPlayers: 0,
+    guildActivity,
+    factionActivity,
+    mapActivity,
+    inactivePlayers: inactivePlayers > 0 ? inactivePlayers : 0
+  };
+}
+
+// v0.5.0 Combat and Death Analytics
+function emptyAddonCombat() {
+  return {
+    totalDeaths: 0,
+    pvpDeaths: 0,
+    pveDeaths: 0,
+    deathsByCause: [],
+    deathsByMap: [],
+    topHostileNpcs: [],
+    kdRatio: 0
+  };
+}
+
+export async function addonOpsCombatDeaths(db) {
+  if (!(await tableExists(db, "game_events"))) return emptyAddonCombat();
+
+  const geColumns = await columnsFor(db, "game_events");
+  if (!geColumns.has("event_type") || !geColumns.has("custom_data")) return emptyAddonCombat();
+
+  const deathEvents = await db.query(`
+    select event_type::text,
+           coalesce(map, 'Unknown') as map,
+           coalesce(custom_data->>'cause', custom_data->>'damage_type', custom_data->>'killer_type', 'Unknown') as cause,
+           coalesce(custom_data->>'killer_name', custom_data->>'attacker_name', 'Unknown') as killer_name,
+           count(*)::int as events
+    from dune.game_events
+    where event_type ilike '%death%' or event_type ilike '%kill%' or custom_data ? 'cause_of_death'
+    group by 1, 2, 3, 4
+    order by events desc
+    limit 50`);
+
+  let totalDeaths = 0;
+  let pvpDeaths = 0;
+  let pveDeaths = 0;
+  const causeMap = new Map();
+  const mapMap = new Map();
+  const npcMap = new Map();
+
+  for (const row of deathEvents.rows || []) {
+    const count = Number(row.events || 0);
+    const cause = String(row.cause || "Unknown");
+    const map = String(row.map || "Unknown");
+    const killer = String(row.killer_name || "");
+
+    totalDeaths += count;
+    const isPvP = /player/i.test(killer) || /pvp/i.test(cause);
+    const isPvE = /npc|creature|environment|fall|drown|fire/i.test(cause) || !isPvP;
+
+    if (isPvP) pvpDeaths += count;
+    if (isPvE) pveDeaths += count;
+
+    causeMap.set(cause, (causeMap.get(cause) || 0) + count);
+    mapMap.set(map, (mapMap.get(map) || 0) + count);
+    if (killer && !/player|unknown/i.test(killer)) {
+      npcMap.set(killer, (npcMap.get(killer) || 0) + count);
+    }
+  }
+
+  return {
+    totalDeaths,
+    pvpDeaths,
+    pveDeaths,
+    deathsByCause: [...causeMap.entries()].map(([cause, count]) => ({ cause, count })).sort((a, b) => b.count - a.count).slice(0, 20),
+    deathsByMap: [...mapMap.entries()].map(([map, count]) => ({ map, count })).sort((a, b) => b.count - a.count),
+    topHostileNpcs: [...npcMap.entries()].map(([name, count]) => ({ name, count })).sort((a, b) => b.count - a.count).slice(0, 20),
+    kdRatio: totalDeaths > 0 ? parseFloat((pvpDeaths / Math.max(totalDeaths, 1)).toFixed(2)) : 0
+  };
+}
+
+// v0.6.0 Resource and Gathering Analytics
+function emptyAddonResources() {
+  return {
+    totalFields: 0,
+    totalValueRemaining: 0,
+    resourcesByType: [],
+    resourcesByMap: [],
+    gatheringSpikes: []
+  };
+}
+
+export async function addonOpsResourcesSummary(db) {
+  if (!(await tableExists(db, "resourcefield_state"))) return emptyAddonResources();
+
+  const rfColumns = await columnsFor(db, "resourcefield_state");
+  const valueCol = firstExistingColumn(rfColumns, ["value_remaining", "value"]);
+  const kindCol = firstExistingColumn(rfColumns, ["field_kind_id", "field_type", "resource_type"]);
+
+  const total = await db.query(`
+    select count(*)::int as total_fields,
+           ${valueCol ? `coalesce(sum(${quoteIdentifier(valueCol)}), 0)::bigint` : "0::bigint"} as total_value
+    from dune.resourcefield_state`);
+
+  let byType = [];
+  if (kindCol) {
+    const typeResult = await db.query(`
+      select ${quoteIdentifier(kindCol)}::text as resource_type,
+             count(*)::int as fields,
+             ${valueCol ? `coalesce(sum(${quoteIdentifier(valueCol)}), 0)::bigint` : "0::bigint"} as total_value
+      from dune.resourcefield_state
+      group by ${quoteIdentifier(kindCol)}
+      order by fields desc
+      limit 30`);
+    byType = typeResult.rows.map((r) => ({
+      type: String(r.resource_type || "Unknown"),
+      fields: Number(r.fields || 0),
+      totalValue: Number(r.total_value || 0)
+    }));
+  }
+
+  let byMap = [];
+  if (rfColumns.has("map")) {
+    const mapResult = await db.query(`
+      select coalesce(map, 'Unknown') as map_name,
+             count(*)::int as fields,
+             ${valueCol ? `coalesce(sum(${quoteIdentifier(valueCol)}), 0)::bigint` : "0::bigint"} as total_value
+      from dune.resourcefield_state
+      group by map
+      order by fields desc`);
+    byMap = mapResult.rows.map((r) => ({
+      map: String(r.map_name || "Unknown"),
+      fields: Number(r.fields || 0),
+      totalValue: Number(r.total_value || 0)
+    }));
+  }
+
+  return {
+    totalFields: Number(total.rows[0]?.total_fields || 0),
+    totalValueRemaining: Number(total.rows[0]?.total_value || 0),
+    resourcesByType: byType,
+    resourcesByMap: byMap,
+    gatheringSpikes: []
+  };
+}
+
+// v0.7.0 Economy and Trade Analytics
+function emptyAddonEconomy() {
+  return {
+    totalCurrencyHolders: 0,
+    totalSupply: 0,
+    currencies: [],
+    activeOrders: 0,
+    fulfilledOrders: 0,
+    topTradedItems: [],
+    totalTaxFees: 0
+  };
+}
+
+export async function addonOpsEconomySummary(db) {
+  if (!(await tableExists(db, "player_virtual_currency_balances"))) return emptyAddonEconomy();
+
+  const currencyResult = await db.query(`
+    select currency_id::text,
+           count(*)::int as holders,
+           coalesce(sum(balance), 0)::bigint as total_supply,
+           coalesce(avg(balance), 0)::bigint as average_balance,
+           coalesce(min(balance), 0)::bigint as min_balance,
+           coalesce(max(balance), 0)::bigint as max_balance
+    from dune.player_virtual_currency_balances
+    group by currency_id
+    order by total_supply desc`);
+
+  let activeOrders = 0;
+  let fulfilledOrders = 0;
+  let topTradedItems = [];
+  let totalTaxFees = 0;
+
+  if (await tableExists(db, "dune_exchange_orders")) {
+    const orderResult = await db.query("select count(*)::int as c from dune.dune_exchange_orders");
+    activeOrders = Number(orderResult.rows[0]?.c || 0);
+
+    const items = await db.query(`
+      select template_id::text,
+             count(*)::int as orders,
+             coalesce(avg(item_price), 0)::bigint as avg_price,
+             coalesce(min(item_price), 0)::bigint as min_price,
+             coalesce(max(item_price), 0)::bigint as max_price
+      from dune.dune_exchange_orders
+      group by template_id
+      order by orders desc
+      limit 20`);
+    topTradedItems = items.rows.map((r) => ({
+      templateId: String(r.template_id || ""),
+      orders: Number(r.orders || 0),
+      avgPrice: Number(r.avg_price || 0),
+      minPrice: Number(r.min_price || 0),
+      maxPrice: Number(r.max_price || 0)
+    }));
+  }
+
+  if (await tableExists(db, "dune_exchange_fulfilled_orders")) {
+    const fulfilled = await db.query("select count(*)::int as c from dune.dune_exchange_fulfilled_orders");
+    fulfilledOrders = Number(fulfilled.rows[0]?.c || 0);
+
+    const fees = await db.query(`
+      select coalesce(sum(fee_amount), 0)::bigint as total_fees
+      from dune.dune_exchange_fulfilled_orders`);
+    totalTaxFees = Number(fees.rows[0]?.total_fees || 0);
+  }
+
+  return {
+    totalCurrencyHolders: currencyResult.rows.reduce((s, r) => s + Number(r.holders || 0), 0),
+    totalSupply: currencyResult.rows.reduce((s, r) => s + Number(r.total_supply || 0), 0),
+    currencies: currencyResult.rows.map((r) => ({
+      currencyId: String(r.currency_id || ""),
+      holders: Number(r.holders || 0),
+      totalSupply: Number(r.total_supply || 0),
+      averageBalance: Number(r.average_balance || 0),
+      minBalance: Number(r.min_balance || 0),
+      maxBalance: Number(r.max_balance || 0)
+    })),
+    activeOrders,
+    fulfilledOrders,
+    topTradedItems,
+    totalTaxFees
+  };
+}
+
+// v0.8.0 Inventory, Crafting, and Storage Analytics
+function emptyAddonInventory() {
+  return {
+    totalItems: 0,
+    totalInventories: 0,
+    itemsByTemplate: [],
+    totalCrafted: 0,
+    storageUsage: []
+  };
+}
+
+export async function addonOpsInventorySummary(db) {
+  if (!(await tableExists(db, "items"))) return emptyAddonInventory();
+
+  const itemResult = await db.query("select count(*)::int as c from dune.items");
+  const totalItems = Number(itemResult.rows[0]?.c || 0);
+
+  let inventories = 0;
+  if (await tableExists(db, "inventories")) {
+    const invResult = await db.query("select count(*)::int as c from dune.inventories");
+    inventories = Number(invResult.rows[0]?.c || 0);
+  }
+
+  const byTemplate = await db.query(`
+    select template_id::text,
+           count(*)::int as count,
+           coalesce(sum(stack_size), 0)::bigint as total_stack
+    from dune.items
+    group by template_id
+    order by count desc
+    limit 30`);
+  const itemsByTemplate = byTemplate.rows.map((r) => ({
+    templateId: String(r.template_id || ""),
+    count: Number(r.count || 0),
+    totalStack: Number(r.total_stack || 0)
+  }));
+
+  let totalCrafted = 0;
+  let storageUsage = [];
+
+  if (await tableExists(db, "item_operations_staging_table")) {
+    const craftResult = await db.query(`
+      select count(*)::int as c
+      from dune.item_operations_staging_table
+      where function_name ilike '%craft%' or function_name ilike '%create%'`);
+    totalCrafted = Number(craftResult.rows[0]?.c || 0);
+  }
+
+  if (await tableExists(db, "inventories") && await tableExists(db, "items")) {
+    const storageResult = await db.query(`
+      select inv.id::text as inventory_id,
+             count(i.*)::int as item_count,
+             coalesce(sum(i.stack_size), 0)::bigint as total_stack
+      from dune.inventories inv
+      left join dune.items i on i.inventory_id = inv.id
+      group by inv.id
+      order by item_count desc
+      limit 20`);
+    storageUsage = storageResult.rows.map((r) => ({
+      inventoryId: String(r.inventory_id || ""),
+      itemCount: Number(r.item_count || 0),
+      totalStack: Number(r.total_stack || 0)
+    }));
+  }
+
+  return {
+    totalItems,
+    totalInventories: inventories,
+    itemsByTemplate,
+    totalCrafted,
+    storageUsage
+  };
+}
+
+// v0.9.0 Location, Territory, and Base Activity
+function emptyAddonLocation() {
+  return {
+    activeMaps: [],
+    totalMarkers: 0,
+    markersByMap: [],
+    playerDensity: [],
+    territoryPressure: []
+  };
+}
+
+export async function addonOpsLocationActivity(db) {
+  if (!(await tableExists(db, "actors"))) return emptyAddonLocation();
+
+  let activeMaps = [];
+  if (await tableExists(db, "player_state")) {
+    const mapResult = await db.query(`
+      select coalesce(nullif(a.map, ''), 'Unknown') as map_name,
+             count(distinct a.id)::int as players,
+             count(*) filter (where ps.online_status::text = 'Online')::int as online
+      from dune.actors a
+      left join dune.player_state ps on ps.player_pawn_id = a.id
+      where a.class ilike '%PlayerCharacter%'
+      group by a.map
+      order by players desc`);
+    activeMaps = mapResult.rows.map((r) => ({
+      map: String(r.map_name || "Unknown"),
+      players: Number(r.players || 0),
+      online: Number(r.online || 0)
+    }));
+  }
+
+  let totalMarkers = 0;
+  let markersByMap = [];
+  if (await tableExists(db, "markers")) {
+    const markerResult = await db.query("select count(*)::int as c from dune.markers");
+    totalMarkers = Number(markerResult.rows[0]?.c || 0);
+
+    const markers = await db.query(`
+      select coalesce(map_name_id::text, 'Unknown') as map_name,
+             count(*)::int as markers
+      from dune.markers
+      group by map_name_id
+      order by markers desc`);
+    markersByMap = markers.rows.map((r) => ({
+      map: String(r.map_name || "Unknown"),
+      markers: Number(r.markers || 0)
+    }));
+  }
+
+  return {
+    activeMaps,
+    totalMarkers,
+    markersByMap,
+    playerDensity: activeMaps,
+    territoryPressure: []
+  };
+}
+
+// v1.0.0 SOC/OPS Operations Center
+function emptyAddonSoc() {
+  return {
+    platformHealth: "Unknown",
+    bridgeRequests: 0,
+    bridgeErrors: 0,
+    bridgeSuccessRate: 0,
+    dataFreshness: "",
+    timestamp: ""
+  };
+}
+
+export async function addonOpsSocSummary(db) {
+  const healthPlayers = await addonOpsHealthPlayers(db);
+  const healthFarms = await addonOpsHealthFarms(db);
+  const activity = await addonOpsActivitySummary(db);
+  const economy = await addonOpsEconomySummary(db);
+  const combat = await addonOpsCombatDeaths(db);
+  const resources = await addonOpsResourcesSummary(db);
+  const inventory = await addonOpsInventorySummary(db);
+  const location = await addonOpsLocationActivity(db);
+
+  const totalPlayers = healthPlayers.total;
+  const onlinePlayers = healthPlayers.onlineStatus.Online || 0;
+  const totalFarms = healthFarms.total;
+
+  const platformHealth = totalFarms > 0 && onlinePlayers > 0
+    ? "Healthy"
+    : totalFarms === 0
+      ? "Degraded - No farm servers"
+      : "Degraded";
+
+  return {
+    platformHealth,
+    bridgeRequests: 0,
+    bridgeErrors: 0,
+    bridgeSuccessRate: 100,
+    dataFreshness: new Date().toISOString(),
+    timestamp: new Date().toISOString(),
+    health: {
+      players: healthPlayers,
+      farms: healthFarms
+    },
+    activity,
+    economy,
+    combat,
+    resources,
+    inventory,
+    location
+  };
+}

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2866,3 +2866,105 @@ function unsupported(feature, requiredTables) {
     reason: `Unsupported by detected schema. Missing required table(s): ${requiredTables.join(", ")}`
   };
 }
+
+function emptyAddonOpsHealthPlayers() {
+  return {
+    total: 0,
+    onlineStatus: {},
+    lifeState: {},
+    characterState: {},
+    combinations: []
+  };
+}
+
+function emptyAddonOpsHealthFarms() {
+  return {
+    total: 0,
+    ready: 0,
+    alive: 0,
+    connectedPlayers: 0,
+    incomingS2SConnections: 0,
+    outgoingS2SConnections: 0
+  };
+}
+
+function addCount(target, key, count) {
+  target[String(key || "Unknown")] = (target[String(key || "Unknown")] || 0) + count;
+}
+
+export async function addonOpsHealthPlayers(db) {
+  if (!(await tableExists(db, "player_state"))) return emptyAddonOpsHealthPlayers();
+
+  const columns = await columnsFor(db, "player_state");
+  const required = ["online_status", "life_state", "character_state"];
+  if (!required.every((column) => columns.has(column))) return emptyAddonOpsHealthPlayers();
+
+  const result = await db.query(`
+    select coalesce(online_status::text, 'Unknown') as online_status,
+           coalesce(life_state::text, 'Unknown') as life_state,
+           coalesce(character_state::text, 'Unknown') as character_state,
+           count(*)::int as players
+    from dune.player_state
+    group by 1, 2, 3
+    order by 1, 2, 3`);
+
+  const out = emptyAddonOpsHealthPlayers();
+  for (const row of result.rows || []) {
+    const players = Number(row.players || 0);
+    const onlineStatus = String(row.online_status || "Unknown");
+    const lifeState = String(row.life_state || "Unknown");
+    const characterState = String(row.character_state || "Unknown");
+
+    out.total += players;
+    addCount(out.onlineStatus, onlineStatus, players);
+    addCount(out.lifeState, lifeState, players);
+    addCount(out.characterState, characterState, players);
+    out.combinations.push({ onlineStatus, lifeState, characterState, players });
+  }
+
+  return out;
+}
+
+export async function addonOpsHealthFarms(db) {
+  if (!(await tableExists(db, "farm_state"))) return emptyAddonOpsHealthFarms();
+
+  const columns = await columnsFor(db, "farm_state");
+  const boolCount = (column) => columns.has(column)
+    ? `sum(case when coalesce(${quoteIdentifier(column)}, false) then 1 else 0 end)::int`
+    : "0::int";
+  const intSum = (column) => columns.has(column)
+    ? `coalesce(sum(coalesce(${quoteIdentifier(column)}, 0)), 0)::int`
+    : "0::int";
+
+  const result = await db.query(`
+    select count(*)::int as total,
+           ${boolCount("ready")} as ready,
+           ${boolCount("alive")} as alive,
+           ${intSum("connected_players")} as connected_players,
+           ${intSum("incoming_s2s_connections")} as incoming_s2s_connections,
+           ${intSum("outgoing_s2s_connections")} as outgoing_s2s_connections
+    from dune.farm_state`);
+
+  const row = result.rows?.[0] || {};
+  return {
+    total: Number(row.total || 0),
+    ready: Number(row.ready || 0),
+    alive: Number(row.alive || 0),
+    connectedPlayers: Number(row.connected_players || 0),
+    incomingS2SConnections: Number(row.incoming_s2s_connections || 0),
+    outgoingS2SConnections: Number(row.outgoing_s2s_connections || 0)
+  };
+}
+
+export async function addonOpsHealthSummaryV2(db) {
+  const [players, farms] = await Promise.all([
+    addonOpsHealthPlayers(db),
+    addonOpsHealthFarms(db)
+  ]);
+
+  return { players, farms };
+}
+
+export async function addonOpsHealthSummary(db) {
+  return addonOpsHealthSummaryV2(db);
+}

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -518,6 +518,48 @@ async function addonBridgeRoute(req, res, path) {
     audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
     return json(res, 200, { ok: true, result });
   }
+  if (action === "ops.activity.summary") {
+    const addon = assertInstalledAddonPermission(config, id, "ops:read");
+    const result = await duneDb.addonOpsActivitySummary(db);
+    audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
+    return json(res, 200, { ok: true, result });
+  }
+  if (action === "ops.combat.deaths") {
+    const addon = assertInstalledAddonPermission(config, id, "ops:read");
+    const result = await duneDb.addonOpsCombatDeaths(db);
+    audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
+    return json(res, 200, { ok: true, result });
+  }
+  if (action === "ops.resources.summary") {
+    const addon = assertInstalledAddonPermission(config, id, "ops:read");
+    const result = await duneDb.addonOpsResourcesSummary(db);
+    audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
+    return json(res, 200, { ok: true, result });
+  }
+  if (action === "ops.economy.summary") {
+    const addon = assertInstalledAddonPermission(config, id, "ops:read");
+    const result = await duneDb.addonOpsEconomySummary(db);
+    audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
+    return json(res, 200, { ok: true, result });
+  }
+  if (action === "ops.inventory.summary") {
+    const addon = assertInstalledAddonPermission(config, id, "ops:read");
+    const result = await duneDb.addonOpsInventorySummary(db);
+    audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
+    return json(res, 200, { ok: true, result });
+  }
+  if (action === "ops.location.activity") {
+    const addon = assertInstalledAddonPermission(config, id, "ops:read");
+    const result = await duneDb.addonOpsLocationActivity(db);
+    audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
+    return json(res, 200, { ok: true, result });
+  }
+  if (action === "ops.soc.summary") {
+    const addon = assertInstalledAddonPermission(config, id, "ops:read");
+    const result = await duneDb.addonOpsSocSummary(db);
+    audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
+    return json(res, 200, { ok: true, result });
+  }
   if (action === "database.query" || action === "database.execute") {
     const query = String(body.query || "");
     const readOnly = isReadOnlySql(query);

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -508,6 +508,16 @@ async function addonBridgeRoute(req, res, path) {
     audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
     return json(res, 200, { ok: true, result });
   }
+  if (action === "ops.health.summary" || action === "ops.health.players" || action === "ops.health.farms" || action === "ops.health.summary.v2") {
+    const addon = assertInstalledAddonPermission(config, id, "ops:read");
+    const result = action === "ops.health.players"
+      ? await duneDb.addonOpsHealthPlayers(db)
+      : action === "ops.health.farms"
+        ? await duneDb.addonOpsHealthFarms(db)
+        : await duneDb.addonOpsHealthSummary(db);
+    audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, ok: true });
+    return json(res, 200, { ok: true, result });
+  }
   if (action === "database.query" || action === "database.execute") {
     const query = String(body.query || "");
     const readOnly = isReadOnlySql(query);

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { assertIdentifier, discoverDbConfig, isReadOnlySql, quoteQualified, redactDbError, rowsResult } from "../src/db.js";
-import { addCurrency, addFactionReputation, addIntel, addonLeadershipPlayers, completeJourneyNode, completeTutorial, deleteInventoryItem, giveItemToPlayer, giveItemToStorage, landsraadOverview, listPlayers, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerJourney, playerPosition, playerResearchItems, resetJourneyNode, resetTutorial, runSql, setLandsraadPlayerContribution, tablePreview, unlockCraftingRecipe, unlockResearchItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError } from "../src/duneDb.js";
+import { addCurrency, addFactionReputation, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, completeJourneyNode, completeTutorial, deleteInventoryItem, giveItemToPlayer, giveItemToStorage, landsraadOverview, listPlayers, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerJourney, playerPosition, playerResearchItems, resetJourneyNode, resetTutorial, runSql, setLandsraadPlayerContribution, tablePreview, unlockCraftingRecipe, unlockResearchItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError } from "../src/duneDb.js";
 
 test("discovers RedBlink Postgres defaults and env overrides", () => {
   assert.deepEqual(discoverDbConfig({}), {
@@ -1027,6 +1027,161 @@ test("tutorial complete and reset use player controller tutorial records", async
   const reset = await resetTutorial(resetDb, 123, { tutorialId: 7 });
   assert.equal(reset.deletedRows, 1);
   assert.ok(resetCalls.some((call) => call.text.includes("delete from dune.tutorial_per_player") && call.values[0] === 55 && call.values[1] === 7));
+});
+
+
+test("OPS health players returns aggregate counts only", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("information_schema.columns")) {
+        return { rows: ["online_status", "life_state", "character_state"].map((column_name) => ({ column_name })) };
+      }
+      if (text.includes("from dune.player_state") && text.includes("group by 1, 2, 3")) {
+        return { rows: [
+          { online_status: "Online", life_state: "Alive", character_state: "Active", players: 2 },
+          { online_status: "Offline", life_state: "Alive", character_state: "Active", players: 1 }
+        ] };
+      }
+      return { rows: [] };
+    }
+  };
+
+  const result = await addonOpsHealthPlayers(db);
+  assert.deepEqual(result, {
+    total: 3,
+    onlineStatus: { Online: 2, Offline: 1 },
+    lifeState: { Alive: 3 },
+    characterState: { Active: 3 },
+    combinations: [
+      { onlineStatus: "Online", lifeState: "Alive", characterState: "Active", players: 2 },
+      { onlineStatus: "Offline", lifeState: "Alive", characterState: "Active", players: 1 }
+    ]
+  });
+  assert.equal(Object.hasOwn(result, "rows"), false);
+  assert.ok(calls.some((call) => String(call.text).includes("count(*)::int as players")));
+});
+
+test("OPS health players falls back to empty aggregate shape when source is missing", async () => {
+  const db = {
+    query: async () => ({ rows: [{ exists: false }] })
+  };
+
+  assert.deepEqual(await addonOpsHealthPlayers(db), {
+    total: 0,
+    onlineStatus: {},
+    lifeState: {},
+    characterState: {},
+    combinations: []
+  });
+});
+
+test("OPS health farms returns aggregate counters only", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("information_schema.columns")) {
+        return { rows: [
+          "ready",
+          "alive",
+          "connected_players",
+          "incoming_s2s_connections",
+          "outgoing_s2s_connections"
+        ].map((column_name) => ({ column_name })) };
+      }
+      if (text.includes("from dune.farm_state")) {
+        return { rows: [{
+          total: 2,
+          ready: 2,
+          alive: 1,
+          connected_players: 7,
+          incoming_s2s_connections: 3,
+          outgoing_s2s_connections: 4
+        }] };
+      }
+      return { rows: [] };
+    }
+  };
+
+  assert.deepEqual(await addonOpsHealthFarms(db), {
+    total: 2,
+    ready: 2,
+    alive: 1,
+    connectedPlayers: 7,
+    incomingS2SConnections: 3,
+    outgoingS2SConnections: 4
+  });
+  assert.ok(calls.some((call) => String(call.text).includes("count(*)::int as total")));
+});
+
+test("OPS health farms falls back to empty aggregate shape when source is missing", async () => {
+  const db = {
+    query: async () => ({ rows: [{ exists: false }] })
+  };
+
+  assert.deepEqual(await addonOpsHealthFarms(db), {
+    total: 0,
+    ready: 0,
+    alive: 0,
+    connectedPlayers: 0,
+    incomingS2SConnections: 0,
+    outgoingS2SConnections: 0
+  });
+});
+
+
+test("OPS health summary compatibility action matches summary v2 shape", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("information_schema.columns")) {
+        const table = values[1];
+        const columns = table === "player_state"
+          ? ["online_status", "life_state", "character_state"]
+          : ["ready", "alive", "connected_players", "incoming_s2s_connections", "outgoing_s2s_connections"];
+        return { rows: columns.map((column_name) => ({ column_name })) };
+      }
+      if (text.includes("from dune.player_state")) {
+        return { rows: [{ online_status: "Online", life_state: "Alive", character_state: "Active", players: 1 }] };
+      }
+      if (text.includes("from dune.farm_state")) {
+        return { rows: [{ total: 1, ready: 1, alive: 1, connected_players: 1, incoming_s2s_connections: 1, outgoing_s2s_connections: 1 }] };
+      }
+      return { rows: [] };
+    }
+  };
+
+  assert.deepEqual(await addonOpsHealthSummary(db), await addonOpsHealthSummaryV2(db));
+});
+
+test("OPS health summary v2 combines player and farm aggregate health", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("information_schema.columns")) {
+        const table = values[1];
+        const columns = table === "player_state"
+          ? ["online_status", "life_state", "character_state"]
+          : ["ready", "alive", "connected_players", "incoming_s2s_connections", "outgoing_s2s_connections"];
+        return { rows: columns.map((column_name) => ({ column_name })) };
+      }
+      if (text.includes("from dune.player_state")) {
+        return { rows: [{ online_status: "Online", life_state: "Alive", character_state: "Active", players: 1 }] };
+      }
+      if (text.includes("from dune.farm_state")) {
+        return { rows: [{ total: 1, ready: 1, alive: 1, connected_players: 1, incoming_s2s_connections: 1, outgoing_s2s_connections: 1 }] };
+      }
+      return { rows: [] };
+    }
+  };
+
+  const result = await addonOpsHealthSummaryV2(db);
+  assert.equal(result.players.total, 1);
+  assert.equal(result.farms.total, 1);
 });
 
 function fakeMutationDb(calls, fixtures = {}) {

--- a/docs/ops-observability-roadmap.md
+++ b/docs/ops-observability-roadmap.md
@@ -1,0 +1,961 @@
+# Dune Ops Observability Roadmap
+
+## 1. Purpose
+
+This roadmap defines the staged delivery plan for Dune Ops Observability across Core bridge capabilities, database telemetry, standard operations metrics, addon UI, and end-to-end validation.
+
+The project will follow these principles:
+
+* **Secure by default:** no raw player, account, identity, coordinate, SQL, PromQL, token, password, or row-level data leaves Core.
+* **Aggregate-only telemetry:** player and server data exposed through addon bridge actions must be summarized, counted, or grouped by low-cardinality operational states.
+* **Permission-gated access:** all telemetry bridge actions require explicit addon permission approval.
+* **Same-origin browser behavior:** addon UI must use the active Console origin and must not hardcode localhost, public IPs, LAN IPs, or DNS names.
+* **Evidence-driven releases:** no release phase is considered complete without repeatable CLI, WebUI, security, and failure-mode evidence.
+* **Industry-aligned SDLC:** release gates map to secure SDLC, application security verification, observability, and supply-chain integrity practices.
+
+## 2. Standards Alignment
+
+This roadmap uses the following industry standards and practices as reference models:
+
+| Area                    | Standard / Practice     | Application to This Project                                                                                                                                                                                                                                                                                      |
+| ----------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Secure SDLC             | NIST SSDF               | Use security requirements, threat review, safe implementation, and verification gates before release. NIST describes SSDF as a core set of secure software development practices intended to reduce vulnerabilities and address root causes.                                                                     |
+| Application Security    | OWASP ASVS              | Use explicit verification requirements for authentication, authorization, input handling, secure configuration, logging, and data protection. OWASP ASVS provides a basis for testing web application technical security controls and secure development requirements.                                           |
+| Observability           | OpenTelemetry concepts  | Model telemetry as stable, low-cardinality metrics/log-derived signals, with clear separation between metrics, logs, traces, resources, attributes, and exporters. OpenTelemetry documents observability concepts and telemetry categories including metrics, logs, traces, resources, and semantic conventions. |
+| Supply Chain Integrity  | SLSA                    | Track build/release provenance, branch state, reviewed changes, and artifact integrity where practical. SLSA is described as an incrementally adoptable set of supply-chain security guidelines with a common vocabulary and checklist for improving software security.                                          |
+| Privacy by Design       | Internal policy gate    | Expose only minimum necessary telemetry, prohibit identity-bearing fields, and add automated forbidden-field checks to every E2E suite.                                                                                                                                                                          |
+| Reliability Engineering | Release-readiness gates | Every phase must define health checks, failure-mode behavior, rollback criteria, and evidence artifacts.                                                                                                                                                                                                         |
+
+## 3. Release Model
+
+Each roadmap phase must pass four release gates before it can be considered complete.
+
+### Gate A — Design Gate
+
+Required before implementation.
+
+Acceptance criteria:
+
+* Scope is written.
+* Data sources are identified.
+* Security/privacy classification is complete.
+* Bridge/API contract is defined.
+* Rollback behavior is documented.
+* E2E evidence plan is documented.
+* No raw sensitive fields are proposed.
+
+### Gate B — Implementation Gate
+
+Required before PR review.
+
+Acceptance criteria:
+
+* Code compiles.
+* Unit tests pass.
+* Permission checks are enforced.
+* Input validation is present.
+* Missing-table/missing-column conditions are handled.
+* No hardcoded public/local endpoints exist in browser-side code.
+* Output schema is stable and documented.
+
+### Gate C — Verification Gate
+
+Required before merge.
+
+Acceptance criteria:
+
+* Target.
+
+### Gate C — Verification Gate
+
+Required before merge.
+
+Acceptance criteria:
+
+* Targeted unit tests pass.
+* Source gate passes.
+* Local CLI E2E passes.
+* Public-origin CLI E2E passes where applicable.
+* WebUI E2E passes where applicable.
+* Privacy regression scan passes.
+* Failure-mode E2E passes for expected degraded states.
+* Changed-file scope matches the intended PR boundary.
+
+### Gate D — Release Gate
+
+Required before marking the phase released.
+
+Acceptance criteria:
+
+* PR merged or release artifact published.
+* Evidence bundle saved.
+* Known limitations documented.
+* Rollback instructions documented.
+* Release notes written.
+* Follow-up issues opened for deferred work.
+* No critical or high-severity security issue remains unresolved.
+
+## 4. Current State
+
+### Phase 0 — Core OPS Health Bridge Foundation
+
+Status: **In review**
+
+PR: `Red-Blink/dune-awakening-selfhost-docker#49`
+
+Delivered:
+
+* `ops:read` addon permission.
+* `ops.health.summary` bridge action.
+* Permission-gated Core addon bridge.
+* Aggregate-only operational health summary.
+* Unit tests for aggregate-only behavior and optional schema handling.
+* Local CLI E2E validation.
+* Public-origin CLI E2E validation.
+* Public WebUI validation.
+* Same-origin addon behavior validation.
+
+Current response boundary:
+
+* server farm totals
+* farm ready/alive counts
+* server connection totals
+* player total
+* connected player count
+* grouped online status counts
+* grouped life state counts
+* grouped character state counts
+
+Current hard exclusions:
+
+* raw database rows
+* player identifiers
+* account identifiers
+* character names
+* Funcom/FLS identifiers
+* actor IDs
+* player IDs
+* coordinates or locations
+* SQL
+* PromQL
+* secrets, tokens, or passwords
+
+Phase 0 release gate:
+
+| Gate                | Status        |
+| ------------------- | ------------- |
+| Design Gate         | Passed        |
+| Implementation Gate | Passed        |
+| Verification Gate   | Passed        |
+| Release Gate        | Pending merge |
+
+## 5. Roadmap Phases
+
+---
+
+# Phase 1 — Telemetry Discovery and Classification
+
+## Objective
+
+Inventory all telemetry available from Dune runtime databases and classify each field before exposing any additional metric through Core.
+
+## Deliverables
+
+* `db-schema-inventory.json`
+* `db-telemetry-catalog.md`
+* `safe-query-candidates.sql`
+* `forbidden-field-report.txt`
+* `telemetry-classification.md`
+
+## Scope
+
+Discovery must capture:
+
+* database files
+* tables
+* columns
+* column types
+* indexes
+* row counts
+* nullable columns
+* low-cardinality candidates
+* sensitive-field candidates
+* safe aggregate query candidates
+
+## Classification Categories
+
+| Classification      | Meaning                                                               | Exposure Rule                |
+| ------------------- | --------------------------------------------------------------------- | ---------------------------- |
+| Safe aggregate      | Count/group/status field with no identity or location                 | May expose after review      |
+| Sensitive aggregate | Useful but potentially revealing if grouped too narrowly              | Requires explicit review     |
+| Unsafe raw data     | Identifier, coordinate, name, token, secret, raw row, serialized blob | Never expose                 |
+| Unknown             | Meaning unclear                                                       | Do not expose until reviewed |
+| Not useful          | No operational value                                                  | Do not expose                |
+
+## Release Gates
+
+### Design Gate
+
+* Table and column discovery approach documented.
+* Read-only DB access confirmed.
+* Classification rubric approved.
+* Forbidden-field list approved.
+* Evidence artifact paths defined.
+
+### Implementation Gate
+
+* Discovery script is read-only.
+* Script does not emit raw player rows.
+* Script flags sensitive names, identifiers, coordinates, and serialized blobs.
+* Script generates machine-readable and human-readable output.
+* Script handles missing DB files gracefully.
+
+### Verification Gate
+
+* Runs against E2E runtime DB.
+* Produces all expected artifacts.
+* Emits no raw player identity data.
+* Emits no raw coordinate data.
+* Emits no secrets or tokens.
+* Output is deterministic enough for review.
+
+### Release Gate
+
+* Telemetry catalog reviewed.
+* Safe query candidates approved.
+* Unsafe fields documented.
+* Follow-up implementation issues created.
+
+## Exit Criteria
+
+Phase 1 is complete only when every discovered DB table/column is classified or marked unknown, and no unknown field is used in a bridge response.
+
+---
+
+# Phase 2 — Expanded Aggregate DB Metrics
+
+## Objective
+
+Convert approved safe DB telemetry into stable Core bridge actions.
+
+## Proposed Bridge Actions
+
+### `ops.health.summary`
+
+Top-level dashboard summary.
+
+Must remain fast, stable, and safe.
+
+### `ops.health.server`
+
+Aggregate server and farm state.
+
+Candidate fields:
+
+* farms total
+* farms ready
+* farms alive
+* farms degraded
+* farm variable health
+* incoming connection totals
+* outgoing connection totals
+
+### `ops.health.players`
+
+Aggregate player state only.
+
+Candidate fields:
+
+* player total
+* connected count
+* online status distribution
+* life state distribution
+* character state distribution
+* encrypted player state availability count
+
+No player list.
+
+### `ops.health.storage`
+
+Database and schema health.
+
+Candidate fields:
+
+* known DB count
+* readable DB count
+* missing DB count
+* expected table presence
+* missing table list
+* row counts per approved table
+* schema capability flags
+
+### `ops.health.capabilities`
+
+Feature detection endpoint.
+
+Candidate fields:
+
+* bridge version
+* supported actions
+* known table availability
+* known column availability
+* privacy profile version
+
+## Release Gates
+
+### Design Gate
+
+* Action contracts written.
+* JSON schemas drafted.
+* Permission model confirmed.
+* Metric naming reviewed.
+* Privacy boundary reviewed.
+* Expected degraded states defined.
+
+### Implementation Gate
+
+* All actions require `ops:read`.
+* All queries are aggregate-only.
+* All table/column access is guarded.
+* Missing DB/table/column returns degraded capability state, not a crash.
+* Unit tests cover present, missing, and empty datasets.
+
+### Verification Gate
+
+* Unit tests pass.
+* Local CLI E2E passes.
+* Public-origin CLI E2E passes.
+* Privacy scan passes against every bridge response.
+* Missing-table E2E passes.
+* Missing-column E2E passes.
+* Empty-DB E2E passes.
+* Unauthorized request fails.
+* Bad CSRF request fails.
+* Addon without `ops:read` fails.
+
+### Release Gate
+
+* API contract documented.
+* Addon compatibility note written.
+* Evidence bundle saved.
+* Follow-up dashboard tasks opened.
+
+## Exit Criteria
+
+Phase 2 is complete when all approved aggregate DB metrics are available through permission-gated Core bridge actions and every response passes privacy regression scanning.
+
+---
+
+# Phase 3 — Standard Runtime / Ops Metrics
+
+## Objective
+
+Add non-game operational metrics for host, container, runtime, network, and logs.
+
+## Metric Groups
+
+### Container Health
+
+* container running state
+* restart count
+* uptime
+* healthcheck status
+* image tag/digest
+* exposed ports
+* mount correctness
+
+### Docker Compose Health
+
+* expected services present
+* expected services running
+* unexpected orphan services
+* compose project name
+* published port mappings
+* network attachments
+* volume mounts
+
+### Host Resource Health
+
+* CPU load
+* memory usage
+* disk usage
+* disk free
+* inode usage
+* swap usage
+* filesystem read-only state
+
+### Process Health
+
+* server process present
+* console process present
+* process uptime
+* listening ports
+* restart indicators
+
+### Network Health
+
+* local Console health endpoint reachable
+* public Console health endpoint reachable
+* health endpoint latency
+* HTTP status
+* reverse proxy/TLS state where applicable
+* port binding correctness
+
+### Log-Derived Health
+
+Aggregate counts only:
+
+* error count by severity
+* warning count
+* last error timestamp
+* last warning timestamp
+* known fatal pattern count
+* restart/crash pattern count
+* auth failure count
+* addon bridge failure count
+
+Raw logs must not be exposed by default.
+
+## Release Gates
+
+### Design Gate
+
+* Runtime data source approved.
+* Least-privilege access plan documented.
+* Host visibility risk reviewed.
+* Log redaction policy written.
+* Metric cardinality rules written.
+
+### Implementation Gate
+
+* Runtime metrics collector is read-only.
+* Log metrics are aggregate-only.
+* No raw log lines returned by default.
+* Sensitive environment variables are excluded.
+* Mount/port checks are normalized and stable.
+* Host access failures degrade gracefully.
+
+### Verification Gate
+
+* Runtime metrics E2E passes.
+* Container stopped failure-mode E2E passes.
+* Public port unavailable E2E passes.
+* Missing Docker socket or restricted host access degrades safely.
+* Log privacy scan passes.
+* No secrets or env vars exposed.
+
+### Release Gate
+
+* Runtime metrics documented.
+* Security caveats documented.
+* Rollback instructions provided.
+* Addon UI tasks updated.
+
+## Exit Criteria
+
+Phase 3 is complete when standard runtime metrics are available without exposing raw logs, secrets, host-sensitive internals, or unbounded high-cardinality labels.
+
+---
+
+# Phase 4 — Unified Telemetry Contract
+
+## Objective
+
+Create a stable response model across DB and runtime telemetry.
+
+## Target Shape
+
+```json
+{
+  "ok": true,
+  "generatedAt": "2026-07-02T00:00:00.000Z",
+  "supported": true,
+  "source": {
+    "kind": "core-addon-bridge",
+    "version": 1
+  },
+  "health": {
+    "status": "healthy",
+    "score": 100,
+    "reasons": []
+  },
+  "server": {},
+  "players": {},
+  "storage": {},
+  "runtime": {},
+  "warnings": [],
+  "errors": []
+}
+```
+
+## Health Status Enum
+
+* `healthy`
+* `degraded`
+* `critical`
+* `unknown`
+* `unsupported`
+
+## Severity Enum
+
+* `info`
+* `warning`
+* `error`
+* `critical`
+
+## Metric Naming Rules
+
+Use stable, low-cardinality names:
+
+* `server.farms.total`
+* `server.farms.ready`
+* `server.farms.alive`
+* `players.total`
+* `players.connected`
+* `storage.databases.readable`
+* `runtime.containers.running`
+* `runtime.disk.freeBytes`
+* `logs.errors.count`
+
+Do not use labels containing:
+
+* player ID
+* account ID
+* character name
+* actor ID
+* coordinate
+* raw path
+* raw query
+* raw log line
+* token
+* secret
+
+## Release Gates
+
+### Design Gate
+
+* Unified schema written.
+* Versioning rules written.
+* Backward compatibility rules written.
+* Deprecation rules written.
+* Error model written.
+
+### Implementation Gate
+
+* All bridge actions return consistent metadata.
+* All warnings/errors follow common shape.
+* Health score calculation is deterministic.
+* Unknown/degraded states are explicit.
+* Schema snapshots are added to tests.
+
+### Verification Gate
+
+* Schema validation passes.
+* Backward compatibility test passes.
+* Degraded-state test passes.
+* Unsupported-state test passes.
+* Privacy scan passes.
+
+### Release Gate
+
+* Contract documentation published.
+* Addon dashboard updated to contract.
+* Release note identifies schema version.
+
+## Exit Criteria
+
+Phase 4 is complete when all telemetry actions share the same envelope, health semantics, and privacy enforcement.
+
+---
+
+# Phase 5 — Addon Dashboard MVP
+
+## Objective
+
+Build the first production-quality Dune Ops Observability dashboard against stable Core bridge actions.
+
+## Dashboard Sections
+
+### Overview
+
+* overall health status
+* generated timestamp
+* server status
+* player population
+* DB/storage status
+* runtime status
+* active warnings/errors
+
+### Server
+
+* farm counts
+* ready/alive status
+* connection totals
+* degradation reasons
+
+### Players
+
+Aggregate only:
+
+* total players
+* connected players
+* online status distribution
+* life state distribution
+* character state distribution
+
+No player list.
+
+### Storage
+
+* database readability
+* expected table presence
+* missing tables
+* row count health
+* schema capability flags
+
+### Runtime
+
+* container state
+* restart count
+* uptime
+* mount correctness
+* port status
+* disk/memory/cpu summary
+
+### Alerts
+
+* critical conditions
+* degraded conditions
+* warning conditions
+* last detected time
+* recommended operator action
+
+## Release Gates
+
+### Design Gate
+
+* UI wireframe completed.
+* Same-origin route behavior documented.
+* Empty/loading/error states defined.
+* Accessibility baseline defined.
+* No raw data display areas proposed.
+
+### Implementation Gate
+
+* Same-origin bridge client implemented.
+* No hardcoded endpoint scan passes.
+* Loading/error/degraded states implemented.
+* Refresh behavior implemented.
+* No player list or raw logs added.
+
+### Verification Gate
+
+* Local WebUI E2E passes.
+* Public WebUI E2E passes.
+* Same-origin validation passes.
+* Browser console has no fatal errors.
+* Addon iframe/content route works.
+* Privacy scan passes against rendered payload.
+
+### Release Gate
+
+* Screenshots captured.
+* Operator usage notes written.
+* Known limitations documented.
+* Addon version tagged.
+
+## Exit Criteria
+
+Phase 5 is complete when the addon dashboard renders all approved bridge telemetry from local and public Console origins without hardcoded endpoints or raw sensitive data.
+
+---
+
+# Phase 6 — Full Observability and Operator Workflow
+
+## Objective
+
+Move from telemetry display to actionable operations.
+
+## Features
+
+* health score trends
+* warning history
+* degraded condition explanations
+* recommended remediation
+* evidence bundle export
+* release validation report
+* operator checklist
+* optional retention of aggregate snapshots
+
+## Release Gates
+
+### Design Gate
+
+* Snapshot retention rules written.
+* Data minimization review completed.
+* Operator workflows documented.
+* Export format documented.
+
+### Implementation Gate
+
+* Snapshots are aggregate-only.
+* Exports exclude raw logs and player data.
+* Retention is bounded.
+* Operator recommendations are deterministic and explainable.
+
+### Verification Gate
+
+* Snapshot E2E passes.
+* Export E2E passes.
+* Retention cleanup E2E passes.
+* Privacy scan passes on stored/exported artifacts.
+
+### Release Gate
+
+* Operator documentation published.
+* Support/troubleshooting notes written.
+* Release marked stable.
+
+## Exit Criteria
+
+Phase 6 is complete when the dashboard supports reliable operator triage without requiring direct DB access, shell access, or raw logs for normal health assessment.
+
+---
+
+## 6. Required E2E Suites
+
+Every phase must add or update E2E coverage.
+
+### Core Bridge E2E
+
+Validates:
+
+* auth required
+* CSRF required
+* `ops:read` required
+* bridge action works
+* aggregate-only result
+* no forbidden fields
+* missing tables handled
+* missing columns handled
+* empty DB handled
+
+### Public-Origin Browser E2E
+
+Validates:
+
+* public URL works
+* same-origin fetch works
+* addon iframe works
+* no hardcoded localhost
+* no hardcoded public IP
+* auth flow works
+* bridge result renders
+
+### Runtime Ops E2E
+
+Validates:
+
+* container mount correctness
+* published ports
+* health endpoint
+* service status
+* disk/memory collection
+* log aggregation
+
+### Privacy Regression E2E
+
+Every serialized response and rendered payload must be scanned for:
+
+* `player_controller_id`
+* `account_id`
+* `character_name`
+* `funcom_id`
+* `fls_id`
+* `actor_id`
+* `player_id`
+* `x_coord`
+* `y_coord`
+* `z_coord`
+* `location`
+* `position`
+* `rows`
+* `select`
+* `promql`
+* `password`
+* `token`
+
+### Failure-Mode E2E
+
+Simulate:
+
+* missing DB file
+* missing table
+* missing column
+* empty table
+* addon lacks `ops:read`
+* unauthenticated request
+* bad CSRF token
+* container stopped
+* public port unavailable
+* missing Docker/host access
+* unreadable logs
+
+## 7. PR Sequencing
+
+### PR 1 — Core Bridge Foundation
+
+Status: **Open**
+
+Scope:
+
+* `ops:read`
+* `ops.health.summary`
+* aggregate DB health
+* tests
+
+### PR 2 — Telemetry Discovery Tooling
+
+Scope:
+
+* DB schema inventory script
+* telemetry catalog generator
+* forbidden-field report
+* safe query candidate output
+* no runtime bridge expansion yet
+
+### PR 3 — Expanded DB Telemetry Bridge Actions
+
+Scope:
+
+* `ops.health.server`
+* `ops.health.players`
+* `ops.health.storage`
+* `ops.health.capabilities`
+* schema tests
+* privacy E2E
+
+### PR 4 — Runtime Ops Metrics Bridge
+
+Scope:
+
+* container status
+* mount status
+* port status
+* host resource summary
+* log-derived aggregate counts
+* runtime failure-mode E2E
+
+### PR 5 — Addon Dashboard MVP
+
+Scope:
+
+* overview dashboard
+* same-origin bridge client
+* server/player/storage cards
+* alert panel
+* public-origin WebUI E2E
+
+### PR 6 — Full Operator Workflow
+
+Scope:
+
+* trend snapshots
+* evidence bundle export
+* operator recommendations
+* bounded retention
+* stable release documentation
+
+## 8. Global Release Gates
+
+No PR should be marked ready unless all applicable checks pass.
+
+### Required Checks
+
+* branch current with upstream
+* changed-file scope verified
+* unit tests pass
+* targeted tests pass
+* local CLI E2E passes
+* public-origin CLI E2E passes where applicable
+* WebUI E2E passes where applicable
+* privacy regression scan passes
+* failure-mode E2E passes
+* no hardcoded endpoint scan passes
+* documentation updated
+* rollback path documented
+
+### Required Evidence
+
+Evidence should be saved under:
+
+```text
+~/dune-work/evidence/ops-observability/<phase-or-pr-name>/
+```
+
+Each evidence bundle should contain:
+
+* command log
+* git state
+* changed-file list
+* test output
+* E2E output
+* WebUI validation notes
+* privacy scan output
+* failure-mode output
+* known limitations
+
+## 9. Non-Negotiable Security Rules
+
+The following must never be exposed through addon bridge responses, dashboard UI, evidence bundles, or exported reports:
+
+* raw player rows
+* player IDs
+* account IDs
+* character names
+* Funcom/FLS identifiers
+* actor IDs
+* coordinates
+* exact positions
+* raw serialized blobs
+* SQL text
+* PromQL text
+* tokens
+* passwords
+* secrets
+* raw logs by default
+* unbounded high-cardinality labels
+
+## 10. Decision Log
+
+| Decision                                          | Rationale                                                                   |
+| ------------------------------------------------- | --------------------------------------------------------------------------- |
+| Use Core bridge instead of direct addon DB access | Keeps local DB/runtime access controlled and permission-gated.              |
+| Use aggregate-only DB telemetry                   | Prevents player identity and location exposure.                             |
+| Separate DB metrics from runtime ops metrics      | Different data sources, risk profiles, and failure modes.                   |
+| Use same-origin browser behavior                  | Prevents localhost/public-IP regressions and supports reverse proxy access. |
+| Add privacy regression scanning to every phase    | Prevents accidental sensitive-field leakage.                                |
+| Build telemetry catalog before expanding metrics  | Avoids exposing unknown or unsafe DB fields.                                |
+| Require release gates for every PR                | Keeps development evidence-driven and reviewable.                           |
+
+## 11. Immediate Next Actions
+
+1. Keep PR #49 focused on Core bridge foundation.
+2. Create PR #50 or equivalent for telemetry discovery tooling.
+3. Generate the DB schema inventory and telemetry catalog from the E2E runtime.
+4. Classify every discovered table/column before adding new bridge actions.
+5. Expand bridge actions only after safe aggregate metrics are approved.
+6. Build the addon dashboard after the bridge contract stabilizes.
+
+## 12. Definition of Done
+
+The roadmap is complete when:
+
+* all approved DB telemetry is cataloged and classified;
+* all safe metrics are exposed through permission-gated bridge actions;
+* standard runtime ops metrics are available without raw logs or secrets;
+* addon UI renders telemetry through same-origin bridge calls;
+* local and public E2E suites pass;
+* privacy regression scans pass for every response and export;
+* release evidence is captured for every phase;
+* operator documentation exists for deployment, troubleshooting, rollback, and validation.


### PR DESCRIPTION
- Supersedes PR #49 (addon-ops-health-bridge) with expanded scope
- Adds  permission (same as PR #49)
- Keep: , , , 
- New bridge actions:

### v0.4.0 — 
  Player activity, online/offline counts, active windows (1h/24h/7d), guild/faction/map activity distribution.

### v0.5.0 — 
  PvP/PvE death analytics by cause, map, and hostile NPC. KD ratio.

### v0.6.0 — 
  Resource field inventory by type and map, total value remaining.

### v0.7.0 — 
  Virtual currency supply/holders, exchange order volume, fulfilled trades, tax/fee totals.

### v0.8.0 — 
  Item counts by template, total inventories, crafting totals, storage heatmap.

### v0.9.0 — 
  Active maps, player density, marker counts, territory pressure indicators.

### v1.0.0 — 
  Unified SOC/operations center aggregating all above metrics in one response.

All actions use the existing  permission. Schema-agnostic discovery: , ,  — gracefully degrade to empty results when tables or columns are missing.

The accompanying addon UI panels and catalog listing will be PR'd to Red-Blink/dune-docker-addons once this core PR is merged.