### PR TITLE
fix: allow grade 1-5 items through live console, only force DB for schematics/augments

### DIFF
--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -1748,8 +1748,8 @@ async function grantPlayerItem(playerId, item, target) {
   const hasExplicitGrade = item.quality !== undefined || item.grade !== undefined;
   const selectedGrade = hasExplicitGrade ? validateGrantGrade(item.quality ?? item.grade) : undefined;
   const selectedAugmentGrade = item.augmentQuality === undefined ? 1 : validateAugmentGrantGrade(item.augmentQuality);
-  const usesDatabaseGrant = (selectedGrade !== undefined && selectedGrade > 0) || itemRequiresDatabaseGrant(resolved) || (item.augments && item.augments.length > 0);
-  const databaseGrade = hasExplicitGrade ? selectedGrade : 0;
+  const usesDatabaseGrant = itemRequiresDatabaseGrant(resolved) || (item.augments && item.augments.length > 0);
+  const databaseGrade = hasExplicitGrade ? selectedGrade : (usesDatabaseGrant ? 1 : 0);
   const payload = {
     playerId: target.actionId || playerId,
     itemId: resolved.itemId,
@@ -1764,7 +1764,7 @@ async function grantPlayerItem(playerId, item, target) {
   if (usesDatabaseGrant) {
     if (!config.mockMode && !target.actorId) throw new Error("A database actor ID is required to grant graded items, schematics, and augments");
     if (!config.mockMode && payload.augments.length > 0 && target.online) {
-      throw new Error("Pre-augmented item grants require the player to be offline. Grade 0 items with no augments can be granted while the player is online. Item Grades 1-5 or Augment Grades 1-5 require the player to be offline.");
+      throw new Error("Augmented item grants require the player to be offline. Grade 0-5 items without augments can be granted while the player is online.");
     }
     const result = config.mockMode
       ? { ok: true, inserted: { template_id: resolved.itemId || payload.itemName, stack_size: payload.quantity, quality_level: databaseGrade } }


### PR DESCRIPTION
## Summary

Removes the `(selectedGrade > 0)` condition from `usesDatabaseGrant` in `grantPlayerItem()`. This allows graded items (quality/grade 1-5) without augments to be granted via the live console command while the player is online. Previously, any item with grade > 0 was forced through the database grant path.

## Changes

- **server.js — grantPlayerItem()**
  - `usesDatabaseGrant` now only checks for schematics (`itemRequiresDatabaseGrant`) and augments — not item grade
  - `databaseGrade` fallback changed from `0` to `1` when no explicit grade is specified but DB path is used (ensures augmented items get valid grade)
  - Error message clarified: only augmented items require offline

## Behavior

| Item Type | Before | After |
|-----------|--------|-------|
| Grade 0, no augments | Live console (online OK) | Live console (online OK) |
| Grade 1-5, no augments | DB path (online OK but DB overhead) | Live console (online OK) |
| Any grade + augments | DB path (offline required) | DB path (offline required) |
| Schematic item | DB path | DB path |

## Testing

```
npm test  →  324 pass, 0 fail, 5 skipped
```
