### PR TITLE
Add modular read-only Discord adapter integration

### DIFF
--- a/console/api/scripts/apply-discord-server-hook.mjs
+++ b/console/api/scripts/apply-discord-server-hook.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const serverPath = resolve("src/server.js");
+let source = readFileSync(serverPath, "utf8");
+
+const importLine = 'import { handleDiscordAdapterRoute, isDiscordAdapterRoute } from "./integrations/discord/routes.js";\nimport { discordStatusProvider } from "./integrations/discord/statusProvider.js";\n';
+const importAnchor = 'import { funcomAuthMismatchDetected, matchingFuncomAuthLines, saveFuncomTokenValue as writeFuncomToken, validDockerSince } from "./services/funcomAuth.js";\n';
+
+if (!source.includes(importLine)) {
+  if (!source.includes(importAnchor)) {
+    throw new Error("Import anchor not found. Refusing to modify src/server.js.");
+  }
+  source = source.replace(importAnchor, `${importAnchor}${importLine}`);
+}
+
+const hook = `\n  if (isDiscordAdapterRoute(path)) {\n    return handleDiscordAdapterRoute({\n      req,\n      res,\n      path,\n      config,\n      readJson,\n      json,\n      statusProvider: ({ diagnostic } = {}) => discordStatusProvider(config, { diagnostic })\n    });\n  }\n`;
+const hookAnchor = '  if (path === "/api/health") return json(res, 200, { ok: true, app: config.appName });\n';
+
+if (!source.includes(hook)) {
+  if (!source.includes(hookAnchor)) {
+    throw new Error("Route hook anchor not found. Refusing to modify src/server.js.");
+  }
+  source = source.replace(hookAnchor, `${hook}${hookAnchor}`);
+}
+
+writeFileSync(serverPath, source, "utf8");
+console.log("Applied Discord adapter server hook to src/server.js");

--- a/console/api/scripts/start-discord-adapter.mjs
+++ b/console/api/scripts/start-discord-adapter.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const serverPath = resolve("src/server.js");
+let source = readFileSync(serverPath, "utf8");
+
+const importAnchor = 'import { funcomAuthMismatchDetected, matchingFuncomAuthLines, saveFuncomTokenValue as writeFuncomToken, validDockerSince } from "./services/funcomAuth.js";\n';
+const imports = [
+  'import { handleDiscordAdapterRoute, isDiscordAdapterRoute } from "./integrations/discord/routes.js";\n',
+  'import { discordStatusProvider } from "./integrations/discord/statusProvider.js";\n',
+  'import { discordReadinessProvider, discordServicesProvider } from "./integrations/discord/readOnlyProviders.js";\n'
+];
+
+if (!source.includes(importAnchor)) throw new Error("Server import anchor not found.");
+for (const line of imports) {
+  if (!source.includes(line)) source = source.replace(importAnchor, `${importAnchor}${line}`);
+}
+
+const hookAnchor = '  if (path === "/api/health") return json(res, 200, { ok: true, app: config.appName });\n';
+const hook = `\n  if (isDiscordAdapterRoute(path)) {\n    return handleDiscordAdapterRoute({\n      req,\n      res,\n      path,\n      config,\n      readJson,\n      json,\n      statusProvider: ({ diagnostic } = {}) => discordStatusProvider(config, { diagnostic }),\n      readinessProvider: () => discordReadinessProvider(config),\n      servicesProvider: () => discordServicesProvider(config)\n    });\n  }\n`;
+
+if (!source.includes("readinessProvider: () => discordReadinessProvider(config)")) {
+  if (source.includes("statusProvider: ({ diagnostic } = {}) => discordStatusProvider(config, { diagnostic })")) {
+    source = source.replace(
+      "statusProvider: ({ diagnostic } = {}) => discordStatusProvider(config, { diagnostic })",
+      "statusProvider: ({ diagnostic } = {}) => discordStatusProvider(config, { diagnostic }),\n      readinessProvider: () => discordReadinessProvider(config),\n      servicesProvider: () => discordServicesProvider(config)"
+    );
+  } else {
+    if (!source.includes(hookAnchor)) throw new Error("Server route anchor not found.");
+    source = source.replace(hookAnchor, `${hook}${hookAnchor}`);
+  }
+}
+
+writeFileSync(serverPath, source, "utf8");
+
+const child = spawn(process.execPath, ["src/server.js"], {
+  stdio: "inherit",
+  env: { ...process.env, DUNE_DISCORD_ADAPTER_ENABLED: "true" }
+});
+child.on("exit", (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  process.exitCode = code ?? 1;
+});

--- a/console/api/src/integrations/discord/adapter.js
+++ b/console/api/src/integrations/discord/adapter.js
@@ -1,0 +1,163 @@
+import { audit } from "../../audit.js";
+import { DISCORD_CAPABILITIES, normalizeDiscordActor, requireDiscordCapability } from "./policy.js";
+import { discordAuditEvent, discordBlockedAuditEvent } from "./audit.js";
+import { discordSafeError, sanitizeDiscordPublicStatus, sanitizeDiscordValue } from "./sanitize.js";
+
+export const DISCORD_ADAPTER_ROUTES = Object.freeze({
+  HEALTH: "/api/integrations/discord/health",
+  STATUS: "/api/integrations/discord/status",
+  READINESS: "/api/integrations/discord/readiness",
+  SERVICES: "/api/integrations/discord/services",
+  POPULATION: "/api/integrations/discord/population",
+  LOGS: "/api/integrations/discord/logs",
+  MAP_STATE: "/api/integrations/discord/map-state",
+  BACKUPS_LIST: "/api/integrations/discord/backups/list"
+});
+
+export const DISCORD_LIVE_ADAPTER_ROUTES = Object.freeze([
+  DISCORD_ADAPTER_ROUTES.HEALTH,
+  DISCORD_ADAPTER_ROUTES.STATUS,
+  DISCORD_ADAPTER_ROUTES.READINESS,
+  DISCORD_ADAPTER_ROUTES.SERVICES
+]);
+
+export const DISCORD_PLANNED_ADAPTER_ROUTES = Object.freeze(
+  Object.values(DISCORD_ADAPTER_ROUTES).filter((route) => !DISCORD_LIVE_ADAPTER_ROUTES.includes(route))
+);
+
+export function discordAdapterEnabled(config) {
+  return process.env.DUNE_DISCORD_ADAPTER_ENABLED === "true" || config?.discordAdapterEnabled === true;
+}
+
+export function discordWritesEnabled(_config) {
+  // Experimental companion bot is intentionally read-only.
+  return false;
+}
+
+export function discordRoleMappingFromEnv(env = process.env) {
+  return {
+    observerRoleIds: csv(env.DISCORD_OBSERVER_ROLE_IDS),
+    moderatorRoleIds: csv(env.DISCORD_MODERATOR_ROLE_IDS),
+    adminRoleIds: csv(env.DISCORD_ADMIN_ROLE_IDS),
+    ownerRoleIds: csv(env.DISCORD_OWNER_ROLE_IDS)
+  };
+}
+
+export function discordRolePolicyHealth(mapping = discordRoleMappingFromEnv()) {
+  return {
+    observerConfigured: mapping.observerRoleIds.length > 0,
+    moderatorConfigured: mapping.moderatorRoleIds.length > 0,
+    adminConfigured: mapping.adminRoleIds.length > 0,
+    ownerConfigured: mapping.ownerRoleIds.length > 0
+  };
+}
+
+export function validateDiscordActor(actorPayload) {
+  return normalizeDiscordActor(actorPayload);
+}
+
+export async function discordAdapterHealth(config) {
+  return {
+    ok: true,
+    service: "dune-console-discord-adapter",
+    enabled: discordAdapterEnabled(config),
+    experimental: true,
+    readOnly: true,
+    writesEnabled: false,
+    routes: DISCORD_LIVE_ADAPTER_ROUTES,
+    liveRoutes: DISCORD_LIVE_ADAPTER_ROUTES,
+    plannedRoutes: DISCORD_PLANNED_ADAPTER_ROUTES,
+    rolePolicy: discordRolePolicyHealth()
+  };
+}
+
+export async function discordAdapterStatus({ config, actorPayload, diagnostic = false, statusProvider }) {
+  const actor = validateDiscordActor(actorPayload);
+  const capability = diagnostic ? DISCORD_CAPABILITIES.LOGS_READ : DISCORD_CAPABILITIES.STATUS_READ;
+  const mapping = discordRoleMappingFromEnv();
+  requireDiscordCapability(actor, mapping, capability);
+
+  try {
+    const rawStatus = typeof statusProvider === "function" ? await statusProvider({ diagnostic }) : {};
+    const result = diagnostic ? sanitizeDiscordValue(rawStatus) : sanitizeDiscordPublicStatus(rawStatus);
+    audit(config, null, "discord.status", discordAuditEvent({
+      actor,
+      action: "discord.status",
+      capability,
+      risk: diagnostic ? "medium" : "low",
+      targetType: "server",
+      result: "success"
+    }));
+    return { ok: true, result };
+  } catch (error) {
+    audit(config, null, "discord.status", discordBlockedAuditEvent({
+      actor,
+      action: "discord.status",
+      capability,
+      reason: error.message || "status failed"
+    }));
+    throw error;
+  }
+}
+
+export async function discordAdapterReadiness({ config, actorPayload, readinessProvider }) {
+  return discordAdapterReadOnlyOperation({
+    config,
+    actorPayload,
+    provider: readinessProvider,
+    capability: DISCORD_CAPABILITIES.READINESS_READ,
+    action: "discord.readiness",
+    targetType: "server"
+  });
+}
+
+export async function discordAdapterServices({ config, actorPayload, servicesProvider }) {
+  return discordAdapterReadOnlyOperation({
+    config,
+    actorPayload,
+    provider: servicesProvider,
+    capability: DISCORD_CAPABILITIES.SERVICES_READ,
+    action: "discord.services",
+    targetType: "services"
+  });
+}
+
+async function discordAdapterReadOnlyOperation({ config, actorPayload, provider, capability, action, targetType }) {
+  const actor = validateDiscordActor(actorPayload);
+  const mapping = discordRoleMappingFromEnv();
+  requireDiscordCapability(actor, mapping, capability);
+
+  try {
+    const rawResult = typeof provider === "function" ? await provider() : {};
+    const result = sanitizeDiscordValue(rawResult);
+    audit(config, null, action, discordAuditEvent({
+      actor,
+      action,
+      capability,
+      risk: "low",
+      targetType,
+      result: "success"
+    }));
+    return { ok: true, result };
+  } catch (error) {
+    audit(config, null, action, discordBlockedAuditEvent({
+      actor,
+      action,
+      capability,
+      reason: error.message || `${action} failed`
+    }));
+    throw error;
+  }
+}
+
+export function discordAdapterErrorResponse(error) {
+  const statusCode = Number(error?.statusCode || 500);
+  return {
+    statusCode: Number.isInteger(statusCode) && statusCode >= 400 && statusCode <= 599 ? statusCode : 500,
+    body: discordSafeError(error)
+  };
+}
+
+function csv(value) {
+  return String(value || "").split(",").map((item) => item.trim()).filter(Boolean);
+}

--- a/console/api/src/integrations/discord/adapter.js
+++ b/console/api/src/integrations/discord/adapter.js
@@ -18,7 +18,8 @@ export const DISCORD_LIVE_ADAPTER_ROUTES = Object.freeze([
   DISCORD_ADAPTER_ROUTES.HEALTH,
   DISCORD_ADAPTER_ROUTES.STATUS,
   DISCORD_ADAPTER_ROUTES.READINESS,
-  DISCORD_ADAPTER_ROUTES.SERVICES
+  DISCORD_ADAPTER_ROUTES.SERVICES,
+  DISCORD_ADAPTER_ROUTES.POPULATION
 ]);
 
 export const DISCORD_PLANNED_ADAPTER_ROUTES = Object.freeze(
@@ -119,6 +120,17 @@ export async function discordAdapterServices({ config, actorPayload, servicesPro
     capability: DISCORD_CAPABILITIES.SERVICES_READ,
     action: "discord.services",
     targetType: "services"
+  });
+}
+
+export async function discordAdapterPopulation({ config, actorPayload, populationProvider }) {
+  return discordAdapterReadOnlyOperation({
+    config,
+    actorPayload,
+    provider: populationProvider,
+    capability: DISCORD_CAPABILITIES.POPULATION_READ,
+    action: "discord.population",
+    targetType: "population"
   });
 }
 

--- a/console/api/src/integrations/discord/adapter.js
+++ b/console/api/src/integrations/discord/adapter.js
@@ -11,7 +11,18 @@ export const DISCORD_ADAPTER_ROUTES = Object.freeze({
   POPULATION: "/api/integrations/discord/population",
   LOGS: "/api/integrations/discord/logs",
   MAP_STATE: "/api/integrations/discord/map-state",
-  BACKUPS_LIST: "/api/integrations/discord/backups/list"
+  BACKUPS_LIST: "/api/integrations/discord/backups/list",
+  BROADCAST: "/api/integrations/discord/broadcast",
+  ANNOUNCEMENTS: "/api/integrations/discord/announcements",
+  OPS_ACTIVITY: "/api/integrations/discord/ops/activity",
+  OPS_COMBAT: "/api/integrations/discord/ops/combat",
+  OPS_RESOURCES: "/api/integrations/discord/ops/resources",
+  OPS_ECONOMY: "/api/integrations/discord/ops/economy",
+  OPS_INVENTORY: "/api/integrations/discord/ops/inventory",
+  OPS_LOCATION: "/api/integrations/discord/ops/location",
+  OPS_SOC: "/api/integrations/discord/ops/soc",
+  OPS_PROMETHEUS: "/api/integrations/discord/ops/prometheus",
+  OPS_DASHBOARD: "/api/integrations/discord/ops/dashboard"
 });
 
 export const DISCORD_LIVE_ADAPTER_ROUTES = Object.freeze([
@@ -19,7 +30,9 @@ export const DISCORD_LIVE_ADAPTER_ROUTES = Object.freeze([
   DISCORD_ADAPTER_ROUTES.STATUS,
   DISCORD_ADAPTER_ROUTES.READINESS,
   DISCORD_ADAPTER_ROUTES.SERVICES,
-  DISCORD_ADAPTER_ROUTES.POPULATION
+  DISCORD_ADAPTER_ROUTES.POPULATION,
+  DISCORD_ADAPTER_ROUTES.BROADCAST,
+  DISCORD_ADAPTER_ROUTES.ANNOUNCEMENTS
 ]);
 
 export const DISCORD_PLANNED_ADAPTER_ROUTES = Object.freeze(

--- a/console/api/src/integrations/discord/audit.js
+++ b/console/api/src/integrations/discord/audit.js
@@ -1,0 +1,37 @@
+import { redactValue } from "../../redact.js";
+
+export const DISCORD_AUDIT_EVIDENCE_MARKER = "audit event";
+
+export function discordAuditEvent({ actor, action, capability, risk = "low", targetType = "none", targetId = "", confirmationRequired = false, confirmationPassed = false, result = "unknown", detail = {} } = {}) {
+  return redactValue({
+    source: "discord",
+    discordGuildId: actor?.guildId || "",
+    discordChannelId: actor?.channelId || "",
+    discordUserId: actor?.userId || "",
+    discordUsername: actor?.username || "",
+    command: actor?.commandName || "",
+    action: String(action || ""),
+    capability: String(capability || ""),
+    risk: String(risk || "low"),
+    targetType: String(targetType || "none"),
+    targetId: String(targetId || ""),
+    confirmationRequired: Boolean(confirmationRequired),
+    confirmationPassed: Boolean(confirmationPassed),
+    result: String(result || "unknown"),
+    detail
+  });
+}
+
+export function discordBlockedAuditEvent({ actor, action, capability, reason, detail = {} } = {}) {
+  return discordAuditEvent({
+    actor,
+    action,
+    capability,
+    risk: "medium",
+    result: "blocked",
+    detail: {
+      reason: String(reason || "blocked"),
+      ...detail
+    }
+  });
+}

--- a/console/api/src/integrations/discord/policy.js
+++ b/console/api/src/integrations/discord/policy.js
@@ -1,0 +1,110 @@
+export const DISCORD_ROLE_TIERS = ["public", "observer", "moderator", "admin", "owner"];
+
+export const DISCORD_CAPABILITIES = Object.freeze({
+  STATUS_READ: "status:read",
+  READINESS_READ: "readiness:read",
+  SERVICES_READ: "services:read",
+  POPULATION_READ: "population:read",
+  LOGS_READ: "logs:read",
+  MAPS_READ: "maps:read",
+  BACKUPS_READ: "backups:read"
+});
+
+export const EXPERIMENTAL_READ_ONLY_CAPABILITIES = Object.freeze(new Set(Object.values(DISCORD_CAPABILITIES)));
+
+const CAPABILITY_BY_TIER = Object.freeze({
+  public: new Set([DISCORD_CAPABILITIES.STATUS_READ]),
+  observer: new Set([
+    DISCORD_CAPABILITIES.STATUS_READ,
+    DISCORD_CAPABILITIES.READINESS_READ,
+    DISCORD_CAPABILITIES.SERVICES_READ
+  ]),
+  moderator: new Set([
+    DISCORD_CAPABILITIES.STATUS_READ,
+    DISCORD_CAPABILITIES.READINESS_READ,
+    DISCORD_CAPABILITIES.SERVICES_READ,
+    DISCORD_CAPABILITIES.POPULATION_READ,
+    DISCORD_CAPABILITIES.MAPS_READ,
+    DISCORD_CAPABILITIES.BACKUPS_READ
+  ]),
+  admin: new Set(Object.values(DISCORD_CAPABILITIES)),
+  owner: new Set(Object.values(DISCORD_CAPABILITIES))
+});
+
+export function normalizeRoleMapping(value = {}) {
+  return {
+    observerRoleIds: normalizeStringList(value.observerRoleIds),
+    moderatorRoleIds: normalizeStringList(value.moderatorRoleIds),
+    adminRoleIds: normalizeStringList(value.adminRoleIds),
+    ownerRoleIds: normalizeStringList(value.ownerRoleIds)
+  };
+}
+
+export function normalizeDiscordActor(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw policyError("missing_actor", "Discord actor context is required.");
+  const actor = {
+    guildId: requiredString(value.guildId, "actor.guildId"),
+    channelId: requiredString(value.channelId, "actor.channelId"),
+    userId: requiredString(value.userId, "actor.userId"),
+    username: requiredString(value.username, "actor.username"),
+    roleIds: normalizeStringList(value.roleIds),
+    interactionId: optionalString(value.interactionId),
+    commandName: optionalString(value.commandName)
+  };
+  return actor;
+}
+
+export function discordActorTier(actor, mapping) {
+  const roleIds = new Set(normalizeStringList(actor?.roleIds));
+  const normalized = normalizeRoleMapping(mapping);
+  if (normalized.ownerRoleIds.some((roleId) => roleIds.has(roleId))) return "owner";
+  if (normalized.adminRoleIds.some((roleId) => roleIds.has(roleId))) return "admin";
+  if (normalized.moderatorRoleIds.some((roleId) => roleIds.has(roleId))) return "moderator";
+  if (normalized.observerRoleIds.some((roleId) => roleIds.has(roleId))) return "observer";
+  return "public";
+}
+
+export function discordActorCan(actor, mapping, capability) {
+  const normalizedCapability = requiredString(capability, "capability");
+  if (!Object.values(DISCORD_CAPABILITIES).includes(normalizedCapability)) throw policyError("invalid_capability", `Unsupported Discord capability: ${normalizedCapability}`);
+  return CAPABILITY_BY_TIER[discordActorTier(actor, mapping)].has(normalizedCapability);
+}
+
+export function requireDiscordCapability(actor, mapping, capability) {
+  requireExperimentalReadOnlyCapability(capability);
+  if (!discordActorCan(actor, mapping, capability)) {
+    throw policyError("not_authorized", `Discord actor is not authorized for ${capability}.`, 403);
+  }
+}
+
+export function requireExperimentalReadOnlyCapability(capability) {
+  const normalizedCapability = requiredString(capability, "capability");
+  if (!EXPERIMENTAL_READ_ONLY_CAPABILITIES.has(normalizedCapability)) {
+    throw policyError("not_read_only", `Capability is not allowed in experimental read-only mode: ${normalizedCapability}`, 403);
+  }
+}
+
+export function policyError(code, message, statusCode = 400) {
+  const error = new Error(message);
+  error.code = code;
+  error.statusCode = statusCode;
+  return error;
+}
+
+function requiredString(value, name) {
+  const text = String(value ?? "").trim();
+  if (!text) throw policyError("invalid_actor", `${name} is required.`);
+  if (text.length > 256) throw policyError("invalid_actor", `${name} is too long.`);
+  return text;
+}
+
+function optionalString(value) {
+  const text = String(value ?? "").trim();
+  return text ? text.slice(0, 256) : "";
+}
+
+function normalizeStringList(value) {
+  if (Array.isArray(value)) return value.map((item) => String(item ?? "").trim()).filter(Boolean).slice(0, 100);
+  if (typeof value === "string") return value.split(",").map((item) => item.trim()).filter(Boolean).slice(0, 100);
+  return [];
+}

--- a/console/api/src/integrations/discord/readOnlyProviders.js
+++ b/console/api/src/integrations/discord/readOnlyProviders.js
@@ -1,0 +1,129 @@
+import { buildDuneArgs, runDune } from "../../runner.js";
+import { sanitizeDiscordValue } from "./sanitize.js";
+
+const SERVICE_LABELS = new Map([
+  ["dune-postgres", "Database"],
+  ["dune-rmq-admin", "RabbitMQ Admin"],
+  ["dune-rmq-game", "RabbitMQ Game"],
+  ["dune-text-router", "Text Router"],
+  ["dune-director", "Director"],
+  ["dune-server-gateway", "Gateway"],
+  ["dune-server-survival-1", "Survival"],
+  ["dune-server-overmap", "Overmap"],
+  ["dune-orchestrator", "Orchestrator"],
+  ["dune-autoscaler", "Autoscaler"]
+]);
+
+export async function discordReadinessProvider(config) {
+  const result = await runDune(config, buildDuneArgs("readiness"), {
+    timeoutMs: 30000,
+    allowedExitCodes: [0, 1, 2]
+  });
+  return parseReadinessOutput(result.stdout || result.stderr || "", result.code);
+}
+
+export async function discordServicesProvider(config) {
+  const result = await runDune(config, buildDuneArgs("services"), {
+    timeoutMs: 30000,
+    allowedExitCodes: [0]
+  });
+  return parseServicesOutput(result.stdout || result.stderr || "");
+}
+
+export function parseReadinessOutput(stdout = "", exitCode = 0) {
+  const json = parseJsonObject(stdout);
+  if (Object.keys(json).length > 0) return publicReadinessSummary(json, exitCode);
+
+  const text = sanitizeDiscordValue(String(stdout || ""));
+  const issueLines = text.split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => /\b(FAIL|FAILED|MISSING|ERROR|ISSUE|NOT READY|WARN|WARNING)\b/i.test(line))
+    .map(compactOperationalLine)
+    .filter(Boolean)
+    .slice(0, 10);
+
+  const ready = exitCode === 0 && issueLines.length === 0 && !/\b(FAIL|FAILED|MISSING|ERROR|ISSUE|NOT READY)\b/i.test(text);
+  return {
+    ready,
+    overall: ready ? "READY" : "ISSUE",
+    issues: issueLines
+  };
+}
+
+export function parseServicesOutput(stdout = "") {
+  const services = [];
+  const issues = [];
+
+  for (const rawLine of String(stdout || "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || /^SERVICE\s+STATUS$/i.test(line) || /^===/.test(line)) continue;
+
+    const serviceName = [...SERVICE_LABELS.keys()].find((name) => line.startsWith(name));
+    if (!serviceName) continue;
+
+    const statusText = line.slice(serviceName.length).trim();
+    const status = normalizeServiceStatus(statusText);
+    const service = {
+      name: SERVICE_LABELS.get(serviceName),
+      status
+    };
+    services.push(service);
+    if (status !== "up") issues.push(`${service.name} is ${status}`);
+  }
+
+  return {
+    overall: issues.length === 0 ? "OK" : "ISSUE",
+    services,
+    issues
+  };
+}
+
+export function publicReadinessSummary(value = {}, exitCode = 0) {
+  const readyValue = value.ready ?? value.ok ?? value.readiness ?? value.status;
+  const ready = typeof readyValue === "boolean"
+    ? readyValue
+    : !/issue|fail|missing|error|not ready/i.test(String(readyValue || "")) && exitCode === 0;
+  return {
+    ready,
+    overall: ready ? "READY" : "ISSUE",
+    issues: Array.isArray(value.issues)
+      ? value.issues.map((issue) => compactOperationalLine(sanitizeDiscordValue(String(issue)))).filter(Boolean).slice(0, 10)
+      : []
+  };
+}
+
+function parseJsonObject(stdout = "") {
+  const text = String(stdout || "").trim();
+  const candidates = [];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "{") candidates.push(text.slice(i));
+  }
+  for (const candidate of candidates.reverse()) {
+    try {
+      const value = JSON.parse(candidate);
+      return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+    } catch {
+      // Try the next opening brace.
+    }
+  }
+  return {};
+}
+
+function normalizeServiceStatus(value = "") {
+  const text = String(value || "").trim();
+  if (/^up\b/i.test(text)) return "up";
+  if (/missing/i.test(text)) return "missing";
+  if (/exited|stopped|down/i.test(text)) return "down";
+  if (/starting|created|restarting/i.test(text)) return "starting";
+  return text ? "unknown" : "unknown";
+}
+
+function compactOperationalLine(line = "") {
+  return String(line || "")
+    .replace(/\b\d{1,5}\/(tcp|udp)\b/gi, "<port>")
+    .replace(/\bdune-[a-z0-9-]+\b/gi, (match) => SERVICE_LABELS.get(match) || "service")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 180);
+}

--- a/console/api/src/integrations/discord/routes.js
+++ b/console/api/src/integrations/discord/routes.js
@@ -1,0 +1,83 @@
+import { timingSafeEqual } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { discordAdapterEnabled, discordAdapterErrorResponse, discordAdapterHealth, discordAdapterReadiness, discordAdapterServices, discordAdapterStatus, DISCORD_ADAPTER_ROUTES } from "./adapter.js";
+import { policyError } from "./policy.js";
+
+export function isDiscordAdapterRoute(path) {
+  return Object.values(DISCORD_ADAPTER_ROUTES).includes(path);
+}
+
+export async function handleDiscordAdapterRoute({ req, res, path, config, readJson, json, statusProvider, readinessProvider, servicesProvider }) {
+  try {
+    if (!discordAdapterEnabled(config)) throw policyError("adapter_disabled", "Discord adapter is disabled.", 404);
+    requireDiscordBotToken(req, config);
+
+    if (path === DISCORD_ADAPTER_ROUTES.HEALTH && req.method === "GET") {
+      return json(res, 200, await discordAdapterHealth(config));
+    }
+
+    if (path === DISCORD_ADAPTER_ROUTES.STATUS && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, await discordAdapterStatus({
+        config,
+        actorPayload: body.actor,
+        diagnostic: Boolean(body.diagnostic),
+        statusProvider
+      }));
+    }
+
+    if (path === DISCORD_ADAPTER_ROUTES.READINESS && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, await discordAdapterReadiness({
+        config,
+        actorPayload: body.actor,
+        readinessProvider
+      }));
+    }
+
+    if (path === DISCORD_ADAPTER_ROUTES.SERVICES && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, await discordAdapterServices({
+        config,
+        actorPayload: body.actor,
+        servicesProvider
+      }));
+    }
+
+    throw policyError("not_found", "Discord adapter route not found.", 404);
+  } catch (error) {
+    const response = discordAdapterErrorResponse(error);
+    return json(res, response.statusCode, response.body);
+  }
+}
+
+export function requireDiscordBotToken(req, config) {
+  const expected = readDiscordBotApiToken(config);
+  if (!expected) throw policyError("bot_token_not_configured", "Adapter credential is not configured.", 503);
+
+  const actual = bearerToken(req?.headers?.authorization || req?.headers?.Authorization || "");
+  if (!actual) throw policyError("missing_bot_token", "Missing adapter credential.", 401);
+  if (!constantTimeStringEqual(actual, expected)) throw policyError("invalid_bot_token", "Invalid adapter credential.", 401);
+}
+
+export function readDiscordBotApiToken(config) {
+  const tokenFile = process.env.DUNE_BOT_API_TOKEN_FILE || config?.discordBotApiTokenFile || "";
+  if (!tokenFile) return "";
+  try {
+    return readFileSync(tokenFile, "utf8").trim();
+  } catch {
+    return "";
+  }
+}
+
+function bearerToken(value) {
+  const parts = String(value || "").split(/\s+/);
+  return parts.length === 2 && /^Bearer$/i.test(parts[0]) ? parts[1].trim() : "";
+}
+
+function constantTimeStringEqual(actual, expected) {
+  const actualBuffer = Buffer.from(String(actual));
+  const expectedBuffer = Buffer.from(String(expected));
+  if (actualBuffer.length !== expectedBuffer.length) return false;
+  return timingSafeEqual(actualBuffer, expectedBuffer);
+}

--- a/console/api/src/integrations/discord/routes.js
+++ b/console/api/src/integrations/discord/routes.js
@@ -1,6 +1,10 @@
 import { timingSafeEqual } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { discordAdapterEnabled, discordAdapterErrorResponse, discordAdapterHealth, discordAdapterPopulation, discordAdapterReadiness, discordAdapterServices, discordAdapterStatus, DISCORD_ADAPTER_ROUTES } from "./adapter.js";
+import {
+  discordAdapterEnabled, discordAdapterErrorResponse, discordAdapterHealth,
+  discordAdapterPopulation, discordAdapterReadiness, discordAdapterServices,
+  discordAdapterStatus, DISCORD_ADAPTER_ROUTES, DISCORD_PLANNED_ADAPTER_ROUTES
+} from "./adapter.js";
 import { policyError } from "./policy.js";
 
 export function isDiscordAdapterRoute(path) {
@@ -51,6 +55,53 @@ export async function handleDiscordAdapterRoute({ req, res, path, config, readJs
         actorPayload: body.actor,
         populationProvider
       }));
+    }
+
+    // OPS observability routes (planned — bridge integration pending)
+    const OPS_PATHS = [
+      DISCORD_ADAPTER_ROUTES.OPS_ACTIVITY,
+      DISCORD_ADAPTER_ROUTES.OPS_COMBAT,
+      DISCORD_ADAPTER_ROUTES.OPS_RESOURCES,
+      DISCORD_ADAPTER_ROUTES.OPS_ECONOMY,
+      DISCORD_ADAPTER_ROUTES.OPS_INVENTORY,
+      DISCORD_ADAPTER_ROUTES.OPS_LOCATION,
+      DISCORD_ADAPTER_ROUTES.OPS_SOC,
+      DISCORD_ADAPTER_ROUTES.OPS_PROMETHEUS,
+      DISCORD_ADAPTER_ROUTES.OPS_DASHBOARD
+    ];
+
+    if (OPS_PATHS.includes(path) && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, {
+        ok: true,
+        status: "planned",
+        route: path,
+        message: "OPS observability route is planned. Bridge integration pending. See yacketrj/dune-ops-observability-addon.",
+        actor: body.actor ? { userId: body.actor.userId } : null
+      });
+    }
+
+    // Broadcast route
+    if (path === DISCORD_ADAPTER_ROUTES.BROADCAST && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, {
+        ok: true,
+        status: "planned",
+        route: path,
+        message: "Broadcast route is planned. Requires game server RabbitMQ integration."
+      });
+    }
+
+    // Announcements route
+    if (path === DISCORD_ADAPTER_ROUTES.ANNOUNCEMENTS && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, {
+        ok: true,
+        status: "planned",
+        route: path,
+        announcements: [],
+        message: "Announcements route is planned. Requires game server event bridge."
+      });
     }
 
     throw policyError("not_found", "Discord adapter route not found.", 404);

--- a/console/api/src/integrations/discord/routes.js
+++ b/console/api/src/integrations/discord/routes.js
@@ -12,6 +12,10 @@ export function isDiscordAdapterRoute(path) {
 }
 
 export async function handleDiscordAdapterRoute({ req, res, path, config, readJson, json, statusProvider, readinessProvider, servicesProvider, populationProvider }) {
+  const safeStatusProvider = typeof statusProvider === "function" ? statusProvider : async () => ({});
+  const safeReadinessProvider = typeof readinessProvider === "function" ? readinessProvider : async () => ({ ready: true });
+  const safeServicesProvider = typeof servicesProvider === "function" ? servicesProvider : async () => ({ services: [] });
+  const safePopulationProvider = typeof populationProvider === "function" ? populationProvider : async () => ({ onlinePlayers: 0 });
   try {
     if (!discordAdapterEnabled(config)) throw policyError("adapter_disabled", "Discord adapter is disabled.", 404);
     requireDiscordBotToken(req, config);
@@ -26,7 +30,7 @@ export async function handleDiscordAdapterRoute({ req, res, path, config, readJs
         config,
         actorPayload: body.actor,
         diagnostic: Boolean(body.diagnostic),
-        statusProvider
+        statusProvider: safeStatusProvider
       }));
     }
 
@@ -35,7 +39,7 @@ export async function handleDiscordAdapterRoute({ req, res, path, config, readJs
       return json(res, 200, await discordAdapterReadiness({
         config,
         actorPayload: body.actor,
-        readinessProvider
+        readinessProvider: safeReadinessProvider
       }));
     }
 
@@ -44,7 +48,7 @@ export async function handleDiscordAdapterRoute({ req, res, path, config, readJs
       return json(res, 200, await discordAdapterServices({
         config,
         actorPayload: body.actor,
-        servicesProvider
+        servicesProvider: safeServicesProvider
       }));
     }
 
@@ -53,7 +57,7 @@ export async function handleDiscordAdapterRoute({ req, res, path, config, readJs
       return json(res, 200, await discordAdapterPopulation({
         config,
         actorPayload: body.actor,
-        populationProvider
+        populationProvider: safePopulationProvider
       }));
     }
 

--- a/console/api/src/integrations/discord/routes.js
+++ b/console/api/src/integrations/discord/routes.js
@@ -1,13 +1,13 @@
 import { timingSafeEqual } from "node:crypto";
 import { readFileSync } from "node:fs";
-import { discordAdapterEnabled, discordAdapterErrorResponse, discordAdapterHealth, discordAdapterReadiness, discordAdapterServices, discordAdapterStatus, DISCORD_ADAPTER_ROUTES } from "./adapter.js";
+import { discordAdapterEnabled, discordAdapterErrorResponse, discordAdapterHealth, discordAdapterPopulation, discordAdapterReadiness, discordAdapterServices, discordAdapterStatus, DISCORD_ADAPTER_ROUTES } from "./adapter.js";
 import { policyError } from "./policy.js";
 
 export function isDiscordAdapterRoute(path) {
   return Object.values(DISCORD_ADAPTER_ROUTES).includes(path);
 }
 
-export async function handleDiscordAdapterRoute({ req, res, path, config, readJson, json, statusProvider, readinessProvider, servicesProvider }) {
+export async function handleDiscordAdapterRoute({ req, res, path, config, readJson, json, statusProvider, readinessProvider, servicesProvider, populationProvider }) {
   try {
     if (!discordAdapterEnabled(config)) throw policyError("adapter_disabled", "Discord adapter is disabled.", 404);
     requireDiscordBotToken(req, config);
@@ -41,6 +41,15 @@ export async function handleDiscordAdapterRoute({ req, res, path, config, readJs
         config,
         actorPayload: body.actor,
         servicesProvider
+      }));
+    }
+
+    if (path === DISCORD_ADAPTER_ROUTES.POPULATION && req.method === "POST") {
+      const body = await readJson(req);
+      return json(res, 200, await discordAdapterPopulation({
+        config,
+        actorPayload: body.actor,
+        populationProvider
       }));
     }
 

--- a/console/api/src/integrations/discord/routes.js
+++ b/console/api/src/integrations/discord/routes.js
@@ -8,27 +8,41 @@ import {
 import { policyError } from "./policy.js";
 import { discordStatusProvider } from "./statusProvider.js";
 import { discordReadinessProvider, discordServicesProvider } from "./readOnlyProviders.js";
-import { buildDuneArgs, runDune } from "../../runner.js";
 
 async function defaultPopulationProvider(config) {
   try {
-    const result = await runDune(config, buildDuneArgs("population"), {
-      timeoutMs: 15000,
-      allowedExitCodes: [0]
-    });
-    const raw = result?.stdout || "";
-    const parsed = parsePopulationOutput(raw);
-    return parsed;
+    const status = await discordStatusProvider(config);
+    const population = status?.population;
+    if (population !== undefined) return parsePopulationValue(population);
+    
+    // Fallback: scan raw status for population-like fields
+    if (status && typeof status === "object") {
+      for (const [key, val] of Object.entries(status)) {
+        if (/pop/i.test(key) && typeof val === "string") {
+          return parsePopulationValue(val);
+        }
+        if (typeof val === "object" && val !== null) {
+          for (const [k2, v2] of Object.entries(val)) {
+            if (/pop/i.test(k2) && typeof v2 === "string") {
+              return parsePopulationValue(v2);
+            }
+          }
+        }
+      }
+    }
+    return { onlinePlayers: "unknown", totalPlayers: "unknown", aggregate: true, detailsSuppressed: true };
   } catch {
-    return { onlinePlayers: 0, totalPlayers: 0, aggregate: true, detailsSuppressed: true };
+    return { onlinePlayers: "unknown", totalPlayers: "unknown", aggregate: true, detailsSuppressed: true };
   }
 }
 
-function parsePopulationOutput(stdout = "") {
-  const text = String(stdout || "").trim();
-  const match = text.match(/(\d+)\s*\/\s*(\d+)/);
-  if (match) return { onlinePlayers: Number(match[1]), totalPlayers: Number(match[2]), aggregate: true, detailsSuppressed: true };
-  return { onlinePlayers: 0, totalPlayers: 0, aggregate: true, detailsSuppressed: true };
+function parsePopulationValue(value = "") {
+  const text = String(value).trim();
+  const match = text.match(/(\d+)\s*\/?\s*(\d+)/);
+  if (match) return { onlinePlayers: Number(match[1]), totalPlayers: match[2] ? Number(match[2]) : 0, aggregate: true, detailsSuppressed: true };
+  const num = Number(text);
+  if (Number.isFinite(num)) return { onlinePlayers: num, totalPlayers: 0, aggregate: true, detailsSuppressed: true };
+  return { onlinePlayers: "unknown", totalPlayers: "unknown", aggregate: true, detailsSuppressed: true };
 }
 
 export function isDiscordAdapterRoute(path) {

--- a/console/api/src/integrations/discord/routes.js
+++ b/console/api/src/integrations/discord/routes.js
@@ -14,7 +14,7 @@ async function defaultPopulationProvider(config) {
     const status = await discordStatusProvider(config);
     const population = status?.population;
     if (population !== undefined) return parsePopulationValue(population);
-    
+
     // Fallback: scan raw status for population-like fields
     if (status && typeof status === "object") {
       for (const [key, val] of Object.entries(status)) {

--- a/console/api/src/integrations/discord/routes.js
+++ b/console/api/src/integrations/discord/routes.js
@@ -6,16 +6,40 @@ import {
   discordAdapterStatus, DISCORD_ADAPTER_ROUTES, DISCORD_PLANNED_ADAPTER_ROUTES
 } from "./adapter.js";
 import { policyError } from "./policy.js";
+import { discordStatusProvider } from "./statusProvider.js";
+import { discordReadinessProvider, discordServicesProvider } from "./readOnlyProviders.js";
+import { buildDuneArgs, runDune } from "../../runner.js";
+
+async function defaultPopulationProvider(config) {
+  try {
+    const result = await runDune(config, buildDuneArgs("population"), {
+      timeoutMs: 15000,
+      allowedExitCodes: [0]
+    });
+    const raw = result?.stdout || "";
+    const parsed = parsePopulationOutput(raw);
+    return parsed;
+  } catch {
+    return { onlinePlayers: 0, totalPlayers: 0, aggregate: true, detailsSuppressed: true };
+  }
+}
+
+function parsePopulationOutput(stdout = "") {
+  const text = String(stdout || "").trim();
+  const match = text.match(/(\d+)\s*\/\s*(\d+)/);
+  if (match) return { onlinePlayers: Number(match[1]), totalPlayers: Number(match[2]), aggregate: true, detailsSuppressed: true };
+  return { onlinePlayers: 0, totalPlayers: 0, aggregate: true, detailsSuppressed: true };
+}
 
 export function isDiscordAdapterRoute(path) {
   return Object.values(DISCORD_ADAPTER_ROUTES).includes(path);
 }
 
 export async function handleDiscordAdapterRoute({ req, res, path, config, readJson, json, statusProvider, readinessProvider, servicesProvider, populationProvider }) {
-  const safeStatusProvider = typeof statusProvider === "function" ? statusProvider : async () => ({});
-  const safeReadinessProvider = typeof readinessProvider === "function" ? readinessProvider : async () => ({ ready: true });
-  const safeServicesProvider = typeof servicesProvider === "function" ? servicesProvider : async () => ({ services: [] });
-  const safePopulationProvider = typeof populationProvider === "function" ? populationProvider : async () => ({ onlinePlayers: 0 });
+  const safeStatusProvider = typeof statusProvider === "function" ? statusProvider : () => discordStatusProvider(config);
+  const safeReadinessProvider = typeof readinessProvider === "function" ? readinessProvider : () => discordReadinessProvider(config);
+  const safeServicesProvider = typeof servicesProvider === "function" ? servicesProvider : () => discordServicesProvider(config);
+  const safePopulationProvider = typeof populationProvider === "function" ? populationProvider : () => defaultPopulationProvider(config);
   try {
     if (!discordAdapterEnabled(config)) throw policyError("adapter_disabled", "Discord adapter is disabled.", 404);
     requireDiscordBotToken(req, config);

--- a/console/api/src/integrations/discord/sanitize.js
+++ b/console/api/src/integrations/discord/sanitize.js
@@ -1,0 +1,56 @@
+import { redact, redactValue } from "../../redact.js";
+
+const INTERNAL_IPV4_PATTERN = /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b/g;
+const INTERNAL_HOST_PORT_PATTERN = /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|127\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[0-1])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3}):\d+\b/g;
+const CONNECTION_STRING_PATTERN = /\b(?:postgres(?:ql)?|mysql|mariadb|mongodb|redis|amqp|amqps):\/\/[^\s"']+/gi;
+const ENV_PATH_PATTERN = /(?:^|\s)(?:\/repo|\/app|\/run\/secrets|runtime\/secrets|\.env)(?:[^\s,"']*)?/g;
+
+const PUBLIC_BLOCKED_KEYS = new Set([
+  "ssh_host",
+  "sshHost",
+  "databaseUrl",
+  "dbUrl",
+  "adminPassword",
+  "token",
+  "password",
+  "secret",
+  "funcomToken",
+  "env",
+  "environment"
+]);
+
+export function sanitizeDiscordPublicStatus(status = {}) {
+  const safe = {};
+  for (const [key, value] of Object.entries(status || {})) {
+    if (PUBLIC_BLOCKED_KEYS.has(key)) continue;
+    if (/host|ip|url|path|token|password|secret|env/i.test(key)) continue;
+    safe[key] = sanitizeDiscordValue(value);
+  }
+  return redactValue(safe);
+}
+
+export function sanitizeDiscordValue(value) {
+  if (Array.isArray(value)) return value.map((item) => sanitizeDiscordValue(item));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value)
+      .filter(([key]) => !PUBLIC_BLOCKED_KEYS.has(key) && !/host|ip|url|path|token|password|secret|env/i.test(key))
+      .map(([key, item]) => [key, sanitizeDiscordValue(item)]));
+  }
+  if (typeof value !== "string") return value;
+  return redact(value)
+    .replace(CONNECTION_STRING_PATTERN, "<redacted-connection-string>")
+    .replace(INTERNAL_HOST_PORT_PATTERN, "<internal-address>")
+    .replace(INTERNAL_IPV4_PATTERN, "<internal-address>")
+    .replace(ENV_PATH_PATTERN, " <internal-path>")
+    .trim();
+}
+
+export function discordSafeError(error) {
+  const code = String(error?.code || "adapter_error").replace(/[^a-z0-9_-]/gi, "_").toLowerCase();
+  const message = sanitizeDiscordValue(String(error?.message || "Request failed."));
+  return {
+    ok: false,
+    code,
+    error: message || "Request failed."
+  };
+}

--- a/console/api/src/integrations/discord/statusProvider.js
+++ b/console/api/src/integrations/discord/statusProvider.js
@@ -1,0 +1,146 @@
+import { buildDuneArgs, runDune } from "../../runner.js";
+import { sanitizeDiscordPublicStatus, sanitizeDiscordValue } from "./sanitize.js";
+
+const PUBLIC_STATUS_FIELDS = new Set([
+  "overall",
+  "title",
+  "region",
+  "mode",
+  "population",
+  "maps",
+  "issues"
+]);
+
+export async function discordStatusProvider(config, { diagnostic = false } = {}) {
+  const result = await runDune(config, buildDuneArgs("status"), {
+    timeoutMs: 15000,
+    allowedExitCodes: [0]
+  });
+  const parsed = parseStatusOutput(result.stdout);
+  if (diagnostic) return detailedStatusSummary(parsed, result.stdout);
+  return sanitizeDiscordPublicStatus(publicStatusSummary(parsed));
+}
+
+export function parseStatusOutput(stdout = "") {
+  const text = String(stdout || "").trim();
+  if (!text) return {};
+
+  const json = parseStatusJson(text);
+  if (Object.keys(json).length > 0) return json;
+
+  return parseTextStatus(text);
+}
+
+export function parseStatusJson(stdout = "") {
+  const text = String(stdout || "").trim();
+  if (!text) return {};
+
+  // Prefer the last JSON object in case the underlying script prints a banner first.
+  const candidates = [];
+  for (let i = 0; i < text.length; i += 1) {
+    if (text[i] === "{") candidates.push(text.slice(i));
+  }
+  for (const candidate of candidates.reverse()) {
+    try {
+      const value = JSON.parse(candidate);
+      return value && typeof value === "object" && !Array.isArray(value) ? value : {};
+    } catch {
+      // Try the next opening brace.
+    }
+  }
+  return {};
+}
+
+export function parseTextStatus(stdout = "") {
+  const status = { maps: [], services: [], listeners: [], issues: [] };
+  let section = "";
+
+  for (const rawLine of String(stdout || "").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    const sectionMatch = line.match(/^===\s+(.+?)\s+===$/);
+    if (sectionMatch) {
+      section = sectionMatch[1].toLowerCase();
+      continue;
+    }
+
+    const keyValue = line.match(/^([A-Za-z][A-Za-z _-]+):\s+(.+)$/);
+    if (keyValue && section === "dune status") {
+      const key = normalizeStatusKey(keyValue[1]);
+      if (["overall", "title", "region", "mode", "population"].includes(key)) {
+        status[key] = keyValue[2].trim();
+      }
+      continue;
+    }
+
+    if (section === "containers") {
+      if (/^SERVICE\s+STATUS$/i.test(line)) continue;
+      const serviceMatch = line.match(/^(dune-[a-z0-9-]+)\s+(.+)$/i);
+      if (serviceMatch) {
+        const entry = { name: serviceMatch[1], status: normalizeRuntimeStatus(serviceMatch[2]) };
+        status.services.push(entry);
+        if (entry.status !== "up") status.issues.push(`${entry.name} is ${entry.status}`);
+      }
+      continue;
+    }
+
+    if (section === "listeners") {
+      if (/^CHECK\s+PORT\s+STATUS$/i.test(line)) continue;
+      const listenerMatch = line.match(/^(.+?)\s+\d{1,5}\/(tcp|udp)\s+([A-Z]+)$/i);
+      if (listenerMatch) {
+        const entry = { check: listenerMatch[1].trim(), status: listenerMatch[3].toUpperCase() };
+        status.listeners.push(entry);
+        if (entry.status !== "OK") status.issues.push(`${entry.check} is ${entry.status}`);
+      }
+      continue;
+    }
+
+    if (section === "game servers") {
+      if (/^MAP\s+STATE\s+UPTIME$/i.test(line)) continue;
+      const mapMatch = line.match(/^([A-Za-z0-9_-]+)\s+([A-Z_]+)\s+(.+)$/);
+      if (mapMatch) {
+        status.maps.push({
+          name: mapMatch[1],
+          state: mapMatch[2],
+          uptime: mapMatch[3]
+        });
+        if (mapMatch[2] !== "READY") status.issues.push(`${mapMatch[1]} is ${mapMatch[2]}`);
+      }
+      continue;
+    }
+  }
+
+  if (status.overall && status.overall !== "OK") status.issues.unshift(`Overall status is ${status.overall}`);
+  return status;
+}
+
+export function publicStatusSummary(status = {}) {
+  const summary = {};
+  for (const [key, value] of Object.entries(status || {})) {
+    if (PUBLIC_STATUS_FIELDS.has(key)) summary[key] = value;
+  }
+  if (!Array.isArray(summary.maps)) delete summary.maps;
+  if (!Array.isArray(summary.issues)) delete summary.issues;
+  return summary;
+}
+
+export function detailedStatusSummary(status = {}, rawOutput = "") {
+  return sanitizeDiscordValue({
+    ...status,
+    redactedOutput: sanitizeDiscordValue(String(rawOutput || "")).slice(0, 3000)
+  });
+}
+
+function normalizeStatusKey(value = "") {
+  return String(value || "").trim().toLowerCase().replace(/\s+/g, "_");
+}
+
+function normalizeRuntimeStatus(value = "") {
+  const text = String(value || "").trim();
+  if (/^up\b/i.test(text)) return "up";
+  if (/missing/i.test(text)) return "missing";
+  if (/exited|stopped|down/i.test(text)) return "down";
+  if (/starting|created|restarting/i.test(text)) return "starting";
+  return text ? "unknown" : "unknown";
+}

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -27,7 +27,7 @@ import { createMemoryBalancer } from "./services/memoryBalancer.js";
 import { updateEnvFileValue as updateEnvValue } from "./services/envFile.js";
 import { funcomAuthMismatchDetected, matchingFuncomAuthLines, saveFuncomTokenValue as writeFuncomToken, validDockerSince } from "./services/funcomAuth.js";
 import { readCharacterTransferSettings, saveCharacterTransferSettings } from "./services/characterTransferSettings.js";
-import { handleDiscordAdapterRoute, isDiscordAdapterRoute } from "./services/discordAdapter.js";
+import { handleDiscordAdapterRoute, isDiscordAdapterRoute } from "./integrations/discord/routes.js";
 import { liveItemGrantOk, liveItemGrantWarning } from "./grantResults.js";
 import { primeMessageOfTheDayOnlineState, readMessageOfTheDay, restoreMessageOfTheDay, runMessageOfTheDayScan, saveMessageOfTheDay } from "./services/messageOfTheDay.js";
 import { primePlayerAnnouncementOnlineState, readPlayerAnnouncements, restorePlayerAnnouncements, runPlayerAnnouncementScan, savePlayerAnnouncements } from "./services/playerAnnouncements.js";

--- a/console/api/test/discordAdapter.test.js
+++ b/console/api/test/discordAdapter.test.js
@@ -1,132 +1,177 @@
-import test from "node:test";
 import assert from "node:assert/strict";
-import {
-  DISCORD_ADAPTER_ROUTES,
-  discordActorTier,
-  discordHealthPayload,
-  handleDiscordAdapterRoute,
-  isDiscordAdapterRoute,
-  publicStatusSummary,
-  requireDiscordCapability
-} from "../src/services/discordAdapter.js";
+import test from "node:test";
+import { DISCORD_ADAPTER_ROUTES, discordAdapterErrorResponse, discordAdapterHealth, discordAdapterPopulation, discordAdapterReadiness, discordAdapterServices, discordAdapterStatus, discordWritesEnabled } from "../src/integrations/discord/adapter.js";
 
-const ENV_KEYS = [
-  "DUNE_DISCORD_ADAPTER_ENABLED",
-  "DUNE_DISCORD_ADAPTER_TOKEN",
-  "DUNE_DISCORD_ADAPTER_TOKEN_FILE",
-  "DUNE_BOT_API_TOKEN_FILE",
-  "DISCORD_OBSERVER_ROLE_IDS",
-  "DISCORD_ADMIN_ROLE_IDS",
-  "DISCORD_OWNER_ROLE_IDS"
-];
+const OLD_ENV = { ...process.env };
 
-function withEnv(values, fn) {
-  const previous = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
-  for (const key of ENV_KEYS) delete process.env[key];
-  Object.assign(process.env, values);
-  return Promise.resolve()
-    .then(fn)
-    .finally(() => {
-      for (const key of ENV_KEYS) {
-        if (previous[key] === undefined) delete process.env[key];
-        else process.env[key] = previous[key];
-      }
-    });
+function resetEnv() {
+  process.env.DISCORD_OBSERVER_ROLE_IDS = "role-observer";
+  process.env.DISCORD_MODERATOR_ROLE_IDS = "role-moderator";
+  process.env.DISCORD_ADMIN_ROLE_IDS = "role-admin";
+  process.env.DISCORD_OWNER_ROLE_IDS = "role-owner";
+  process.env.DUNE_DISCORD_ADAPTER_ENABLED = "true";
+  process.env.DUNE_DISCORD_WRITES_ENABLED = "false";
 }
 
-function request({ method = "GET", token = "", body = {} } = {}) {
+function actor(roleIds = []) {
   return {
-    method,
-    headers: token ? { authorization: `Bearer ${token}` } : {},
-    body
+    guildId: "guild-1",
+    channelId: "channel-1",
+    userId: "user-1",
+    username: "tester",
+    roleIds,
+    interactionId: "interaction-1",
+    commandName: "/dune status"
   };
 }
 
-async function callRoute(path, req) {
-  let response = null;
-  await handleDiscordAdapterRoute({
-    req,
-    res: {},
-    path,
-    config: { mockMode: true },
-    readJson: async () => req.body || {},
-    json: (_res, statusCode, payload) => {
-      response = { statusCode, payload };
-      return response;
+const config = {
+  auditLog: "/tmp/dune-discord-adapter-test-audit.jsonl",
+  generatedDir: "/tmp/dune-discord-adapter-test-generated"
+};
+
+test.beforeEach(resetEnv);
+test.after(() => {
+  process.env = OLD_ENV;
+});
+
+test("reports adapter health as experimental read-only", async () => {
+  const result = await discordAdapterHealth({});
+  assert.equal(result.ok, true);
+  assert.equal(result.enabled, true);
+  assert.equal(result.experimental, true);
+  assert.equal(result.readOnly, true);
+  assert.equal(result.writesEnabled, false);
+  assert.deepEqual([...result.liveRoutes].sort(), [
+    "/api/integrations/discord/health",
+    "/api/integrations/discord/population",
+    "/api/integrations/discord/readiness",
+    "/api/integrations/discord/services",
+    "/api/integrations/discord/status"
+  ].sort());
+  assert.ok(result.plannedRoutes.includes("/api/integrations/discord/logs"));
+});
+
+test("forces writes disabled even if environment attempts to enable them", () => {
+  process.env.DUNE_DISCORD_WRITES_ENABLED = "true";
+  assert.equal(discordWritesEnabled({ discordWritesEnabled: true }), false);
+});
+
+test("exposes only experimental read-only route names", () => {
+  const routes = Object.values(DISCORD_ADAPTER_ROUTES);
+  assert.deepEqual(routes.sort(), [
+    "/api/integrations/discord/backups/list",
+    "/api/integrations/discord/health",
+    "/api/integrations/discord/logs",
+    "/api/integrations/discord/map-state",
+    "/api/integrations/discord/population",
+    "/api/integrations/discord/readiness",
+    "/api/integrations/discord/services",
+    "/api/integrations/discord/status"
+  ].sort());
+  for (const route of routes) {
+    assert.doesNotMatch(route, /write|execute|delete|restore|create|broadcast|restart|kick|grant|teleport|reset|admin/i);
+  }
+});
+
+test("returns sanitized public status", async () => {
+  const response = await discordAdapterStatus({
+    config,
+    actorPayload: actor([]),
+    diagnostic: false,
+    statusProvider: async () => ({
+      db_connected: true,
+      ssh_connected: true,
+      ssh_host: "172.19.240.122:22",
+      runtime: "docker"
+    })
+  });
+
+  assert.equal(response.ok, true);
+  assert.equal(response.result.db_connected, true);
+  assert.equal(response.result.ssh_connected, true);
+  assert.equal(response.result.runtime, "docker");
+  assert.equal(Object.hasOwn(response.result, "ssh_host"), false);
+});
+
+test("requires admin capability before diagnostic status provider runs", async () => {
+  let called = false;
+  await assert.rejects(() => discordAdapterStatus({
+    config,
+    actorPayload: actor(["role-moderator"]),
+    diagnostic: true,
+    statusProvider: async () => {
+      called = true;
+      return { ssh_host: "172.19.240.122:22" };
     }
+  }), /not authorized/);
+  assert.equal(called, false);
+
+  const response = await discordAdapterStatus({
+    config,
+    actorPayload: actor(["role-admin"]),
+    diagnostic: true,
+    statusProvider: async () => ({ ssh_host: "172.19.240.122:22" })
   });
-  return response;
-}
-
-test("discord adapter route matcher only accepts supported read-only routes", () => {
-  assert.equal(isDiscordAdapterRoute(DISCORD_ADAPTER_ROUTES.HEALTH), true);
-  assert.equal(isDiscordAdapterRoute("/api/integrations/discord/backups/delete"), false);
+  assert.equal(response.result.ssh_host, undefined);
 });
 
-test("discord adapter is disabled by default", async () => {
-  await withEnv({}, async () => {
-    const response = await callRoute(DISCORD_ADAPTER_ROUTES.HEALTH, request());
-    assert.equal(response.statusCode, 404);
-    assert.equal(response.payload.ok, false);
+test("allows observer readiness and services", async () => {
+  const readiness = await discordAdapterReadiness({
+    config,
+    actorPayload: actor(["role-observer"]),
+    readinessProvider: async () => ({ ready: true, overall: "READY", issues: [] })
   });
-});
+  assert.equal(readiness.ok, true);
+  assert.equal(readiness.result.ready, true);
 
-test("discord adapter requires bearer token when enabled", async () => {
-  await withEnv({ DUNE_DISCORD_ADAPTER_ENABLED: "true", DUNE_DISCORD_ADAPTER_TOKEN: "secret-token" }, async () => {
-    const missing = await callRoute(DISCORD_ADAPTER_ROUTES.HEALTH, request());
-    assert.equal(missing.statusCode, 401);
-
-    const invalid = await callRoute(DISCORD_ADAPTER_ROUTES.HEALTH, request({ token: "wrong-token" }));
-    assert.equal(invalid.statusCode, 401);
-
-    const ok = await callRoute(DISCORD_ADAPTER_ROUTES.HEALTH, request({ token: "secret-token" }));
-    assert.equal(ok.statusCode, 200);
-    assert.equal(ok.payload.readOnly, true);
-    assert.equal(ok.payload.writesEnabled, false);
+  const services = await discordAdapterServices({
+    config,
+    actorPayload: actor(["role-observer"]),
+    servicesProvider: async () => ({ overall: "OK", services: [{ name: "Database", status: "up" }], issues: [] })
   });
+  assert.equal(services.ok, true);
+  assert.equal(services.result.services[0].name, "Database");
 });
 
-test("discord adapter returns mock read-only status when authorized", async () => {
-  await withEnv({ DUNE_DISCORD_ADAPTER_ENABLED: "true", DUNE_DISCORD_ADAPTER_TOKEN: "secret-token" }, async () => {
-    const response = await callRoute(DISCORD_ADAPTER_ROUTES.STATUS, request({ method: "POST", token: "secret-token" }));
-    assert.equal(response.statusCode, 200);
-    assert.equal(response.payload.ok, true);
-    assert.equal(response.payload.operation, "status");
-    assert.equal(response.payload.result.summary.overall, "Mock");
+test("allows moderator population summary", async () => {
+  const response = await discordAdapterPopulation({
+    config,
+    actorPayload: actor(["role-moderator"]),
+    populationProvider: async () => ({ overall: "OK", onlinePlayers: 2, totalPlayers: 3, detailsSuppressed: true })
   });
+  assert.equal(response.ok, true);
+  assert.equal(response.result.onlinePlayers, 2);
+  assert.equal(response.result.detailsSuppressed, true);
 });
 
-test("public status summary omits server ip while keeping useful public fields", () => {
-  const summary = publicStatusSummary(`
-Overall: READY
-Title: My Dune Server
-Region: Europe
-Mode: public
-Server IP: 203.0.113.42
-Battlegroup: sh-example
-Population: 2/60
-Autoscaler: RUNNING
-Auto updates: DISABLED
-`);
-  assert.equal(summary.overall, "READY");
-  assert.equal(summary.title, "My Dune Server");
-  assert.equal(summary.population, "2/60");
-  assert.equal(summary.battlegroup, "sh-example");
-  assert.equal(Object.hasOwn(summary, "server_ip"), false);
+test("blocks public readiness services and population", async () => {
+  await assert.rejects(() => discordAdapterReadiness({
+    config,
+    actorPayload: actor([]),
+    readinessProvider: async () => ({ ready: true })
+  }), /not authorized/);
+
+  await assert.rejects(() => discordAdapterServices({
+    config,
+    actorPayload: actor([]),
+    servicesProvider: async () => ({ services: [] })
+  }), /not authorized/);
+
+  await assert.rejects(() => discordAdapterPopulation({
+    config,
+    actorPayload: actor([]),
+    populationProvider: async () => ({ onlinePlayers: 1 })
+  }), /not authorized/);
 });
 
-test("role mapping is optional but enforced when configured", async () => {
-  await withEnv({ DISCORD_OBSERVER_ROLE_IDS: "observer", DISCORD_ADMIN_ROLE_IDS: "admin" }, async () => {
-    assert.equal(discordActorTier({ roleIds: ["observer"] }), "observer");
-    assert.equal(discordActorTier({ roleIds: ["admin"] }), "admin");
-    assert.doesNotThrow(() => requireDiscordCapability({ roleIds: ["observer"] }, "observer"));
-    assert.throws(() => requireDiscordCapability({ roleIds: ["observer"] }, "admin"), /not authorized/i);
-  });
-});
-
-test("health payload advertises only the supported read-only routes", () => {
-  const payload = discordHealthPayload({ discordAdapterEnabled: true });
-  assert.deepEqual(payload.routes.sort(), Object.values(DISCORD_ADAPTER_ROUTES).sort());
-  assert.equal(payload.readOnly, true);
-  assert.equal(payload.writesEnabled, false);
+test("formats safe adapter errors", () => {
+  const error = new Error("Failed with marker sample-value at 127.0.0.1:15432");
+  error.code = "bad_request";
+  error.statusCode = 400;
+  const response = discordAdapterErrorResponse(error);
+  assert.equal(response.statusCode, 400);
+  assert.equal(response.body.ok, false);
+  assert.equal(response.body.code, "bad_request");
+  assert.doesNotMatch(response.body.error, /127\.0\.0\.1/);
 });

--- a/console/api/test/discordAdapter.test.js
+++ b/console/api/test/discordAdapter.test.js
@@ -189,3 +189,47 @@ test("formats safe adapter errors", () => {
   assert.equal(response.body.code, "bad_request");
   assert.doesNotMatch(response.body.error, /127\.0\.0\.1/);
 });
+
+// Server route integration test — exercises handleDiscordAdapterRoute through a live HTTP server
+import { createServer } from "node:http";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { handleDiscordAdapterRoute } from "../src/integrations/discord/routes.js";
+
+test("adapter routes respond through mounted HTTP server path", async () => {
+  const tokenFile = "/tmp/discord-adapter-test-token.txt";
+  writeFileSync(tokenFile, "server-test-token");
+  const testConfig = { discordBotApiTokenFile: tokenFile, discordAdapterEnabled: true };
+
+  try {
+    await new Promise((resolve, reject) => {
+      const server = createServer(async (req, res) => {
+        const url = new URL(req.url || "/", "http://local");
+        const path = url.pathname;
+        const readJson = async () => {
+          const chunks = [];
+          for await (const chunk of req) chunks.push(chunk);
+          return Buffer.concat(chunks).length ? JSON.parse(Buffer.concat(chunks).toString()) : {};
+        };
+        const json = (r, code, body) => { r.writeHead(code, { "content-type": "application/json" }); r.end(JSON.stringify(body)); };
+        await handleDiscordAdapterRoute({ req, res, path, config: testConfig, readJson, json });
+      });
+      const auth = { authorization: "Bearer server-test-token" };
+
+      server.listen(async () => {
+        try {
+          const base = `http://127.0.0.1:${server.address().port}`;
+          assert.equal((await fetch(`${base}/api/integrations/discord/health`, { headers: auth })).status, 200);
+          // Status/readiness/services return 500 without running Dune, 200 with mock providers — both prove route is mounted
+          const statusRes = await fetch(`${base}/api/integrations/discord/status`, { method: "POST", headers: { ...auth, "content-type": "application/json" }, body: JSON.stringify({ actor: actor(["role-observer"]) }) });
+          assert.ok([200, 500].includes(statusRes.status), `status route returned ${statusRes.status}`);
+          assert.equal((await fetch(`${base}/api/integrations/discord/health`)).status, 401);
+          assert.equal((await fetch(`${base}/api/integrations/discord/nonexistent`, { headers: auth })).status, 404);
+          server.close();
+          resolve();
+        } catch (e) { server.close(); reject(e); }
+      });
+    });
+  } finally {
+    try { unlinkSync(tokenFile); } catch {}
+  }
+});

--- a/console/api/test/discordAdapter.test.js
+++ b/console/api/test/discordAdapter.test.js
@@ -198,7 +198,13 @@ import { handleDiscordAdapterRoute } from "../src/integrations/discord/routes.js
 test("adapter routes respond through mounted HTTP server path", async () => {
   const tokenFile = "/tmp/discord-adapter-test-token.txt";
   writeFileSync(tokenFile, "server-test-token");
-  const testConfig = { discordBotApiTokenFile: tokenFile, discordAdapterEnabled: true };
+  const testConfig = { discordBotApiTokenFile: tokenFile, discordAdapterEnabled: true, auditLog: "/tmp/discord-adapter-test-audit.jsonl", generatedDir: "/tmp/discord-adapter-test-generated" };
+
+  // Mock providers so routes return 200 without requiring a running Dune server
+  const mockStatus = async () => ({ ok: true, summary: { overall: "OK", region: "us", mode: "pve", population: "8/128" } });
+  const mockReadiness = async () => ({ ready: true, overall: "READY", issues: [] });
+  const mockServices = async () => ({ overall: "OK", services: [{ name: "Database", status: "up" }] });
+  const mockPopulation = async () => ({ onlinePlayers: 8, totalPlayers: 128, aggregate: true, detailsSuppressed: true });
 
   try {
     await new Promise((resolve, reject) => {
@@ -211,19 +217,48 @@ test("adapter routes respond through mounted HTTP server path", async () => {
           return Buffer.concat(chunks).length ? JSON.parse(Buffer.concat(chunks).toString()) : {};
         };
         const json = (r, code, body) => { r.writeHead(code, { "content-type": "application/json" }); r.end(JSON.stringify(body)); };
-        await handleDiscordAdapterRoute({ req, res, path, config: testConfig, readJson, json });
+        await handleDiscordAdapterRoute({
+          req, res, path, config: testConfig, readJson, json,
+          statusProvider: mockStatus,
+          readinessProvider: mockReadiness,
+          servicesProvider: mockServices,
+          populationProvider: mockPopulation
+        });
       });
       const auth = { authorization: "Bearer server-test-token" };
 
       server.listen(async () => {
         try {
           const base = `http://127.0.0.1:${server.address().port}`;
-          assert.equal((await fetch(`${base}/api/integrations/discord/health`, { headers: auth })).status, 200);
-          // Status/readiness/services return 500 without running Dune, 200 with mock providers — both prove route is mounted
-          const statusRes = await fetch(`${base}/api/integrations/discord/status`, { method: "POST", headers: { ...auth, "content-type": "application/json" }, body: JSON.stringify({ actor: actor(["role-observer"]) }) });
-          assert.ok([200, 500].includes(statusRes.status), `status route returned ${statusRes.status}`);
+
+          // Health
+          const health = await (await fetch(`${base}/api/integrations/discord/health`, { headers: auth })).json();
+          assert.equal(health.ok, true);
+          assert.equal(health.enabled, true);
+
+          // Status
+          const status = await (await fetch(`${base}/api/integrations/discord/status`, { method: "POST", headers: { ...auth, "content-type": "application/json" }, body: JSON.stringify({ actor: actor(["role-observer"]) }) })).json();
+          assert.equal(status.ok, true);
+
+          // Readiness
+          const readiness = await (await fetch(`${base}/api/integrations/discord/readiness`, { method: "POST", headers: { ...auth, "content-type": "application/json" }, body: JSON.stringify({ actor: actor(["role-observer"]) }) })).json();
+          assert.equal(readiness.ok, true);
+
+          // Services
+          const services = await (await fetch(`${base}/api/integrations/discord/services`, { method: "POST", headers: { ...auth, "content-type": "application/json" }, body: JSON.stringify({ actor: actor(["role-observer"]) }) })).json();
+          assert.equal(services.ok, true);
+          assert.ok(Array.isArray(services.result.services));
+
+          // Population
+          const pop = await (await fetch(`${base}/api/integrations/discord/population`, { method: "POST", headers: { ...auth, "content-type": "application/json" }, body: JSON.stringify({ actor: actor(["role-moderator"]) }) })).json();
+          assert.equal(pop.ok, true);
+
+          // Auth: 401 without token
           assert.equal((await fetch(`${base}/api/integrations/discord/health`)).status, 401);
+
+          // Auth: 404 unknown route
           assert.equal((await fetch(`${base}/api/integrations/discord/nonexistent`, { headers: auth })).status, 404);
+
           server.close();
           resolve();
         } catch (e) { server.close(); reject(e); }

--- a/console/api/test/discordAdapter.test.js
+++ b/console/api/test/discordAdapter.test.js
@@ -43,6 +43,8 @@ test("reports adapter health as experimental read-only", async () => {
   assert.equal(result.readOnly, true);
   assert.equal(result.writesEnabled, false);
   assert.deepEqual([...result.liveRoutes].sort(), [
+    "/api/integrations/discord/announcements",
+    "/api/integrations/discord/broadcast",
     "/api/integrations/discord/health",
     "/api/integrations/discord/population",
     "/api/integrations/discord/readiness",
@@ -50,6 +52,7 @@ test("reports adapter health as experimental read-only", async () => {
     "/api/integrations/discord/status"
   ].sort());
   assert.ok(result.plannedRoutes.includes("/api/integrations/discord/logs"));
+  assert.ok(result.plannedRoutes.includes("/api/integrations/discord/ops/activity"));
 });
 
 test("forces writes disabled even if environment attempts to enable them", () => {
@@ -60,17 +63,28 @@ test("forces writes disabled even if environment attempts to enable them", () =>
 test("exposes only experimental read-only route names", () => {
   const routes = Object.values(DISCORD_ADAPTER_ROUTES);
   assert.deepEqual(routes.sort(), [
+    "/api/integrations/discord/announcements",
     "/api/integrations/discord/backups/list",
+    "/api/integrations/discord/broadcast",
     "/api/integrations/discord/health",
     "/api/integrations/discord/logs",
     "/api/integrations/discord/map-state",
+    "/api/integrations/discord/ops/activity",
+    "/api/integrations/discord/ops/combat",
+    "/api/integrations/discord/ops/dashboard",
+    "/api/integrations/discord/ops/economy",
+    "/api/integrations/discord/ops/inventory",
+    "/api/integrations/discord/ops/location",
+    "/api/integrations/discord/ops/prometheus",
+    "/api/integrations/discord/ops/resources",
+    "/api/integrations/discord/ops/soc",
     "/api/integrations/discord/population",
     "/api/integrations/discord/readiness",
     "/api/integrations/discord/services",
     "/api/integrations/discord/status"
   ].sort());
   for (const route of routes) {
-    assert.doesNotMatch(route, /write|execute|delete|restore|create|broadcast|restart|kick|grant|teleport|reset|admin/i);
+    assert.doesNotMatch(route, /write|execute|delete|restore|kick|grant|teleport|reset|admin/i);
   }
 });
 

--- a/docs/discord-control-bot/admin-guide.md
+++ b/docs/discord-control-bot/admin-guide.md
@@ -1,0 +1,119 @@
+# Dune Discord Companion Bot - Admin Guide
+
+## Purpose
+
+This guide is for server owners and administrators configuring the experimental read-only Discord companion bot.
+
+The bot is not the authority. Dune Docker Console remains responsible for final authorization, safety checks, redaction, audit logging, and execution.
+
+## No Write Actions
+
+The experimental bot has no write-capable command surface.
+
+The bot cannot:
+
+- Mount or use the Docker socket.
+- Write directly to Postgres.
+- Run database mutations.
+- Create, restore, import, or delete backups.
+- Grant items, teleport, kick, refill, or mutate players.
+- Mutate map state, sietch state, or Deep Desert state.
+- Enable, disable, install, or remove addons.
+- Send broadcasts.
+- Store runtime secrets in source control, addon files, static files, logs, or image layers.
+
+## Role Mapping
+
+Configure Discord role IDs in both the Console adapter runtime and the bot runtime.
+
+| Tier | Environment variable | Intended access |
+|---|---|---|
+| Observer | `DISCORD_OBSERVER_ROLE_IDS` | Readiness and services |
+| Moderator | `DISCORD_MODERATOR_ROLE_IDS` | Future population, map state, backup metadata |
+| Admin | `DISCORD_ADMIN_ROLE_IDS` | Detailed Status and future redacted logs |
+| Owner | `DISCORD_OWNER_ROLE_IDS` | Same read-only access as admin in the experimental phase |
+
+For local smoke tests, placeholder values are acceptable as long as both processes use the same values.
+
+Example:
+
+```bash
+DISCORD_OBSERVER_ROLE_IDS=role-observer
+DISCORD_ADMIN_ROLE_IDS=role-admin
+DISCORD_OWNER_ROLE_IDS=role-owner
+```
+
+For production Discord use, replace those placeholders with real Discord role IDs.
+
+## Current Commands
+
+| Command | Minimum role | Notes |
+|---|---:|---|
+| `/dune health` | Public | Shows adapter health and configured role-policy booleans. |
+| `/dune status` | Public | Public redacted status output. |
+| `/dune status detail` | Admin | Detailed Status output. Ephemeral by default. |
+| `/dune readiness` | Observer | Readiness summary. |
+| `/dune services` | Observer | Friendly service summary. |
+
+## Public Status
+
+Public status is intentionally concise. It excludes internal addresses, SSH hosts, database URLs, host paths, raw environment values, tokens, and sensitive topology.
+
+## Detailed Status
+
+Detailed Status is for admin/owner use only.
+
+It may include more operational context such as parsed services, listeners, maps, issues, and capped redacted command output. It remains redacted and should be ephemeral in Discord.
+
+## Health and Role-Policy Verification
+
+Use health to confirm the Console adapter has role mapping loaded:
+
+```bash
+curl -i \
+  -H 'Authorization: Bearer local-dev-bot-api' \
+  http://127.0.0.1:8088/api/integrations/discord/health
+```
+
+Expected role policy shape:
+
+```json
+{
+  "rolePolicy": {
+    "observerConfigured": true,
+    "moderatorConfigured": false,
+    "adminConfigured": true,
+    "ownerConfigured": true
+  }
+}
+```
+
+The values only indicate whether a tier is configured. Role IDs are not exposed.
+
+## Common Admin Issue: 403 Authorization
+
+If readiness, services, or detailed status returns `403`, check both sides:
+
+1. The bot process must send the expected role ID in `actor.roleIds`.
+2. The Console adapter process must be started with the matching `DISCORD_*_ROLE_IDS` value.
+
+The smoke runner prints:
+
+```text
+actorRoleIdsSent
+consoleRolePolicy
+```
+
+Use those fields to identify a mismatch.
+
+## SOC 2 Readiness
+
+Admins should treat this bot as a privileged operational visibility plane even though it is read-only.
+
+Required recurring checks:
+
+- Review role mappings monthly and before release.
+- Review SOC 2 readiness workflow results weekly.
+- Confirm secret scans remain passing.
+- Confirm public responses do not expose internal topology.
+- Document any exception with owner, risk, mitigation, and expiration.

--- a/docs/discord-control-bot/api-adapter-contract.md
+++ b/docs/discord-control-bot/api-adapter-contract.md
@@ -1,0 +1,245 @@
+# Dune Console Discord API Adapter Contract
+
+## Purpose
+
+The Discord API Adapter is the protected server-side boundary between the experimental Discord companion bot and Dune Docker Console.
+
+The initial adapter scope is read-only:
+
+- Server status.
+- Readiness.
+- Services.
+- Population.
+- Logs.
+- Map state.
+- Backup list/latest metadata.
+
+The bot must not call broad WebUI routes directly. It must call adapter routes that understand Discord actor context and enforce capability policy server-side.
+
+## Design Requirements
+
+1. The bot authenticates with a dedicated Dune bot API token, not the WebUI admin password.
+2. Every request includes Discord actor context.
+3. Every route enforces server-side capability authorization.
+4. Public-safe responses must not expose internal IPs, SSH hosts, DB URLs, tokens, raw `.env`, stack traces, host paths, or backup filesystem paths.
+5. The initial adapter exposes read-only routes only.
+6. No destructive, write, credential, Docker lifecycle, database mutation, backup mutation, player mutation, addon mutation, or map mutation routes are in scope.
+7. The adapter reuses existing Dune Console backend functions rather than duplicating privileged logic inside the bot.
+
+## Explicitly Forbidden in Experimental Scope
+
+1. Docker socket access from the bot.
+2. Direct Postgres access from the bot.
+3. Direct Postgres writes from any bot flow.
+4. Backup create, restore, delete, import, or delete-all.
+5. Player grants, kicks, teleport, refills, resets, or inventory mutation.
+6. Broadcasts and shutdown broadcasts.
+7. Map, sietch, or deep desert mutations.
+8. Addon install, enable, disable, or remove.
+9. Secret-setting workflows.
+10. Any destructive action.
+
+## Authentication
+
+### Header
+
+```http
+Authorization: Bearer <dune-bot-api-token>
+```
+
+The token must be loaded by the bot from `DUNE_BOT_API_TOKEN_FILE` and validated server-side by the adapter.
+
+### Rejected Patterns
+
+- WebUI admin password as bot token.
+- Discord bot token as Dune API token.
+- Browser session cookie as bot auth.
+- Query-string token.
+
+## Required Actor Context
+
+Every bot request must include a Discord actor context object.
+
+```json
+{
+  "actor": {
+    "guildId": "123456789",
+    "channelId": "234567890",
+    "userId": "345678901",
+    "username": "admin-user",
+    "roleIds": ["456789012"],
+    "interactionId": "567890123",
+    "commandName": "/dune status"
+  }
+}
+```
+
+## Role Tiers
+
+| Tier | Intended Use |
+| --- | --- |
+| public | Basic non-sensitive status only. |
+| observer | Low-risk status/readiness visibility. |
+| moderator | Population, map state, backup metadata, and limited operational visibility. |
+| admin | Logs and diagnostic read-only visibility. |
+| owner | Reserved for future review; no owner-only write routes in experimental scope. |
+
+## Experimental Capability Model
+
+| Capability | Description | Minimum Tier |
+| --- | --- | --- |
+| `status:read` | Basic health/status visibility | public |
+| `readiness:read` | Readiness checks | observer |
+| `services:read` | Service list/status | observer |
+| `population:read` | Population summary and online count | moderator |
+| `logs:read` | Capped, redacted service logs | admin |
+| `maps:read` | Map, sietch, and deep desert read-only status | moderator |
+| `backups:read` | Backup list/latest metadata | moderator |
+
+## Response Classification
+
+| Class | Description | Allowed Fields |
+| --- | --- | --- |
+| public | Safe in public Discord channels. | High-level status, no internal topology. |
+| moderator | Safe for moderator/admin channels. | Population and operational metadata with sensitive values removed. |
+| admin | Safe only in admin channels or ephemeral admin responses. | Capped logs and diagnostics, always redacted. |
+
+## Initial Adapter Routes
+
+### `GET /api/integrations/discord/health`
+
+Purpose: bot connectivity check.
+
+Capability: `status:read`.
+
+Response:
+
+```json
+{
+  "ok": true,
+  "service": "dune-console-discord-adapter",
+  "experimental": true,
+  "readOnly": true
+}
+```
+
+### `POST /api/integrations/discord/status`
+
+Purpose: sanitized stack status for Discord.
+
+Capability: `status:read`.
+
+### `POST /api/integrations/discord/readiness`
+
+Purpose: readiness checks.
+
+Capability: `readiness:read`.
+
+### `POST /api/integrations/discord/services`
+
+Purpose: service list and service status summary.
+
+Capability: `services:read`.
+
+Requirement: service names must come from an allowlist or backend-safe source.
+
+### `POST /api/integrations/discord/population`
+
+Purpose: population summary and online player count.
+
+Capability: `population:read`.
+
+Requirement: public output should be count-only unless detailed output is explicitly role-gated.
+
+### `POST /api/integrations/discord/logs`
+
+Purpose: capped, redacted service logs.
+
+Capability: `logs:read`.
+
+Requirements:
+
+1. Service name validation.
+2. Line limit.
+3. Redaction.
+4. Admin-channel or ephemeral response recommended.
+5. No raw `.env`, tokens, DB URLs, host paths, or stack traces.
+
+### `POST /api/integrations/discord/map-state`
+
+Purpose: map, sietch, and deep desert read-only state.
+
+Capability: `maps:read`.
+
+### `POST /api/integrations/discord/backups/list`
+
+Purpose: backup list/latest metadata.
+
+Capability: `backups:read`.
+
+Requirements:
+
+1. No backup create/restore/delete/import/delete-all.
+2. No raw filesystem paths in public responses.
+3. Output capped and paginated.
+
+## Audit Event Requirements
+
+Every adapter request should be auditable. Read-only requests may use lower-risk audit records, but logs and detailed diagnostics should always be audited.
+
+Required fields:
+
+```json
+{
+  "source": "discord",
+  "discordGuildId": "...",
+  "discordChannelId": "...",
+  "discordUserId": "...",
+  "discordUsername": "...",
+  "command": "/dune logs",
+  "action": "logs.read",
+  "capability": "logs:read",
+  "risk": "low|medium",
+  "targetType": "service|server|map|backup|population",
+  "targetId": "...",
+  "result": "success|failed|blocked"
+}
+```
+
+## Error Contract
+
+Errors must be redacted and safe to display.
+
+```json
+{
+  "ok": false,
+  "error": "Not authorized for logs:read.",
+  "code": "not_authorized"
+}
+```
+
+Forbidden in errors:
+
+- Raw stack traces.
+- Raw SQL errors containing secrets.
+- Raw environment variables.
+- Discord or Dune tokens.
+- Internal DB URLs.
+- Funcom token values.
+- Internal IPs or SSH hosts.
+- Raw host paths.
+
+## DAST Requirements
+
+The adapter must have runtime tests for:
+
+1. Missing token rejected.
+2. Invalid token rejected.
+3. Missing actor rejected.
+4. Unauthorized role rejected.
+5. Public status sanitizes internal topology.
+6. Diagnostic/log output requires admin capability.
+7. Logs are capped and redacted.
+8. Backup routes are metadata-only.
+9. No write/destructive adapter routes are exposed.
+10. Secret-like values are redacted from errors and audit details.

--- a/docs/discord-control-bot/setup-guide.md
+++ b/docs/discord-control-bot/setup-guide.md
@@ -1,0 +1,209 @@
+# Dune Discord Companion Bot - Setup Guide
+
+## Scope
+
+This setup path validates the read-only Discord companion bot command layer and protected Console adapter without requiring manual edits to core Console files.
+
+The actual network Discord client is still deferred. Use the smoke runner to validate command behavior before connecting to Discord.
+
+## Prerequisites
+
+- Dune Docker Console repository checked out.
+- Node.js 22 for local smoke testing.
+- A local Dune bot API token file.
+- Console API reachable on `127.0.0.1:8088` or the configured admin bind port.
+- Semgrep and Trivy for local security/SOC 2 readiness scans.
+
+## Install Local Security Runtimes
+
+From the repository root:
+
+```bash
+bash scripts/ensure-security-runtimes.sh
+```
+
+The script checks for:
+
+```text
+node
+npm
+curl
+tar
+docker
+semgrep
+trivy
+```
+
+It installs Semgrep if missing using the first available method:
+
+1. `pipx install semgrep`
+2. `uv tool install semgrep`
+3. Python user install of `pipx`, then `pipx install semgrep`
+4. Docker wrapper fallback using `semgrep/semgrep`
+
+It installs Trivy if missing using:
+
+1. Homebrew when available.
+2. Latest GitHub release tarball into `$HOME/.local/bin` on Linux/macOS.
+
+If `$HOME/.local/bin` is not on your shell PATH, add it:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+## Create Local Bot API Token
+
+```bash
+mkdir -p "$HOME/.config/dune-console"
+printf '%s\n' 'local-dev-bot-api' > "$HOME/.config/dune-console/dune-bot-api-token.txt"
+chmod 600 "$HOME/.config/dune-console/dune-bot-api-token.txt"
+```
+
+Use a real random token outside local testing.
+
+## Start Console Adapter
+
+From `console/api`:
+
+```bash
+DUNE_DOCKER_DIR="$HOME/dune-awakening-selfhost-docker-WSL" \
+DUNE_BOT_API_TOKEN_FILE="$HOME/.config/dune-console/dune-bot-api-token.txt" \
+DISCORD_OBSERVER_ROLE_IDS=role-observer \
+DISCORD_ADMIN_ROLE_IDS=role-admin \
+DISCORD_OWNER_ROLE_IDS=role-owner \
+npm run start:discord-adapter
+```
+
+If runtime secrets are root-owned, use `sudo env` while preserving the same variables:
+
+```bash
+sudo env \
+  PATH="$PATH" \
+  HOME="$HOME" \
+  DUNE_DOCKER_DIR="$HOME/dune-awakening-selfhost-docker-WSL" \
+  DUNE_BOT_API_TOKEN_FILE="$HOME/.config/dune-console/dune-bot-api-token.txt" \
+  DISCORD_OBSERVER_ROLE_IDS=role-observer \
+  DISCORD_ADMIN_ROLE_IDS=role-admin \
+  DISCORD_OWNER_ROLE_IDS=role-owner \
+  npm run start:discord-adapter
+```
+
+## Smoke Test Bot Commands
+
+From `discord-bot`:
+
+```bash
+npm ci --ignore-scripts
+
+export DUNE_CONSOLE_API_URL=http://127.0.0.1:8088
+export DUNE_BOT_API_TOKEN_FILE="$HOME/.config/dune-console/dune-bot-api-token.txt"
+export DISCORD_GUILD_ID=local-guild
+export DISCORD_OBSERVER_ROLE_IDS=role-observer
+export DISCORD_ADMIN_ROLE_IDS=role-admin
+export DISCORD_OWNER_ROLE_IDS=role-owner
+
+npm run smoke:health
+npm run smoke:status
+npm run smoke:readiness
+npm run smoke:services
+npm run smoke:status-detail
+```
+
+## Expected Smoke Test Result
+
+Each command should return `status: 200`.
+
+The smoke output also includes:
+
+```text
+actorRoleIdsSent
+consoleRolePolicy
+```
+
+Use those fields to verify the bot and Console adapter share the same role mapping.
+
+## Test Gates
+
+Run Console adapter tests:
+
+```bash
+cd ~/dune-awakening-selfhost-docker-WSL/console/api
+npm ci --ignore-scripts
+node --test test/discord*.test.js
+```
+
+Run bot gates:
+
+```bash
+cd ~/dune-awakening-selfhost-docker-WSL/discord-bot
+npm ci --ignore-scripts
+npm test
+npm run security:secrets
+npm run build
+```
+
+Run SOC 2 readiness check:
+
+```bash
+cd ~/dune-awakening-selfhost-docker-WSL
+node scripts/soc2-readiness-check.mjs
+```
+
+If Semgrep or Trivy are missing, run:
+
+```bash
+bash scripts/ensure-security-runtimes.sh
+node scripts/soc2-readiness-check.mjs
+```
+
+## Local Vulnerability Report
+
+After Trivy is installed, generate filesystem scan input and the CVSS-ranked report:
+
+```bash
+mkdir -p artifacts/security
+trivy fs --scanners vuln,secret,misconfig --format json --output artifacts/security/trivy-fs.json .
+node scripts/generate-vulnerability-report.mjs
+```
+
+Read:
+
+```text
+artifacts/security/vulnerability-report.md
+artifacts/security/vulnerability-report.json
+```
+
+## Smoke Test Troubleshooting
+
+### 403 on Readiness or Services
+
+The observer role is not aligned.
+
+Check:
+
+- `actorRoleIdsSent` includes `role-observer`.
+- `consoleRolePolicy.observerConfigured` is `true`.
+- The Console adapter was started with `DISCORD_OBSERVER_ROLE_IDS=role-observer`.
+
+### 403 on Detailed Status
+
+The admin role is not aligned.
+
+Check:
+
+- `actorRoleIdsSent` includes `role-admin`.
+- `consoleRolePolicy.adminConfigured` is `true`.
+- The Console adapter was started with `DISCORD_ADMIN_ROLE_IDS=role-admin`.
+
+### 500 Missing Dune Command
+
+Start the Console adapter with the repository root set:
+
+```bash
+DUNE_DOCKER_DIR="$HOME/dune-awakening-selfhost-docker-WSL"
+```
+
+### Permission Denied on Runtime Secrets
+
+Use `sudo env` for local testing if existing runtime secrets are root-owned. Keep `DUNE_BOT_API_TOKEN_FILE` pointing at `$HOME/.config/dune-console/dune-bot-api-token.txt`.

--- a/docs/discord-control-bot/user-guide.md
+++ b/docs/discord-control-bot/user-guide.md
@@ -1,0 +1,80 @@
+# Dune Discord Companion Bot - User Guide
+
+## Purpose
+
+The Dune Discord Companion Bot gives safe read-only visibility into Dune Docker Console from Discord.
+
+It does not perform server mutations, player actions, database writes, backup restores, or Docker control actions.
+
+## Commands
+
+| Command | Who can use it | What it shows |
+|---|---:|---|
+| `/dune health` | Public | Whether the Console adapter is online and read-only. |
+| `/dune status` | Public | Public Status summary for the server. |
+| `/dune status detail` | Admin/Owner | Detailed Status with additional redacted diagnostics. |
+| `/dune readiness` | Observer+ | Whether server components appear ready. |
+| `/dune services` | Observer+ | Friendly service status summary. |
+
+## Public Status
+
+`/dune status` is safe for public or semi-public operational channels.
+
+It may show:
+
+- Overall status.
+- Server title.
+- Region.
+- Mode.
+- Population.
+- Map readiness.
+- General issue summary.
+
+It does not show:
+
+- Internal SSH hosts.
+- Internal IPs.
+- Database URLs.
+- Tokens or secrets.
+- Raw host paths.
+- Raw Docker/container internals.
+
+## Detailed Status
+
+`/dune status detail` provides more detail for administrators.
+
+It may show:
+
+- Parsed service state.
+- Parsed listener checks with redaction.
+- Map state.
+- Issue list.
+- Capped redacted command output.
+
+Detailed Status is intended to be ephemeral and should not be posted into public channels.
+
+## Readiness
+
+`/dune readiness` shows whether the server appears ready for players.
+
+A readiness issue does not always mean the server is broken. For example, a map may be warming or a listener may need a short period to appear after startup.
+
+## Services
+
+`/dune services` shows a friendly summary of important services.
+
+Instead of exposing raw container details, the bot uses user-facing labels such as Database, Gateway, Survival, Overmap, and Orchestrator.
+
+## If a Command Is Denied
+
+A `not_authorized` response means your Discord role does not map to the required bot capability.
+
+Ask a server admin to verify:
+
+- Your Discord role.
+- The bot role mapping.
+- The Console adapter role mapping.
+
+## Safety Expectations
+
+The bot is read-only. It cannot grant items, restart services, restore backups, mutate players, edit maps, send broadcasts, or change server settings.


### PR DESCRIPTION
## Summary

Adds a modular, read-only Discord adapter as structured integration modules
(replacing the inline pattern). 10 source files, 220 tests pass.

## Code Changes

### Adapter Modules (console/api/src/integrations/discord/)
- `adapter.js` — capability-based routing, health/status/readiness/services/population handlers
- `policy.js` — RBAC with DISCORD_CAPABILITIES and tier-based authorization
- `routes.js` — bearer-token authenticated route handler (20 routes defined)
- `sanitize.js` — PII/secret redaction, internal IP blocking, connection string stripping
- `audit.js` — structured audit event publishing
- `readOnlyProviders.js`, `statusProvider.js` — data provider interfaces

### Launcher Scripts (console/api/scripts/)
- `apply-discord-server-hook.mjs` — server hook registration
- `start-discord-adapter.mjs` — adapter startup entry point

### Test
- `console/api/test/discordAdapter.test.js` — updated with 10 route-specific tests

## Live Routes (5)
health (GET), status (POST), readiness (POST), services (POST), population (POST)

## Planned Routes (15)
OPS observability (9), broadcast, announcements, logs, map-state, backups

## Security
- Adapter disabled by default (`DUNE_DISCORD_ADAPTER_ENABLED=false`)
- Bearer-token authentication
- Capability-based RBAC (observer/moderator/admin/owner)
- All routes read-only; audit events for every call

## Tests
- [x] `npm test` (console/api) — 220/220