### PR TITLE
[Feature] Add Guilds page to Arrakis Management

### DIFF
--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -1356,6 +1356,97 @@ async function leadershipGuilds(db) {
   return guilds;
 }
 
+const NEUTRAL_GUILD_FACTION_ID = 3;
+
+function guildFactionDisplayName(row) {
+  const factionId = row.guild_faction;
+  if (!factionId || Number(factionId) === NEUTRAL_GUILD_FACTION_ID) return "Neutral";
+  return row.guild_faction_name || `Faction ${factionId}`;
+}
+
+export async function listGuilds(db, { q = "" } = {}) {
+  if (!(await tableExists(db, "guilds"))) return unsupported("guilds", ["dune.guilds"]);
+  const guildColumns = await columnsFor(db, "guilds");
+  const guildIdColumn = firstExistingColumn(guildColumns, ["guild_id", "id"]);
+  const guildNameColumn = firstExistingColumn(guildColumns, ["guild_name", "name", "display_name"]);
+  if (!guildIdColumn || !guildNameColumn) return unsupported("guilds", ["dune.guilds"]);
+  const guildFactionColumn = firstExistingColumn(guildColumns, ["guild_faction", "faction_id", "faction"]);
+  const guildDescriptionColumn = firstExistingColumn(guildColumns, ["guild_description", "description"]);
+  const hasMembers = await tableExists(db, "guild_members");
+  let memberGuildColumn = "";
+  if (hasMembers) {
+    const memberColumns = await columnsFor(db, "guild_members");
+    memberGuildColumn = firstExistingColumn(memberColumns, ["guild_id", "id"]);
+  }
+  const hasFactions = guildFactionColumn && await tableExists(db, "factions");
+
+  const values = [];
+  let where = "1=1";
+  if (q) {
+    values.push(`%${q}%`);
+    where += ` and g.${quoteIdentifier(guildNameColumn)} ilike $${values.length}`;
+  }
+
+  const memberCountSelect = hasMembers && memberGuildColumn
+    ? `(select count(*) from dune.guild_members gm where gm.${quoteIdentifier(memberGuildColumn)} = g.${quoteIdentifier(guildIdColumn)})`
+    : "0";
+
+  const result = await db.query(`
+    select g.${quoteIdentifier(guildIdColumn)}::text as guild_id,
+           coalesce(g.${quoteIdentifier(guildNameColumn)}, '') as guild_name,
+           ${guildFactionColumn ? `coalesce(g.${quoteIdentifier(guildFactionColumn)}::text, '')` : "''"} as guild_faction,
+           ${hasFactions ? "coalesce(f.name, '')" : "''"} as guild_faction_name,
+           ${guildDescriptionColumn ? `coalesce(g.${quoteIdentifier(guildDescriptionColumn)}, '')` : "''"} as guild_description,
+           ${memberCountSelect}::int as member_count
+    from dune.guilds g
+    ${hasFactions ? `left join dune.factions f on f.id = g.${quoteIdentifier(guildFactionColumn)}` : ""}
+    where ${where}
+    order by lower(coalesce(g.${quoteIdentifier(guildNameColumn)}, '')), g.${quoteIdentifier(guildIdColumn)}
+    limit 500`, values);
+
+  const rows = result.rows.map((row) => ({ ...row, guild_faction: guildFactionDisplayName(row) }));
+  return { capabilities: { guilds: true, guildMembers: hasMembers }, rows };
+}
+
+export async function guildMembers(db, guildId) {
+  const id = intParam(guildId, "guild id", 1);
+  if (!(await tableExists(db, "guild_members")) || !(await tableExists(db, "guilds"))) {
+    return unsupported("guildMembers", ["dune.guild_members", "dune.guilds"]);
+  }
+  const memberColumns = await columnsFor(db, "guild_members");
+  const guildColumns = await columnsFor(db, "guilds");
+  const memberGuildColumn = firstExistingColumn(memberColumns, ["guild_id", "id"]);
+  const memberPlayerColumn = firstExistingColumn(memberColumns, ["player_id", "player_controller_id", "actor_id", "account_id", "player_pawn_id"]);
+  const memberRoleColumn = firstExistingColumn(memberColumns, ["role_id", "role"]);
+  const guildIdColumn = firstExistingColumn(guildColumns, ["guild_id", "id"]);
+  if (!memberGuildColumn || !memberPlayerColumn || !guildIdColumn) {
+    return unsupported("guildMembers", ["dune.guild_members", "dune.guilds"]);
+  }
+
+  const hasPlayerState = await tableExists(db, "player_state");
+  const hasActors = await tableExists(db, "actors");
+  const memberPlayerRef = `gm.${quoteIdentifier(memberPlayerColumn)}`;
+  const joins = [];
+  if (hasPlayerState) joins.push(`left join dune.player_state ps_by_controller on ps_by_controller.player_controller_id = ${memberPlayerRef}`);
+  if (hasActors) joins.push(`left join dune.actors a_by_actor_id on a_by_actor_id.id = ${memberPlayerRef}`);
+  if (hasPlayerState) joins.push(`left join dune.player_state ps_by_account on ps_by_account.account_id = coalesce(${hasActors ? "a_by_actor_id.owner_account_id" : "null"}, ${memberPlayerRef})`);
+  const characterNameSelect = hasPlayerState
+    ? "coalesce(ps_by_controller.character_name, ps_by_account.character_name, '')"
+    : "''";
+
+  const result = await db.query(`
+    select ${memberPlayerRef}::text as player_id,
+           ${memberRoleColumn ? `gm.${quoteIdentifier(memberRoleColumn)}::text` : "''"} as role_id,
+           ${characterNameSelect} as character_name
+    from dune.guild_members gm
+    join dune.guilds g on g.${quoteIdentifier(guildIdColumn)} = gm.${quoteIdentifier(memberGuildColumn)}
+    ${joins.join("\n    ")}
+    where gm.${quoteIdentifier(memberGuildColumn)} = $1
+    order by ${memberRoleColumn ? `gm.${quoteIdentifier(memberRoleColumn)} asc, ` : ""}lower(${characterNameSelect})`, [id]);
+
+  return { capabilities: { guildMembers: true }, rows: result.rows };
+}
+
 function firstExistingColumn(columns, names) {
   return names.find((name) => columns.has(name)) || "";
 }

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -335,6 +335,8 @@ async function handleApi(req, res) {
   if (path === "/api/players") return dbJson(res, () => duneDb.listPlayers(db, { q: url.searchParams.get("q") || "" }));
   if (path === "/api/players/online") return dbJson(res, () => duneDb.listPlayers(db, { online: true }));
   if (path === "/api/players/search") return dbJson(res, () => duneDb.listPlayers(db, { q: url.searchParams.get("q") || "" }));
+  if (path === "/api/guilds") return dbJson(res, () => duneDb.listGuilds(db, { q: url.searchParams.get("q") || "" }));
+  if (path.match(/^\/api\/guilds\/[^/]+\/members$/)) return dbJson(res, () => duneDb.guildMembers(db, decodeURIComponent(path.split("/")[3])));
   if (path === "/api/admin/items/catalog") return json(res, 200, { rows: listCatalogItems(config.repoRoot, { q: url.searchParams.get("q") || "", limit: url.searchParams.get("limit") || 500 }) });
   if (path === "/api/admin/items/search") return commandJson(res, "adminItemSearch", { q: url.searchParams.get("q") || "" });
   if (path === "/api/admin/items") return commandJson(res, url.searchParams.get("category") ? "adminItemListCategory" : "adminItemList", { category: url.searchParams.get("category") || "" });

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { assertIdentifier, discoverDbConfig, isReadOnlySql, quoteQualified, redactDbError, rowsResult } from "../src/db.js";
-import { addCurrency, addFactionReputation, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, completeJourneyNode, completeTutorial, deleteInventoryItem, giveItemToPlayer, giveItemToStorage, landsraadOverview, listPlayers, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerJourney, playerPosition, playerResearchItems, repairVehicleDecay, resetJourneyNode, resetTutorial, runSql, setLandsraadPlayerContribution, tablePreview, unlockCraftingRecipe, unlockResearchItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError } from "../src/duneDb.js";
+import { addCurrency, addFactionReputation, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, completeJourneyNode, completeTutorial, deleteInventoryItem, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listGuilds, listPlayers, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerJourney, playerPosition, playerResearchItems, repairVehicleDecay, resetJourneyNode, resetTutorial, runSql, setLandsraadPlayerContribution, tablePreview, unlockCraftingRecipe, unlockResearchItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError } from "../src/duneDb.js";
 
 test("discovers RedBlink Postgres defaults and env overrides", () => {
   assert.deepEqual(discoverDbConfig({}), {
@@ -554,6 +554,224 @@ test("addon leadership players include level and faction summaries", async () =>
     ["Test Two", 7, "Harkonnen"]
   ]);
   assert.deepEqual(result.rows.map((row) => row.guild), ["Water Sellers", "Spice Guild"]);
+});
+
+test("list guilds returns capability response when dune.guilds is missing", async () => {
+  const db = {
+    query: async () => ({ rows: [{ exists: false }] })
+  };
+  const result = await listGuilds(db, {});
+  assert.equal(result.capabilities.guilds, false);
+  assert.match(result.reason, /dune\.guilds/);
+});
+
+test("list guilds returns rows with description and member count", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: ["dune.guilds", "dune.guild_members"].includes(name) }] };
+      }
+      if (text.includes("information_schema.columns")) {
+        const table = String(values[1] || "");
+        if (table === "guilds") return { rows: ["guild_id", "guild_name", "guild_faction", "guild_description"].map((column_name) => ({ column_name })) };
+        if (table === "guild_members") return { rows: ["player_id", "guild_id", "role_id"].map((column_name) => ({ column_name })) };
+        return { rows: [] };
+      }
+      return { rows: [
+        { guild_id: "1", guild_name: "Water Sellers", guild_faction: "1", guild_faction_name: "", guild_description: "Trade guild", member_count: 4 }
+      ] };
+    }
+  };
+  const result = await listGuilds(db, {});
+  assert.equal(result.capabilities.guilds, true);
+  assert.equal(result.capabilities.guildMembers, true);
+  assert.equal(result.rows.length, 1);
+  assert.equal(result.rows[0].guild_name, "Water Sellers");
+  assert.equal(result.rows[0].guild_description, "Trade guild");
+  assert.equal(result.rows[0].member_count, 4);
+});
+
+test("list guilds resolves faction id to a name when dune.factions has a match", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: ["dune.guilds", "dune.guild_members", "dune.factions"].includes(name) }] };
+      }
+      if (text.includes("information_schema.columns")) {
+        const table = String(values[1] || "");
+        if (table === "guilds") return { rows: ["guild_id", "guild_name", "guild_faction"].map((column_name) => ({ column_name })) };
+        if (table === "guild_members") return { rows: ["player_id", "guild_id"].map((column_name) => ({ column_name })) };
+        return { rows: [] };
+      }
+      return { rows: [
+        { guild_id: "1", guild_name: "House Guard", guild_faction: "1", guild_faction_name: "Atreides", guild_description: "", member_count: 2 }
+      ] };
+    }
+  };
+  const result = await listGuilds(db, {});
+  assert.equal(result.rows[0].guild_faction, "Atreides");
+});
+
+test("list guilds treats faction id 3 as Neutral even when dune.factions is present", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: ["dune.guilds", "dune.guild_members", "dune.factions"].includes(name) }] };
+      }
+      if (text.includes("information_schema.columns")) {
+        const table = String(values[1] || "");
+        if (table === "guilds") return { rows: ["guild_id", "guild_name", "guild_faction"].map((column_name) => ({ column_name })) };
+        if (table === "guild_members") return { rows: ["player_id", "guild_id"].map((column_name) => ({ column_name })) };
+        return { rows: [] };
+      }
+      return { rows: [
+        { guild_id: "2", guild_name: "Unaligned Traders", guild_faction: "3", guild_faction_name: "", guild_description: "", member_count: 1 }
+      ] };
+    }
+  };
+  const result = await listGuilds(db, {});
+  assert.equal(result.rows[0].guild_faction, "Neutral");
+});
+
+test("list guilds falls back to a numeric faction label when dune.factions has no matching row", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: ["dune.guilds", "dune.guild_members", "dune.factions"].includes(name) }] };
+      }
+      if (text.includes("information_schema.columns")) {
+        const table = String(values[1] || "");
+        if (table === "guilds") return { rows: ["guild_id", "guild_name", "guild_faction"].map((column_name) => ({ column_name })) };
+        if (table === "guild_members") return { rows: ["player_id", "guild_id"].map((column_name) => ({ column_name })) };
+        return { rows: [] };
+      }
+      return { rows: [
+        { guild_id: "3", guild_name: "Unknown Alliance", guild_faction: "9", guild_faction_name: "", guild_description: "", member_count: 0 }
+      ] };
+    }
+  };
+  const result = await listGuilds(db, {});
+  assert.equal(result.rows[0].guild_faction, "Faction 9");
+});
+
+test("list guilds filters by name when a search query is given", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: ["dune.guilds", "dune.guild_members"].includes(name) }] };
+      }
+      if (text.includes("information_schema.columns")) {
+        const table = String(values[1] || "");
+        if (table === "guilds") return { rows: ["guild_id", "guild_name"].map((column_name) => ({ column_name })) };
+        if (table === "guild_members") return { rows: ["player_id", "guild_id"].map((column_name) => ({ column_name })) };
+        return { rows: [] };
+      }
+      return { rows: [] };
+    }
+  };
+  await listGuilds(db, { q: "Water" });
+  const guildQuery = calls.find((call) => call.text.includes("from dune.guilds g"));
+  assert.ok(guildQuery);
+  assert.match(guildQuery.text, /ilike \$1/);
+  assert.deepEqual(guildQuery.values, ["%Water%"]);
+});
+
+test("guild members returns capability response when required tables are missing", async () => {
+  const db = {
+    query: async () => ({ rows: [{ exists: false }] })
+  };
+  const result = await guildMembers(db, 1);
+  assert.equal(result.capabilities.guildMembers, false);
+  assert.match(result.reason, /dune\.guild_members/);
+});
+
+test("guild members returns member rows with player id, role, and character name", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: ["dune.guild_members", "dune.guilds", "dune.player_state"].includes(name) }] };
+      }
+      if (text.includes("information_schema.columns")) {
+        const table = String(values[1] || "");
+        if (table === "guild_members") return { rows: ["player_id", "guild_id", "role_id"].map((column_name) => ({ column_name })) };
+        if (table === "guilds") return { rows: ["guild_id", "guild_name"].map((column_name) => ({ column_name })) };
+        return { rows: [] };
+      }
+      if (text.includes("from dune.guild_members gm")) {
+        return { rows: [
+          { player_id: "301", role_id: "100", character_name: "Leader One" },
+          { player_id: "302", role_id: "1", character_name: "Member Two" }
+        ] };
+      }
+      return { rows: [] };
+    }
+  };
+  const result = await guildMembers(db, 1);
+  assert.equal(result.capabilities.guildMembers, true);
+  assert.deepEqual(result.rows, [
+    { player_id: "301", role_id: "100", character_name: "Leader One" },
+    { player_id: "302", role_id: "1", character_name: "Member Two" }
+  ]);
+});
+
+test("guild members joins player_controller_id, actor id, and owning account as a defensive identity fallback", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: ["dune.guild_members", "dune.guilds", "dune.player_state", "dune.actors"].includes(name) }] };
+      }
+      if (text.includes("information_schema.columns")) {
+        const table = String(values[1] || "");
+        if (table === "guild_members") return { rows: ["player_id", "guild_id", "role_id"].map((column_name) => ({ column_name })) };
+        if (table === "guilds") return { rows: ["guild_id", "guild_name"].map((column_name) => ({ column_name })) };
+        return { rows: [] };
+      }
+      return { rows: [] };
+    }
+  };
+  await guildMembers(db, 1);
+  const memberQuery = calls.find((call) => call.text.includes("from dune.guild_members gm"));
+  assert.ok(memberQuery);
+  assert.match(memberQuery.text, /left join dune\.player_state ps_by_controller on ps_by_controller\.player_controller_id = gm\."player_id"/);
+  assert.match(memberQuery.text, /left join dune\.actors a_by_actor_id on a_by_actor_id\.id = gm\."player_id"/);
+  assert.match(memberQuery.text, /left join dune\.player_state ps_by_account on ps_by_account\.account_id = coalesce\(a_by_actor_id\.owner_account_id, gm\."player_id"\)/);
+  assert.match(memberQuery.text, /coalesce\(ps_by_controller\.character_name, ps_by_account\.character_name, ''\)/);
+});
+
+test("guild members falls back to a direct account-id join when dune.actors is unavailable", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: ["dune.guild_members", "dune.guilds", "dune.player_state"].includes(name) }] };
+      }
+      if (text.includes("information_schema.columns")) {
+        const table = String(values[1] || "");
+        if (table === "guild_members") return { rows: ["player_id", "guild_id", "role_id"].map((column_name) => ({ column_name })) };
+        if (table === "guilds") return { rows: ["guild_id", "guild_name"].map((column_name) => ({ column_name })) };
+        return { rows: [] };
+      }
+      return { rows: [] };
+    }
+  };
+  await guildMembers(db, 1);
+  const memberQuery = calls.find((call) => call.text.includes("from dune.guild_members gm"));
+  assert.ok(memberQuery);
+  assert.doesNotMatch(memberQuery.text, /dune\.actors/);
+  assert.match(memberQuery.text, /left join dune\.player_state ps_by_account on ps_by_account\.account_id = coalesce\(null, gm\."player_id"\)/);
 });
 
 test("addon leadership players derive character level from level component XP", async () => {

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { Fragment, Suspense, lazy, useCallback, useEffect, useRef, useState } from "react";
-import { Archive, Database, FileText, Gift, Heart, Home, Landmark, Map as MapIcon, MessageCircle, PackagePlus, RefreshCw, Server, Settings, Sparkles, Users } from "lucide-react";
+import { Archive, Database, FileText, Gift, Heart, Home, Landmark, Map as MapIcon, MessageCircle, PackagePlus, RefreshCw, Server, Settings, Shield, Sparkles, Users } from "lucide-react";
 import { api, post, setCsrfToken } from "./api/client";
 import { serverApi } from "./api/server";
 import { updatesApi } from "./api/updates";
@@ -31,7 +31,7 @@ import {
 import { parseUpdateTask, stackVersionButtonLabel, stackVersionButtonTitle } from "./features/updates/updateUtils";
 import { formatUiSentence, stripAnsi, summarizeCommandText, titleCase } from "./lib/display";
 
-type Tab = "Home" | "Server Control" | "Services" | "Players" | "Landsraad" | "Admin Tools" | "Live Map" | "Maps" | "Care Package" | "Addons" | "Database" | "Storage" | "Backups" | "Logs" | "Updates" | "Settings";
+type Tab = "Home" | "Server Control" | "Services" | "Players" | "Guilds" | "Landsraad" | "Admin Tools" | "Live Map" | "Maps" | "Care Package" | "Addons" | "Database" | "Storage" | "Backups" | "Logs" | "Updates" | "Settings";
 type SetupState = { files: Record<string, boolean>; config: Record<string, unknown> };
 let openConfirmDialog: ((request: ConfirmDialogRequest) => void) | null = null;
 
@@ -40,6 +40,7 @@ const AdminToolsPanel = lazy(() => import("./features/adminTools/AdminToolsPanel
 const BackupsPanel = lazy(() => import("./features/backups/BackupsPanel").then((module) => ({ default: module.BackupsPanel })));
 const CarePackagePanel = lazy(() => import("./features/carePackage/CarePackagePanel").then((module) => ({ default: module.CarePackagePanel })));
 const DatabasePanel = lazy(() => import("./features/database/DatabasePanel").then((module) => ({ default: module.DatabasePanel })));
+const GuildsPanel = lazy(() => import("./features/guilds/GuildsPanel").then((module) => ({ default: module.GuildsPanel })));
 const LogsPanel = lazy(() => import("./features/logs/LogsPanel").then((module) => ({ default: module.LogsPanel })));
 const LiveMapPanel = lazy(() => import("./features/liveMap/LiveMapPanel").then((module) => ({ default: module.LiveMapPanel })));
 const LandsraadPanel = lazy(() => import("./features/landsraad/LandsraadPanel").then((module) => ({ default: module.LandsraadPanel })));
@@ -107,6 +108,7 @@ const navGroups: { title: string; items: { tab: Tab; icon: React.ReactNode }[] }
     items: [
       { tab: "Maps", icon: <MapIcon size={18} /> },
       { tab: "Players", icon: <Users size={18} /> },
+      { tab: "Guilds", icon: <Shield size={18} /> },
       { tab: "Live Map", icon: <MapIcon size={18} /> },
       { tab: "Landsraad", icon: <Landmark size={18} /> },
       { tab: "Admin Tools", icon: <PackagePlus size={18} /> },
@@ -524,6 +526,7 @@ export function App() {
         }} />}
         {!redeploySetupOpen && tab === "Services" && <LazyTabBoundary label="Loading Services"><ServicesPanel services={services} setServices={setServices} setTask={setTask} openLogs={(service) => { setRedeploySetupOpen(false); setSelectedLogService(service); setTab("Logs"); }} onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Players" && <LazyTabBoundary label="Loading Players"><PlayersPanel onError={setError} renderCharacterAdmin={(props) => <LazyTabBoundary label="Loading Player Details"><CharacterAdminUI {...props} onError={setError} confirmAction={confirmDialog} waitForTask={waitForTaskSilently} formatMutationResult={formatMutationResult} /></LazyTabBoundary>} /></LazyTabBoundary>}
+        {!redeploySetupOpen && tab === "Guilds" && <LazyTabBoundary label="Loading Guilds"><GuildsPanel onError={setError} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Landsraad" && <LazyTabBoundary label="Loading Landsraad"><LandsraadPanel onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Admin Tools" && <LazyTabBoundary label="Loading Admin Tools"><AdminToolsPanel onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Live Map" && <LazyTabBoundary label="Loading Live Map"><LiveMapPanel onError={setError} confirmAction={confirmDialog} waitForTask={waitForTaskSilently} taskTechnicalDetails={taskTechnicalDetails} /></LazyTabBoundary>}

--- a/console/web/src/api/guilds.ts
+++ b/console/web/src/api/guilds.ts
@@ -1,0 +1,6 @@
+import { api } from "./client";
+
+export const guildsApi = {
+  list: (q = "") => api<{ rows: Record<string, unknown>[]; capabilities: Record<string, unknown>; reason?: string }>(`/api/guilds${q ? `?q=${encodeURIComponent(q)}` : ""}`),
+  members: (guildId: string) => api<{ rows: Record<string, unknown>[]; capabilities: Record<string, unknown>; reason?: string }>(`/api/guilds/${encodeURIComponent(guildId)}/members`)
+};

--- a/console/web/src/features/guilds/GuildsPanel.tsx
+++ b/console/web/src/features/guilds/GuildsPanel.tsx
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { guildsApi } from "../../api/guilds";
+import { DataTable } from "../../components/common/DataTable";
+import { formatCell } from "../../lib/display";
+
+type GuildsPanelProps = {
+  onError: (text: string) => void;
+};
+
+const GUILDS_AUTO_REFRESH_MS = 10_000;
+
+export function GuildsPanel({ onError }: GuildsPanelProps) {
+  const [q, setQ] = useState("");
+  const [rows, setRows] = useState<Record<string, unknown>[]>([]);
+  const [selectedGuild, setSelectedGuild] = useState<Record<string, unknown> | null>(null);
+  const [memberRows, setMemberRows] = useState<Record<string, unknown>[]>([]);
+  const [membersLoading, setMembersLoading] = useState(false);
+  const refreshInFlight = useRef(false);
+  const qRef = useRef(q);
+
+  useEffect(() => {
+    qRef.current = q;
+  }, [q]);
+
+  const load = useCallback(async (options: { silent?: boolean } = {}) => {
+    if (refreshInFlight.current) return;
+    refreshInFlight.current = true;
+    if (!options.silent) onError("");
+    try {
+      const result = await guildsApi.list(qRef.current);
+      const nextRows = result.rows || [];
+      setRows(nextRows);
+      setSelectedGuild((current) => {
+        if (!current) return current;
+        const currentId = String(current.guild_id || "");
+        return nextRows.find((row) => String(row.guild_id || "") === currentId) || current;
+      });
+    } catch (error) {
+      if (!options.silent) onError(error instanceof Error ? error.message : String(error));
+    } finally {
+      refreshInFlight.current = false;
+    }
+  }, [onError]);
+
+  async function openGuild(row: Record<string, unknown>) {
+    const guildId = String(row.guild_id || "");
+    if (selectedGuild && String(selectedGuild.guild_id || "") === guildId) {
+      setSelectedGuild(null);
+      setMemberRows([]);
+      return;
+    }
+    setSelectedGuild(row);
+    setMembersLoading(true);
+    try {
+      const result = await guildsApi.members(guildId);
+      setMemberRows(result.rows || []);
+    } catch (error) {
+      onError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setMembersLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const refresh = () => {
+      if (document.visibilityState === "hidden") return;
+      void load({ silent: true });
+    };
+
+    const interval = window.setInterval(refresh, GUILDS_AUTO_REFRESH_MS);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [load]);
+
+  return (
+    <section className="panel">
+      <div className="panel-title"><h2>Guilds</h2><div className="action-row"><button onClick={() => void load()}>Refresh</button></div></div>
+      <div className="action-row"><input value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search guild name" /><button onClick={() => void load()}>Search</button></div>
+      <DataTable rows={rows} columns={["guild_name", "guild_faction", "member_count", "guild_description"]} tableClassName="guilds-table" onRowClick={openGuild} emptyMessage="No guilds have been found yet." />
+      {selectedGuild && (
+        <div className="guild-members-panel">
+          <div className="panel-title">
+            <h3>Members of {String(selectedGuild.guild_name || "Guild")}</h3>
+            <button onClick={() => { setSelectedGuild(null); setMemberRows([]); }}>Close</button>
+          </div>
+          <DataTable
+            rows={memberRows}
+            columns={["character_name", "role_id"]}
+            tableClassName="guild-members-table"
+            emptyMessage={membersLoading ? "Loading members..." : "This guild has no members."}
+            renderCell={(row, col) => {
+              if (col === "role_id") return String(row.role_id) === "100" ? "Leader" : "Member";
+              return formatCell(row[col]);
+            }}
+          />
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
1st Pass of this page.

-Read-only guild list and member drilldown under Arrakis Management, with schema-flexible backend queries mirroring the Players page. 
-Resolves guild faction to a display name and fixes the guild_members-to-player join to fall back across player_controller_id, actor_id, and account_id instead of guessing a single key.