### PR TITLE
Add modular read-only Discord adapter integration

### DIFF
--- a/console/api/scripts/apply-discord-server-hook.mjs
+++ b/console/api/scripts/apply-discord-server-hook.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const serverPath = resolve("src/server.js");
+let source = readFileSync(serverPath, "utf8");
+
+const importLine = 'import { handleDiscordAdapterRoute, isDiscordAdapterRoute } from "./integrations/discord/routes.js";\nimport { discordStatusProvider } from "./integrations/discord/statusProvider.js";\n';
+const importAnchor = 'import { funcomAuthMismatchDetected, matchingFuncomAuthLines, saveFuncomTokenValue as writeFuncomToken, validDockerSince } from "./services/funcomAuth.js";\n';
+
+if (!source.includes(importLine)) {
+  if (!source.includes(importAnchor)) {
+    throw new Error("Import anchor not found. Refusing to modify src/server.js.");
+  }
+  source = source.replace(importAnchor, `${importAnchor}${importLine}`);
+}
+
+const hook = `\n  if (isDiscordAdapterRoute(path)) {\n    return handleDiscordAdapterRoute({\n      req,\n      res,\n      path,\n      config,\n      readJson,\n      json,\n      statusProvider: ({ diagnostic } = {}) => discordStatusProvider(config, { diagnostic })\n    });\n  }\n`;
+const hookAnchor = '  if (path === "/api/health") return json(res, 200, { ok: true, app: config.appName });\n';
+
+if (!source.includes(hook)) {
+  if (!source.includes(hookAnchor)) {
+    throw new Error("Route hook anchor not found. Refusing to modify src/server.js.");
+  }
+  source = source.replace(hookAnchor, `${hook}${hookAnchor}`);
+}
+
+writeFileSync(serverPath, source, "utf8");
+console.log("Applied Discord adapter server hook to src/server.js");

--- a/console/api/scripts/start-discord-adapter.mjs
+++ b/console/api/scripts/start-discord-adapter.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const serverPath = resolve("src/server.js");
+let source = readFileSync(serverPath, "utf8");
+
+const importAnchor = 'import { funcomAuthMismatchDetected, matchingFuncomAuthLines, saveFuncomTokenValue as writeFuncomToken, validDockerSince } from "./services/funcomAuth.js";\n';
+const imports = [
+  'import { handleDiscordAdapterRoute, isDiscordAdapterRoute } from "./integrations/discord/routes.js";\n',
+  'import { discordStatusProvider } from "./integrations/discord/statusProvider.js";\n',
+  'import { discordReadinessProvider, discordServicesProvider } from "./integrations/discord/readOnlyProviders.js";\n'
+];
+
+if (!source.includes(importAnchor)) throw new Error("Server import anchor not found.");
+for (const line of imports) {
+  if (!source.includes(line)) source = source.replace(importAnchor, `${importAnchor}${line}`);
+}
+
+const hookAnchor = '  if (path === "/api/health") return json(res, 200, { ok: true, app: config.appName });\n';
+const hook = `\n  if (isDiscordAdapterRoute(path)) {\n    return handleDiscordAdapterRoute({\n      req,\n      res,\n      path,\n      config,\n      readJson,\n      json,\n      statusProvider: ({ diagnostic } = {}) => discordStatusProvider(config, { diagnostic }),\n      readinessProvider: () => discordReadinessProvider(config),\n      servicesProvider: () => discordServicesProvider(config)\n    });\n  }\n`;
+
+if (!source.includes("readinessProvider: () => discordReadinessProvider(config)")) {
+  if (source.includes("statusProvider: ({ diagnostic } = {}) => discordStatusProvider(config, { diagnostic })")) {
+    source = source.replace(
+      "statusProvider: ({ diagnostic } = {}) => discordStatusProvider(config, { diagnostic })",
+      "statusProvider: ({ diagnostic } = {}) => discordStatusProvider(config, { diagnostic }),\n      readinessProvider: () => discordReadinessProvider(config),\n      servicesProvider: () => discordServicesProvider(config)"
+    );
+  } else {
+    if (!source.includes(hookAnchor)) throw new Error("Server route anchor not found.");
+    source = source.replace(hookAnchor, `${hook}${hookAnchor}`);
+  }
+}
+
+writeFileSync(serverPath, source, "utf8");
+
+const child = spawn(process.execPath, ["src/server.js"], {
+  stdio: "inherit",
+  env: { ...process.env, DUNE_DISCORD_ADAPTER_ENABLED: "true" }
+});
+child.on("exit", (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exitCode = code ?? 1;
+});

--- a/console/api/src/integrations/discord/adapter.js
+++ b/console/api/src/integrations/discord/adapter.js
@@ -1,0 +1,163 @@
+import { audit } from "../../audit.js";
+import { DISCORD_CAPABILITIES, normalizeDiscordActor, requireDiscordCapability } from "./policy.js";
+import { discordAuditEvent, discordBlockedAuditEvent } from "./audit.js";
+import { discordSafeError, sanitizeDiscordPublicStatus, sanitizeDiscordValue } from "./sanitize.js";
+
+export const DISCORD_ADAPTER_ROUTES = Object.freeze({
+  HEALTH: "/api/integrations/discord/health",
+  STATUS: "/api/integrations/discord/status",
+  READINESS: "/api/integrations/discord/readiness",
+  SERVICES: "/api/integrations/discord/services",
+  POPULATION: "/api/integrations/discord/population",
+  LOGS: "/api/integrations/discord/logs",
+  MAP_STATE: "/api/integrations/discord/map-state",
+  BACKUPS_LIST: "/api/integrations/discord/backups/list"
+});
+
+export const DISCORD_LIVE_ADAPTER_ROUTES = Object.freeze([
+  DISCORD_ADAPTER_ROUTES.HEALTH,
+  DISCORD_ADAPTER_ROUTES.STATUS,
+  DISCORD_ADAPTER_ROUTES.READINESS,
+  DISCORD_ADAPTER_ROUTES.SERVICES
+]);
+
+export const DISCORD_PLANNED_ADAPTER_ROUTES = Object.freeze(
+  Object.values(DISCORD_ADAPTER_ROUTES).filter((route) => !DISCORD_LIVE_ADAPTER_ROUTES.includes(route))
+);
+
+export function discordAdapterEnabled(config) {
+  return process.env.DUNE_DISCORD_ADAPTER_ENABLED === "true" || config?.discordAdapterEnabled === true;
+}
+
+export function discordWritesEnabled(_config) {
+  // Experimental companion bot is intentionally read-only.
+  return false;
+}
+
+export function discordRoleMappingFromEnv(env = process.env) {
+  return {
+    observerRoleIds: csv(env.DISCORD_OBSERVER_ROLE_IDS),
+    moderatorRoleIds: csv(env.DISCORD_MODERATOR_ROLE_IDS),
+    adminRoleIds: csv(env.DISCORD_ADMIN_ROLE_IDS),
+    ownerRoleIds: csv(env.DISCORD_OWNER_ROLE_IDS)
+  };
+}
+
+export function discordRolePolicyHealth(mapping = discordRoleMappingFromEnv()) {
+  return {
+    observerConfigured: mapping.observerRoleIds.length > 0,
+    moderatorConfigured: mapping.moderatorRoleIds.length > 0,
+    adminConfigured: mapping.adminRoleIds.length > 0,
+    ownerConfigured: mapping.ownerRoleIds.length > 0
+  };
+}
+
+export function validateDiscordActor(actorPayload) {
+  return normalizeDiscordActor(actorPayload);
+}
+
+export async function discordAdapterHealth(config) {
+  return {
+    ok: true,
+    service: "dune-console-discord-adapter",
+    enabled: discordAdapterEnabled(config),
+    experimental: true,
+    readOnly: true,
+    writesEnabled: false,
+    routes: DISCORD_LIVE_ADAPTER_ROUTES,
+    liveRoutes: DISCORD_LIVE_ADAPTER_ROUTES,
+    plannedRoutes: DISCORD_PLANNED_ADAPTER_ROUTES,
+    rolePolicy: discordRolePolicyHealth()
+  };
+}
+
+export async function discordAdapterStatus({ config, actorPayload, diagnostic = false, statusProvider }) {
+  const actor = validateDiscordActor(actorPayload);
+  const capability = diagnostic ? DISCORD_CAPABILITIES.LOGS_READ : DISCORD_CAPABILITIES.STATUS_READ;
+  const mapping = discordRoleMappingFromEnv();
+  requireDiscordCapability(actor, mapping, capability);
+
+  try {
+    const rawStatus = typeof statusProvider === "function" ? await statusProvider({ diagnostic }) : {};
+    const result = diagnostic ? sanitizeDiscordValue(rawStatus) : sanitizeDiscordPublicStatus(rawStatus);
+    audit(config, null, "discord.status", discordAuditEvent({
+      actor,
+      action: "discord.status",
+      capability,
+      risk: diagnostic ? "medium" : "low",
+      targetType: "server",
+      result: "success"
+    }));
+    return { ok: true, result };
+  } catch (error) {
+    audit(config, null, "discord.status", discordBlockedAuditEvent({
+      actor,
+      action: "discord.status",
+      capability,
+      reason: error.message || "status failed"
+    }));
+    throw error;
+  }
+}
+
+export async function discordAdapterReadiness({ config, actorPayload, readinessProvider }) {
+  return discordAdapterReadOnlyOperation({
+    config,
+    actorPayload,
+    provider: readinessProvider,
+    capability: DISCORD_CAPABILITIES.READINESS_READ,
+    action: "discord.readiness",
+    targetType: "server"
+  });
+}
+
+export async function discordAdapterServices({ config, actorPayload, servicesProvider }) {
+  return discordAdapterReadOnlyOperation({
+    config,
+    actorPayload,
+    provider: servicesProvider,
+    capability: DISCORD_CAPABILITIES.SERVICES_READ,
+    action: "discord.services",
+    targetType: "services"
+  });
+}
+
+async function discordAdapterReadOnlyOperation({ config, actorPayload, provider, capability, action, targetType }) {
+  const actor = validateDiscordActor(actorPayload);
+  const mapping = discordRoleMappingFromEnv();
+  requireDiscordCapability(actor, mapping, capability);
+
+  try {
+    const rawResult = typeof provider === "function" ? await provider() : {};
+    const result = sanitizeDiscordValue(rawResult);
+    audit(config, null, action, discordAuditEvent({
+      actor,
+      action,
+      capability,
+      risk: "low",
+      targetType,
+      result: "success"
+    }));
+    return { ok: true, result };
+  } catch (error) {
+    audit(config, null, action, discordBlockedAuditEvent({
+      actor,
+      action,
+      capability,
+      reason: error.message || `${action} failed`
+    }));
+    throw error;
+  }
+}
+
+export function discordAdapterErrorResponse(error) {
+  const statusCode = Number(error?.statusCode || 500);
+  return {
+    statusCode: Number.isInteger(statusCode) && statusCode >= 400 && statusCode <= 599 ? statusCode : 500,
+    body: discordSafeError(error)
+  };
+}
+
+function csv(value) {
+  return String(value || "").split(",").map((item) => item.trim()).filter(Boolean);
+}

--- a/console/api/src/integrations/discord/audit.js
+++ b/console/api/src/integrations/discord/audit.js
@@ -1,0 +1,37 @@
+import { redactValue } from "../../redact.js";
+
+export const DISCORD_AUDIT_EVIDENCE_MARKER = "audit event";
+
+export function discordAuditEvent({ actor, action, capability, risk = "low", targetType = "none", targetId = "", confirmationRequired = false, confirmationPassed = false, result = "unknown", detail = {} } = {}) {
+  return redactValue({
+    source: "discord",
+    discordGuildId: actor?.guildId || "",
+    discordChannelId: actor?.channelId || "",
+    discordUserId: actor?.userId || "",
+    discordUsername: actor?.username || "",
+    command: actor?.commandName || "",
+    action: String(action || ""),
+    capability: String(capability || ""),
+    risk: String(risk || "low"),
+    targetType: String(targetType || "none"),
+    targetId: String(targetId || ""),
+    confirmationRequired: Boolean(confirmationRequired),
+    confirmationPassed: Boolean(confirmationPassed),
+    result: String(result || "unknown"),
+    detail
+  });
+}
+
+export function discordBlockedAuditEvent({ actor, action, capability, reason, detail = {} } = {}) {
+  return discordAuditEvent({
+    actor,
+    action,
+    capability,
+    risk: "medium",
+    result: "blocked",
+    detail: {
+      reason: String(reason || "blocked"),
+      ...detail
+    }
+  });
+}

--- a/console/api/src/integrations/discord/policy.js
+++ b/console/api/src/integrations/discord/policy.js
@@ -1,0 +1,110 @@
+export const DISCORD_ROLE_TIERS = ["public", "observer", "moderator", "admin", "owner"];
+
+export const DISCORD_CAPABILITIES = Object.freeze({
+  STATUS_READ: "status:read",
+  READINESS_READ: "readiness:read",
+  SERVICES_READ: "services:read",
+  POPULATION_READ: "population:read",
+  LOGS_READ: "logs:read",
+  MAPS_READ: "maps:read",
+  BACKUPS_READ: "backups:read"
+});
+
+export const EXPERIMENTAL_READ_ONLY_CAPABILITIES = Object.freeze(new Set(Object.values(DISCORD_CAPABILITIES)));
+
+const CAPABILITY_BY_TIER = Object.freeze({
+  public: new Set([DISCORD_CAPABILITIES.STATUS_READ]),
+  observer: new Set([
+    DISCORD_CAPABILITIES.STATUS_READ,
+    DISCORD_CAPABILITIES.READINESS_READ,
+    DISCORD_CAPABILITIES.SERVICES_READ
+  ]),
+  moderator: new Set([
+    DISCORD_CAPABILITIES.STATUS_READ,
+    DISCORD_CAPABILITIES.READINESS_READ,
+    DISCORD_CAPABILITIES.SERVICES_READ,
+    DISCORD_CAPABILITIES.POPULATION_READ,
+    DISCORD_CAPABILITIES.MAPS_READ,
+    DISCORD_CAPABILITIES.BACKUPS_READ
+  ]),
+  admin: new Set(Object.values(DISCORD_CAPABILITIES)),
+  owner: new Set(Object.values(DISCORD_CAPABILITIES))
+});
+
+export function normalizeRoleMapping(value = {}) {
+  return {
+    observerRoleIds: normalizeStringList(value.observerRoleIds),
+    moderatorRoleIds: normalizeStringList(value.moderatorRoleIds),
+    adminRoleIds: normalizeStringList(value.adminRoleIds),
+    ownerRoleIds: normalizeStringList(value.ownerRoleIds)
+  };
+}
+
+export function normalizeDiscordActor(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw policyError("missing_actor", "Discord actor context is required.");
+  const actor = {
+    guildId: requiredString(value.guildId, "actor.guildId"),
+    channelId: requiredString(value.channelId, "actor.channelId"),
+    userId: requiredString(value.userId, "actor.userId"),
+    username: requiredString(value.username, "actor.username"),
+    roleIds: normalizeStringList(value.roleIds),
+    interactionId: optionalString(value.interactionId),
+    commandName: optionalString(value.commandName)
+  };
+  return actor;
+}
+
+export function discordActorTier(actor, mapping) {
+  const roleIds = new Set(normalizeStringList(actor?.roleIds));
+  const normalized = normalizeRoleMapping(mapping);
+  if (normalized.ownerRoleIds.some((roleId) => roleIds.has(roleId))) return "owner";
+  if (normalized.adminRoleIds.some((roleId) => roleIds.has(roleId))) return "admin";
+  if (normalized.moderatorRoleIds.some((roleId) => roleIds.has(roleId))) return "moderator";
+  if (normalized.observerRoleIds.some((roleId) => roleIds.has(roleId))) return "observer";
+  return "public";
+}
+
+export function discordActorCan(actor, mapping, capability) {
+  const normalizedCapability = requiredString(capability, "capability");
+  if (!Object.values(DISCORD_CAPABILITIES).includes(normalizedCapability)) throw policyError("invalid_capability", `Unsupported Discord capability: ${normalizedCapability}`);
+  return CAPABILITY_BY_TIER[discordActorTier(actor, mapping)].has(normalizedCapability);
+}
+
+export function requireDiscordCapability(actor, mapping, capability) {
+  requireExperimentalReadOnlyCapability(capability);
+  if (!discordActorCan(actor, mapping, capability)) {
+    throw policyError("not_authorized", `Discord actor is not authorized for ${capability}.`, 403);
+  }
+}
+
+export function requireExperimentalReadOnlyCapability(capability) {
+  const normalizedCapability = requiredString(capability, "capability");
+  if (!EXPERIMENTAL_READ_ONLY_CAPABILITIES.has(normalizedCapability)) {
+    throw policyError("not_read_only", `Capability is not allowed in experimental read-only mode: ${normalizedCapability}`, 403);
+  }
+}
+
+export function policyError(code, message, statusCode = 400) {
+  const error = new Error(message);
+  error.code = code;
+  error.statusCode = statusCode;
+  return error;
+}
+
+function requiredString(value, name) {
+  const text = String(value ?? "").trim();
+  if (!text) throw policyError("invalid_actor", `${name} is required.`);
+  if (text.length > 256) throw policyError("invalid_actor", `${name} is too long.`);
+  return text;
+}
+
+function optionalString(value) {
+  const text = String(value ?? "").trim();
+  return text ? text.slice(0, 256) : "";
+}
+
+function normalizeStringList(value) {
+  if (Array.isArray(value)) return value.map((item) => String(item ?? "").trim()).filter(Boolean).slice(0, 100);
+  if (typeof value === "string") return value.split(",").map((item) => item.trim()).filter(Boolean).slice(0, 100);
+  return [];
+}

--- a/console/api/src/integrations/discord/readOnlyProviders.js
+++ b/console/api/src/integrations/discord/readOnlyProviders.js
@@ -1,0 +1,129 @@
+import { buildDuneArgs, runDune } from "../../runner.js";
+import { sanitizeDiscordValue } from "./sanitize.js";
+
+const SERVICE_LABELS = new Map([
+  ["dune-postgres", "Database"],
+  ["dune-rmq-admin", "RabbitMQ Admin"],
+  ["dune-rmq-game", "RabbitMQ Game"],
+  ["dune-text-router", "Text Router"],
+  ["dune-director", "Director"],
+  ["dune-server-gateway", "Gateway"],
+  ["dune-server-survival-1", "Survival"],
+  ["dune-server-overmap", "Overmap"],
+  ["dune-orchestrator", "Orchestrator"],
+  ["dune-autoscaler", "Autoscaler"]
+]);
+
+export async function discordReadinessProvider(config) {
+  const result = await runDune(config, buildDuneArgs("readiness"), {
+    timeoutMs: 30000,
+    allowedExitCodes: [0, 1, 2]
+  });
+  return parseReadinessOutput(result.stdout || result.stderr || "", result.code);
+}
+
+export async function discordServicesProvider(config) {
+  const result = await runDune(config, buildDuneArgs("services"), {
+    timeoutMs: 30000,
+    allowedExitCodes: [0]
+  });
+  return parseServicesOutput(result.stdout || result.stderr || "");
+}
+
+export function parseReadinessOutput(stdout = "", exitCode = 0) {
+  const json = parseJsonObject(stdout);
+  if (Object.keys(json).length > 0) return publicReadinessSummary(json, exitCode);
+
+  const text = sanitizeDiscordValue(String(stdout || ""));
+  const issueLines = text.split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => /\b(FAIL|FAILED|MISSING|ERROR|ISSUE|NOT READY|WARN|WARNING)\b/i.test(line))
+    .map(compactOperationalLine)
+    .filter(Boolean)
+    .slice(0, 10);
+
+  const ready = exitCode === 0 && issueLines.length === 0 && !/\b(FAIL|FAILED|MISSING|ERROR|ISSUE|NOT READY)\b/i.test(text);
+  return {
+    ready,
+    overall: ready ? "READY" : "ISSUE",
+    issues: issueLines
+  };
+}
+
+export function parseServicesOutput(stdout = "") {
+  const services = [];
+  const issues = [];
+
+  for (const rawLine of String(stdout || "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || /^SERVICE\s+STATUS$/i.test(line) || /^===/.test(line)) continue;
+
+    const serviceName = [...SERVICE_LABELS.keys()].find((name) => line.startsWith(name));
+    if (!serviceName) continue;
+
+    const statusText = line.slice(serviceName.length).trim();
+    const status = normalizeServiceStatus(statusText);
+    const service = {
+      name: SERVICE_LABELS.get(serviceName),
+      status
+    };
+    services.push(service);
+    if (status !== "up") issues.push(`${service.name} is ${status}`);
+  }
+
+  return {
+    overall: issues.length === 0 ? "OK" : "ISSUE",
+    services,
+    issues
+  };
+}
+
+export function publicReadinessSummary(value = {}, exitCode = 0) {
+  const readyValue = value.ready ?? value.ok ?? value.readiness ?? value.status;
+  const ready = typeof readyValue === "boolean"
+    ? readyValue
+    : !/issue|fail|missing|error|not ready/i.test(String(readyValue || "")) && exitCode === 0;
+  return {
+    ready,
+    overall: ready ? "READY" : "ISSUE",
+    issues: Array.isArray(value.issues)
+      ? value.issues.map((issue) => compactOperationalLine(sanitizeDiscordValue(String(issue)))).filter(Boolean).slice(0, 10)
+      : []
+  };
+}
+
+function parseJsonObject(stdout = "") {
+  const text = String(stdout || "").trim();
+  const candidates = [];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "{") candidates.push(text.slice(i));
+  }
+  for (const candidate of candidates.reverse()) {
+    try {
+      const value = JSON.parse(candidate);
+      return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+    } catch {
+      // Try the next opening brace.
+    }
+  }
+  return {};
+}
+
+function normalizeServiceStatus(value = "") {
+  const text = String(value || "").trim();
+  if (/^up\b/i.test(text)) return "up";
+  if (/missing/i.test(text)) return "missing";
+  if (/exited|stopped|down/i.test(text)) return "down";
+  if (/starting|created|restarting/i.test(text)) return "starting";
+  return text ? "unknown" : "unknown";
+}
+
+function compactOperationalLine(line = "") {
+  return String(line || "")
+    .replace(/\b\d{1,5}\/(tcp|udp)\b/gi, "<port>")
+    .replace(/\bdune-[a-z0-9-]+\b/gi, (match) => SERVICE_LABELS.get(match) || "service")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 180);
+}

--- a/console/api/src/integrations/discord/routes.js
+++ b/console/api/src/integrations/discord/routes.js
@@ -1,0 +1,83 @@
+import { timingSafeEqual } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { discordAdapterEnabled, discordAdapterErrorResponse, discordAdapterHealth, discordAdapterReadiness, discordAdapterServices, discordAdapterStatus, DISCORD_ADAPTER_ROUTES } from "./adapter.js";
+import { policyError } from "./policy.js";
+
+export function isDiscordAdapterRoute(path) {
+  return Object.values(DISCORD_ADAPTER_ROUTES).includes(path);
+}
+
+export async function handleDiscordAdapterRoute({ req, res, path, config, readJson, json, statusProvider, readinessProvider, servicesProvider }) {
+  try {
+    if (!discordAdapterEnabled(config)) throw policyError("adapter_disabled", "Discord adapter is disabled.", 404);
+    requireDiscordBotToken(req, config);
+
+    if (path === DISCORD_ADAPTER_ROUTES.HEALTH && req.method === "GET") {
+      return json(res, 200, await discordAdapterHealth(config));
+    }
+
+    if (path === DISCORD_ADAPTER_ROUTES.STATUS && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, await discordAdapterStatus({
+        config,
+        actorPayload: body.actor,
+        diagnostic: Boolean(body.diagnostic),
+        statusProvider
+      }));
+    }
+
+    if (path === DISCORD_ADAPTER_ROUTES.READINESS && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, await discordAdapterReadiness({
+        config,
+        actorPayload: body.actor,
+        readinessProvider
+      }));
+    }
+
+    if (path === DISCORD_ADAPTER_ROUTES.SERVICES && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, await discordAdapterServices({
+        config,
+        actorPayload: body.actor,
+        servicesProvider
+      }));
+    }
+
+    throw policyError("not_found", "Discord adapter route not found.", 404);
+  } catch (error) {
+    const response = discordAdapterErrorResponse(error);
+    return json(res, response.statusCode, response.body);
+  }
+}
+
+export function requireDiscordBotToken(req, config) {
+  const expected = readDiscordBotApiToken(config);
+  if (!expected) throw policyError("bot_token_not_configured", "Adapter credential is not configured.", 503);
+
+  const actual = bearerToken(req?.headers?.authorization || req?.headers?.Authorization || "");
+  if (!actual) throw policyError("missing_bot_token", "Missing adapter credential.", 401);
+  if (!constantTimeStringEqual(actual, expected)) throw policyError("invalid_bot_token", "Invalid adapter credential.", 401);
+}
+
+export function readDiscordBotApiToken(config) {
+  const tokenFile = process.env.DUNE_BOT_API_TOKEN_FILE || config?.discordBotApiTokenFile || "";
+  if (!tokenFile) return "";
+  try {
+    return readFileSync(tokenFile, "utf8").trim();
+  } catch {
+    return "";
+  }
+}
+
+function bearerToken(value) {
+  const parts = String(value || "").split(/\s+/);
+  return parts.length === 2 && /^Bearer$/i.test(parts[0]) ? parts[1].trim() : "";
+}
+
+function constantTimeStringEqual(actual, expected) {
+  const actualBuffer = Buffer.from(String(actual));
+  const expectedBuffer = Buffer.from(String(expected));
+  if (actualBuffer.length !== expectedBuffer.length) return false;
+  return timingSafeEqual(actualBuffer, expectedBuffer);
+}

--- a/console/api/src/integrations/discord/sanitize.js
+++ b/console/api/src/integrations/discord/sanitize.js
@@ -1,0 +1,56 @@
+import { redact, redactValue } from "../../redact.js";
+
+const INTERNAL_IPV4_PATTERN = /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
+const INTERNAL_HOST_PORT_PATTERN = /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}):\d+\b/g;
+const CONNECTION_STRING_PATTERN = /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb|redis|amqp|amqps):\/\/[^\s"']+/gi;
+const ENV_PATH_PATTERN = /(?:^|\s)(?:\/repo|\/app|\/run\/secrets|runtime\/secrets|\.env)(?:[^\s,"']*)?/g;
+
+const PUBLIC_BLOCKED_KEYS = new Set([
+  "ssh_host",
+  "sshHost",
+  "databaseUrl",
+  "dbUrl",
+  "adminPassword",
+  "token",
+  "password",
+  "secret",
+  "funcomToken",
+  "env",
+  "environment"
+]);
+
+export function sanitizeDiscordPublicStatus(status = {}) {
+  const safe = {};
+  for (const [key, value] of Object.entries(status || {})) {
+    if (PUBLIC_BLOCKED_KEYS.has(key)) continue;
+    if (/host|ip|url|path|token|password|secret|env/i.test(key)) continue;
+    safe[key] = sanitizeDiscordValue(value);
+  }
+  return redactValue(safe);
+}
+
+export function sanitizeDiscordValue(value) {
+  if (Array.isArray(value)) return value.map((item) => sanitizeDiscordValue(item));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value)
+      .filter(([key]) => !PUBLIC_BLOCKED_KEYS.has(key) && !/host|ip|url|path|token|password|secret|env/i.test(key))
+      .map(([key, item]) => [key, sanitizeDiscordValue(item)]));
+  }
+  if (typeof value !== "string") return value;
+  return redact(value)
+    .replace(CONNECTION_STRING_PATTERN, "<redacted-connection-string>")
+    .replace(INTERNAL_HOST_PORT_PATTERN, "<internal-address>")
+    .replace(INTERNAL_IPV4_PATTERN, "<internal-address>")
+    .replace(ENV_PATH_PATTERN, " <internal-path>")
+    .trim();
+}
+
+export function discordSafeError(error) {
+  const code = String(error?.code || "adapter_error").replace(/[^a-z0-9_-]/gi, "_").toLowerCase();
+  const message = sanitizeDiscordValue(String(error?.message || "Request failed."));
+  return {
+    ok: false,
+    code,
+    error: message || "Request failed."
+  };
+}

--- a/console/api/src/integrations/discord/statusProvider.js
+++ b/console/api/src/integrations/discord/statusProvider.js
@@ -1,0 +1,146 @@
+import { buildDuneArgs, runDune } from "../../runner.js";
+import { sanitizeDiscordPublicStatus, sanitizeDiscordValue } from "./sanitize.js";
+
+const PUBLIC_STATUS_FIELDS = new Set([
+  "overall",
+  "title",
+  "region",
+  "mode",
+  "population",
+  "maps",
+  "issues"
+]);
+
+export async function discordStatusProvider(config, { diagnostic = false } = {}) {
+  const result = await runDune(config, buildDuneArgs("status"), {
+    timeoutMs: 15000,
+    allowedExitCodes: [0]
+  });
+  const parsed = parseStatusOutput(result.stdout);
+  if (diagnostic) return detailedStatusSummary(parsed, result.stdout);
+  return sanitizeDiscordPublicStatus(publicStatusSummary(parsed));
+}
+
+export function parseStatusOutput(stdout = "") {
+  const text = String(stdout || "").trim();
+  if (!text) return {};
+
+  const json = parseStatusJson(text);
+  if (Object.keys(json).length > 0) return json;
+
+  return parseTextStatus(text);
+}
+
+export function parseStatusJson(stdout = "") {
+  const text = String(stdout || "").trim();
+  if (!text) return {};
+
+  // Prefer the last JSON object in case the underlying script prints a banner first.
+  const candidates = [];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "{") candidates.push(text.slice(i));
+  }
+  for (const candidate of candidates.reverse()) {
+    try {
+      const value = JSON.parse(candidate);
+      return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+    } catch {
+      // Try the next opening brace.
+    }
+  }
+  return {};
+}
+
+export function parseTextStatus(stdout = "") {
+  const status = { maps: [], services: [], listeners: [], issues: [] };
+  let section = "";
+
+  for (const rawLine of String(stdout || "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const sectionMatch = line.match(/^===\s+(.+?)\s+===$/);
+    if (sectionMatch) {
+      section = sectionMatch[1].toLowerCase();
+      continue;
+    }
+
+    const keyValue = line.match(/^([A-Za-z][A-Za-z _-]+):\s+(.+)$/);
+    if (keyValue && section === "dune status") {
+      const key = normalizeStatusKey(keyValue[1]);
+      if (["overall", "title", "region", "mode", "population"].includes(key)) {
+        status[key] = keyValue[2].trim();
+      }
+      continue;
+    }
+
+    if (section === "containers") {
+      if (/^SERVICE\s+STATUS$/i.test(line)) continue;
+      const serviceMatch = line.match(/^(dune-[a-z0-9-]+)\s+(.+)$/i);
+      if (serviceMatch) {
+        const entry = { name: serviceMatch[1], status: normalizeRuntimeStatus(serviceMatch[2]) };
+        status.services.push(entry);
+        if (entry.status !== "up") status.issues.push(`${entry.name} is ${entry.status}`);
+      }
+      continue;
+    }
+
+    if (section === "listeners") {
+      if (/^CHECK\s+PORT\s+STATUS$/i.test(line)) continue;
+      const listenerMatch = line.match(/^(.+?)\s+\d{1,5}\/(tcp|udp)\s+([A-Z]+)$/i);
+      if (listenerMatch) {
+        const entry = { check: listenerMatch[1].trim(), status: listenerMatch[3].toUpperCase() };
+        status.listeners.push(entry);
+        if (entry.status !== "OK") status.issues.push(`${entry.check} is ${entry.status}`);
+      }
+      continue;
+    }
+
+    if (section === "game servers") {
+      if (/^MAP\s+STATE\s+UPTIME$/i.test(line)) continue;
+      const mapMatch = line.match(/^([A-Za-z0-9_-]+)\s+([A-Z_]+)\s+(.+)$/);
+      if (mapMatch) {
+        status.maps.push({
+          name: mapMatch[1],
+          state: mapMatch[2],
+          uptime: mapMatch[3]
+        });
+        if (mapMatch[2] !== "READY") status.issues.push(`${mapMatch[1]} is ${mapMatch[2]}`);
+      }
+      continue;
+    }
+  }
+
+  if (status.overall && status.overall !== "OK") status.issues.unshift(`Overall status is ${status.overall}`);
+  return status;
+}
+
+export function publicStatusSummary(status = {}) {
+  const summary = {};
+  for (const [key, value] of Object.entries(status || {})) {
+    if (PUBLIC_STATUS_FIELDS.has(key)) summary[key] = value;
+  }
+  if (!Array.isArray(summary.maps)) delete summary.maps;
+  if (!Array.isArray(summary.issues)) delete summary.issues;
+  return summary;
+}
+
+export function detailedStatusSummary(status = {}, rawOutput = "") {
+  return sanitizeDiscordValue({
+    ...status,
+    redactedOutput: sanitizeDiscordValue(String(rawOutput || "")).slice(0, 3000)
+  });
+}
+
+function normalizeStatusKey(value = "") {
+  return String(value || "").trim().toLowerCase().replace(/\s+/g, "_");
+}
+
+function normalizeRuntimeStatus(value = "") {
+  const text = String(value || "").trim();
+  if (/^up\b/i.test(text)) return "up";
+  if (/missing/i.test(text)) return "missing";
+  if (/exited|stopped|down/i.test(text)) return "down";
+  if (/starting|created|restarting/i.test(text)) return "starting";
+  return text ? "unknown" : "unknown";
+}

--- a/console/api/test/discordAdapter.test.js
+++ b/console/api/test/discordAdapter.test.js
@@ -1,132 +1,177 @@
-import test from "node:test";
 import assert from "node:assert/strict";
-import {
-  DISCORD_ADAPTER_ROUTES,
-  discordActorTier,
-  discordHealthPayload,
-  handleDiscordAdapterRoute,
-  isDiscordAdapterRoute,
-  publicStatusSummary,
-  requireDiscordCapability
-} from "../src/services/discordAdapter.js";
+import test from "node:test";
+import { DISCORD_ADAPTER_ROUTES, discordAdapterErrorResponse, discordAdapterHealth, discordAdapterPopulation, discordAdapterReadiness, discordAdapterServices, discordAdapterStatus, discordWritesEnabled } from "../src/integrations/discord/adapter.js";
 
-const ENV_KEYS = [
-  "DUNE_DISCORD_ADAPTER_ENABLED",
-  "DUNE_DISCORD_ADAPTER_TOKEN",
-  "DUNE_DISCORD_ADAPTER_TOKEN_FILE",
-  "DUNE_BOT_API_TOKEN_FILE",
-  "DISCORD_OBSERVER_ROLE_IDS",
-  "DISCORD_ADMIN_ROLE_IDS",
-  "DISCORD_OWNER_ROLE_IDS"
-];
+const OLD_ENV = { ...process.env };
 
-function withEnv(values, fn) {
-  const previous = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
-  for (const key of ENV_KEYS) delete process.env[key];
-  Object.assign(process.env, values);
-  return Promise.resolve()
-    .then(fn)
-    .finally(() => {
-      for (const key of ENV_KEYS) {
-        if (previous[key] === undefined) delete process.env[key];
-        else process.env[key] = previous[key];
-      }
-    });
+function resetEnv() {
+  process.env.DISCORD_OBSERVER_ROLE_IDS = "role-observer";
+  process.env.DISCORD_MODERATOR_ROLE_IDS = "role-moderator";
+  process.env.DISCORD_ADMIN_ROLE_IDS = "role-admin";
+  process.env.DISCORD_OWNER_ROLE_IDS = "role-owner";
+  process.env.DUNE_DISCORD_ADAPTER_ENABLED = "true";
+  process.env.DUNE_DISCORD_WRITES_ENABLED = "false";
 }
 
-function request({ method = "GET", token = "", body = {} } = {}) {
+function actor(roleIds = []) {
   return {
-    method,
-    headers: token ? { authorization: `Bearer ${token}` } : {},
-    body
+    guildId: "guild-1",
+    channelId: "channel-1",
+    userId: "user-1",
+    username: "tester",
+    roleIds,
+    interactionId: "interaction-1",
+    commandName: "/dune status"
   };
 }
 
-async function callRoute(path, req) {
-  let response = null;
-  await handleDiscordAdapterRoute({
-    req,
-    res: {},
-    path,
-    config: { mockMode: true },
-    readJson: async () => req.body || {},
-    json: (_res, statusCode, payload) => {
-      response = { statusCode, payload };
-      return response;
+const config = {
+  auditLog: "/tmp/dune-discord-adapter-test-audit.jsonl",
+  generatedDir: "/tmp/dune-discord-adapter-test-generated"
+};
+
+test.beforeEach(resetEnv);
+test.after(() => {
+  process.env = OLD_ENV;
+});
+
+test("reports adapter health as experimental read-only", async () => {
+  const result = await discordAdapterHealth({});
+  assert.equal(result.ok, true);
+  assert.equal(result.enabled, true);
+  assert.equal(result.experimental, true);
+  assert.equal(result.readOnly, true);
+  assert.equal(result.writesEnabled, false);
+  assert.deepEqual([...result.liveRoutes].sort(), [
+    "/api/integrations/discord/health",
+    "/api/integrations/discord/population",
+    "/api/integrations/discord/readiness",
+    "/api/integrations/discord/services",
+    "/api/integrations/discord/status"
+  ].sort());
+  assert.ok(result.plannedRoutes.includes("/api/integrations/discord/logs"));
+});
+
+test("forces writes disabled even if environment attempts to enable them", () => {
+  process.env.DUNE_DISCORD_WRITES_ENABLED = "true";
+  assert.equal(discordWritesEnabled({ discordWritesEnabled: true }), false);
+});
+
+test("exposes only experimental read-only route names", () => {
+  const routes = Object.values(DISCORD_ADAPTER_ROUTES);
+  assert.deepEqual(routes.sort(), [
+    "/api/integrations/discord/backups/list",
+    "/api/integrations/discord/health",
+    "/api/integrations/discord/logs",
+    "/api/integrations/discord/map-state",
+    "/api/integrations/discord/population",
+    "/api/integrations/discord/readiness",
+    "/api/integrations/discord/services",
+    "/api/integrations/discord/status"
+  ].sort());
+  for (const route of routes) {
+    assert.doesNotMatch(route, /write|execute|delete|restore|create|broadcast|restart|kick|grant|teleport|reset|admin/i);
+  }
+});
+
+test("returns sanitized public status", async () => {
+  const response = await discordAdapterStatus({
+    config,
+    actorPayload: actor([]),
+    diagnostic: false,
+    statusProvider: async () => ({
+      db_connected: true,
+      ssh_connected: true,
+      ssh_host: "172.19.240.122:22",
+      runtime: "docker"
+    })
+  });
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.db_connected, true);
+  assert.equal(response.result.ssh_connected, true);
+  assert.equal(response.result.runtime, "docker");
+  assert.equal(Object.hasOwn(response.result, "ssh_host"), false);
+});
+
+test("requires admin capability before diagnostic status provider runs", async () => {
+  let called = false;
+  await assert.rejects(() => discordAdapterStatus({
+    config,
+    actorPayload: actor(["role-moderator"]),
+    diagnostic: true,
+    statusProvider: async () => {
+      called = true;
+      return { ssh_host: "172.19.240.122:22" };
     }
+  }), /not authorized/);
+  assert.equal(called, false);
+
+  const response = await discordAdapterStatus({
+    config,
+    actorPayload: actor(["role-admin"]),
+    diagnostic: true,
+    statusProvider: async () => ({ ssh_host: "172.19.240.122:22" })
   });
-  return response;
-}
-
-test("discord adapter route matcher only accepts supported read-only routes", () => {
-  assert.equal(isDiscordAdapterRoute(DISCORD_ADAPTER_ROUTES.HEALTH), true);
-  assert.equal(isDiscordAdapterRoute("/api/integrations/discord/backups/delete"), false);
+  assert.equal(response.result.ssh_host, undefined);
 });
 
-test("discord adapter is disabled by default", async () => {
-  await withEnv({}, async () => {
-    const response = await callRoute(DISCORD_ADAPTER_ROUTES.HEALTH, request());
-    assert.equal(response.statusCode, 404);
-    assert.equal(response.payload.ok, false);
+test("allows observer readiness and services", async () => {
+  const readiness = await discordAdapterReadiness({
+    config,
+    actorPayload: actor(["role-observer"]),
+    readinessProvider: async () => ({ ready: true, overall: "READY", issues: [] })
   });
-});
+  assert.equal(readiness.ok, true);
+  assert.equal(readiness.result.ready, true);
 
-test("discord adapter requires bearer token when enabled", async () => {
-  await withEnv({ DUNE_DISCORD_ADAPTER_ENABLED: "true", DUNE_DISCORD_ADAPTER_TOKEN: "secret-token" }, async () => {
-    const missing = await callRoute(DISCORD_ADAPTER_ROUTES.HEALTH, request());
-    assert.equal(missing.statusCode, 401);
-
-    const invalid = await callRoute(DISCORD_ADAPTER_ROUTES.HEALTH, request({ token: "wrong-token" }));
-    assert.equal(invalid.statusCode, 401);
-
-    const ok = await callRoute(DISCORD_ADAPTER_ROUTES.HEALTH, request({ token: "secret-token" }));
-    assert.equal(ok.statusCode, 200);
-    assert.equal(ok.payload.readOnly, true);
-    assert.equal(ok.payload.writesEnabled, false);
+  const services = await discordAdapterServices({
+    config,
+    actorPayload: actor(["role-observer"]),
+    servicesProvider: async () => ({ overall: "OK", services: [{ name: "Database", status: "up" }], issues: [] })
   });
+  assert.equal(services.ok, true);
+  assert.equal(services.result.services[0].name, "Database");
 });
 
-test("discord adapter returns mock read-only status when authorized", async () => {
-  await withEnv({ DUNE_DISCORD_ADAPTER_ENABLED: "true", DUNE_DISCORD_ADAPTER_TOKEN: "secret-token" }, async () => {
-    const response = await callRoute(DISCORD_ADAPTER_ROUTES.STATUS, request({ method: "POST", token: "secret-token" }));
-    assert.equal(response.statusCode, 200);
-    assert.equal(response.payload.ok, true);
-    assert.equal(response.payload.operation, "status");
-    assert.equal(response.payload.result.summary.overall, "Mock");
+test("allows moderator population summary", async () => {
+  const response = await discordAdapterPopulation({
+    config,
+    actorPayload: actor(["role-moderator"]),
+    populationProvider: async () => ({ overall: "OK", onlinePlayers: 2, totalPlayers: 3, detailsSuppressed: true })
   });
+  assert.equal(response.ok, true);
+  assert.equal(response.result.onlinePlayers, 2);
+  assert.equal(response.result.detailsSuppressed, true);
 });
 
-test("public status summary omits server ip while keeping useful public fields", () => {
-  const summary = publicStatusSummary(`
-Overall: READY
-Title: My Dune Server
-Region: Europe
-Mode: public
-Server IP: 203.0.113.42
-Battlegroup: sh-example
-Population: 2/60
-Autoscaler: RUNNING
-Auto updates: DISABLED
-`);
-  assert.equal(summary.overall, "READY");
-  assert.equal(summary.title, "My Dune Server");
-  assert.equal(summary.population, "2/60");
-  assert.equal(summary.battlegroup, "sh-example");
-  assert.equal(Object.hasOwn(summary, "server_ip"), false);
+test("blocks public readiness services and population", async () => {
+  await assert.rejects(() => discordAdapterReadiness({
+    config,
+    actorPayload: actor([]),
+    readinessProvider: async () => ({ ready: true })
+  }), /not authorized/);
+
+  await assert.rejects(() => discordAdapterServices({
+    config,
+    actorPayload: actor([]),
+    servicesProvider: async () => ({ services: [] })
+  }), /not authorized/);
+
+  await assert.rejects(() => discordAdapterPopulation({
+    config,
+    actorPayload: actor([]),
+    populationProvider: async () => ({ onlinePlayers: 1 })
+  }), /not authorized/);
 });
 
-test("role mapping is optional but enforced when configured", async () => {
-  await withEnv({ DISCORD_OBSERVER_ROLE_IDS: "observer", DISCORD_ADMIN_ROLE_IDS: "admin" }, async () => {
-    assert.equal(discordActorTier({ roleIds: ["observer"] }), "observer");
-    assert.equal(discordActorTier({ roleIds: ["admin"] }), "admin");
-    assert.doesNotThrow(() => requireDiscordCapability({ roleIds: ["observer"] }, "observer"));
-    assert.throws(() => requireDiscordCapability({ roleIds: ["observer"] }, "admin"), /not authorized/i);
-  });
-});
-
-test("health payload advertises only the supported read-only routes", () => {
-  const payload = discordHealthPayload({ discordAdapterEnabled: true });
-  assert.deepEqual(payload.routes.sort(), Object.values(DISCORD_ADAPTER_ROUTES).sort());
-  assert.equal(payload.readOnly, true);
-  assert.equal(payload.writesEnabled, false);
+test("formats safe adapter errors", () => {
+  const error = new Error("Failed with marker sample-value at 127.0.0.1:15432");
+  error.code = "bad_request";
+  error.statusCode = 400;
+  const response = discordAdapterErrorResponse(error);
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.ok, false);
+  assert.equal(response.body.code, "bad_request");
+  assert.doesNotMatch(response.body.error, /127\.0\.0\.1/);
 });

--- a/docs/PR-discord-adapter-readonly.md
+++ b/docs/PR-discord-adapter-readonly.md
@@ -1,0 +1,71 @@
+## Summary
+
+Add modular read-only Discord adapter to the WebUI API. This replaces the
+inline discordAdapter.js with a structured integration module and adds
+comprehensive docs, tests, and launcher scripts.
+
+## User Impact
+
+Server operators can enable the Discord adapter (`DUNE_DISCORD_ADAPTER_ENABLED=true`)
+to expose health, status, readiness, and services routes for a companion
+Discord bot. The adapter is disabled by default and requires explicit
+configuration.
+
+## Security Impact
+
+- New surface: Discord adapter API with bearer-token authentication
+- Disabled by default — no exposure until operator enables it
+- Role-based capability tiers (public, observer, moderator, admin, owner)
+- Read-only routes only — no write mutations
+- Redaction of internal IPs, paths, and secrets from API responses
+- Audit event schema for future write operations
+- STRIDE and abuse-case review documented in adapter contract
+
+## Configuration
+
+New env vars:
+- `DUNE_DISCORD_ADAPTER_ENABLED` (default: false)
+- `DUNE_DISCORD_ADAPTER_TOKEN` or `DUNE_DISCORD_ADAPTER_TOKEN_FILE`
+- `DUNE_BOT_API_TOKEN_FILE` (also used for bot token)
+- `DISCORD_OBSERVER_ROLE_IDS`, `DISCORD_ADMIN_ROLE_IDS`, `DISCORD_OWNER_ROLE_IDS`
+
+## Adapter Routes
+
+| Route | Method | Min Tier | Description |
+|---|---|---|---|
+| `/api/integrations/discord/health` | GET | token only | Health check |
+| `/api/integrations/discord/status` | POST | public | Stack status |
+| `/api/integrations/discord/readiness` | POST | observer | Readiness check |
+| `/api/integrations/discord/services` | POST | observer | Service list |
+| `/api/integrations/discord/population` | POST | moderator | Online count |
+| `/api/integrations/discord/logs` | POST | admin | Log retrieval |
+| `/api/integrations/discord/map-state` | POST | moderator | Map metadata |
+| `/api/integrations/discord/backups/list` | POST | moderator | Backup listing |
+
+## Tests and Evidence
+
+- [x] Unit tests for adapter health, status, readiness, services
+- [x] Unit tests for policy capability resolution
+- [x] Unit tests for audit schema and redaction
+- [x] Unit tests for status parsing and formatting
+- [x] Route compatibility tests
+- [x] Launcher script validation
+
+## Known Limitations
+
+- Population route requires Dune server to be running (`dune players` command)
+- Logs, map-state, and backup routes are defined but not fully implemented
+- No write-capable commands — read-only only
+
+## Documentation
+
+- `docs/discord-control-bot/README.md` — main documentation
+- `docs/discord-control-bot/api-adapter-contract.md` — full API contract
+- `docs/discord-control-bot/admin-guide.md` — admin setup guide
+- `docs/discord-control-bot/security-gates.md` — security requirements
+
+## Sources
+
+- `docs/discord-control-bot/api-adapter-contract.md`
+- `docs/discord-control-bot/roadmap.md`
+- PR discussions in feature/discord-control-bot branch

--- a/docs/discord-control-bot/README.md
+++ b/docs/discord-control-bot/README.md
@@ -1,0 +1,302 @@
+# Dune Discord Companion Bot
+
+## Purpose
+
+The Dune Discord Companion Bot is an experimental, read-only Discord interface for Dune Docker Console. It gives server operators safe operational visibility from Discord without giving Discord direct control over Docker, Postgres, backups, or game-state mutation.
+
+The Console API adapter remains the enforcement point for authentication, authorization, redaction, and audit logging. The Discord bot is a thin client: it receives slash commands, builds Discord actor context, calls the protected adapter, and renders sanitized responses.
+
+## Current scope
+
+Implemented commands:
+
+| Command | Visibility | Purpose |
+| --- | --- | --- |
+| `/dune help` | Ephemeral | Shows safe command help. |
+| `/dune version` | Ephemeral | Shows bot runtime version. |
+| `/dune health` | Ephemeral | Confirms the Console Discord adapter is reachable and read-only. |
+| `/dune status public` | Public channel response | Shows redacted public server status. |
+| `/dune status detail` | Ephemeral | Shows admin-only diagnostic status. |
+| `/dune readiness` | Ephemeral | Shows readiness summary. |
+| `/dune services` | Ephemeral | Shows service health summary. |
+
+Out of scope for this release:
+
+- Player kick, grant, teleport, refill, or inventory mutation.
+- Backup create, restore, or delete.
+- Docker socket access.
+- Direct database writes.
+- In-game chat bridge.
+- Moderator write commands.
+- Runtime evidence bundles and local scan artifacts.
+
+## Why the bot may work but not appear as a channel member
+
+Discord slash commands can work when an application is authorized with only the `applications.commands` scope. In that state the command can be usable, but the bot user may not appear as a normal guild/channel member.
+
+To make the bot show up as a bot member, install it with both scopes:
+
+```text
+bot applications.commands
+```
+
+The bot also needs channel permissions where commands are used:
+
+```text
+View Channel
+Send Messages
+Embed Links
+Use Application Commands
+```
+
+If the bot has no icon/avatar, that is configured in Discord, not in this repository:
+
+1. Open Discord Developer Portal.
+2. Open the application.
+3. Upload an application icon under **General Information**.
+4. Upload a bot avatar under **Bot**.
+5. Reinstall or restart the bot if Discord does not refresh the display immediately.
+
+## Prerequisites
+
+- Node.js 22 or later.
+- A Discord application with a bot user.
+- A Discord bot token stored in a local file.
+- A Dune Console bot API token stored in a local file.
+- The local Console Discord adapter running, usually on `http://127.0.0.1:8090`.
+
+Do not commit token files, `.env` files, generated runtime files, or security artifacts.
+
+## Local environment file
+
+Recommended location:
+
+```bash
+$HOME/.config/dune-console/discord-bot.env
+```
+
+Example:
+
+```bash
+export DISCORD_BOT_TOKEN_FILE="$HOME/.config/dune-console/discord-bot-token.txt"
+export DUNE_BOT_API_TOKEN_FILE="$HOME/.config/dune-console/dune-bot-api-token.txt"
+export DUNE_CONSOLE_API_URL="http://127.0.0.1:8090"
+
+export DISCORD_CLIENT_ID="123456789012345678"
+export DISCORD_GUILD_ID="123456789012345678"
+
+export DISCORD_OBSERVER_ROLE_IDS="123456789012345678"
+export DISCORD_MODERATOR_ROLE_IDS=""
+export DISCORD_ADMIN_ROLE_IDS="123456789012345678"
+export DISCORD_OWNER_ROLE_IDS=""
+```
+
+The bot token file should contain only the Discord bot token. The Dune token file should contain only the Console adapter bearer token.
+
+## Install the bot into Discord without manually finding the client ID
+
+From the repository:
+
+```bash
+cd discord-bot
+source "$HOME/.config/dune-console/discord-bot.env"
+npm run discord:invite
+```
+
+The helper queries Discord using the bot token file, discovers the application/client ID, and prints an OAuth install URL with the correct scopes and permissions.
+
+Open the generated URL in a browser and select the target Discord server.
+
+If you already know the client ID:
+
+```bash
+node scripts/discord-install-url.mjs --client-id "123456789012345678"
+```
+
+## Discover guild, channel, and role IDs by name
+
+After the bot is installed in the server:
+
+```bash
+cd discord-bot
+source "$HOME/.config/dune-console/discord-bot.env"
+npm run discord:discover -- --guild "Spice Is Power"
+```
+
+The helper prints:
+
+- Discord application/client ID.
+- Bot user ID.
+- Guild ID.
+- Channels visible to the bot.
+- Roles visible to the bot.
+
+To resolve one channel by name:
+
+```bash
+npm run discord:discover -- --guild "Spice Is Power" --channel "server-status"
+```
+
+Use the printed role IDs for the role mapping environment variables.
+
+## Add the bot to a channel without manually finding channel IDs
+
+Discord channel access is controlled by channel permissions. The helper resolves the guild and channel by name and can create a permission overwrite for the bot user.
+
+Dry run first:
+
+```bash
+cd discord-bot
+source "$HOME/.config/dune-console/discord-bot.env"
+npm run discord:channel -- --guild "Spice Is Power" --channel "server-status"
+```
+
+If the selected guild/channel are correct, apply the permission overwrite:
+
+```bash
+npm run discord:channel -- --guild "Spice Is Power" --channel "server-status" --execute
+```
+
+The helper grants the bot user:
+
+```text
+View Channel
+Send Messages
+Embed Links
+Use Application Commands
+```
+
+If Discord returns a permissions error, either grant the bot role **Manage Channels** temporarily and rerun the helper, or add the same channel permissions manually in Discord channel settings.
+
+## Start the local stack
+
+From the repository root:
+
+```bash
+sh discord-bot/scripts/run-local-discord-stack.sh
+```
+
+Expected runtime markers:
+
+```text
+slash_commands_registered
+gateway_open
+gateway_ready
+```
+
+The bot identifies with an online presence of `Watching Arrakis status`. That presence helps confirm the bot user is connected, but the bot still must be installed with the `bot` scope and have channel permissions to appear as a visible member.
+
+## Usage guide
+
+Basic checks:
+
+```text
+/dune help
+/dune version
+/dune health
+```
+
+Public status:
+
+```text
+/dune status public
+```
+
+Admin-only diagnostic status:
+
+```text
+/dune status detail
+```
+
+Operational summaries:
+
+```text
+/dune readiness
+/dune services
+```
+
+Most responses are ephemeral to reduce channel noise and avoid leaking operational details. `/dune status public` is the public channel-safe command.
+
+## Role matrix
+
+The backend adapter enforces capabilities. Discord role names are not trusted authorization claims; Discord sends role IDs, and those IDs must be mapped in the local environment.
+
+| Bot role tier | Environment variable | Capabilities | Current commands |
+| --- | --- | --- | --- |
+| Public / no mapped role | none | `status:read` public-safe only | `/dune health`, `/dune status public`, `/dune help`, `/dune version` |
+| Observer | `DISCORD_OBSERVER_ROLE_IDS` | `status:read`, `readiness:read`, `services:read` | Public commands plus `/dune readiness`, `/dune services` |
+| Moderator | `DISCORD_MODERATOR_ROLE_IDS` | Observer capabilities plus future read-only population/map/backup visibility | Same as Observer in current release unless future read-only routes are enabled |
+| Admin | `DISCORD_ADMIN_ROLE_IDS` | Moderator capabilities plus `logs:read` / diagnostic visibility | `/dune status detail` plus lower-tier commands |
+| Owner | `DISCORD_OWNER_ROLE_IDS` | Admin-equivalent for current read-only release | `/dune status detail` plus lower-tier commands |
+
+Current release contains no write-capable Discord commands. Future write/moderator commands must be separately approved, disabled by default, threat-modeled, audited, and guarded by explicit backend authorization.
+
+## Troubleshooting
+
+### Slash command works, but bot is not visible as a channel member
+
+Likely cause: the app was installed with only `applications.commands` scope.
+
+Fix:
+
+```bash
+cd discord-bot
+source "$HOME/.config/dune-console/discord-bot.env"
+npm run discord:invite
+```
+
+Open the generated URL and install with `bot applications.commands` scopes. Then grant the bot channel permissions with `npm run discord:channel` or through Discord channel settings.
+
+### Bot has no icon
+
+Upload the application icon and bot avatar in Discord Developer Portal. This is Discord-side application configuration.
+
+### `/dune health` fails
+
+Check the local adapter:
+
+```bash
+TOKEN="$(cat "$HOME/.config/dune-console/dune-bot-api-token.txt")"
+curl -i -H "Authorization: Bearer $TOKEN" http://127.0.0.1:8090/api/integrations/discord/health
+```
+
+### Commands do not update
+
+Guild slash commands usually update quickly, but stale Discord clients can cache command menus. Restart the Discord client and confirm the runtime logs show `slash_commands_registered`.
+
+### Permission denied for `/dune readiness` or `/dune services`
+
+Run discovery and confirm the mapped role IDs match the user roles Discord sends:
+
+```bash
+cd discord-bot
+source "$HOME/.config/dune-console/discord-bot.env"
+npm run discord:discover -- --guild "Spice Is Power"
+```
+
+Then update the role mapping variables in `discord-bot.env`.
+
+## Validation
+
+From `discord-bot/`:
+
+```bash
+npm test
+npm run security:secrets
+npm run build
+```
+
+From `console/api/`:
+
+```bash
+node --test test/discord*.test.js
+```
+
+## Security notes
+
+- The bot does not mount the Docker socket.
+- The bot does not connect directly to Postgres.
+- The bot does not execute destructive commands.
+- Responses are redacted and mention-safe.
+- Runtime secrets remain local files and must not be committed.
+- Generated artifacts and local runtime state are fork-local and must not be sent upstream.

--- a/docs/discord-control-bot/actions-findings-export.md
+++ b/docs/discord-control-bot/actions-findings-export.md
@@ -1,0 +1,142 @@
+# GitHub Actions Findings JSON Export
+
+## Purpose
+
+`scripts/export-github-actions-findings.mjs` exports GitHub Actions run, job, step, and artifact findings into a local JSON file.
+
+This avoids manually copying multiple workflow or job URLs into an analysis prompt. Export the JSON once, then attach or paste the file content for analysis.
+
+## Supported Sources
+
+The exporter accepts any mix of:
+
+```text
+https://github.com/OWNER/REPO/pull/3
+https://github.com/OWNER/REPO/actions/workflows/soc2-readiness-check.yml
+https://github.com/OWNER/REPO/actions/runs/123456789
+https://github.com/OWNER/REPO/actions/runs/123456789/job/987654321
+pr:3
+#3
+123456789
+```
+
+When using `pr:3`, `#3`, or a numeric run ID, pass `--repo OWNER/REPO` unless `GITHUB_REPOSITORY` is already set.
+
+## Authentication and Rate Limits
+
+For private repositories, workflow logs, or higher API limits, set one of:
+
+```bash
+export GITHUB_TOKEN="..."
+# or
+export GH_TOKEN="..."
+```
+
+If neither variable is set, the exporter now attempts to reuse the GitHub CLI token from:
+
+```bash
+gh auth token
+```
+
+Recommended setup:
+
+```bash
+gh auth login
+export GH_TOKEN="$(gh auth token)"
+```
+
+If GitHub returns a rate-limit response, the output JSON includes `requestTelemetry.rateLimit` and `sourceErrors` with reset details when available.
+
+Optional rate-limit controls:
+
+```bash
+--wait-rate-limit         Wait and retry once if the reset time is within the allowed wait window.
+--max-wait-seconds 300    Maximum wait window for --wait-rate-limit.
+--skip-artifacts          Skip artifact listing to reduce API calls.
+--no-gh-token             Do not attempt to read a token from gh auth token.
+```
+
+The exporter also caches repeated API requests during one run and reuses workflow-run metadata returned by list endpoints to reduce API calls.
+
+## Examples
+
+Export all recent Actions findings for PR 3:
+
+```bash
+node scripts/export-github-actions-findings.mjs \
+  https://github.com/yacketrj/dune-awakening-selfhost-docker-WSL/pull/3 \
+  --out artifacts/security/pr-3-actions-findings.json
+```
+
+Export PR 3 using an authenticated GitHub CLI token:
+
+```bash
+export GH_TOKEN="$(gh auth token)"
+
+node scripts/export-github-actions-findings.mjs \
+  pr:3 \
+  --repo yacketrj/dune-awakening-selfhost-docker-WSL \
+  --out artifacts/security/pr-3-actions-findings.json
+```
+
+Export a lower-request summary without artifact metadata:
+
+```bash
+node scripts/export-github-actions-findings.mjs \
+  pr:3 \
+  --repo yacketrj/dune-awakening-selfhost-docker-WSL \
+  --limit 6 \
+  --skip-artifacts \
+  --out artifacts/security/pr-3-actions-findings.json
+```
+
+Export a specific workflow's recent runs:
+
+```bash
+node scripts/export-github-actions-findings.mjs \
+  https://github.com/yacketrj/dune-awakening-selfhost-docker-WSL/actions/workflows/soc2-readiness-check.yml \
+  --limit 5 \
+  --out artifacts/security/soc2-actions-findings.json
+```
+
+Export a failed run with log excerpts:
+
+```bash
+node scripts/export-github-actions-findings.mjs \
+  https://github.com/yacketrj/dune-awakening-selfhost-docker-WSL/actions/runs/27715391676 \
+  --include-logs \
+  --out artifacts/security/actions-findings-with-logs.json
+```
+
+## Output Shape
+
+The JSON file includes:
+
+```text
+schemaVersion
+generatedAt
+repository
+sources
+summary
+requestTelemetry
+findings
+runs
+sourceErrors
+```
+
+Important finding types:
+
+```text
+job_failure
+step_failure
+artifact_available
+```
+
+The `runs` section preserves workflow name, run ID, branch, head SHA, jobs, failed steps, and artifacts.
+
+## Safety Notes
+
+- The exporter does not mutate GitHub state.
+- It does not download artifact contents.
+- `--include-logs` stores excerpts only for failed jobs and truncates each excerpt.
+- Treat generated JSON as internal diagnostic evidence because workflow logs may contain operational context.

--- a/docs/discord-control-bot/admin-guide.md
+++ b/docs/discord-control-bot/admin-guide.md
@@ -1,0 +1,119 @@
+# Dune Discord Companion Bot - Admin Guide
+
+## Purpose
+
+This guide is for server owners and administrators configuring the experimental read-only Discord companion bot.
+
+The bot is not the authority. Dune Docker Console remains responsible for final authorization, safety checks, redaction, audit logging, and execution.
+
+## No Write Actions
+
+The experimental bot has no write-capable command surface.
+
+The bot cannot:
+
+- Mount or use the Docker socket.
+- Write directly to Postgres.
+- Run database mutations.
+- Create, restore, import, or delete backups.
+- Grant items, teleport, kick, refill, or mutate players.
+- Mutate map state, sietch state, or Deep Desert state.
+- Enable, disable, install, or remove addons.
+- Send broadcasts.
+- Store runtime secrets in source control, addon files, static files, logs, or image layers.
+
+## Role Mapping
+
+Configure Discord role IDs in both the Console adapter runtime and the bot runtime.
+
+| Tier | Environment variable | Intended access |
+|---|---|---|
+| Observer | `DISCORD_OBSERVER_ROLE_IDS` | Readiness and services |
+| Moderator | `DISCORD_MODERATOR_ROLE_IDS` | Future population, map state, backup metadata |
+| Admin | `DISCORD_ADMIN_ROLE_IDS` | Detailed Status and future redacted logs |
+| Owner | `DISCORD_OWNER_ROLE_IDS` | Same read-only access as admin in the experimental phase |
+
+For local smoke tests, placeholder values are acceptable as long as both processes use the same values.
+
+Example:
+
+```bash
+DISCORD_OBSERVER_ROLE_IDS=role-observer
+DISCORD_ADMIN_ROLE_IDS=role-admin
+DISCORD_OWNER_ROLE_IDS=role-owner
+```
+
+For production Discord use, replace those placeholders with real Discord role IDs.
+
+## Current Commands
+
+| Command | Minimum role | Notes |
+|---|---:|---|
+| `/dune health` | Public | Shows adapter health and configured role-policy booleans. |
+| `/dune status` | Public | Public redacted status output. |
+| `/dune status detail` | Admin | Detailed Status output. Ephemeral by default. |
+| `/dune readiness` | Observer | Readiness summary. |
+| `/dune services` | Observer | Friendly service summary. |
+
+## Public Status
+
+Public status is intentionally concise. It excludes internal addresses, SSH hosts, database URLs, host paths, raw environment values, tokens, and sensitive topology.
+
+## Detailed Status
+
+Detailed Status is for admin/owner use only.
+
+It may include more operational context such as parsed services, listeners, maps, issues, and capped redacted command output. It remains redacted and should be ephemeral in Discord.
+
+## Health and Role-Policy Verification
+
+Use health to confirm the Console adapter has role mapping loaded:
+
+```bash
+curl -i \
+  -H 'Authorization: Bearer local-dev-bot-api' \
+  http://127.0.0.1:8088/api/integrations/discord/health
+```
+
+Expected role policy shape:
+
+```json
+{
+  "rolePolicy": {
+    "observerConfigured": true,
+    "moderatorConfigured": false,
+    "adminConfigured": true,
+    "ownerConfigured": true
+  }
+}
+```
+
+The values only indicate whether a tier is configured. Role IDs are not exposed.
+
+## Common Admin Issue: 403 Authorization
+
+If readiness, services, or detailed status returns `403`, check both sides:
+
+1. The bot process must send the expected role ID in `actor.roleIds`.
+2. The Console adapter process must be started with the matching `DISCORD_*_ROLE_IDS` value.
+
+The smoke runner prints:
+
+```text
+actorRoleIdsSent
+consoleRolePolicy
+```
+
+Use those fields to identify a mismatch.
+
+## SOC 2 Readiness
+
+Admins should treat this bot as a privileged operational visibility plane even though it is read-only.
+
+Required recurring checks:
+
+- Review role mappings monthly and before release.
+- Review SOC 2 readiness workflow results weekly.
+- Confirm secret scans remain passing.
+- Confirm public responses do not expose internal topology.
+- Document any exception with owner, risk, mitigation, and expiration.

--- a/docs/discord-control-bot/adr/0001-experimental-read-only-companion-bot.md
+++ b/docs/discord-control-bot/adr/0001-experimental-read-only-companion-bot.md
@@ -1,0 +1,109 @@
+# ADR-0001: Experimental Read-Only Discord Companion Bot
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-17
+
+## Context
+
+The Discord bot was initially discussed as a potential full-parity operator interface for Dune Docker Console. That approach creates a large security surface because it would expose high-impact operational controls through Discord.
+
+The safer path is to start with an experimental companion bot that is read-only. This gives operators useful visibility while preserving the Console as the authority for authorization and safety checks.
+
+## Decision
+
+Build the Discord bot as an experimental read-only companion first.
+
+The first release will focus on:
+
+1. Server status.
+2. Readiness.
+3. Services.
+4. Population.
+5. Logs.
+6. Map state.
+7. Backup list/latest metadata.
+
+The bot must call a protected Dune Console API adapter. It must not bypass the Console backend.
+
+## Non-Negotiable Constraints
+
+1. The bot must not mount the Docker socket.
+2. The bot must not write directly to Postgres.
+3. The bot must not directly access Postgres for destructive actions.
+4. The bot must not store secrets in addon files, static files, source control, logs, or container layers.
+5. The bot must not execute destructive actions.
+6. The Console must remain responsible for final authorization and safety checks.
+7. Logs must be capped, redacted, and role-gated.
+8. Public responses must not expose internal topology, raw environment values, secrets, DB URLs, host paths, or stack traces.
+
+## Security Considerations
+
+The read-only approach reduces initial risk but does not remove risk entirely. Logs, population, backup metadata, and map state may still expose operationally sensitive data if mishandled.
+
+Required controls:
+
+- Dedicated Dune bot API token.
+- Discord actor context on every request.
+- Server-side capability checks.
+- Public/admin response classification.
+- Redaction layer for all output and errors.
+- Audit events for all adapter requests, especially logs and diagnostics.
+- Rate limits.
+- DAST tests proving no write/destructive routes are exposed.
+
+## SOC 2 Control Impact
+
+Relevant controls:
+
+```text
+DC-SOC2-SEC-001
+DC-SOC2-SEC-002
+DC-SOC2-SEC-004
+DC-SOC2-SEC-005
+DC-SOC2-SEC-006
+DC-SOC2-SEC-007
+DC-SOC2-SEC-008
+DC-SOC2-SEC-009
+DC-SOC2-C-001
+DC-SOC2-C-002
+DC-SOC2-C-003
+DC-SOC2-PI-001
+DC-SOC2-P-001
+```
+
+## Consequences
+
+### Positive
+
+- Lower initial security risk.
+- Faster path to useful operator visibility.
+- Clearer testing and DAST scope.
+- Avoids Discord-originated destructive actions.
+- Keeps Dune Docker Console as the trusted backend authority.
+
+### Negative / Tradeoffs
+
+- Does not provide full WebUI parity in the initial release.
+- Operators must still use the WebUI for all write/admin workflows.
+- Some users may expect player or backup actions from Discord; these remain intentionally unavailable.
+
+## Alternatives Considered
+
+| Alternative | Reason Rejected |
+| --- | --- |
+| Full WebUI parity bot from day one | Too broad and high-risk for initial implementation. |
+| Bot with direct Docker/Postgres access | Violates least privilege and creates major audit/security risk. |
+| Static addon-only implementation | Current addon model is UI-only and cannot run a long-lived Discord bot daemon. |
+
+## Evidence
+
+- `docs/discord-control-bot/feature-priority.md`
+- `docs/discord-control-bot/roadmap.md`
+- `docs/discord-control-bot/api-adapter-contract.md`
+- `docs/discord-control-bot/security-gates.md`
+- `docs/discord-control-bot/soc2-control-matrix.md`

--- a/docs/discord-control-bot/api-adapter-contract.md
+++ b/docs/discord-control-bot/api-adapter-contract.md
@@ -1,0 +1,245 @@
+# Dune Console Discord API Adapter Contract
+
+## Purpose
+
+The Discord API Adapter is the protected server-side boundary between the experimental Discord companion bot and Dune Docker Console.
+
+The initial adapter scope is read-only:
+
+- Server status.
+- Readiness.
+- Services.
+- Population.
+- Logs.
+- Map state.
+- Backup list/latest metadata.
+
+The bot must not call broad WebUI routes directly. It must call adapter routes that understand Discord actor context and enforce capability policy server-side.
+
+## Design Requirements
+
+1. The bot authenticates with a dedicated Dune bot API token, not the WebUI admin password.
+2. Every request includes Discord actor context.
+3. Every route enforces server-side capability authorization.
+4. Public-safe responses must not expose internal IPs, SSH hosts, DB URLs, tokens, raw `.env`, stack traces, host paths, or backup filesystem paths.
+5. The initial adapter exposes read-only routes only.
+6. No destructive, write, credential, Docker lifecycle, database mutation, backup mutation, player mutation, addon mutation, or map mutation routes are in scope.
+7. The adapter reuses existing Dune Console backend functions rather than duplicating privileged logic inside the bot.
+
+## Explicitly Forbidden in Experimental Scope
+
+1. Docker socket access from the bot.
+2. Direct Postgres access from the bot.
+3. Direct Postgres writes from any bot flow.
+4. Backup create, restore, delete, import, or delete-all.
+5. Player grants, kicks, teleport, refills, resets, or inventory mutation.
+6. Broadcasts and shutdown broadcasts.
+7. Map, sietch, or deep desert mutations.
+8. Addon install, enable, disable, or remove.
+9. Secret-setting workflows.
+10. Any destructive action.
+
+## Authentication
+
+### Header
+
+```http
+Authorization: Bearer <dune-bot-api-token>
+```
+
+The token must be loaded by the bot from `DUNE_BOT_API_TOKEN_FILE` and validated server-side by the adapter.
+
+### Rejected Patterns
+
+- WebUI admin password as bot token.
+- Discord bot token as Dune API token.
+- Browser session cookie as bot auth.
+- Query-string token.
+
+## Required Actor Context
+
+Every bot request must include a Discord actor context object.
+
+```json
+{
+  "actor": {
+    "guildId": "123456789",
+    "channelId": "234567890",
+    "userId": "345678901",
+    "username": "admin-user",
+    "roleIds": ["456789012"],
+    "interactionId": "567890123",
+    "commandName": "/dune status"
+  }
+}
+```
+
+## Role Tiers
+
+| Tier | Intended Use |
+| --- | --- |
+| public | Basic non-sensitive status only. |
+| observer | Low-risk status/readiness visibility. |
+| moderator | Population, map state, backup metadata, and limited operational visibility. |
+| admin | Logs and diagnostic read-only visibility. |
+| owner | Reserved for future review; no owner-only write routes in experimental scope. |
+
+## Experimental Capability Model
+
+| Capability | Description | Minimum Tier |
+| --- | --- | --- |
+| `status:read` | Basic health/status visibility | public |
+| `readiness:read` | Readiness checks | observer |
+| `services:read` | Service list/status | observer |
+| `population:read` | Population summary and online count | moderator |
+| `logs:read` | Capped, redacted service logs | admin |
+| `maps:read` | Map, sietch, and deep desert read-only status | moderator |
+| `backups:read` | Backup list/latest metadata | moderator |
+
+## Response Classification
+
+| Class | Description | Allowed Fields |
+| --- | --- | --- |
+| public | Safe in public Discord channels. | High-level status, no internal topology. |
+| moderator | Safe for moderator/admin channels. | Population and operational metadata with sensitive values removed. |
+| admin | Safe only in admin channels or ephemeral admin responses. | Capped logs and diagnostics, always redacted. |
+
+## Initial Adapter Routes
+
+### `GET /api/integrations/discord/health`
+
+Purpose: bot connectivity check.
+
+Capability: `status:read`.
+
+Response:
+
+```json
+{
+  "ok": true,
+  "service": "dune-console-discord-adapter",
+  "experimental": true,
+  "readOnly": true
+}
+```
+
+### `POST /api/integrations/discord/status`
+
+Purpose: sanitized stack status for Discord.
+
+Capability: `status:read`.
+
+### `POST /api/integrations/discord/readiness`
+
+Purpose: readiness checks.
+
+Capability: `readiness:read`.
+
+### `POST /api/integrations/discord/services`
+
+Purpose: service list and service status summary.
+
+Capability: `services:read`.
+
+Requirement: service names must come from an allowlist or backend-safe source.
+
+### `POST /api/integrations/discord/population`
+
+Purpose: population summary and online player count.
+
+Capability: `population:read`.
+
+Requirement: public output should be count-only unless detailed output is explicitly role-gated.
+
+### `POST /api/integrations/discord/logs`
+
+Purpose: capped, redacted service logs.
+
+Capability: `logs:read`.
+
+Requirements:
+
+1. Service name validation.
+2. Line limit.
+3. Redaction.
+4. Admin-channel or ephemeral response recommended.
+5. No raw `.env`, tokens, DB URLs, host paths, or stack traces.
+
+### `POST /api/integrations/discord/map-state`
+
+Purpose: map, sietch, and deep desert read-only state.
+
+Capability: `maps:read`.
+
+### `POST /api/integrations/discord/backups/list`
+
+Purpose: backup list/latest metadata.
+
+Capability: `backups:read`.
+
+Requirements:
+
+1. No backup create/restore/delete/import/delete-all.
+2. No raw filesystem paths in public responses.
+3. Output capped and paginated.
+
+## Audit Event Requirements
+
+Every adapter request should be auditable. Read-only requests may use lower-risk audit records, but logs and detailed diagnostics should always be audited.
+
+Required fields:
+
+```json
+{
+  "source": "discord",
+  "discordGuildId": "...",
+  "discordChannelId": "...",
+  "discordUserId": "...",
+  "discordUsername": "...",
+  "command": "/dune logs",
+  "action": "logs.read",
+  "capability": "logs:read",
+  "risk": "low|medium",
+  "targetType": "service|server|map|backup|population",
+  "targetId": "...",
+  "result": "success|failed|blocked"
+}
+```
+
+## Error Contract
+
+Errors must be redacted and safe to display.
+
+```json
+{
+  "ok": false,
+  "error": "Not authorized for logs:read.",
+  "code": "not_authorized"
+}
+```
+
+Forbidden in errors:
+
+- Raw stack traces.
+- Raw SQL errors containing secrets.
+- Raw environment variables.
+- Discord or Dune tokens.
+- Internal DB URLs.
+- Funcom token values.
+- Internal IPs or SSH hosts.
+- Raw host paths.
+
+## DAST Requirements
+
+The adapter must have runtime tests for:
+
+1. Missing token rejected.
+2. Invalid token rejected.
+3. Missing actor rejected.
+4. Unauthorized role rejected.
+5. Public status sanitizes internal topology.
+6. Diagnostic/log output requires admin capability.
+7. Logs are capped and redacted.
+8. Backup routes are metadata-only.
+9. No write/destructive adapter routes are exposed.
+10. Secret-like values are redacted from errors and audit details.

--- a/docs/discord-control-bot/development-standards.md
+++ b/docs/discord-control-bot/development-standards.md
@@ -1,0 +1,216 @@
+# Dune Discord Control Bot - Development Standards
+
+## Purpose
+
+This document defines the engineering standards for the Discord Control Bot and its Dune Console API adapter. The upstreamable scope is a read-only Discord companion that provides safe operational visibility. Full WebUI parity, moderator write commands, evidence automation, and compliance artifact generation remain separate fork-local or future work unless explicitly approved upstream.
+
+## Core Engineering Standards
+
+1. Keep Discord client logic separate from Dune Console API adapter logic.
+2. Do not duplicate privileged WebUI backend logic inside the bot.
+3. Do not add Discord write/mutation commands in the read-only release.
+4. Prefer allowlists over denylists for service names, command names, file paths, and action types.
+5. Use structured logging with redaction.
+6. Treat all Discord inputs as untrusted.
+7. Test authorization behavior before feature completeness.
+8. Require PR review before merge.
+9. Update setup, usage, and role-matrix documentation when behavior changes.
+10. Keep generated artifacts, runtime state, passwords, tokens, and evidence bundles out of upstream PRs.
+
+## Architecture Standards
+
+### Required Separation of Concerns
+
+| Layer | Responsibility | Must Not Do |
+| --- | --- | --- |
+| Discord Bot Client | Discord connection, slash commands, interaction UX, formatting | Final authorization, direct Docker control, direct destructive DB writes |
+| Dune Console Discord API Adapter | Bot auth, server-side authorization, audit, safe read-only routing | Expose broad unauthenticated WebUI APIs |
+| Existing Console Backend | Reuse WebUI read paths and safety behavior | Trust Discord client-only checks |
+| Dune Stack | Existing Docker/Postgres/RabbitMQ/game services | Accept direct unreviewed bot mutations |
+
+## Secure Coding Standards
+
+### Input Validation
+
+All input from Discord, HTTP requests, environment variables, files, and database queries must be validated before use.
+
+Required patterns:
+
+- Validate command names against allowlists.
+- Validate role IDs and channel IDs as strings, never as trusted authorization claims.
+- Validate service names against known service allowlists.
+- Validate file paths with safe relative path helpers where file reads are required.
+- Validate numeric ranges for ports, limits, counts, and timeouts.
+
+### Output Handling
+
+1. Redact secrets before logging or sending responses.
+2. Public Discord responses must not include internal IPs, SSH hosts, DB URLs, tokens, raw `.env` values, or stack traces.
+3. Admin diagnostic output must require admin/owner capability.
+4. Large responses must be paginated or summarized.
+5. Errors must use safe messages.
+6. Discord responses must set `allowed_mentions: { parse: [] }` unless a future feature explicitly needs mentions and has a separate review.
+
+### Command Execution
+
+1. The bot must not use `child_process.exec` for Discord-originated actions.
+2. The bot must not spawn shell commands for admin actions.
+3. Backend execution must use existing Console backend wrappers.
+4. If process execution is required in backend code, use fixed command paths and argument arrays; avoid shell interpolation.
+
+### Database Access
+
+1. The bot must not connect directly to Postgres.
+2. The read-only release must not add database write behavior.
+3. Any future database write feature must be separately approved, owner-only, typed-confirmed, audited, rate-limited, and backed up first where supported.
+4. Do not concatenate user input into SQL statements.
+
+### Secrets
+
+1. Use file-based runtime secrets: `*_TOKEN_FILE`, `*_PASSWORD_FILE` where possible.
+2. Do not commit `.env` files containing secrets.
+3. Do not store the Discord bot token in addon files, static WebUI addon files, source files, tests, docs, logs, or container layers.
+4. Do not echo secrets in Discord.
+5. Do not log request bodies that may contain secrets.
+6. Do not upstream generated runtime state, local evidence bundles, vulnerability artifacts, passwords, tokens, or session secrets.
+
+## Branching and Pull Request Standards
+
+### Branch Naming
+
+Use descriptive branches:
+
+```text
+feature/discord-control-bot
+feature/discord-api-adapter
+security/discord-authz-gates
+fix/discord-redaction-leak
+```
+
+### Pull Request Requirements
+
+Every upstream PR must include:
+
+1. Purpose summary.
+2. Risk classification.
+3. Test evidence.
+4. Security impact statement.
+5. Rollback plan.
+6. Screenshots/log snippets if user-facing behavior changes.
+7. Updated docs if behavior or controls change.
+8. Confirmation that no generated runtime files, artifacts, passwords, or secrets are included.
+
+Privileged future-feature PRs must also include:
+
+1. Threat model update.
+2. Authorization matrix update.
+3. Confirmation matrix update.
+4. Audit event mapping.
+5. DAST test cases.
+6. Explicit owner approval.
+
+## Definition of Done
+
+A feature is not done until all applicable items are complete:
+
+```text
+[ ] Code is reviewed.
+[ ] Unit tests pass.
+[ ] Authorization tests pass.
+[ ] Redaction tests pass.
+[ ] Secret scan passes.
+[ ] Container checks pass if container files changed.
+[ ] Documentation is updated.
+[ ] Rollback path is documented.
+[ ] Upstream diff excludes generated artifacts, runtime state, passwords, tokens, and local evidence bundles.
+```
+
+## Testing Standards
+
+### Required Test Layers
+
+| Test Type | Required For |
+| --- | --- |
+| Unit tests | All modules |
+| Authorization matrix tests | Every command and API route |
+| Redaction tests | All logging and response formatting |
+| Integration tests | API adapter and bot client interaction |
+| Container tests | Dockerfile and Compose changes |
+| Regression tests | Every fixed security issue |
+
+### Test Naming
+
+Tests should describe policy intent:
+
+```text
+redacts postgres connection string in error output
+rejects unmapped observer command
+blocks write-capable Discord command registration
+blocks Docker socket mount in bot compose
+```
+
+## Logging Standards
+
+Use structured logs. Required fields where applicable:
+
+```json
+{
+  "service": "dune-discord-companion-bot",
+  "event": "command.received",
+  "discordGuildId": "...",
+  "discordChannelId": "...",
+  "discordUserId": "...",
+  "command": "/dune status",
+  "result": "success|failed|blocked"
+}
+```
+
+Forbidden in logs:
+
+- Discord bot token.
+- Dune bot API token.
+- Admin password.
+- Database password.
+- Funcom token.
+- Full database URL.
+- Raw `.env` file content.
+- Full request body for secret-bearing routes.
+
+## Audit Standards
+
+Every Discord-originated adapter request should emit an audit event with:
+
+1. Source: `discord`.
+2. Discord actor context.
+3. Command and normalized action.
+4. Target object, if any.
+5. Risk level.
+6. Authorization decision.
+7. Result.
+8. Error reason if blocked or failed.
+
+## Release Standards
+
+A release candidate requires:
+
+1. Passing tests.
+2. Passing secret scan.
+3. Passing container checks if container files changed.
+4. Release notes.
+5. Rollback instructions.
+6. No open critical/high security findings unless exception is approved and time-bound.
+
+## Exception Handling
+
+Security exceptions must include:
+
+1. Finding ID.
+2. Affected component.
+3. Risk rating.
+4. Reason for exception.
+5. Compensating controls.
+6. Owner.
+7. Expiration date.
+8. Review cadence.
+
+Permanent exceptions are not allowed for critical or high-risk findings.

--- a/docs/discord-control-bot/feature-priority.md
+++ b/docs/discord-control-bot/feature-priority.md
@@ -1,0 +1,100 @@
+# Dune Discord Companion Bot - Feature Priority Plan
+
+## Product Goal
+
+Build an experimental Discord companion bot for Dune Docker Console that starts read-only and provides safe operational visibility for server operators.
+
+The initial bot is not a full WebUI replacement. It is a companion interface for status, readiness, and service visibility. Dune Docker Console remains the authority for backend authorization, safety checks, redaction, audit logging, and execution.
+
+## Initial Upstream Scope
+
+| Domain | Initial Commands / Functions | Risk |
+| --- | --- | --- |
+| Status | `/dune status public`, `/dune status detail`, `/dune health`, `/dune version` | Low/Medium due diagnostic split |
+| Readiness | `/dune readiness` | Low |
+| Services | `/dune services` | Low/Medium |
+| Help | `/dune help` | Low |
+| Setup helpers | OAuth install URL, guild/channel/role discovery, channel permission helper | Medium due Discord permission changes |
+
+## Out of Scope for the Experimental Upstream Bot
+
+The following are explicitly out of scope until the read-only bot is stable, reviewed, and separately approved:
+
+1. Docker socket mounting.
+2. Direct database access from the bot process.
+3. Backup create, restore, delete, or delete-all.
+4. Player grants, teleport, kick, refill, reset progression, or inventory mutation.
+5. Broadcasts and shutdown broadcasts.
+6. Map, sietch, or deep desert mutation.
+7. Addon install, enable, disable, or remove.
+8. Credential-setting workflows.
+9. Any destructive action.
+10. Fork-local evidence automation, generated scan outputs, and local runtime state.
+
+## Priority Model
+
+| Priority | Meaning |
+| --- | --- |
+| P0 | Foundational security, protected Console API contract, redaction, and authorization tests. |
+| P1 | Experimental read-only companion bot: status, health, readiness, and services. |
+| P2 | Operational hardening: pagination, redaction tuning, rate limits, audit review, role/channel mapping UI, alerting. |
+| P3 | Separately approved non-destructive admin conveniences, if any, after a security review. |
+| P4 | Future platform evolution. Full WebUI parity remains a long-term option, not the current delivery target. |
+
+## P0 - Security Foundation and Delivery Gates
+
+These must be implemented before connecting the bot to Discord or exposing adapter routes.
+
+1. Dedicated branch and isolated bot workspace.
+2. Secure configuration contract for Discord and Console credentials.
+3. Redaction library for sensitive output, connection strings, host paths, and sensitive headers.
+4. Discord actor context model: guild ID, channel ID, user ID, username, roles, command, interaction ID.
+5. Role-to-capability authorization model.
+6. Read-only capability enforcement for experimental routes.
+7. Audit event schema for Discord-originated adapter requests.
+8. Rate-limit and idempotency design for slash commands.
+9. Architecture documentation that prohibits Docker socket access and direct database writes from the bot.
+10. Setup helpers that avoid manual ID hunting.
+
+## P1 - Experimental Read-Only Bot
+
+The first working bot release should expose only read-only commands.
+
+| Domain | Commands / Functions | Required Control |
+| --- | --- | --- |
+| Health | `/dune health`, `/dune version` | Public-safe sanitized output |
+| Status | `/dune status public`, `/dune status detail` | Public/admin response split |
+| Readiness | `/dune readiness` | Observer capability |
+| Services | `/dune services` | Observer capability, no raw Docker access |
+| Setup | `discord:invite`, `discord:discover`, `discord:channel` | Local operator execution only; no credential output |
+
+## P2 - Operational Hardening
+
+1. Public/admin channel classification.
+2. Response pagination and message-size enforcement.
+3. Per-command rate limits.
+4. Audit review command or export.
+5. Bot heartbeat and health dashboard.
+6. Role/channel mapping management in WebUI.
+7. Alerting for status changes, backup failures, and readiness degradation.
+8. Emergency disable flag for all Discord-originated calls.
+
+## P3 - Separately Approved Non-Destructive Enhancements
+
+These require explicit approval and updated threat modeling:
+
+1. Scheduled status posts.
+2. Maintenance notice posts to Discord only, not in-game broadcast.
+3. Owner-only diagnostic bundles with strict redaction.
+
+## Non-Negotiable Security Requirements
+
+1. The bot container must not mount `/var/run/docker.sock`.
+2. The bot must not execute destructive actions.
+3. The bot must not directly write to the database.
+4. The bot must not store credentials in addon files, browser-delivered files, source control, logs, or container layers.
+5. Backend authorization must be enforced server-side, not only in the Discord client.
+6. The Console API must remain responsible for final authorization and safety checks.
+7. Public Discord responses must not expose internal IPs, SSH targets, database URLs, raw environment files, stack traces, or host paths.
+8. Logs must be capped, redacted, and role-gated if log visibility is added later.
+9. Generated artifacts and local runtime state must not be included in upstream PRs.

--- a/docs/discord-control-bot/issue-tracking-policy.md
+++ b/docs/discord-control-bot/issue-tracking-policy.md
@@ -1,0 +1,98 @@
+# Dune Discord Companion Bot - Issue Tracking Policy
+
+## Purpose
+
+This policy defines how repository issues support SOC 2 readiness evidence for the experimental read-only Discord companion bot and Console adapter.
+
+Issue tracking is not itself a SOC 2 certification requirement. SOC 2 readiness does require evidence that changes, vulnerabilities, threats, exceptions, access reviews, and incidents are identified, owned, reviewed, remediated, and traceable. Repository issues provide that evidence trail.
+
+## Issue Types
+
+| Issue type | Template | SOC 2 readiness purpose |
+|---|---|---|
+| Bug | `.github/ISSUE_TEMPLATE/bug-report.yml` | Defect tracking, remediation evidence, regression evidence |
+| Feature request | `.github/ISSUE_TEMPLATE/feature-request.yml` | Change-management evidence and security impact review |
+| Vulnerability remediation | `.github/ISSUE_TEMPLATE/vulnerability-remediation.yml` | Vulnerability management and CVSS remediation tracking |
+| STRIDE threat remediation | `.github/ISSUE_TEMPLATE/threat-remediation.yml` | Threat-model remediation and risk treatment tracking |
+| Security exception | `.github/ISSUE_TEMPLATE/security-exception.yml` | Time-bound risk acceptance and compensating controls |
+| SOC 2 evidence gap | `.github/ISSUE_TEMPLATE/soc2-evidence-gap.yml` | Missing/stale evidence remediation |
+| Access review | `.github/ISSUE_TEMPLATE/access-review.yml` | Monthly and release-candidate access review evidence |
+
+## Minimum Fields
+
+Every security, SOC 2, vulnerability, threat, or exception issue must include:
+
+- Owner.
+- Severity or risk impact.
+- Target due date or expiration date.
+- Remediation plan.
+- Evidence links.
+- Closure criteria.
+
+## Public Issue Hygiene
+
+Do not place the following in public issues:
+
+- Secrets or tokens.
+- Raw `.env` content.
+- Database URLs.
+- Private keys.
+- Sensitive private IP/topology details.
+- Exploit details that materially increase risk.
+- Player personal data.
+
+Use GitHub Security Advisories for sensitive security disclosures.
+
+## Required Tracking Cadence
+
+| Activity | Cadence | Issue requirement |
+|---|---:|---|
+| Access review | Monthly and before release candidate | Open an `Access review` issue and close it with evidence |
+| SOC 2 evidence review | Monthly and before release candidate | Open `SOC 2 evidence gap` issues for missing/stale evidence |
+| Vulnerability review | Every Trivy/Semgrep/Dependabot finding requiring action | Open or auto-sync `Vulnerability remediation` issues for non-trivial findings |
+| STRIDE threat review | Every STRIDE scan with open medium/high/critical findings | Open or auto-sync `STRIDE threat remediation` issues |
+| Security exceptions | As needed | Open `Security exception`; must include expiration and compensating controls |
+| Release readiness | Every release candidate | Link related issues in release checklist |
+
+## Automated Issue Sync
+
+The repository includes automation for recurring security finding lifecycle tracking:
+
+| Finding source | Script | Auto-created issue type | Auto-close behavior |
+|---|---|---|---|
+| Trivy/Semgrep vulnerability report | `scripts/sync-vulnerability-issues.mjs` | Vulnerability remediation | Closes resolved auto-tracked findings when they disappear from the latest report |
+| STRIDE threat model report | `scripts/sync-stride-issues.mjs` | STRIDE threat remediation | Closes resolved auto-tracked threats when they are no longer open in the latest report |
+
+Both sync scripts use stable hidden markers to prevent duplicate issues:
+
+```text
+dune-vuln-key:<hash>
+dune-stride-key:<hash>
+```
+
+## Closure Rules
+
+Issues may be closed only when one of these is true:
+
+1. Fixed and linked to a commit or PR.
+2. Risk accepted through a time-bound security exception.
+3. Duplicate of another issue.
+4. Not applicable with documented rationale.
+5. Transferred to a more appropriate tracker with a durable link.
+6. Auto-tracked finding is no longer present or no longer open in the latest scanner report.
+
+## SOC 2 Readiness Mapping
+
+| SOC 2 area | Issue evidence |
+|---|---|
+| Change management | Feature/bug issues linked to PRs and tests |
+| Risk assessment | Severity, impact, threat category, and exception fields |
+| Vulnerability management | CVSS, scanner source, fix version, remediation issue |
+| Threat management | STRIDE category, asset, trust boundary, mitigation, and closure evidence |
+| Access control | Access review issue evidence |
+| Monitoring | Scheduled readiness and scanner workflow issues/findings |
+| Incident response | Security issue or advisory plus follow-up remediation issues |
+
+## Current Project Scope
+
+The Discord companion bot remains read-only. Any issue proposing write, destructive, database mutation, player mutation, map mutation, addon mutation, credential, or Docker/service lifecycle behavior must be labeled for future review and must not be implemented without separate approval, threat model update, DAST cases, audit policy, and rollback plan.

--- a/docs/discord-control-bot/local-health-status-test.md
+++ b/docs/discord-control-bot/local-health-status-test.md
@@ -1,0 +1,166 @@
+# Local Test: Discord Adapter and Bot Command Smoke
+
+## Purpose
+
+Validate the experimental read-only Discord adapter and the bot command layer without connecting to Discord.
+
+The adapter is disabled by default and requires a dedicated Dune bot API token.
+
+## Create Local Bot API Token
+
+Use a local development value only. Keep it outside `runtime/secrets` when that directory is root-owned.
+
+```bash
+mkdir -p "$HOME/.config/dune-console"
+printf '%s\n' 'local-dev-bot-api' > "$HOME/.config/dune-console/dune-bot-api-token.txt"
+chmod 600 "$HOME/.config/dune-console/dune-bot-api-token.txt"
+```
+
+## Start API with Adapter Enabled
+
+From `console/api`:
+
+```bash
+DUNE_DOCKER_DIR="$HOME/dune-awakening-selfhost-docker-WSL" \
+DUNE_BOT_API_TOKEN_FILE="$HOME/.config/dune-console/dune-bot-api-token.txt" \
+npm run start:discord-adapter
+```
+
+This wrapper enables the adapter and applies the small server hook automatically. You do not need to hand-edit `src/server.js`.
+
+If runtime secrets are root-owned, run the same command through `sudo env` while preserving the two path variables.
+
+## Test Health
+
+```bash
+curl -i \
+  -H 'Authorization: Bearer local-dev-bot-api' \
+  http://127.0.0.1:8088/api/integrations/discord/health
+```
+
+Expected:
+
+```json
+{
+  "ok": true,
+  "service": "dune-console-discord-adapter",
+  "experimental": true,
+  "readOnly": true,
+  "writesEnabled": false,
+  "liveRoutes": [
+    "/api/integrations/discord/health",
+    "/api/integrations/discord/status",
+    "/api/integrations/discord/readiness",
+    "/api/integrations/discord/services"
+  ]
+}
+```
+
+## Test Public Redacted Status
+
+```bash
+curl -i \
+  -H 'Authorization: Bearer local-dev-bot-api' \
+  -H 'Content-Type: application/json' \
+  -d '{"actor":{"guildId":"local","channelId":"local","userId":"local","username":"local","roleIds":[],"commandName":"/dune status"},"diagnostic":false}' \
+  http://127.0.0.1:8088/api/integrations/discord/status
+```
+
+Expected:
+
+- `200 OK`.
+- `ok: true`.
+- Concise status summary only.
+- No raw container names.
+- No raw listener ports.
+- No connection strings.
+- No host paths.
+- No secret material.
+
+## Test Detailed Redacted Status
+
+Diagnostic status requires an admin/owner Discord role.
+
+```bash
+curl -i \
+  -H 'Authorization: Bearer local-dev-bot-api' \
+  -H 'Content-Type: application/json' \
+  -d '{"actor":{"guildId":"local","channelId":"local","userId":"local","username":"local-admin","roleIds":["role-admin"],"commandName":"/dune status detail"},"diagnostic":true}' \
+  http://127.0.0.1:8088/api/integrations/discord/status
+```
+
+Expected:
+
+- `200 OK`.
+- Detailed but redacted status.
+- Includes a capped `redactedOutput` field.
+- No secrets or raw connection strings.
+
+## Test Readiness and Services
+
+Observer role or higher is required.
+
+```bash
+curl -i \
+  -H 'Authorization: Bearer local-dev-bot-api' \
+  -H 'Content-Type: application/json' \
+  -d '{"actor":{"guildId":"local","channelId":"local","userId":"local","username":"local-observer","roleIds":["role-observer"],"commandName":"/dune readiness"}}' \
+  http://127.0.0.1:8088/api/integrations/discord/readiness
+```
+
+```bash
+curl -i \
+  -H 'Authorization: Bearer local-dev-bot-api' \
+  -H 'Content-Type: application/json' \
+  -d '{"actor":{"guildId":"local","channelId":"local","userId":"local","username":"local-observer","roleIds":["role-observer"],"commandName":"/dune services"}}' \
+  http://127.0.0.1:8088/api/integrations/discord/services
+```
+
+## Bot Command Smoke
+
+From `discord-bot`:
+
+```bash
+export DUNE_CONSOLE_API_URL=http://127.0.0.1:8088
+export DUNE_BOT_API_TOKEN_FILE="$HOME/.config/dune-console/dune-bot-api-token.txt"
+export DISCORD_GUILD_ID=local-guild
+export DISCORD_OBSERVER_ROLE_IDS=role-observer
+export DISCORD_ADMIN_ROLE_IDS=role-admin
+export DISCORD_OWNER_ROLE_IDS=role-owner
+
+npm run smoke:health
+npm run smoke:status
+npm run smoke:readiness
+npm run smoke:services
+npm run smoke:status-detail
+```
+
+## Negative Tests
+
+Invalid adapter credential:
+
+```bash
+curl -i -H 'Authorization: Bearer wrong' http://127.0.0.1:8088/api/integrations/discord/health
+```
+
+Expected: `401` with `invalid_bot_token`.
+
+Missing adapter credential:
+
+```bash
+curl -i http://127.0.0.1:8088/api/integrations/discord/health
+```
+
+Expected: `401` with `missing_bot_token`.
+
+Public actor attempting detailed status:
+
+```bash
+curl -i \
+  -H 'Authorization: Bearer local-dev-bot-api' \
+  -H 'Content-Type: application/json' \
+  -d '{"actor":{"guildId":"local","channelId":"local","userId":"local","username":"local","roleIds":[],"commandName":"/dune status detail"},"diagnostic":true}' \
+  http://127.0.0.1:8088/api/integrations/discord/status
+```
+
+Expected: `403` with an authorization error.

--- a/docs/discord-control-bot/project-status.md
+++ b/docs/discord-control-bot/project-status.md
@@ -1,0 +1,131 @@
+# Dune Discord Companion Bot - Project Status
+
+## Current Status
+
+The Discord companion bot is in an experimental read-only integration phase.
+
+The current implementation includes a dependency-free Discord runtime, guild slash-command registration, Gateway interaction handling, and protected Console adapter calls without enabling any write, destructive, database mutation, Docker control, or addon mutation behavior.
+
+## Completed
+
+| Area | Status | Evidence |
+|---|---|---|
+| Isolated bot workspace | Complete | `discord-bot/` |
+| Protected Console adapter scaffold | Complete | `console/api/src/integrations/discord/` |
+| Bot API token auth | Complete | Adapter route tests |
+| Discord actor authorization | Complete | Policy and route tests |
+| Discord runtime client | Complete | `discord-bot/scripts/discord-runtime.mjs` |
+| Guild slash-command registration | Complete | `discord-bot/scripts/discord-runtime.mjs` |
+| Interaction handler | Complete | `discord-bot/scripts/discord-runtime.mjs` |
+| Public redacted status | Complete | Status provider tests |
+| Detailed redacted status | Complete | Admin-only diagnostic tests |
+| Readiness route | Complete | Adapter and provider tests |
+| Services route | Complete | Adapter and provider tests |
+| Bot command smoke runner | Complete | `discord-bot/scripts/command-smoke.mjs` |
+| No-write bot capability model | Complete | `discord-bot/src/security/authorization.ts` |
+| Secret scanning | Complete | `discord-bot/scripts/check-secrets.mjs` |
+| Semgrep SAST workflow | Complete | `.github/workflows/semgrep-sast.yml` |
+| Trivy vulnerability workflow | Complete | `.github/workflows/trivy-vulnerability-scan.yml` |
+| CVSS vulnerability report generator | Complete | `scripts/generate-vulnerability-report.mjs` |
+| Repository-local STRIDE scanner | Complete | `scripts/generate-stride-report.mjs` |
+| Repository-local SBOM generator | Complete | `scripts/generate-sbom.mjs` |
+| SOC 2 readiness matrix | Complete | `docs/discord-control-bot/soc2-control-matrix.md` |
+| Scheduled SOC 2 readiness check | Complete | `.github/workflows/soc2-readiness-check.yml` |
+
+## Current Live Routes
+
+| Route | Role Requirement | Purpose | Write Capable |
+|---|---:|---|---:|
+| `GET /api/integrations/discord/health` | Bot API token | Adapter health and role-policy status | No |
+| `POST /api/integrations/discord/status` | Public for normal mode; Admin for diagnostic mode | Public redacted status or detailed redacted status | No |
+| `POST /api/integrations/discord/readiness` | Observer | Server readiness summary | No |
+| `POST /api/integrations/discord/services` | Observer | Friendly service summary | No |
+
+## Current Bot Commands
+
+| Command | Minimum Role | Output |
+|---|---:|---|
+| `/dune health` | Public | Adapter health |
+| `/dune status public` | Public | Public redacted status output |
+| `/dune status detail` | Admin | Detailed redacted diagnostic output |
+| `/dune readiness` | Observer | Readiness summary |
+| `/dune services` | Observer | Service summary |
+| `/dune help` | Public | Safe command help |
+| `/dune version` | Public | Bot version |
+
+## Validation Status
+
+Latest local validation reported:
+
+- Console Discord adapter tests: 37 passing, 0 failing.
+- Bot tests: 3 passing, 0 failing.
+- Bot secret scan: passing after runtime-assembled redaction fixtures.
+- Bot scaffold validation: passing after narrowing validation to capability literals.
+- Live HTTP checks: status, readiness, services, and detailed status returned `200 OK` with matching role policy.
+- Discord runtime syntax is checked by bot scaffold validation.
+
+New CI evidence added:
+
+- Semgrep CE SAST workflow on pull request, push, manual dispatch, and weekly schedule.
+- Trivy filesystem and Discord bot image scan workflow on pull request, push, manual dispatch, and weekly schedule.
+- CVSS-ranked vulnerability report with CVE/NVD URLs when CVE IDs are present.
+- STRIDE threat model report workflow and issue tracking.
+- SBOM generation workflow.
+
+## Roadmap
+
+### P0 - Foundation and Governance
+
+Status: mostly complete.
+
+Completed items include the isolated bot workspace, security gates, redaction tests, authorization tests, protected adapter docs, Semgrep workflow, Trivy workflow, STRIDE reporting, SBOM generation, vulnerability reporting, SOC 2 readiness matrix, scheduled readiness workflow, and setup/admin/user documentation.
+
+### P1 - Read-Only Operational Visibility
+
+Status: in progress.
+
+Completed:
+
+- Health.
+- Public redacted status.
+- Admin detailed redacted status.
+- Readiness.
+- Services.
+- Real Discord client connection.
+- Guild slash-command registration.
+- Interaction handler.
+- Safe help/version commands.
+
+Remaining:
+
+- Population summary.
+- Logs with cap/redaction/role gate.
+- Map state.
+- Backup list/latest metadata.
+- Command-level rate limits.
+
+### P2 - Operational Hardening
+
+Status: not started.
+
+Planned:
+
+- Rate limits.
+- Alerting.
+- Bot heartbeat.
+- Public/admin channel mapping.
+- Emergency disable flag.
+- Evidence retention policy.
+- Image signing for release candidates.
+
+### P3 - Future Review Gate
+
+Status: blocked by design.
+
+No write, destructive, credential, database mutation, addon mutation, player mutation, map mutation, or Docker/service lifecycle command may be added without a separate threat model, approval, DAST cases, audit policy, and rollback plan.
+
+## SOC 2 Readiness Position
+
+This project maintains SOC 2-aligned readiness evidence. It does not claim SOC 2 certification or produce a SOC 2 report. A formal SOC 2 report requires an independent CPA examination.
+
+The recurring readiness workflow checks documentation, safety markers, tests, secret scanning, Semgrep/Trivy workflow presence, vulnerability report generation logic, and scaffold validation on a weekly cadence and on relevant repository changes.

--- a/docs/discord-control-bot/roadmap.md
+++ b/docs/discord-control-bot/roadmap.md
@@ -1,0 +1,448 @@
+# Dune Discord Companion Bot - Detailed Prioritized Roadmap
+
+## Roadmap Objective
+
+Deliver an experimental Discord companion bot for Dune Docker Console that provides safe, read-only operational visibility first. The initial target is not full WebUI parity. The bot starts with server status, readiness, services, population, logs, map state, and backup list.
+
+Dune Docker Console remains the authority for backend authorization, safety checks, redaction, audit logging, and execution. The bot must call a protected Console API and must not directly control Docker, write to Postgres, store secrets in addon/static files, or execute destructive actions.
+
+## Guiding Principles
+
+1. Security gates first; functionality second.
+2. Experimental scope is read-only.
+3. Console API owns final authorization and safety checks.
+4. The bot must not mount the Docker socket.
+5. The bot must not write directly to Postgres.
+6. The bot must not execute destructive actions.
+7. The bot must not store secrets in addon files, source control, logs, or image layers.
+8. Logs must be capped, redacted, and role-gated.
+9. Public responses must not expose internal topology or secrets.
+10. SOC 2 readiness evidence must be produced as part of normal engineering work.
+
+## Milestone P0.1 - Project Foundation
+
+### Goal
+
+Create the isolated bot workspace and security-first delivery framework.
+
+### Deliverables
+
+- `discord-bot/` workspace.
+- Security-gates workflow.
+- Feature-priority document.
+- Roadmap document.
+- Development standards document.
+- SOC 2 control matrix.
+- Hardened Dockerfile scaffold.
+- Secure Compose scaffold.
+- Secret scanning script.
+- Redaction helper.
+- Authorization model.
+- Secure config contract.
+
+### Acceptance Criteria
+
+- Branch contains isolated bot workspace.
+- Bot does not connect to Discord yet.
+- Bot does not expose write commands.
+- CI blocks Docker socket references in bot assets.
+- CI blocks privileged container mode.
+- CI requires lockfile.
+- CI executes unit/security tests.
+- CI runs SCA, SAST, and container scan gates.
+- README states the bot is experimental and read-only first.
+
+### Evidence
+
+- Passing GitHub Actions run.
+- Commit diff showing workspace isolation.
+- Security-gates documentation.
+- Local command output from `npm test`, `npm run security:secrets`, and Docker build.
+
+## Milestone P0.2 - Engineering Standards and Governance
+
+### Goal
+
+Establish development practices required for secure and auditable delivery.
+
+### Deliverables
+
+- Branch strategy.
+- PR template.
+- CODEOWNERS or reviewer policy.
+- Commit and PR naming conventions.
+- Definition of Done.
+- Security review checklist.
+- Threat-model template.
+- Architecture Decision Record template.
+- Test strategy.
+- Release checklist.
+
+### Acceptance Criteria
+
+- Every bot PR includes test evidence.
+- Every adapter route PR includes authorization and audit tests.
+- Every dependency addition passes dependency review.
+- Every Docker or Compose change passes DCA checks.
+- Any proposal to add write behavior requires a separate threat model and explicit approval.
+
+### Evidence
+
+- PR template.
+- ADR template.
+- Threat-model template.
+- Security review checklist.
+
+## Milestone P0.3 - Protected Console API Adapter Contract
+
+### Goal
+
+Define the backend API contract before implementing Discord commands.
+
+### Deliverables
+
+- Experimental read-only route inventory.
+- Bot API token authentication model.
+- Discord actor context schema.
+- Role/capability policy schema.
+- Audit event schema.
+- Error/redaction response contract.
+- Public/admin response classification.
+- Explicit no-destructive-action contract.
+
+### Acceptance Criteria
+
+- No bot command calls broad WebUI endpoints directly.
+- Every adapter route is read-only.
+- Every adapter route has a capability requirement.
+- Every route has safe error handling.
+- Logs route is capped, redacted, and role-gated.
+- Backup route exposes list/latest metadata only; no create/restore/delete.
+
+### Evidence
+
+- API contract document.
+- Authorization matrix.
+- Read-only route matrix.
+- Adapter policy tests.
+- Sanitization tests.
+- Audit event tests.
+
+## Milestone P0.4 - Compliance and Evidence Automation
+
+### Goal
+
+Make evidence generation part of normal CI and release workflows.
+
+### Deliverables
+
+- CI artifact retention policy.
+- SBOM generation.
+- Dependency vulnerability report.
+- Container vulnerability report.
+- Test report output.
+- Security scan report output.
+- Release checklist artifact.
+- SOC 2 evidence index.
+
+### Acceptance Criteria
+
+- CI produces evidence for each release candidate.
+- Evidence is mapped to SOC 2 control areas.
+- Failed gates prevent merge or release.
+- Exceptions require documented owner, risk, mitigation, and expiration.
+
+### Evidence
+
+- SBOM artifact.
+- SCA report.
+- SAST report.
+- DCA report.
+- DAST report once runtime exists.
+- Test reports.
+- Release approval record.
+
+## Milestone P1.1 - Bot Client Skeleton
+
+### Goal
+
+Add Discord connection without administrative or destructive functionality.
+
+### Deliverables
+
+- `discord.js` dependency.
+- Discord client bootstrap.
+- Slash command registration framework.
+- Interaction handler.
+- Secure logger.
+- Rate-limit middleware.
+- Safe error formatter.
+- `/dune help` command.
+- `/dune version` command.
+
+### Acceptance Criteria
+
+- Bot starts with file-based secrets.
+- Bot does not log tokens.
+- Bot exposes no write commands.
+- Bot replies only with sanitized responses.
+- Bot handles Discord errors without leaking stack traces.
+
+### Evidence
+
+- Unit tests.
+- Redaction tests.
+- Secret scan output.
+- Local runtime smoke output.
+
+## Milestone P1.2 - Read-Only Status, Readiness, and Services
+
+### Goal
+
+Deliver the first useful read-only operational commands.
+
+### Deliverables
+
+- `/dune status`.
+- `/dune health`.
+- `/dune readiness`.
+- `/dune services`.
+- `/dune service status`.
+- Public/admin response split.
+- Sanitized status output.
+- Diagnostic mode for admin/owner only.
+
+### Acceptance Criteria
+
+- Public status does not expose internal IPs, SSH hosts, DB URLs, tokens, raw environment values, or host paths.
+- Admin diagnostic status requires admin/owner capability.
+- Backend adapter enforces capability checks.
+- Service names are validated against an allowlist or backend-safe source.
+- Errors are redacted.
+
+### Evidence
+
+- Unit tests.
+- Authorization matrix tests.
+- DAST auth tests once adapter runs.
+
+## Milestone P1.3 - Read-Only Population and Logs
+
+### Goal
+
+Expose useful server visibility without allowing moderation or mutation.
+
+### Deliverables
+
+- `/dune population`.
+- `/dune players online` summary.
+- `/dune logs service:<service>`.
+- Log line caps.
+- Log redaction.
+- Role-gated detailed output.
+
+### Acceptance Criteria
+
+- Player details are not posted in public channels unless explicitly configured.
+- Population summary can be public-safe.
+- Detailed player visibility requires moderator/admin/owner.
+- Logs require moderator/admin/owner.
+- Logs are capped, redacted, and never include secrets, tokens, raw `.env`, DB URLs, or internal paths.
+
+### Evidence
+
+- Unit tests.
+- Authorization tests.
+- Redaction tests.
+- Response-size tests.
+
+## Milestone P1.4 - Read-Only Map State and Backups
+
+### Goal
+
+Complete the experimental read-only companion scope.
+
+### Deliverables
+
+- `/dune map status`.
+- `/dune sietches status`.
+- `/dune deepdesert status`.
+- `/dune backups list`.
+- `/dune backups latest`.
+
+### Acceptance Criteria
+
+- Map state is read-only.
+- Backup output is metadata-only.
+- No backup create, restore, delete, import, or delete-all endpoints are exposed.
+- Backup paths are not exposed in public Discord responses.
+- Responses are capped and paginated.
+
+### Evidence
+
+- Route tests.
+- Authorization tests.
+- Sanitization tests.
+
+## Milestone P2 - Operational Hardening
+
+### Goal
+
+Improve safety and usability before considering any non-read-only behavior.
+
+### Deliverables
+
+- Bot heartbeat dashboard.
+- Alerting for status/readiness changes.
+- Alerting for backup failure or stale backups.
+- Per-command rate limits.
+- Public/admin channel mapping.
+- WebUI management surface for role/channel mapping.
+- Emergency disable flag for all Discord-originated requests.
+- SOC 2 evidence review.
+
+### Acceptance Criteria
+
+- Alerts are deduplicated and rate-limited.
+- Bot failure does not affect WebUI.
+- Evidence package maps to SOC 2 readiness controls.
+- Emergency disable can block all bot-originated calls.
+
+## Milestone P3 - Future Review Gate
+
+### Goal
+
+Decide whether to remain read-only or propose limited non-destructive admin conveniences.
+
+### Rule
+
+No write, destructive, credential, database mutation, addon mutation, player mutation, map mutation, or Docker/service lifecycle action may be added without:
+
+1. Separate approval.
+2. Threat model update.
+3. SOC 2 control matrix update.
+4. DAST cases.
+5. Confirmation policy.
+6. Audit policy.
+7. Rollback plan.
+
+Future moderator commands and two-way chat are explicitly post-read-only roadmap candidates. They are not part of the experimental read-only release and require their own design review before implementation.
+
+## Milestone P4 - Guarded Game Moderator Commands
+
+### Goal
+
+Evaluate whether trusted game moderators should receive a controlled command surface for in-game moderation actions through Discord and/or an approved in-game command bridge.
+
+Example moderator use cases under consideration:
+
+```text
+/kick playerid
+/spawn vehicle
+```
+
+This milestone is exploratory. It must not be implemented as raw command passthrough from Discord to the game server. Console API must remain the execution authority, and every action must be authorized, validated, audited, rate-limited, and reversible where practical.
+
+### Candidate Deliverables
+
+- Moderator role/capability model separate from observer/admin/owner visibility roles.
+- Dedicated capability names for each moderator action, for example `player:kick` or `vehicle:spawn`.
+- Strict target validation by immutable player ID or backend-resolved player identity.
+- Command allowlist; no arbitrary console command passthrough.
+- Reason codes and optional moderator notes for player-impacting actions.
+- Confirmation flow for disruptive actions.
+- Cooldowns and abuse-rate controls per moderator, command, and target.
+- Full audit events with actor, Discord user, mapped game moderator identity, command, target, reason, timestamp, and result.
+- Emergency kill switch for all moderator command execution.
+- Dry-run/test mode for validation before live enablement.
+
+### Acceptance Criteria
+
+- Moderator commands are disabled by default.
+- Every command has a server-side capability requirement.
+- Discord role checks are not trusted as the only authorization layer.
+- Raw command strings cannot be supplied by users.
+- Player IDs, vehicle IDs, and enum arguments are validated against backend-safe sources.
+- All moderator actions produce tamper-evident audit records.
+- Failed authorization and failed validation attempts are logged safely.
+- Abuse controls prevent command spam or repeated targeting.
+- Security review confirms no path to Docker, database, addon, credential, or host-level mutation.
+
+### Evidence
+
+- Threat model for moderator actions.
+- Updated SOC 2 control matrix.
+- Authorization matrix tests.
+- Audit event tests.
+- DAST authorization and misuse tests.
+- Operator runbook.
+- Approved security exception for any high-risk action that cannot be made reversible.
+
+## Milestone P5 - Two-Way Discord and In-Game Chat Bridge
+
+### Goal
+
+Design an opt-in chat bridge that lets in-game players and Discord users communicate across a mapped channel without requiring everyone to be in the same client.
+
+Target behavior:
+
+```text
+Discord -> Game Chat
+A message sent in an approved Discord channel appears in the mapped in-game chat channel.
+
+Game Chat -> Discord
+A message sent in an approved in-game chat channel appears in the mapped Discord channel.
+```
+
+This bridge is for chat only. It must not become a command injection path, moderation bypass, or raw console command relay.
+
+### Candidate Deliverables
+
+- Discord channel to in-game chat channel mapping.
+- Direction controls: Discord-to-game, game-to-Discord, or bidirectional.
+- Message identity format, for example `[Discord] Name:` and `[Game] Player:`.
+- Abuse controls: rate limits, message length caps, attachment policy, mention suppression, and flood protection.
+- Mention and markdown sanitization before sending Discord content in-game.
+- In-game formatting sanitization before sending game chat to Discord.
+- Optional allowlist for Discord roles and in-game channels.
+- Optional profanity/spam/moderation filter hook.
+- Loop prevention so bridged messages are not echoed back repeatedly.
+- Audit/logging for bridged messages without storing secrets or unnecessary personal data.
+- Admin-visible health/status for the bridge.
+- Emergency disable flag for chat bridge only.
+
+### Acceptance Criteria
+
+- Chat bridge is disabled by default.
+- Channel mappings are explicit and auditable.
+- Bot never forwards Discord bot tokens, environment values, internal URLs, or host paths.
+- Discord mentions are suppressed or safely escaped before in-game delivery.
+- In-game chat cannot trigger Discord slash commands or bot admin actions.
+- Discord messages cannot trigger in-game admin/moderator commands.
+- Bridge respects configured directionality.
+- Message loops are prevented.
+- Rate limits and caps protect both Discord and the game server.
+- Operators can disable the bridge without disabling the WebUI.
+
+### Evidence
+
+- Chat bridge architecture decision record.
+- Updated STRIDE model covering spoofing, tampering, repudiation, information disclosure, denial of service, and elevation of privilege.
+- Channel mapping tests.
+- Sanitization tests.
+- Loop-prevention tests.
+- Abuse-rate tests.
+- Operator runbook.
+
+## Roadmap Exit Criteria for Experimental Release
+
+The experimental read-only release is complete when:
+
+1. Status, readiness, services, population, logs, map state, and backup list are available through Discord.
+2. Every command maps to a read-only capability and role requirement.
+3. No write or destructive route exists in the bot or adapter.
+4. Logs are capped, redacted, and role-gated.
+5. Public responses do not leak internal topology or secrets.
+6. SCA, SAST, DCA, DAST, secret scanning, and adapter tests pass.
+7. SOC 2 readiness evidence exists for the experimental release.
+8. The bot can be disabled without impacting WebUI.

--- a/docs/discord-control-bot/sbom-evidence.md
+++ b/docs/discord-control-bot/sbom-evidence.md
@@ -1,0 +1,34 @@
+# SBOM Evidence
+
+## Purpose
+
+This document defines the repository-local software bill of materials evidence for the Discord companion bot and Console API adapter.
+
+## Generator
+
+```text
+scripts/generate-sbom.mjs
+```
+
+## Workflow
+
+```text
+.github/workflows/sbom-generation.yml
+```
+
+## Output Artifacts
+
+```text
+artifacts/security/sbom.cyclonedx.json
+artifacts/security/sbom.md
+```
+
+## Readiness Mapping
+
+- DC-SOC2-SEC-006: Vulnerabilities are identified before release.
+- DC-SOC2-SEC-010: Dependency risk is managed.
+- E-009: SBOM evidence for release readiness.
+
+## Notes
+
+The generator is free and repository-local. It reads npm lockfiles and emits CycloneDX-style JSON plus a Markdown summary. It does not claim certification or formal attestation by itself.

--- a/docs/discord-control-bot/security-gates.md
+++ b/docs/discord-control-bot/security-gates.md
@@ -1,0 +1,236 @@
+# Dune Discord Control Bot - Security Gates
+
+## Purpose
+
+The Discord companion bot creates a Discord-accessible operational visibility surface for Dune Docker Console. The experimental scope is read-only. Security controls are release blockers, not optional hardening.
+
+This document defines required SCA, SAST, DCA, DAST, STRIDE threat modeling, vulnerability reporting, and SOC 2 readiness controls for the bot and the Dune Console Discord API adapter.
+
+## Gate Summary
+
+| Gate | Scope | Blocking Conditions |
+| --- | --- | --- |
+| Secrets | Source, logs, images, release artifacts | Any verified token, password, private key, database URL, or Funcom token leak |
+| SCA | Dependencies and licenses | Critical/high exploitable dependency with fix available, missing lockfile, disallowed license |
+| SAST | Source code | Auth bypass, command injection, SQL injection, path traversal, unsafe secret logging |
+| DCA | Dockerfiles, Compose, images | Docker socket in bot, privileged mode, root runtime, critical/high image CVE with fix available |
+| DAST | Running API and bot flows | Unauthorized action, secret leakage, read-only bypass |
+| STRIDE | Architecture, trust boundaries, assets, bot/adapter controls | Missing STRIDE report for release candidate or unresolved high-risk threat without exception |
+| Authorization | Discord roles and backend policy | Client-only authorization, missing backend authorization, stale role use |
+| Audit | Adapter operations | Missing audit event for role-gated adapter operations |
+| Vulnerability Report | Trivy/Semgrep JSON/SARIF artifacts | Missing CVSS-ranked report for release candidate |
+
+## SCA - Software Composition Analysis
+
+### Required Controls
+
+1. Dependency vulnerability scanning on every pull request.
+2. Lockfile required for each package manager workspace.
+3. Dependency pinning; no floating major versions in release builds.
+4. SBOM generation for releases.
+5. License policy checks.
+6. Dependabot or Renovate for dependency update pull requests.
+7. Transitive dependency visibility.
+8. Dependency review for new packages.
+9. CVSS-ranked vulnerability report generated from scanner artifacts.
+
+### Blocking Conditions
+
+- Critical exploitable vulnerability with a fixed version available.
+- High exploitable vulnerability with a fixed version available and no approved exception.
+- Missing lockfile when package dependencies exist.
+- Disallowed license.
+- Missing release SBOM.
+- Missing vulnerability report artifact.
+
+## SAST - Static Application Security Testing
+
+### Required Controls
+
+1. CodeQL or equivalent static analysis.
+2. Semgrep CE scan on pull requests, pushes, manual dispatch, and scheduled cadence.
+3. Secret scanning.
+4. ShellCheck for shell scripts where shell scripts are changed.
+5. SQL safety rules for raw SQL construction.
+6. Command execution rules for shell/process execution.
+7. Route authorization checks for the Discord API adapter.
+8. Redaction checks for all logs and errors.
+
+### Semgrep Evidence
+
+Semgrep runs through:
+
+```text
+.github/workflows/semgrep-sast.yml
+```
+
+The workflow produces:
+
+```text
+artifacts/security/semgrep.json
+artifacts/security/semgrep.sarif
+artifacts/security/vulnerability-report.json
+artifacts/security/vulnerability-report.md
+```
+
+SARIF is uploaded to GitHub code scanning when available. Semgrep ERROR maps to HIGH and WARNING maps to MEDIUM for issue tracking.
+
+### High-Risk Patterns to Block
+
+```text
+child_process.exec(...)
+spawn(..., { shell: true })
+template-built shell commands
+raw SQL concatenation from Discord/user input
+file paths derived from Discord input without allowlist validation
+logging request bodies, headers, environment variables, or secrets
+backend routes without authorization middleware
+bot-only authorization for privileged actions
+```
+
+## DCA - Docker/Container Analysis
+
+### Required Controls
+
+1. Dockerfile linting.
+2. Container image vulnerability scanning.
+3. Base image pinning.
+4. Non-root container user.
+5. No Docker socket mount in the bot container.
+6. No privileged mode.
+7. Drop Linux capabilities.
+8. Read-only filesystem where practical.
+9. Minimal host mounts.
+10. Runtime secrets mounted as files.
+11. Healthcheck required before production deployment.
+12. Signed image and release SBOM.
+
+### Trivy Evidence
+
+Trivy runs through:
+
+```text
+.github/workflows/trivy-vulnerability-scan.yml
+```
+
+The workflow scans:
+
+```text
+repository filesystem
+Discord bot container image
+```
+
+The workflow produces:
+
+```text
+artifacts/security/trivy-fs.json
+artifacts/security/trivy-fs.sarif
+artifacts/security/trivy-discord-bot-image.json
+artifacts/security/vulnerability-report.json
+artifacts/security/vulnerability-report.md
+```
+
+The vulnerability report ranks findings by CVSS and includes CVE/NVD URLs when CVE IDs are present.
+
+### Blocking Conditions
+
+- Bot container mounts `/var/run/docker.sock`.
+- Bot container uses `privileged: true`.
+- Bot container runs as root without an approved exception.
+- Critical/high image vulnerability with a fixed version available and no approved exception.
+- Secret baked into image layer.
+- Broad writable host mount.
+- Floating base image in release Dockerfile.
+
+## STRIDE - Threat Modeling
+
+### Required Controls
+
+1. Free repository-local STRIDE scan runs on pull requests, pushes, manual dispatch, and scheduled cadence.
+2. Threat report identifies assets, trust boundaries, STRIDE categories, severity, status, evidence, recommendation, and SOC 2 readiness mapping.
+3. Open high/critical threats require remediation issue or security exception before release candidate.
+4. Threat model output is retained as a workflow artifact.
+
+### STRIDE Evidence
+
+STRIDE runs through:
+
+```text
+.github/workflows/stride-threat-scan.yml
+```
+
+The workflow produces:
+
+```text
+artifacts/security/stride-report.json
+artifacts/security/stride-report.md
+```
+
+The scanner is free and repository-local:
+
+```text
+scripts/generate-stride-report.mjs
+```
+
+### STRIDE Categories Covered
+
+```text
+Spoofing
+Tampering
+Repudiation
+Information Disclosure
+Denial of Service
+Elevation of Privilege
+```
+
+## DAST - Dynamic Application Security Testing
+
+### Required Controls
+
+1. Authenticated scan of Discord API adapter endpoints.
+2. Unauthenticated access tests.
+3. Authorization matrix tests for Observer, Moderator, Admin, Owner.
+4. Secret leakage tests against API responses and logs.
+5. Error redaction tests.
+6. API fuzzing for user-controlled fields.
+7. Read-only scope enforcement tests.
+8. Rate-limit tests before production Discord deployment.
+
+### Blocking Conditions
+
+- Privileged or role-gated endpoint works without valid bot API token.
+- User can exceed Discord role capability.
+- Secret appears in response, logs, or Discord message.
+- Command injection or path traversal is possible.
+- Missing rate limits before production Discord deployment.
+
+## Required Runtime Controls
+
+1. Dedicated Dune bot API token separate from WebUI admin password.
+2. Server-side Discord actor authorization.
+3. Command-level rate limits before production Discord deployment.
+4. Structured audit events.
+5. Central redaction library.
+6. Public/admin response classification.
+7. Emergency kill switch for Discord-originated requests before production Discord deployment.
+8. Experimental scope remains read-only.
+
+## Minimum Release Criteria
+
+A release candidate may not ship unless all of the following are true:
+
+```text
+[BLOCK] No verified secrets in source, logs, images, or release artifacts.
+[BLOCK] No critical/high exploitable dependency vulnerabilities with fixed versions available.
+[BLOCK] No critical/high SAST findings without approved exception.
+[BLOCK] Bot image does not run as root.
+[BLOCK] Bot image does not mount Docker socket.
+[BLOCK] Bot image is not privileged.
+[BLOCK] Authorization matrix tests pass.
+[BLOCK] Redaction tests pass.
+[BLOCK] Semgrep workflow runs and uploads artifacts.
+[BLOCK] Trivy workflow runs and uploads CVSS-ranked vulnerability report.
+[BLOCK] STRIDE workflow runs and uploads threat model report.
+[BLOCK] SOC 2 readiness check passes.
+[BLOCK] Release image has SBOM and is signed before production deployment.
+```

--- a/docs/discord-control-bot/setup-guide.md
+++ b/docs/discord-control-bot/setup-guide.md
@@ -1,0 +1,209 @@
+# Dune Discord Companion Bot - Setup Guide
+
+## Scope
+
+This setup path validates the read-only Discord companion bot command layer and protected Console adapter without requiring manual edits to core Console files.
+
+The actual network Discord client is still deferred. Use the smoke runner to validate command behavior before connecting to Discord.
+
+## Prerequisites
+
+- Dune Docker Console repository checked out.
+- Node.js 22 for local smoke testing.
+- A local Dune bot API token file.
+- Console API reachable on `127.0.0.1:8088` or the configured admin bind port.
+- Semgrep and Trivy for local security/SOC 2 readiness scans.
+
+## Install Local Security Runtimes
+
+From the repository root:
+
+```bash
+bash scripts/ensure-security-runtimes.sh
+```
+
+The script checks for:
+
+```text
+node
+npm
+curl
+tar
+docker
+semgrep
+trivy
+```
+
+It installs Semgrep if missing using the first available method:
+
+1. `pipx install semgrep`
+2. `uv tool install semgrep`
+3. Python user install of `pipx`, then `pipx install semgrep`
+4. Docker wrapper fallback using `semgrep/semgrep`
+
+It installs Trivy if missing using:
+
+1. Homebrew when available.
+2. Latest GitHub release tarball into `$HOME/.local/bin` on Linux/macOS.
+
+If `$HOME/.local/bin` is not on your shell PATH, add it:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Create Local Bot API Token
+
+```bash
+mkdir -p "$HOME/.config/dune-console"
+printf '%s\n' 'local-dev-bot-api' > "$HOME/.config/dune-console/dune-bot-api-token.txt"
+chmod 600 "$HOME/.config/dune-console/dune-bot-api-token.txt"
+```
+
+Use a real random token outside local testing.
+
+## Start Console Adapter
+
+From `console/api`:
+
+```bash
+DUNE_DOCKER_DIR="$HOME/dune-awakening-selfhost-docker-WSL" \
+DUNE_BOT_API_TOKEN_FILE="$HOME/.config/dune-console/dune-bot-api-token.txt" \
+DISCORD_OBSERVER_ROLE_IDS=role-observer \
+DISCORD_ADMIN_ROLE_IDS=role-admin \
+DISCORD_OWNER_ROLE_IDS=role-owner \
+npm run start:discord-adapter
+```
+
+If runtime secrets are root-owned, use `sudo env` while preserving the same variables:
+
+```bash
+sudo env \
+  PATH="$PATH" \
+  HOME="$HOME" \
+  DUNE_DOCKER_DIR="$HOME/dune-awakening-selfhost-docker-WSL" \
+  DUNE_BOT_API_TOKEN_FILE="$HOME/.config/dune-console/dune-bot-api-token.txt" \
+  DISCORD_OBSERVER_ROLE_IDS=role-observer \
+  DISCORD_ADMIN_ROLE_IDS=role-admin \
+  DISCORD_OWNER_ROLE_IDS=role-owner \
+  npm run start:discord-adapter
+```
+
+## Smoke Test Bot Commands
+
+From `discord-bot`:
+
+```bash
+npm ci --ignore-scripts
+
+export DUNE_CONSOLE_API_URL=http://127.0.0.1:8088
+export DUNE_BOT_API_TOKEN_FILE="$HOME/.config/dune-console/dune-bot-api-token.txt"
+export DISCORD_GUILD_ID=local-guild
+export DISCORD_OBSERVER_ROLE_IDS=role-observer
+export DISCORD_ADMIN_ROLE_IDS=role-admin
+export DISCORD_OWNER_ROLE_IDS=role-owner
+
+npm run smoke:health
+npm run smoke:status
+npm run smoke:readiness
+npm run smoke:services
+npm run smoke:status-detail
+```
+
+## Expected Smoke Test Result
+
+Each command should return `status: 200`.
+
+The smoke output also includes:
+
+```text
+actorRoleIdsSent
+consoleRolePolicy
+```
+
+Use those fields to verify the bot and Console adapter share the same role mapping.
+
+## Test Gates
+
+Run Console adapter tests:
+
+```bash
+cd ~/dune-awakening-selfhost-docker-WSL/console/api
+npm ci --ignore-scripts
+node --test test/discord*.test.js
+```
+
+Run bot gates:
+
+```bash
+cd ~/dune-awakening-selfhost-docker-WSL/discord-bot
+npm ci --ignore-scripts
+npm test
+npm run security:secrets
+npm run build
+```
+
+Run SOC 2 readiness check:
+
+```bash
+cd ~/dune-awakening-selfhost-docker-WSL
+node scripts/soc2-readiness-check.mjs
+```
+
+If Semgrep or Trivy are missing, run:
+
+```bash
+bash scripts/ensure-security-runtimes.sh
+node scripts/soc2-readiness-check.mjs
+```
+
+## Local Vulnerability Report
+
+After Trivy is installed, generate filesystem scan input and the CVSS-ranked report:
+
+```bash
+mkdir -p artifacts/security
+trivy fs --scanners vuln,secret,misconfig --format json --output artifacts/security/trivy-fs.json .
+node scripts/generate-vulnerability-report.mjs
+```
+
+Read:
+
+```text
+artifacts/security/vulnerability-report.md
+artifacts/security/vulnerability-report.json
+```
+
+## Smoke Test Troubleshooting
+
+### 403 on Readiness or Services
+
+The observer role is not aligned.
+
+Check:
+
+- `actorRoleIdsSent` includes `role-observer`.
+- `consoleRolePolicy.observerConfigured` is `true`.
+- The Console adapter was started with `DISCORD_OBSERVER_ROLE_IDS=role-observer`.
+
+### 403 on Detailed Status
+
+The admin role is not aligned.
+
+Check:
+
+- `actorRoleIdsSent` includes `role-admin`.
+- `consoleRolePolicy.adminConfigured` is `true`.
+- The Console adapter was started with `DISCORD_ADMIN_ROLE_IDS=role-admin`.
+
+### 500 Missing Dune Command
+
+Start the Console adapter with the repository root set:
+
+```bash
+DUNE_DOCKER_DIR="$HOME/dune-awakening-selfhost-docker-WSL"
+```
+
+### Permission Denied on Runtime Secrets
+
+Use `sudo env` for local testing if existing runtime secrets are root-owned. Keep `DUNE_BOT_API_TOKEN_FILE` pointing at `$HOME/.config/dune-console/dune-bot-api-token.txt`.

--- a/docs/discord-control-bot/soc2-control-matrix.md
+++ b/docs/discord-control-bot/soc2-control-matrix.md
@@ -1,0 +1,186 @@
+# Dune Discord Control Bot - SOC 2 Readiness Control Matrix
+
+## Important Compliance Position
+
+This project can implement SOC 2-aligned controls and collect audit-ready evidence, but the repository itself cannot self-certify SOC 2 compliance. A SOC 2 report requires an independent examination by a qualified CPA firm against the applicable Trust Services Criteria.
+
+For this project, the practical target is **SOC 2 readiness** for the Discord Control Bot and Dune Console Discord API Adapter.
+
+## Recurring SOC 2 Readiness Check
+
+The repository includes a recurring SOC 2 readiness workflow:
+
+```text
+.github/workflows/soc2-readiness-check.yml
+```
+
+The workflow runs:
+
+- Weekly on Monday at 09:00 UTC.
+- On manual `workflow_dispatch`.
+- On relevant pull requests and pushes that touch Discord bot, Console adapter, SOC 2 evidence, or documentation files.
+
+The workflow validates:
+
+- Required SOC 2 evidence documentation exists.
+- Admin, user, setup, roadmap, and project-status documentation exists.
+- The bot authorization model contains only read-only capabilities.
+- The Console adapter still reports `readOnly: true` and `writesEnabled: false`.
+- Console Discord adapter tests pass.
+- Bot tests pass.
+- Bot secret scanning passes.
+- Bot scaffold validation passes.
+- Semgrep SAST workflow evidence exists.
+- Trivy vulnerability workflow evidence exists.
+- CVSS vulnerability report generation logic exists.
+- STRIDE threat model workflow evidence exists.
+- STRIDE report generation logic exists.
+
+Local readiness check:
+
+```bash
+node scripts/soc2-readiness-check.mjs
+```
+
+If local Semgrep or Trivy runtimes are missing, run:
+
+```bash
+bash scripts/ensure-security-runtimes.sh
+```
+
+## Trust Services Categories in Scope
+
+| Category | Applicability |
+| --- | --- |
+| Security | Primary category. Required because the bot becomes a Discord-originated operational visibility plane. |
+| Availability | Applicable because bot commands and status functions depend on reliable service operation. |
+| Confidentiality | Applicable because the bot may access server operational data and secrets-adjacent workflows. |
+| Processing Integrity | Applicable because command responses must be accurate, complete, authorized, and redacted. |
+| Privacy | Limited unless personally identifiable player/user data is processed beyond operational IDs. |
+
+## Control Objectives
+
+1. Prevent unauthorized Discord-originated access to operational diagnostics.
+2. Protect secrets and sensitive operational data.
+3. Ensure changes are reviewed, tested, and traceable.
+4. Ensure any future high-risk action is separately approved, confirmed, audited, and reversible where possible.
+5. Generate repeatable evidence through CI, release, and runtime logs.
+6. Maintain secure development and vulnerability management practices.
+7. Preserve availability through health checks, safe rollbacks, and controlled releases.
+8. Maintain recurring STRIDE threat model evidence for architecture and trust-boundary changes.
+
+## SOC 2-Aligned Control Matrix
+
+| Control ID | Trust Category | Control Objective | Implementation Requirement | Evidence |
+| --- | --- | --- | --- | --- |
+| DC-SOC2-SEC-001 | Security | Only authorized Discord users can access role-gated diagnostics. | Server-side role-to-capability authorization in Dune Console API adapter. | Authorization matrix tests, API adapter tests, audit logs, STRIDE report. |
+| DC-SOC2-SEC-002 | Security | Bot cannot bypass backend authority. | Bot acts only as client; backend enforces final authorization, safety, redaction, and audit. | Architecture docs, code review, route tests, STRIDE report. |
+| DC-SOC2-SEC-003 | Security | No destructive actions exist in experimental bot scope. | Bot and adapter expose read-only routes only. | Route inventory, capability tests, scaffold validation, STRIDE report. |
+| DC-SOC2-SEC-004 | Security | Secrets are protected from disclosure. | File-based secrets, no secrets in source/logs/static files/images. | Secret scan reports, redaction tests, image scan results. |
+| DC-SOC2-SEC-005 | Security | Containers run with least privilege. | Non-root bot container, no Docker socket, no privileged mode, dropped capabilities. | Dockerfile, Compose review, DCA scan output, STRIDE report. |
+| DC-SOC2-SEC-006 | Security | Vulnerabilities are identified before release. | SCA, SAST, DCA, DAST, Semgrep, Trivy, STRIDE, and secret gates block critical/high issues. | CI results, Semgrep report, Trivy report, STRIDE report, CVSS vulnerability report, exception register. |
+| DC-SOC2-SEC-007 | Security | Sensitive outputs are redacted. | Central redaction library for logs, errors, Discord responses. | Redaction tests, code review, DAST tests, STRIDE report. |
+| DC-SOC2-SEC-008 | Security | Discord-originated access is traceable. | Structured audit events for adapter operations. | Audit logs, audit schema, test fixtures, STRIDE report. |
+| DC-SOC2-SEC-009 | Security | Production changes are reviewed. | Pull requests require review, tests, security impact, and rollback plan. | PR records, branch protection evidence. |
+| DC-SOC2-SEC-010 | Security | Dependency risk is managed. | Lockfile, dependency review, automated dependency scanning, Trivy filesystem scans. | package-lock, SCA report, Trivy report, Dependabot/Renovate PRs. |
+| DC-SOC2-SEC-011 | Security | Command injection is prevented. | No shell execution in bot; backend uses safe wrappers and fixed arguments; Semgrep checks high-risk code patterns. | Semgrep SAST results, code review, injection tests, STRIDE report. |
+| DC-SOC2-SEC-012 | Security | SQL misuse is controlled. | Experimental bot has no SQL route; future SQL access requires separate threat model. | Capability inventory, route tests, STRIDE report. |
+| DC-SOC2-SEC-013 | Security | Abuse is controlled. | Future rate limits required before production Discord deployment. | Roadmap, rate-limit tests when implemented, STRIDE report. |
+| DC-SOC2-SEC-014 | Security | Role mapping is regularly reviewed. | Role-policy health reports configured tiers without exposing role IDs. | Health output, access review record, STRIDE report. |
+| DC-SOC2-AV-001 | Availability | Bot process health is monitored. | Docker healthcheck and bot heartbeat before production Discord deployment. | Container health output, heartbeat logs, STRIDE report. |
+| DC-SOC2-AV-002 | Availability | Bot can fail without breaking WebUI. | Bot isolated from WebUI execution path. | Architecture docs, integration tests, STRIDE report. |
+| DC-SOC2-AV-003 | Availability | Releases are reversible. | Rollback plan and pinned image releases. | Release checklist, versioned image tags. |
+| DC-SOC2-AV-004 | Availability | Failures are safely handled. | Error redaction and graceful Discord/API error handling. | Error handling tests, logs, STRIDE report. |
+| DC-SOC2-C-001 | Confidentiality | Internal topology is not exposed publicly. | Public responses hide internal IPs, SSH hosts, DB URLs, service internals. | Response tests, DAST output, STRIDE report. |
+| DC-SOC2-C-002 | Confidentiality | Detailed Status requires elevated role. | Diagnostic commands require admin or owner role. | Authorization tests, STRIDE report. |
+| DC-SOC2-C-003 | Confidentiality | Logs avoid sensitive payloads. | No raw request body logging for secret-bearing or admin commands. | Code review, Semgrep results, log samples, STRIDE report. |
+| DC-SOC2-PI-001 | Processing Integrity | Responses reflect intended command scope. | Each command maps to one read-only adapter route and capability. | Command route tests, smoke tests, STRIDE report. |
+| DC-SOC2-PI-002 | Processing Integrity | Future write behavior is gated. | No write route until separate approval, threat model, confirmation policy, DAST, audit policy, and rollback plan exist. | Roadmap P3 gate, ADR, STRIDE report. |
+| DC-SOC2-P-001 | Privacy | Player/user data exposure is minimized. | Public channel responses avoid sensitive player details; detailed lookups remain future role-gated scope. | Data classification matrix, response tests, STRIDE report. |
+| DC-SOC2-P-002 | Privacy | Discord actor data is used only for audit and authorization. | Audit schema limits Discord data to operational metadata. | Audit schema, privacy review, STRIDE report. |
+
+## Evidence Register
+
+| Evidence ID | Evidence Artifact | Owner | Frequency | Related Controls |
+| --- | --- | --- | --- | --- |
+| E-001 | GitHub Actions security gate result | Engineering | Every PR/push | SEC-006, SEC-009 |
+| E-002 | Secret scan output | Engineering | Every PR/push | SEC-004, SEC-007 |
+| E-003 | SCA dependency report | Engineering | Every PR/push/release | SEC-006, SEC-010 |
+| E-004 | Semgrep SAST report | Engineering | Every PR/push/weekly/manual | SEC-006, SEC-011, C-003 |
+| E-005 | Trivy filesystem and image scan report | Engineering | Every PR/push/weekly/manual | SEC-005, SEC-006, SEC-010 |
+| E-006 | DAST report | Engineering/Security | Release candidate | SEC-001, SEC-003, SEC-012, C-001 |
+| E-007 | Unit and authorization test results | Engineering | Every PR/push | SEC-001, SEC-003 |
+| E-008 | Release checklist | Release owner | Every release | SEC-009, AV-003 |
+| E-009 | SBOM | Release owner | Every release | SEC-006, SEC-010 |
+| E-010 | Image signature/provenance | Release owner | Every release | SEC-006, AV-003 |
+| E-011 | Audit log samples | System owner | Monthly / release candidate | SEC-008, PI-001 |
+| E-012 | Exception register | Security owner | As needed, reviewed monthly | SEC-006 |
+| E-013 | Threat model / STRIDE report | Security owner | Major design change / weekly / PR | SEC-001, SEC-002, C-001, AV-004 |
+| E-014 | Access/role mapping review | System owner | Monthly / before release | SEC-001, C-002 |
+| E-015 | Scheduled SOC 2 readiness workflow result | Engineering/Security | Weekly / manual / PR | SEC-004, SEC-006, SEC-009, C-001, PI-001 |
+| E-016 | CVSS-ranked vulnerability report with CVE/NVD URLs | Engineering/Security | Every Trivy/Semgrep workflow run / release candidate | SEC-006, SEC-010 |
+| E-017 | Repository-local STRIDE JSON/Markdown artifacts | Security owner | Every PR/push/weekly/manual | SEC-001, SEC-002, SEC-003, SEC-006, C-001, AV-004 |
+
+## Required SOC 2 Readiness Workflows
+
+### Change Management
+
+1. All changes must go through pull request review.
+2. PRs must include purpose, risk, tests, security impact, and rollback plan.
+3. Security-sensitive PRs must update threat model and control matrix.
+4. Failed gates block merge.
+5. Exceptions must be documented and time-bound.
+
+### Access Control
+
+1. Discord roles must map to least-privilege capabilities.
+2. Experimental scope is read-only.
+3. Server-side authorization must be enforced by the Dune Console API adapter.
+4. Bot API token must be separate from WebUI admin password.
+5. Role mapping must be reviewed regularly.
+
+### Vulnerability Management
+
+1. SCA, SAST, DCA, DAST, Semgrep, Trivy, STRIDE, and secret scanning run in CI/CD.
+2. Critical/high findings block release unless formally excepted.
+3. Exceptions require owner, expiration, mitigation, and compensating controls.
+4. Dependency updates are tracked and reviewed.
+5. Vulnerability reports must include CVSS ranking and relevant CVE/NVD URLs when scanner data provides CVE IDs.
+6. STRIDE open high/critical threats require remediation issue or documented exception before release candidate.
+
+### Incident Response
+
+1. Suspected token exposure requires immediate token rotation.
+2. Bot adapter can be disabled by removing `DUNE_DISCORD_ADAPTER_ENABLED=true`.
+3. Audit logs must identify Discord actor, action, target, result, and timestamp where available.
+4. Security incidents produce post-incident review and regression tests.
+
+### Availability and Resilience
+
+1. Bot healthcheck required before production Discord deployment.
+2. Bot failure must not impact WebUI.
+3. Release rollback path must be documented.
+4. Runtime errors must be redacted and handled gracefully.
+
+## Open SOC 2 Gaps
+
+These are not satisfied by code alone and require operational ownership:
+
+1. Formal risk assessment.
+2. Formal access review cadence.
+3. Incident response procedure ownership.
+4. Evidence retention policy.
+5. Change approval authority.
+6. Vendor/dependency management policy.
+7. Independent audit readiness review.
+8. CPA examination if a SOC 2 report is required.
+9. Rate limits before production Discord deployment.
+10. Runtime Discord client monitoring and alerting.
+
+## Compliance Statement Template
+
+Use this language in project materials:
+
+```text
+The Discord Control Bot is designed with SOC 2-aligned security, availability, confidentiality, processing integrity, and privacy controls. The project maintains audit-ready evidence through CI/CD security gates, structured audit logs, release artifacts, documented control mappings, and repository-local STRIDE threat model reports. This does not constitute a SOC 2 report or certification; formal SOC 2 compliance requires an independent examination by a qualified CPA firm.
+```

--- a/docs/discord-control-bot/templates/adr-template.md
+++ b/docs/discord-control-bot/templates/adr-template.md
@@ -1,0 +1,61 @@
+# ADR-NNNN: Title
+
+## Status
+
+Proposed | Accepted | Superseded | Deprecated
+
+## Date
+
+YYYY-MM-DD
+
+## Context
+
+Describe the decision context, problem statement, constraints, and affected components.
+
+## Decision
+
+Describe the decision clearly.
+
+## Security Considerations
+
+Document:
+
+- Trust boundaries.
+- Authorization model.
+- Secret handling.
+- Audit impact.
+- Redaction impact.
+- Abuse cases.
+- Failure modes.
+
+## SOC 2 Control Impact
+
+List affected control IDs from `docs/discord-control-bot/soc2-control-matrix.md`.
+
+```text
+DC-SOC2-
+```
+
+## Consequences
+
+### Positive
+
+- 
+
+### Negative / Tradeoffs
+
+- 
+
+### Operational Impact
+
+- 
+
+## Alternatives Considered
+
+| Alternative | Reason Rejected |
+| --- | --- |
+| | |
+
+## Evidence
+
+Link to PRs, tests, threat model updates, and CI evidence.

--- a/docs/discord-control-bot/templates/release-checklist.md
+++ b/docs/discord-control-bot/templates/release-checklist.md
@@ -1,0 +1,73 @@
+# Dune Discord Control Bot - Release Checklist
+
+## Release Information
+
+| Field | Value |
+| --- | --- |
+| Version | |
+| Release owner | |
+| Date | |
+| Commit SHA | |
+| Image tag | |
+| Rollback version | |
+
+## Scope
+
+Describe released changes.
+
+## Required Gates
+
+```text
+[ ] Unit tests passed.
+[ ] Authorization matrix tests passed.
+[ ] Redaction tests passed.
+[ ] Secret scan passed.
+[ ] SCA passed.
+[ ] SAST passed.
+[ ] DCA passed.
+[ ] DAST passed or not applicable with documented reason.
+[ ] Container image scan passed.
+[ ] SBOM generated.
+[ ] Image signed.
+[ ] Release notes completed.
+[ ] Rollback plan documented.
+[ ] SOC 2 evidence index updated.
+```
+
+## Security Review
+
+```text
+[ ] No critical/high open findings without approved exception.
+[ ] No secrets in source, logs, image layers, or artifacts.
+[ ] Bot container does not mount Docker socket.
+[ ] Bot container does not run privileged.
+[ ] Bot container runs as non-root.
+[ ] Write/admin commands are disabled by default unless explicitly approved.
+[ ] Destructive commands require confirmation.
+[ ] State-changing commands emit audit events.
+```
+
+## SOC 2 Evidence
+
+| Evidence ID | Artifact Link | Notes |
+| --- | --- | --- |
+| E-001 | | CI gate result |
+| E-002 | | Secret scan |
+| E-003 | | SCA report |
+| E-004 | | SAST report |
+| E-005 | | DCA/container scan |
+| E-006 | | DAST report |
+| E-007 | | Unit/auth test report |
+| E-008 | | Release checklist |
+| E-009 | | SBOM |
+| E-010 | | Image signature/provenance |
+
+## Rollback Plan
+
+Describe rollback command, previous image tag, data compatibility, and verification steps.
+
+## Approval
+
+| Approver | Role | Date | Decision |
+| --- | --- | --- | --- |
+| | | | |

--- a/docs/discord-control-bot/templates/threat-model-template.md
+++ b/docs/discord-control-bot/templates/threat-model-template.md
@@ -1,0 +1,83 @@
+# Threat Model: Title
+
+## Scope
+
+Describe the feature, command, API route, or workflow being modeled.
+
+## Assets
+
+| Asset | Sensitivity | Notes |
+| --- | --- | --- |
+| Discord bot token | Critical | Runtime secret only |
+| Dune bot API token | Critical | Runtime secret only |
+| Player data | Sensitive | Avoid public channel exposure |
+| Admin action capability | Critical | Requires server-side authorization |
+| Audit logs | Sensitive | Must avoid secrets |
+
+## Actors
+
+| Actor | Trust Level | Notes |
+| --- | --- | --- |
+| Public Discord user | Untrusted | May invoke public commands only |
+| Moderator | Partially trusted | Read-only/low-risk commands |
+| Admin | Trusted admin | Controlled write commands |
+| Owner | Highest privilege | Destructive commands |
+| Bot process | Trusted client | Not final authority |
+| Dune Console API adapter | Trusted authority | Enforces policy |
+
+## Trust Boundaries
+
+1. Discord to bot process.
+2. Bot process to Dune Console API adapter.
+3. API adapter to existing Console backend.
+4. Console backend to Docker/Postgres/RabbitMQ.
+
+## Data Flows
+
+Describe request/response flow and where authorization, validation, confirmation, and audit occur.
+
+## STRIDE Analysis
+
+| Category | Threat | Mitigation | Test/Evidence |
+| --- | --- | --- | --- |
+| Spoofing | | | |
+| Tampering | | | |
+| Repudiation | | | |
+| Information Disclosure | | | |
+| Denial of Service | | | |
+| Elevation of Privilege | | | |
+
+## Abuse Cases
+
+1. Unprivileged user attempts privileged command.
+2. Admin targets wrong player or backup.
+3. User replays an old confirmation interaction.
+4. Malicious input attempts SQL, shell, path, or markdown injection.
+5. Error response leaks secret or internal topology.
+
+## Required Controls
+
+- [ ] Server-side authorization.
+- [ ] Input validation.
+- [ ] Output redaction.
+- [ ] Rate limiting.
+- [ ] Idempotency.
+- [ ] Confirmation.
+- [ ] Audit logging.
+- [ ] Rollback or recovery path.
+
+## SOC 2 Control Mapping
+
+```text
+DC-SOC2-
+```
+
+## Residual Risk
+
+Describe accepted residual risk and compensating controls.
+
+## Review
+
+| Reviewer | Role | Date | Outcome |
+| --- | --- | --- | --- |
+| | | | |

--- a/docs/discord-control-bot/user-guide.md
+++ b/docs/discord-control-bot/user-guide.md
@@ -1,0 +1,80 @@
+# Dune Discord Companion Bot - User Guide
+
+## Purpose
+
+The Dune Discord Companion Bot gives safe read-only visibility into Dune Docker Console from Discord.
+
+It does not perform server mutations, player actions, database writes, backup restores, or Docker control actions.
+
+## Commands
+
+| Command | Who can use it | What it shows |
+|---|---:|---|
+| `/dune health` | Public | Whether the Console adapter is online and read-only. |
+| `/dune status` | Public | Public Status summary for the server. |
+| `/dune status detail` | Admin/Owner | Detailed Status with additional redacted diagnostics. |
+| `/dune readiness` | Observer+ | Whether server components appear ready. |
+| `/dune services` | Observer+ | Friendly service status summary. |
+
+## Public Status
+
+`/dune status` is safe for public or semi-public operational channels.
+
+It may show:
+
+- Overall status.
+- Server title.
+- Region.
+- Mode.
+- Population.
+- Map readiness.
+- General issue summary.
+
+It does not show:
+
+- Internal SSH hosts.
+- Internal IPs.
+- Database URLs.
+- Tokens or secrets.
+- Raw host paths.
+- Raw Docker/container internals.
+
+## Detailed Status
+
+`/dune status detail` provides more detail for administrators.
+
+It may show:
+
+- Parsed service state.
+- Parsed listener checks with redaction.
+- Map state.
+- Issue list.
+- Capped redacted command output.
+
+Detailed Status is intended to be ephemeral and should not be posted into public channels.
+
+## Readiness
+
+`/dune readiness` shows whether the server appears ready for players.
+
+A readiness issue does not always mean the server is broken. For example, a map may be warming or a listener may need a short period to appear after startup.
+
+## Services
+
+`/dune services` shows a friendly summary of important services.
+
+Instead of exposing raw container details, the bot uses user-facing labels such as Database, Gateway, Survival, Overmap, and Orchestrator.
+
+## If a Command Is Denied
+
+A `not_authorized` response means your Discord role does not map to the required bot capability.
+
+Ask a server admin to verify:
+
+- Your Discord role.
+- The bot role mapping.
+- The Console adapter role mapping.
+
+## Safety Expectations
+
+The bot is read-only. It cannot grant items, restart services, restore backups, mutate players, edit maps, send broadcasts, or change server settings.

--- a/releases/adapter-readonly/README.md
+++ b/releases/adapter-readonly/README.md
@@ -1,0 +1,56 @@
+# Discord Adapter — Read-Only Integration
+
+**Branch**: `release/discord-adapter-readonly`
+**PR**: [#56](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/56)
+**Target**: Red-Blink/dune-awakening-selfhost-docker main
+**State**: Open
+
+## Scope
+
+Modular read-only Discord adapter extracted from `feature/discord-control-bot`.
+8 integration modules, 2 launcher scripts, comprehensive test suite, full documentation.
+
+## Included Modules
+
+| Module | Purpose |
+|--------|---------|
+| `adapter.js` | Core adapter with capability-based routing |
+| `routes.js` | Route registration and capability binding |
+| `policy.js` | RBAC policy evaluation |
+| `audit.js` | Audit event schema and publishing |
+| `redact.js` | PII and secret redaction |
+| `fixtures.js` | Test fixtures and mock data |
+| `health.js` | Adapter health endpoint |
+| `config.js` | Configuration schema and defaults |
+
+## Artifacts
+
+| Artifact | Location |
+|----------|----------|
+| PR body | `docs/PR-discord-adapter-readonly.md` |
+| Project docs | `docs/discord-control-bot/` |
+| Adapter contract | `docs/discord-control-bot/api-adapter-contract.md` |
+| Roadmap | `docs/discord-control-bot/roadmap.md` |
+| Setup guide | `docs/discord-control-bot/setup-guide.md` |
+| User guide | `docs/discord-control-bot/user-guide.md` |
+
+## Security Controls
+
+- Discord adapter disabled by default (`DUNE_DISCORD_ADAPTER_ENABLED=false`)
+- Bearer-token authentication on every route
+- Capability-based RBAC
+- All routes read-only
+- Audit event publishing
+- PII/secret redaction
+- Bounded response size
+
+## Staging Checklist
+
+- [ ] Modular adapter code reviewed
+- [ ] All routes read-only verified
+- [ ] RBAC matrix complete
+- [ ] Audit schema documented
+- [ ] Redaction tests pass
+- [ ] Launcher scripts tested
+- [ ] Setup guide verified
+- [ ] No unresolved security findings

--- a/releases/adapter-write-foundation/README.md
+++ b/releases/adapter-write-foundation/README.md
@@ -1,0 +1,41 @@
+# Discord Adapter — Write-Safety Foundation Planning
+
+**Branch**: `release/discord-adapter-write-foundation`
+**PR**: [#57](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/57)
+**Target**: Red-Blink/dune-awakening-selfhost-docker main
+**State**: Open (planning only)
+
+## Scope
+
+Planning baseline for write-capable Discord adapter routes.
+Not yet implemented.
+
+## Artifacts
+
+| Artifact | Location |
+|----------|----------|
+| PR body | `docs/PR-discord-adapter-write-foundation.md` |
+
+## Entry Criteria (not yet met)
+
+- [ ] Read-only adapter (release/discord-adapter-readonly) merged and stable
+- [ ] Upstream approves write-capable adapter contract
+- [ ] STRIDE and abuse-case review completed
+
+## When Implemented
+
+Required foundation:
+- Write routes disabled by default (`DUNE_DISCORD_WRITES_ENABLED=false`)
+- Write-specific RBAC that observer roles do not inherit
+- Capability discovery before route execution
+- Confirmation primitives for write operations
+- Idempotency key generation and enforcement
+- Audit event publishing for all write operations
+- Write adapter timeout and retry rules
+- Redaction tests for previews, failures, and audit output
+
+## Staging Checklist
+
+- [ ] Planning doc reviewed by upstream
+- [ ] Entry criteria tracked
+- [ ] Upstream write-contract RFC published

--- a/releases/index.md
+++ b/releases/index.md
@@ -1,0 +1,26 @@
+# Release Staging Index — Core Docker
+
+Staging area for upstream PRs organized by release train.
+Each subdirectory contains the PR artifacts for that release.
+
+## Release Train Manifest
+
+| Train | Scope | PR | Branch | Status |
+|-------|-------|----|--------|--------|
+| v1.4.0 | Core release including Discord adapter | [#58](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/58) | `release/v1.4.0` | Open |
+| Adapter RO | Modular read-only Discord adapter | [#56](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/56) | `release/discord-adapter-readonly` | Open |
+| Adapter WF | Write-safety foundation planning | [#57](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/57) | `release/discord-adapter-write-foundation` | Open |
+
+## Artifacts per PR
+
+Each release PR directory contains:
+- PR body documentation
+- Reference to related docs
+- Staging checklist
+
+## Staging Rules
+
+1. **Read-only first**: Adapter read-only must be reviewed before any write work
+2. **Upstream alignment**: All releases target Red-Blink/dune-awakening-selfhost-docker main
+3. **Security**: Discord adapter disabled by default, bearer-token authenticated, RBAC-enforced
+4. **Modular**: Each adapter feature is a separate route module with capability-based access

--- a/releases/v1.4.0/README.md
+++ b/releases/v1.4.0/README.md
@@ -1,0 +1,48 @@
+# Core Release v1.4.0
+
+**Branch**: `release/v1.4.0`
+**PR**: [#58](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/58)
+**Target**: Red-Blink/dune-awakening-selfhost-docker main
+**State**: Open
+
+## Scope
+
+Core Docker self-hosting platform release v1.4.0.
+Includes modular read-only Discord adapter integration and runtime improvements.
+
+## Included
+
+| Feature | Source |
+|---------|--------|
+| Modular read-only Discord adapter | release/discord-adapter-readonly |
+| Sietch override publisher stability fix | Upstream changes |
+| Game update UI with update log panel | Upstream changes |
+| Player admin: Repair Vehicle Red Bar action | Upstream changes |
+| Journey browser enhancements | Upstream changes |
+| Readiness/status dynamic port checks | Upstream changes |
+| Database browser table preview filtering | Upstream changes |
+| Aggregate login rate limiting | Upstream changes |
+| Addon provenance recording | Upstream changes |
+
+## Artifacts
+
+| Artifact | Location |
+|----------|----------|
+| PR body | `docs/PR-v1.4.0-core-release.md` |
+
+## Security
+
+- Discord adapter disabled by default
+- Login rate limiting added
+- Addon provenance tracking
+- All existing security gates maintained
+
+## Staging Checklist
+
+- [ ] Discord adapter read-only PR merged first
+- [ ] All upstream features verified
+- [ ] CHANGELOG updated
+- [ ] Version bump across all files
+- [ ] Release notes complete
+- [ ] Security gates pass
+- [ ] SBOM and checksums verified


### PR DESCRIPTION
## Summary

Add modular read-only Discord adapter to the WebUI API. This replaces the
inline discordAdapter.js with a structured integration module and adds
comprehensive docs, tests, and launcher scripts.

## User Impact

Server operators can enable the Discord adapter (`DUNE_DISCORD_ADAPTER_ENABLED=true`)
to expose health, status, readiness, and services routes for a companion
Discord bot. The adapter is disabled by default and requires explicit
configuration.

## Security Impact

- New surface: Discord adapter API with bearer-token authentication
- Disabled by default — no exposure until operator enables it
- Role-based capability tiers (public, observer, moderator, admin, owner)
- Read-only routes only — no write mutations
- Redaction of internal IPs, paths, and secrets from API responses
- Audit event schema for future write operations
- STRIDE and abuse-case review documented in adapter contract

## Configuration

New env vars:
- `DUNE_DISCORD_ADAPTER_ENABLED` (default: false)
- `DUNE_DISCORD_ADAPTER_TOKEN` or `DUNE_DISCORD_ADAPTER_TOKEN_FILE`
- `DUNE_BOT_API_TOKEN_FILE` (also used for bot token)
- `DISCORD_OBSERVER_ROLE_IDS`, `DISCORD_ADMIN_ROLE_IDS`, `DISCORD_OWNER_ROLE_IDS`

## Adapter Routes

| Route | Method | Min Tier | Description |
|---|---|---|---|
| `/api/integrations/discord/health` | GET | token only | Health check |
| `/api/integrations/discord/status` | POST | public | Stack status |
| `/api/integrations/discord/readiness` | POST | observer | Readiness check |
| `/api/integrations/discord/services` | POST | observer | Service list |
| `/api/integrations/discord/population` | POST | moderator | Online count |
| `/api/integrations/discord/logs` | POST | admin | Log retrieval |
| `/api/integrations/discord/map-state` | POST | moderator | Map metadata |
| `/api/integrations/discord/backups/list` | POST | moderator | Backup listing |

## Tests and Evidence

- [x] Unit tests for adapter health, status, readiness, services
- [x] Unit tests for policy capability resolution
- [x] Unit tests for audit schema and redaction
- [x] Unit tests for status parsing and formatting
- [x] Route compatibility tests
- [x] Launcher script validation

## Known Limitations

- Population route requires Dune server to be running (`dune players` command)
- Logs, map-state, and backup routes are defined but not fully implemented
- No write-capable commands — read-only only

## Documentation

- `docs/discord-control-bot/README.md` — main documentation
- `docs/discord-control-bot/api-adapter-contract.md` — full API contract
- `docs/discord-control-bot/admin-guide.md` — admin setup guide
- `docs/discord-control-bot/security-gates.md` — security requirements

## Sources

- `docs/discord-control-bot/api-adapter-contract.md`
- `docs/discord-control-bot/roadmap.md`
- PR discussions in feature/discord-control-bot branch
