### PR TITLE
Discord adapter: write-safety foundation planning

### DIFF
--- a/docs/PR-discord-adapter-write-foundation.md
+++ b/docs/PR-discord-adapter-write-foundation.md
@@ -1,0 +1,36 @@
+## Summary
+
+Write-safety foundation for the Discord adapter. **Future train — not yet implemented.**
+This PR establishes the planning baseline and entry criteria for introducing
+write-capable Discord adapter routes.
+
+## Entry Criteria (not yet met)
+
+- [ ] Read-only adapter (release/discord-adapter-readonly) merged and stable
+- [ ] Upstream approves write-capable adapter contract
+- [ ] STRIDE and abuse-case review completed
+
+## When Implemented
+
+Required foundation:
+- Write routes disabled by default (`DUNE_DISCORD_WRITES_ENABLED=false`)
+- Write-specific RBAC that observer roles do not inherit
+- Capability discovery before route execution
+- Confirmation primitives for write operations
+- Idempotency key generation and enforcement
+- Audit event publishing for all write operations
+- Write adapter timeout and retry rules
+- Redaction tests for previews, failures, and audit output
+
+## Security Impact (future)
+
+- All write paths disabled by default — no execution risk until explicitly enabled
+- Dedicated write capability tiers (write-admin, write-owner)
+- Confirmation cannot be bypassed
+- Audit trail for every write operation
+- Ephemeral Discord responses for write results
+
+## Sources
+
+- `docs/discord-control-bot/roadmap.md` (on release/discord-adapter-readonly)
+- `docs/discord-control-bot/api-adapter-contract.md`

--- a/releases/adapter-readonly/README.md
+++ b/releases/adapter-readonly/README.md
@@ -1,0 +1,56 @@
+# Discord Adapter — Read-Only Integration
+
+**Branch**: `release/discord-adapter-readonly`
+**PR**: [#56](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/56)
+**Target**: Red-Blink/dune-awakening-selfhost-docker main
+**State**: Open
+
+## Scope
+
+Modular read-only Discord adapter extracted from `feature/discord-control-bot`.
+8 integration modules, 2 launcher scripts, comprehensive test suite, full documentation.
+
+## Included Modules
+
+| Module | Purpose |
+|--------|---------|
+| `adapter.js` | Core adapter with capability-based routing |
+| `routes.js` | Route registration and capability binding |
+| `policy.js` | RBAC policy evaluation |
+| `audit.js` | Audit event schema and publishing |
+| `redact.js` | PII and secret redaction |
+| `fixtures.js` | Test fixtures and mock data |
+| `health.js` | Adapter health endpoint |
+| `config.js` | Configuration schema and defaults |
+
+## Artifacts
+
+| Artifact | Location |
+|----------|----------|
+| PR body | `docs/PR-discord-adapter-readonly.md` |
+| Project docs | `docs/discord-control-bot/` |
+| Adapter contract | `docs/discord-control-bot/api-adapter-contract.md` |
+| Roadmap | `docs/discord-control-bot/roadmap.md` |
+| Setup guide | `docs/discord-control-bot/setup-guide.md` |
+| User guide | `docs/discord-control-bot/user-guide.md` |
+
+## Security Controls
+
+- Discord adapter disabled by default (`DUNE_DISCORD_ADAPTER_ENABLED=false`)
+- Bearer-token authentication on every route
+- Capability-based RBAC
+- All routes read-only
+- Audit event publishing
+- PII/secret redaction
+- Bounded response size
+
+## Staging Checklist
+
+- [ ] Modular adapter code reviewed
+- [ ] All routes read-only verified
+- [ ] RBAC matrix complete
+- [ ] Audit schema documented
+- [ ] Redaction tests pass
+- [ ] Launcher scripts tested
+- [ ] Setup guide verified
+- [ ] No unresolved security findings

--- a/releases/adapter-write-foundation/README.md
+++ b/releases/adapter-write-foundation/README.md
@@ -1,0 +1,41 @@
+# Discord Adapter — Write-Safety Foundation Planning
+
+**Branch**: `release/discord-adapter-write-foundation`
+**PR**: [#57](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/57)
+**Target**: Red-Blink/dune-awakening-selfhost-docker main
+**State**: Open (planning only)
+
+## Scope
+
+Planning baseline for write-capable Discord adapter routes.
+Not yet implemented.
+
+## Artifacts
+
+| Artifact | Location |
+|----------|----------|
+| PR body | `docs/PR-discord-adapter-write-foundation.md` |
+
+## Entry Criteria (not yet met)
+
+- [ ] Read-only adapter (release/discord-adapter-readonly) merged and stable
+- [ ] Upstream approves write-capable adapter contract
+- [ ] STRIDE and abuse-case review completed
+
+## When Implemented
+
+Required foundation:
+- Write routes disabled by default (`DUNE_DISCORD_WRITES_ENABLED=false`)
+- Write-specific RBAC that observer roles do not inherit
+- Capability discovery before route execution
+- Confirmation primitives for write operations
+- Idempotency key generation and enforcement
+- Audit event publishing for all write operations
+- Write adapter timeout and retry rules
+- Redaction tests for previews, failures, and audit output
+
+## Staging Checklist
+
+- [ ] Planning doc reviewed by upstream
+- [ ] Entry criteria tracked
+- [ ] Upstream write-contract RFC published

--- a/releases/index.md
+++ b/releases/index.md
@@ -1,0 +1,26 @@
+# Release Staging Index — Core Docker
+
+Staging area for upstream PRs organized by release train.
+Each subdirectory contains the PR artifacts for that release.
+
+## Release Train Manifest
+
+| Train | Scope | PR | Branch | Status |
+|-------|-------|----|--------|--------|
+| v1.4.0 | Core release including Discord adapter | [#58](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/58) | `release/v1.4.0` | Open |
+| Adapter RO | Modular read-only Discord adapter | [#56](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/56) | `release/discord-adapter-readonly` | Open |
+| Adapter WF | Write-safety foundation planning | [#57](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/57) | `release/discord-adapter-write-foundation` | Open |
+
+## Artifacts per PR
+
+Each release PR directory contains:
+- PR body documentation
+- Reference to related docs
+- Staging checklist
+
+## Staging Rules
+
+1. **Read-only first**: Adapter read-only must be reviewed before any write work
+2. **Upstream alignment**: All releases target Red-Blink/dune-awakening-selfhost-docker main
+3. **Security**: Discord adapter disabled by default, bearer-token authenticated, RBAC-enforced
+4. **Modular**: Each adapter feature is a separate route module with capability-based access

--- a/releases/v1.4.0/README.md
+++ b/releases/v1.4.0/README.md
@@ -1,0 +1,48 @@
+# Core Release v1.4.0
+
+**Branch**: `release/v1.4.0`
+**PR**: [#58](https://github.com/Red-Blink/dune-awakening-selfhost-docker/pull/58)
+**Target**: Red-Blink/dune-awakening-selfhost-docker main
+**State**: Open
+
+## Scope
+
+Core Docker self-hosting platform release v1.4.0.
+Includes modular read-only Discord adapter integration and runtime improvements.
+
+## Included
+
+| Feature | Source |
+|---------|--------|
+| Modular read-only Discord adapter | release/discord-adapter-readonly |
+| Sietch override publisher stability fix | Upstream changes |
+| Game update UI with update log panel | Upstream changes |
+| Player admin: Repair Vehicle Red Bar action | Upstream changes |
+| Journey browser enhancements | Upstream changes |
+| Readiness/status dynamic port checks | Upstream changes |
+| Database browser table preview filtering | Upstream changes |
+| Aggregate login rate limiting | Upstream changes |
+| Addon provenance recording | Upstream changes |
+
+## Artifacts
+
+| Artifact | Location |
+|----------|----------|
+| PR body | `docs/PR-v1.4.0-core-release.md` |
+
+## Security
+
+- Discord adapter disabled by default
+- Login rate limiting added
+- Addon provenance tracking
+- All existing security gates maintained
+
+## Staging Checklist
+
+- [ ] Discord adapter read-only PR merged first
+- [ ] All upstream features verified
+- [ ] CHANGELOG updated
+- [ ] Version bump across all files
+- [ ] Release notes complete
+- [ ] Security gates pass
+- [ ] SBOM and checksums verified


### PR DESCRIPTION
## Summary

Write-safety foundation for the Discord adapter. **Future train — not yet implemented.**
This PR establishes the planning baseline and entry criteria for introducing
write-capable Discord adapter routes.

## Entry Criteria (not yet met)

- [ ] Read-only adapter (release/discord-adapter-readonly) merged and stable
- [ ] Upstream approves write-capable adapter contract
- [ ] STRIDE and abuse-case review completed

## When Implemented

Required foundation:
- Write routes disabled by default (`DUNE_DISCORD_WRITES_ENABLED=false`)
- Write-specific RBAC that observer roles do not inherit
- Capability discovery before route execution
- Confirmation primitives for write operations
- Idempotency key generation and enforcement
- Audit event publishing for all write operations
- Write adapter timeout and retry rules
- Redaction tests for previews, failures, and audit output

## Security Impact (future)

- All write paths disabled by default — no execution risk until explicitly enabled
- Dedicated write capability tiers (write-admin, write-owner)
- Confirmation cannot be bypassed
- Audit trail for every write operation
- Ephemeral Discord responses for write results

## Sources

- `docs/discord-control-bot/roadmap.md` (on release/discord-adapter-readonly)
- `docs/discord-control-bot/api-adapter-contract.md`
