### PR TITLE
fix: orchestrator COPY paths — build context is ./orchestrator, not repo root

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -31,10 +31,10 @@ RUN useradd -m -s /bin/bash dune \
  && chown -R dune:dune /home/dune /srv/dune \
  && usermod -aG docker dune
 
-COPY orchestrator/dune_orchestrator.py /usr/local/bin/dune
+COPY dune_orchestrator.py /usr/local/bin/dune
 RUN chmod +x /usr/local/bin/dune
 
-COPY orchestrator/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/tests/container-lifecycle-test.sh
+++ b/tests/container-lifecycle-test.sh
@@ -123,7 +123,7 @@ done
 # ── Test 10: Orchestrator Dockerfile builds ──
 echo ""
 echo "10. Orchestrator Dockerfile builds"
-if docker build --quiet -f "$REPO_ROOT/orchestrator/Dockerfile" -t "dune-orch-test:lifecycle" "$REPO_ROOT" 2>&1 > /dev/null; then
+if docker build --quiet -f "$REPO_ROOT/orchestrator/Dockerfile" -t "dune-orch-test:lifecycle" "$REPO_ROOT/orchestrator" 2>&1 > /dev/null; then
   pass "orchestrator Dockerfile builds"
 else
   fail "orchestrator Dockerfile build failed"


### PR DESCRIPTION
PR #13 changed the orchestrator Dockerfile COPY paths to use `orchestrator/` prefix, but the compose build context is `./orchestrator`, not the repo root. This caused `dune init` to fail with:

```
COPY orchestrator/entrypoint.sh /usr/local/bin/entrypoint.sh
ERROR: failed to calculate checksum: "/orchestrator/entrypoint.sh": not found
```

Fix: restore COPY paths relative to the `./orchestrator` build context (`COPY dune_orchestrator.py`, `COPY entrypoint.sh`).