### PR TITLE
feat: add opt-in Prometheus metrics stack and monitoring scripts

### DIFF
--- a/docker-compose.metrics.yml
+++ b/docker-compose.metrics.yml
@@ -1,0 +1,80 @@
+services:
+  dune-prometheus:
+    image: ${METRICS_PROMETHEUS_IMAGE:-prom/prometheus:latest}
+    container_name: dune-prometheus
+    restart: unless-stopped
+    networks:
+      - dune-net
+    ports:
+      - "127.0.0.1:${METRICS_PROMETHEUS_PORT:-9090}:9090"
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=${METRICS_RETENTION_TIME:-7d}
+      - --storage.tsdb.retention.size=${METRICS_RETENTION_SIZE:-2GB}
+      - --web.console.libraries=/usr/share/prometheus/console_libraries
+      - --web.console.templates=/usr/share/prometheus/consoles
+      - --web.enable-lifecycle
+    volumes:
+      - ./runtime/metrics/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./runtime/metrics/rules:/etc/prometheus/rules:ro
+      - dune-prometheus-data:/prometheus
+    security_opt:
+      - no-new-privileges:true
+
+  dune-node-exporter:
+    image: ${METRICS_NODE_EXPORTER_IMAGE:-quay.io/prometheus/node-exporter:latest}
+    container_name: dune-node-exporter
+    restart: unless-stopped
+    networks:
+      - dune-net
+    command:
+      - --path.rootfs=/host
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/docker/netns|var/lib/docker/.+)($$|/)
+      - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$$
+    pid: host
+    volumes:
+      # Avoid :rslave by default because WSL/Docker Desktop root mounts may not be shared/slave mounts.
+      - /:/host:ro
+    security_opt:
+      - no-new-privileges:true
+
+  dune-cadvisor:
+    image: ${METRICS_CADVISOR_IMAGE:-gcr.io/cadvisor/cadvisor:latest}
+    container_name: dune-cadvisor
+    restart: unless-stopped
+    networks:
+      - dune-net
+    privileged: true
+    command:
+      - --docker_only=true
+      - --housekeeping_interval=10s
+      - --store_container_labels=false
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+      - /dev/disk:/dev/disk:ro
+
+  dune-postgres-exporter:
+    image: ${METRICS_POSTGRES_EXPORTER_IMAGE:-quay.io/prometheuscommunity/postgres-exporter:latest}
+    container_name: dune-postgres-exporter
+    restart: unless-stopped
+    networks:
+      - dune-net
+    environment:
+      DATA_SOURCE_URI: dune-postgres:5432/dune?sslmode=disable
+      DATA_SOURCE_USER: ${DUNE_DB_USER:-dune}
+      DATA_SOURCE_PASS: ${DUNE_DB_PASSWORD:-dune}
+      PG_EXPORTER_DISABLE_DEFAULT_METRICS: "false"
+      PG_EXPORTER_DISABLE_SETTINGS_METRICS: "false"
+    security_opt:
+      - no-new-privileges:true
+
+networks:
+  dune-net:
+    external: true
+
+volumes:
+  dune-prometheus-data:

--- a/runtime/metrics/prometheus.yml
+++ b/runtime/metrics/prometheus.yml
@@ -1,0 +1,51 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  scrape_timeout: 10s
+
+rule_files:
+  - /etc/prometheus/rules/*.yml
+
+scrape_configs:
+  - job_name: dune-prometheus
+    static_configs:
+      - targets:
+          - dune-prometheus:9090
+        labels:
+          service: prometheus
+
+  - job_name: dune-node
+    static_configs:
+      - targets:
+          - dune-node-exporter:9100
+        labels:
+          service: node-exporter
+
+  - job_name: dune-cadvisor
+    scrape_interval: 10s
+    static_configs:
+      - targets:
+          - dune-cadvisor:8080
+        labels:
+          service: cadvisor
+
+  - job_name: dune-postgres
+    static_configs:
+      - targets:
+          - dune-postgres-exporter:9187
+        labels:
+          service: postgres-exporter
+
+  - job_name: dune-rabbitmq-admin
+    static_configs:
+      - targets:
+          - dune-rmq-admin:15692
+        labels:
+          service: rabbitmq-admin
+
+  - job_name: dune-rabbitmq-game
+    static_configs:
+      - targets:
+          - dune-rmq-game:15692
+        labels:
+          service: rabbitmq-game

--- a/runtime/metrics/rules/containers.yml
+++ b/runtime/metrics/rules/containers.yml
@@ -1,0 +1,49 @@
+groups:
+  - name: dune-containers
+    rules:
+      - alert: DuneContainerMissing
+        expr: absent(container_last_seen{name=~"dune-.*|redblink-dune-docker-console"})
+        for: 2m
+        labels:
+          severity: warning
+          service: cadvisor
+        annotations:
+          summary: Dune container metrics are missing
+          description: cAdvisor is not reporting expected Dune container metrics.
+
+      - alert: DuneContainerHighMemory
+        expr: |
+          (
+            container_memory_working_set_bytes{name=~"dune-.*|redblink-dune-docker-console"}
+            / container_spec_memory_limit_bytes{name=~"dune-.*|redblink-dune-docker-console"}
+          ) * 100 > 90
+          and container_spec_memory_limit_bytes{name=~"dune-.*|redblink-dune-docker-console"} > 0
+        for: 10m
+        labels:
+          severity: warning
+          service: cadvisor
+        annotations:
+          summary: Dune container memory usage is high
+          description: A Dune container is using more than 90% of its memory limit for 10 minutes.
+
+      - alert: DuneContainerMemoryFailures
+        expr: increase(container_memory_failcnt{name=~"dune-.*|redblink-dune-docker-console"}[10m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          service: cadvisor
+        annotations:
+          summary: Dune container memory allocation failures detected
+          description: A Dune container memory fail counter increased in the last 10 minutes.
+
+      - alert: DuneContainerNetworkErrors
+        expr: |
+          rate(container_network_receive_errors_total{name=~"dune-.*|redblink-dune-docker-console"}[5m]) > 0
+          or rate(container_network_transmit_errors_total{name=~"dune-.*|redblink-dune-docker-console"}[5m]) > 0
+        for: 10m
+        labels:
+          severity: warning
+          service: cadvisor
+        annotations:
+          summary: Dune container network errors detected
+          description: A Dune container is reporting network receive or transmit errors.

--- a/runtime/metrics/rules/dune-stack.yml
+++ b/runtime/metrics/rules/dune-stack.yml
@@ -1,0 +1,3 @@
+groups:
+  - name: dune-stack
+    rules: []

--- a/runtime/metrics/rules/host.yml
+++ b/runtime/metrics/rules/host.yml
@@ -1,0 +1,62 @@
+groups:
+  - name: dune-host
+    rules:
+      - alert: DuneHostHighCpu
+        expr: 100 * (1 - avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m]))) > 85
+        for: 10m
+        labels:
+          severity: warning
+          service: node-exporter
+        annotations:
+          summary: Dune host CPU usage is high
+          description: Host CPU usage has been above 85% for 10 minutes.
+
+      - alert: DuneHostHighMemory
+        expr: 100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) > 90
+        for: 10m
+        labels:
+          severity: warning
+          service: node-exporter
+        annotations:
+          summary: Dune host memory usage is high
+          description: Host memory usage has been above 90% for 10 minutes.
+
+      - alert: DuneHostLowAvailableMemory
+        expr: node_memory_MemAvailable_bytes < 2147483648
+        for: 5m
+        labels:
+          severity: critical
+          service: node-exporter
+        annotations:
+          summary: Dune host available memory is critically low
+          description: Host available memory has been below 2 GiB for 5 minutes.
+
+      - alert: DuneHostHighFilesystemUsage
+        expr: 100 * (1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"})) > 85
+        for: 15m
+        labels:
+          severity: warning
+          service: node-exporter
+        annotations:
+          summary: Dune host filesystem usage is high
+          description: A host filesystem has been above 85% usage for 15 minutes.
+
+      - alert: DuneHostCriticalFilesystemUsage
+        expr: 100 * (1 - (node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"})) > 95
+        for: 5m
+        labels:
+          severity: critical
+          service: node-exporter
+        annotations:
+          summary: Dune host filesystem usage is critical
+          description: A host filesystem has been above 95% usage for 5 minutes.
+
+      - alert: DuneHostFilesystemReadonly
+        expr: node_filesystem_readonly{fstype!~"tmpfs|overlay"} == 1
+        for: 1m
+        labels:
+          severity: critical
+          service: node-exporter
+        annotations:
+          summary: Dune host filesystem is read-only
+          description: A host filesystem is reporting read-only state.

--- a/runtime/metrics/rules/postgres.yml
+++ b/runtime/metrics/rules/postgres.yml
@@ -1,0 +1,67 @@
+groups:
+  - name: dune-postgres
+    rules:
+      - alert: DunePostgresDown
+        expr: pg_up == 0
+        for: 1m
+        labels:
+          severity: critical
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres is down
+          description: postgres_exporter reports pg_up == 0.
+
+      - alert: DunePostgresExporterScrapeError
+        expr: pg_exporter_last_scrape_error == 1
+        for: 5m
+        labels:
+          severity: warning
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres exporter scrape error
+          description: postgres_exporter has reported scrape errors for 5 minutes.
+
+      - alert: DunePostgresHighConnections
+        expr: 100 * (sum(pg_stat_activity_count) / sum(pg_settings_max_connections)) > 80
+        for: 10m
+        labels:
+          severity: warning
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres connection usage is high
+          description: Postgres active connections are above 80% of max connections.
+
+      - alert: DunePostgresCriticalConnections
+        expr: 100 * (sum(pg_stat_activity_count) / sum(pg_settings_max_connections)) > 95
+        for: 2m
+        labels:
+          severity: critical
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres connection usage is critical
+          description: Postgres active connections are above 95% of max connections.
+
+      - alert: DunePostgresDeadlocks
+        expr: increase(pg_stat_database_deadlocks{datname="dune"}[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres deadlocks detected
+          description: The Dune database deadlock counter increased in the last 5 minutes.
+
+      - alert: DunePostgresLowCacheHitRatio
+        expr: |
+          100 * (
+            pg_stat_database_blks_hit{datname="dune"}
+            /
+            (pg_stat_database_blks_hit{datname="dune"} + pg_stat_database_blks_read{datname="dune"})
+          ) < 95
+        for: 15m
+        labels:
+          severity: warning
+          service: postgres-exporter
+        annotations:
+          summary: Dune Postgres cache hit ratio is low
+          description: The Dune database cache hit ratio has been below 95% for 15 minutes.

--- a/runtime/metrics/rules/rabbitmq.yml
+++ b/runtime/metrics/rules/rabbitmq.yml
@@ -1,0 +1,64 @@
+groups:
+  - name: dune-rabbitmq
+    rules:
+      - alert: DuneRabbitMQDown
+        expr: rabbitmq_up == 0
+        for: 1m
+        labels:
+          severity: critical
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ broker is down
+          description: RabbitMQ Prometheus metrics report rabbitmq_up == 0.
+
+      - alert: DuneRabbitMQHighMemory
+        expr: 100 * (rabbitmq_process_resident_memory_bytes / rabbitmq_resident_memory_limit_bytes) > 80
+        for: 10m
+        labels:
+          severity: warning
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ memory usage is high
+          description: RabbitMQ resident memory is above 80% of its limit.
+
+      - alert: DuneRabbitMQHighFileDescriptors
+        expr: 100 * (rabbitmq_process_open_fds / rabbitmq_process_max_fds) > 80
+        for: 10m
+        labels:
+          severity: warning
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ file descriptor usage is high
+          description: RabbitMQ open file descriptors are above 80% of max file descriptors.
+
+      - alert: DuneRabbitMQQueueBacklog
+        expr: rabbitmq_queue_messages_ready > 1000
+        for: 10m
+        labels:
+          severity: warning
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ queue backlog detected
+          description: RabbitMQ ready queue messages have been above 1000 for 10 minutes.
+
+      - alert: DuneRabbitMQUnackedBacklog
+        expr: rabbitmq_queue_messages_unacked > 1000
+        for: 10m
+        labels:
+          severity: warning
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ unacked backlog detected
+          description: RabbitMQ unacked messages have been above 1000 for 10 minutes.
+
+      - alert: DuneRabbitMQUnroutableMessages
+        expr: |
+          rate(rabbitmq_global_messages_unroutable_dropped_total[5m]) > 0
+          or rate(rabbitmq_global_messages_unroutable_returned_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+          service: rabbitmq
+        annotations:
+          summary: Dune RabbitMQ unroutable messages detected
+          description: RabbitMQ unroutable dropped or returned message counters are increasing.

--- a/runtime/scripts/dune
+++ b/runtime/scripts/dune
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1091
+# .env is runtime/operator-local and may not exist during static analysis.
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
@@ -111,6 +113,14 @@ command_can_sudo_reexec_safely() {
   case "$cmd" in
     status|ps|servers|ports|ping|ping-diagnostics|ready|logs|doctor)
       return 0
+      ;;
+    metrics)
+      case "$target" in
+        ""|status|ps|logs|config|help|--help|-h)
+          return 0
+          ;;
+      esac
+      return 1
       ;;
     *)
       return 1
@@ -335,6 +345,11 @@ EOF
     runtime/scripts/console.sh "$@"
     ;;
 
+  metrics)
+    shift || true
+    bash runtime/scripts/metrics-stack.sh "$@"
+    ;;
+
   update)
     shift || true
     set -a
@@ -432,6 +447,7 @@ Usage:
   dune logs <service> [--raw]
   dune restart <service>
   dune console restart
+  dune metrics [start|stop|restart|status|logs|config|pull]
   dune update [check|auto enable|auto disable|auto status|--yes]
   dune self-update [check|list|install [latest|<tag>]]
   dune restart-schedule [enable <HH:MM> [notify-minutes]|disable|status]

--- a/runtime/scripts/metrics-stack.sh
+++ b/runtime/scripts/metrics-stack.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+command_name="${1:-status}"
+compose_file="docker-compose.metrics.yml"
+metrics_project_name="${DUNE_METRICS_COMPOSE_PROJECT_NAME:-${DUNE_COMPOSE_PROJECT_NAME:-dune-awakening-selfhost-docker}-metrics}"
+prometheus_port="${METRICS_PROMETHEUS_PORT:-}"
+
+if [ -z "$prometheus_port" ] && [ -f .env ]; then
+  prometheus_port="$(awk -F= '/^METRICS_PROMETHEUS_PORT=/ {print $2; exit}' .env | sed 's/[[:space:]"]//g' || true)"
+fi
+prometheus_port="${prometheus_port:-9090}"
+
+compose() {
+  COMPOSE_PROJECT_NAME="$metrics_project_name" \
+    COMPOSE_IGNORE_ORPHANS=true \
+    docker compose -f "$compose_file" "$@"
+}
+
+require_docker() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is not available."
+    exit 1
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    echo "Docker is not reachable from this shell."
+    exit 1
+  fi
+  if ! docker compose version >/dev/null 2>&1; then
+    echo "Docker Compose v2 is required."
+    exit 1
+  fi
+}
+
+require_curl_python() {
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required for metrics validation."
+    exit 1
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required for metrics validation output parsing."
+    exit 1
+  fi
+}
+
+ensure_compose_file() {
+  if [ ! -f "$compose_file" ]; then
+    echo "Missing $compose_file."
+    exit 1
+  fi
+}
+
+ensure_network() {
+  docker network create dune-net >/dev/null 2>&1 || true
+}
+
+print_url() {
+  echo "Prometheus: http://127.0.0.1:${prometheus_port}"
+}
+
+curl_prometheus() {
+  local path="$1"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsS --max-time 3 "http://127.0.0.1:${prometheus_port}${path}"
+    return $?
+  fi
+  return 127
+}
+
+query_prometheus() {
+  local query="$1"
+  curl -fsS --max-time 5 -G "http://127.0.0.1:${prometheus_port}/api/v1/query" \
+    --data-urlencode "query=${query}"
+}
+
+wait_for_prometheus_targets() {
+  local attempt
+  [ "${METRICS_SKIP_TARGET_WAIT:-0}" != "1" ] || return 0
+  command -v curl >/dev/null 2>&1 || return 0
+  command -v python3 >/dev/null 2>&1 || return 0
+
+  for attempt in $(seq 1 10); do
+    [ "${METRICS_VERBOSE:-0}" != "1" ] || echo "Waiting for Prometheus targets (${attempt}/10)..."
+    if curl_prometheus "/api/v1/targets" >/tmp/dune-prometheus-targets.json 2>/dev/null; then
+      if python3 - <<'PY'
+import json
+from pathlib import Path
+payload = json.loads(Path('/tmp/dune-prometheus-targets.json').read_text())
+raise SystemExit(0 if payload.get('data', {}).get('activeTargets') else 1)
+PY
+      then
+        rm -f /tmp/dune-prometheus-targets.json
+        return 0
+      fi
+    fi
+    sleep 1
+  done
+  rm -f /tmp/dune-prometheus-targets.json
+}
+
+show_targets() {
+  if command -v curl >/dev/null 2>&1 && curl_prometheus "/api/v1/targets" >/tmp/dune-prometheus-targets.json 2>/dev/null; then
+    if command -v python3 >/dev/null 2>&1; then
+      python3 - <<'PY'
+import json
+from pathlib import Path
+payload = json.loads(Path('/tmp/dune-prometheus-targets.json').read_text())
+active_targets = payload.get('data', {}).get('activeTargets', [])
+print(f"active_targets={len(active_targets)}")
+if not active_targets:
+    print("No active Prometheus targets reported yet. This is not a passing validation state; re-run status or inspect /api/v1/targets.")
+for target in active_targets:
+    labels = target.get('labels', {})
+    job = labels.get('job', '-')
+    instance = labels.get('instance', '-')
+    health = target.get('health', '-')
+    last_error = target.get('lastError') or ''
+    suffix = f" ({last_error})" if last_error else ''
+    print(f"{job}\t{instance}\t{health}{suffix}")
+PY
+    else
+      echo "Target API reachable. Install python3 for formatted target output."
+    fi
+    rm -f /tmp/dune-prometheus-targets.json
+  else
+    echo "target API unavailable"
+  fi
+}
+
+show_status() {
+  require_docker
+  ensure_compose_file
+
+  echo "=== Metrics containers ==="
+  docker ps -a \
+    --filter "name=dune-prometheus" \
+    --filter "name=dune-node-exporter" \
+    --filter "name=dune-cadvisor" \
+    --filter "name=dune-postgres-exporter" \
+    --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" || true
+
+  echo
+  echo "=== Prometheus health ==="
+  if curl_prometheus "/-/healthy" >/dev/null 2>&1; then
+    echo "healthy"
+    print_url
+  else
+    echo "not reachable on 127.0.0.1:${prometheus_port}"
+  fi
+
+  echo
+  echo "=== Prometheus targets ==="
+  show_targets
+}
+
+validate_metrics() {
+  require_docker
+  require_curl_python
+  ensure_compose_file
+
+  local fail=0
+  local tmp_targets tmp_rules tmp_up tmp_pg
+  tmp_targets="$(mktemp)"
+  tmp_rules="$(mktemp)"
+  tmp_up="$(mktemp)"
+  tmp_pg="$(mktemp)"
+
+  echo "=== Metrics validation ==="
+  print_url
+
+  echo
+  echo "Checking Prometheus health..."
+  if curl_prometheus "/-/healthy" >/dev/null 2>&1; then
+    echo "OK   Prometheus health"
+  else
+    echo "FAIL Prometheus is not healthy on 127.0.0.1:${prometheus_port}"
+    fail=1
+  fi
+
+  echo
+  echo "Checking Prometheus targets..."
+  if curl_prometheus "/api/v1/targets" >"$tmp_targets" 2>/dev/null; then
+    if ! python3 - "$tmp_targets" <<'PY'
+import json
+import sys
+from pathlib import Path
+payload = json.loads(Path(sys.argv[1]).read_text())
+targets = payload.get('data', {}).get('activeTargets', [])
+expected = {'dune-prometheus', 'dune-node', 'dune-cadvisor', 'dune-postgres'}
+seen = {target.get('labels', {}).get('job') for target in targets}
+missing = sorted(expected - seen)
+print(f"active_targets={len(targets)}")
+for target in targets:
+    labels = target.get('labels', {})
+    job = labels.get('job', '-')
+    instance = labels.get('instance', '-')
+    health = target.get('health', '-')
+    last_error = target.get('lastError') or ''
+    suffix = f" ({last_error})" if last_error else ''
+    print(f"{job}\t{instance}\t{health}{suffix}")
+if missing:
+    print("Missing required jobs: " + ", ".join(missing))
+    raise SystemExit(1)
+if not targets:
+    print("No active targets returned.")
+    raise SystemExit(1)
+PY
+    then
+      fail=1
+    fi
+  else
+    echo "FAIL target API unavailable"
+    fail=1
+  fi
+
+  echo
+  echo "Checking Prometheus rules..."
+  if curl_prometheus "/api/v1/rules" >"$tmp_rules" 2>/dev/null; then
+    if ! python3 - "$tmp_rules" <<'PY'
+import json
+import sys
+from pathlib import Path
+payload = json.loads(Path(sys.argv[1]).read_text())
+groups = payload.get('data', {}).get('groups', [])
+print(f"rule_groups={len(groups)}")
+for group in groups:
+    name = group.get('name', '-')
+    rules = group.get('rules', [])
+    print(f"{name}\trules={len(rules)}")
+if not groups:
+    print("No rule groups returned.")
+    raise SystemExit(1)
+PY
+    then
+      fail=1
+    fi
+  else
+    echo "FAIL rules API unavailable"
+    fail=1
+  fi
+
+  echo
+  echo "Checking scrape health with query: up"
+  if query_prometheus "up" >"$tmp_up" 2>/dev/null; then
+    if ! python3 - "$tmp_up" <<'PY'
+import json
+import sys
+from pathlib import Path
+payload = json.loads(Path(sys.argv[1]).read_text())
+results = payload.get('data', {}).get('result', [])
+if not results:
+    print("No up results returned.")
+    raise SystemExit(1)
+failed = []
+for result in results:
+    metric = result.get('metric', {})
+    job = metric.get('job', '-')
+    instance = metric.get('instance', '-')
+    value = result.get('value', [None, '0'])[1]
+    print(f"{job}\t{instance}\tup={value}")
+    if value != '1':
+        failed.append(f"{job}/{instance}={value}")
+if failed:
+    print("Unhealthy scrape targets: " + ", ".join(failed))
+    raise SystemExit(1)
+PY
+    then
+      fail=1
+    fi
+  else
+    echo "FAIL Prometheus query failed: up"
+    fail=1
+  fi
+
+  echo
+  echo "Checking Postgres exporter with query: pg_up"
+  if query_prometheus "pg_up" >"$tmp_pg" 2>/dev/null; then
+    if ! python3 - "$tmp_pg" <<'PY'
+import json
+import sys
+from pathlib import Path
+payload = json.loads(Path(sys.argv[1]).read_text())
+results = payload.get('data', {}).get('result', [])
+if not results:
+    print("No pg_up results returned.")
+    raise SystemExit(1)
+failed = []
+for result in results:
+    metric = result.get('metric', {})
+    job = metric.get('job', '-')
+    instance = metric.get('instance', '-')
+    value = result.get('value', [None, '0'])[1]
+    print(f"{job}\t{instance}\tpg_up={value}")
+    if value != '1':
+        failed.append(f"{job}/{instance}={value}")
+if failed:
+    print("Postgres exporter connectivity failed: " + ", ".join(failed))
+    raise SystemExit(1)
+PY
+    then
+      fail=1
+    fi
+  else
+    echo "FAIL Prometheus query failed: pg_up"
+    fail=1
+  fi
+
+  rm -f "$tmp_targets" "$tmp_rules" "$tmp_up" "$tmp_pg"
+
+  echo
+  if [ "$fail" -eq 0 ]; then
+    echo "READY: metrics validation passed."
+  else
+    echo "FAIL: metrics validation failed."
+  fi
+  return "$fail"
+}
+
+case "$command_name" in
+  start|up)
+    require_docker
+    ensure_compose_file
+    ensure_network
+    echo "Starting Dune metrics stack..."
+    compose up -d
+    wait_for_prometheus_targets || true
+    echo
+    show_status
+    ;;
+
+  stop|down)
+    require_docker
+    ensure_compose_file
+    echo "Stopping Dune metrics stack..."
+    compose down
+    ;;
+
+  restart)
+    require_docker
+    ensure_compose_file
+    ensure_network
+    echo "Restarting Dune metrics stack..."
+    compose down
+    compose up -d
+    wait_for_prometheus_targets || true
+    echo
+    show_status
+    ;;
+
+  status|ps)
+    show_status
+    ;;
+
+  validate|check)
+    validate_metrics
+    ;;
+
+  logs)
+    require_docker
+    ensure_compose_file
+    shift || true
+    compose logs "$@"
+    ;;
+
+  config)
+    require_docker
+    ensure_compose_file
+    compose config
+    ;;
+
+  pull)
+    require_docker
+    ensure_compose_file
+    compose pull
+    ;;
+
+  help|--help|-h)
+    cat <<EOF
+Usage:
+  dune metrics start
+  dune metrics stop
+  dune metrics restart
+  dune metrics status
+  dune metrics validate
+  dune metrics logs [service]
+  dune metrics config
+  dune metrics pull
+
+The metrics stack is opt-in and independent from the game stack.
+Prometheus binds to 127.0.0.1:${prometheus_port} by default.
+Metrics compose project: ${metrics_project_name}
+EOF
+    ;;
+
+  *)
+    echo "Unknown metrics command: $command_name"
+    echo "Run: dune metrics --help"
+    exit 1
+    ;;
+esac

--- a/tests/metrics-stack-unit.sh
+++ b/tests/metrics-stack-unit.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+test_no=0
+
+note() {
+  printf '# %s\n' "$*"
+}
+
+ok() {
+  test_no=$((test_no + 1))
+  printf 'ok %02d - %s\n' "$test_no" "$*"
+}
+
+fail() {
+  test_no=$((test_no + 1))
+  printf 'not ok %02d - %s\n' "$test_no" "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local expected="$2"
+  local label="$3"
+
+  if grep -Fq -- "$expected" "$file"; then
+    ok "$label"
+    return 0
+  fi
+
+  echo "Expected to find: $expected" >&2
+  echo "--- output ---" >&2
+  cat "$file" >&2
+  echo "--------------" >&2
+  fail "$label"
+}
+
+assert_command_fails() {
+  local output_file="$1"
+  local label="$2"
+  shift 2
+
+  if "$@" >"$output_file" 2>&1; then
+    echo "--- unexpected success output ---" >&2
+    cat "$output_file" >&2
+    echo "-------------------------------" >&2
+    fail "$label"
+  fi
+
+  ok "$label"
+}
+
+show_output_block() {
+  local title="$1"
+  local file="$2"
+
+  note "$title"
+  sed 's/^/#   /' "$file"
+}
+
+echo "TAP version 13"
+note "metrics-stack unit tests"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+mkdir -p "$tmpdir/bin"
+ok "created isolated test harness directory"
+
+cat >"$tmpdir/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  info)
+    exit 0
+    ;;
+  compose)
+    shift || true
+    case "${1:-}" in
+      version)
+        echo "Docker Compose version v2.test"
+        exit 0
+        ;;
+      -f)
+        # Support: docker compose -f docker-compose.metrics.yml config
+        if [ "${3:-}" = "config" ]; then
+          echo "services: {}"
+          exit 0
+        fi
+        ;;
+    esac
+    echo "unexpected docker compose args: $*" >&2
+    exit 1
+    ;;
+  ps)
+    cat <<'PS'
+NAMES                    STATUS                    PORTS
+dune-prometheus          Up 1 minute               127.0.0.1:9090->9090/tcp
+dune-cadvisor            Up 1 minute (healthy)     8080/tcp
+dune-node-exporter       Up 1 minute               9100/tcp
+dune-postgres-exporter   Up 1 minute               9187/tcp
+PS
+    exit 0
+    ;;
+  network)
+    exit 0
+    ;;
+  *)
+    echo "unexpected docker args: $*" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "$tmpdir/bin/docker"
+ok "installed fake docker command"
+
+cat >"$tmpdir/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"${FAKE_CURL_LOG:?FAKE_CURL_LOG is required}"
+args=" $* "
+mode="${FAKE_PROMETHEUS_MODE:-ok}"
+
+if [[ "$args" == *"/-/healthy"* ]]; then
+  echo "healthy"
+  exit 0
+fi
+
+if [[ "$args" == *"/api/v1/targets"* ]]; then
+  if [ "$mode" = "missing-target" ]; then
+    cat <<'JSON'
+{"status":"success","data":{"activeTargets":[
+  {"labels":{"job":"dune-prometheus","instance":"dune-prometheus:9090"},"health":"up"},
+  {"labels":{"job":"dune-cadvisor","instance":"dune-cadvisor:8080"},"health":"up"},
+  {"labels":{"job":"dune-postgres","instance":"dune-postgres-exporter:9187"},"health":"up"}
+]}}
+JSON
+  else
+    cat <<'JSON'
+{"status":"success","data":{"activeTargets":[
+  {"labels":{"job":"dune-prometheus","instance":"dune-prometheus:9090"},"health":"up"},
+  {"labels":{"job":"dune-node","instance":"dune-node-exporter:9100"},"health":"up"},
+  {"labels":{"job":"dune-cadvisor","instance":"dune-cadvisor:8080"},"health":"up"},
+  {"labels":{"job":"dune-postgres","instance":"dune-postgres-exporter:9187"},"health":"up"},
+  {"labels":{"job":"dune-rabbitmq-admin","instance":"dune-rmq-admin:15692"},"health":"up"},
+  {"labels":{"job":"dune-rabbitmq-game","instance":"dune-rmq-game:15692"},"health":"up"}
+]}}
+JSON
+  fi
+  exit 0
+fi
+
+if [[ "$args" == *"/api/v1/rules"* ]]; then
+  cat <<'JSON'
+{"status":"success","data":{"groups":[
+  {"name":"dune-host","rules":[{"name":"DuneHostHighCpu"}]},
+  {"name":"dune-containers","rules":[{"name":"DuneContainerMetricsMissing"}]},
+  {"name":"dune-postgres","rules":[{"name":"DunePostgresDown"}]},
+  {"name":"dune-rabbitmq","rules":[{"name":"DuneRabbitmqDown"}]},
+  {"name":"dune-stack","rules":[]}
+]}}
+JSON
+  exit 0
+fi
+
+if [[ "$args" == *"query=pg_up"* ]]; then
+  cat <<'JSON'
+{"status":"success","data":{"resultType":"vector","result":[
+  {"metric":{"job":"dune-postgres","instance":"dune-postgres-exporter:9187"},"value":[1782798595.497,"1"]}
+]}}
+JSON
+  exit 0
+fi
+
+if [[ "$args" == *"query=up"* ]]; then
+  cat <<'JSON'
+{"status":"success","data":{"resultType":"vector","result":[
+  {"metric":{"job":"dune-postgres","instance":"dune-postgres-exporter:9187"},"value":[1782798595.478,"1"]},
+  {"metric":{"job":"dune-cadvisor","instance":"dune-cadvisor:8080"},"value":[1782798595.478,"1"]},
+  {"metric":{"job":"dune-rabbitmq-admin","instance":"dune-rmq-admin:15692"},"value":[1782798595.478,"1"]},
+  {"metric":{"job":"dune-rabbitmq-game","instance":"dune-rmq-game:15692"},"value":[1782798595.478,"1"]},
+  {"metric":{"job":"dune-prometheus","instance":"dune-prometheus:9090"},"value":[1782798595.478,"1"]},
+  {"metric":{"job":"dune-node","instance":"dune-node-exporter:9100"},"value":[1782798595.478,"1"]}
+]}}
+JSON
+  exit 0
+fi
+
+echo "unexpected curl args: $*" >&2
+exit 1
+EOF
+chmod +x "$tmpdir/bin/curl"
+ok "installed fake curl/Prometheus command"
+
+export PATH="$tmpdir/bin:$PATH"
+export FAKE_CURL_LOG="$tmpdir/curl.log"
+ok "wired fake commands into PATH"
+
+note "running happy-path metrics validation"
+pass_output="$tmpdir/pass.out"
+: >"$FAKE_CURL_LOG"
+METRICS_PROMETHEUS_PORT=9090 bash runtime/scripts/metrics-stack.sh validate >"$pass_output"
+show_output_block "happy-path validator output" "$pass_output"
+assert_contains "$pass_output" "OK   Prometheus health" "validator reports Prometheus health"
+assert_contains "$pass_output" "active_targets=6" "validator counts all six active targets"
+assert_contains "$pass_output" "dune-rabbitmq-admin" "validator includes RabbitMQ admin target"
+assert_contains "$pass_output" "dune-rabbitmq-game" "validator includes RabbitMQ game target"
+assert_contains "$pass_output" "rule_groups=5" "validator reports loaded rule groups"
+assert_contains "$pass_output" "pg_up=1" "validator confirms Postgres exporter connectivity"
+assert_contains "$pass_output" "READY: metrics validation passed." "validator returns READY on healthy fixtures"
+assert_contains "$FAKE_CURL_LOG" "--data-urlencode query=up" "validator URL-encodes the up query"
+assert_contains "$FAKE_CURL_LOG" "--data-urlencode query=pg_up" "validator URL-encodes the pg_up query"
+
+note "running required-target failure validation"
+missing_output="$tmpdir/missing.out"
+assert_command_fails "$missing_output" "validator fails when required target is missing" \
+  env FAKE_PROMETHEUS_MODE=missing-target METRICS_PROMETHEUS_PORT=9090 bash runtime/scripts/metrics-stack.sh validate
+show_output_block "missing-target validator output" "$missing_output"
+assert_contains "$missing_output" "Missing required jobs: dune-node" "validator names missing required target"
+assert_contains "$missing_output" "FAIL: metrics validation failed." "validator prints failure summary"
+
+echo "1..$test_no"
+note "metrics-stack unit tests completed"


### PR DESCRIPTION
## Summary

Adds an opt-in operational metrics stack to support server health monitoring without changing the default runtime path.

## What this adds

- **`docker-compose.metrics.yml`** — Prometheus with node-exporter, cAdvisor, postgres-exporter, and RabbitMQ metric endpoints
- **Prometheus rule files** — Alert rules for host, container, Postgres, and RabbitMQ health
- **`dune metrics` CLI** — Start, stop, restart, status, validate, logs, config, and pull commands
- **Validation script** — `dune metrics validate` checks target health, rule loading, scrape health, and Postgres connectivity

## Design

- Opt-in: does not start automatically with the game stack
- Prometheus binds to `127.0.0.1:9090` only (not publicly exposed)
- Exporters attach to the internal `dune-net` network
- All containers use `no-new-privileges:true` except cAdvisor (requires `privileged: true` for cgroup metrics)

## Testing

```bash
bash tests/metrics-stack-unit.sh
```

See `docs/E2E-METRICS-TESTING.md` for full E2E procedure.

## Rollback

Remove the metrics compose file and the `dune metrics` block from `runtime/scripts/dune`:

```bash
rm docker-compose.metrics.yml
rm -rf runtime/metrics/
sed -i '/metrics)/,/;;/d' runtime/scripts/dune
```
