### PR TITLE
[Feature] Add Base Page

### DIFF
--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2121,9 +2121,14 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
   const safePage = intParam(page, "page", 0);
   const offset = safePage * safePageSize;
 
+  // Owner resolution (lowest-rank permission holder) is a per-base correlated LATERAL —
+  // expensive at scale. When searching, the `having` clause needs it to filter on, so it
+  // must run inside `matched` (before pagination) for every candidate base. When not
+  // searching, defer it to the final SELECT so it only runs for the page being displayed.
+  const searching = Boolean(q);
   const values = [];
   let having = "";
-  if (q) {
+  if (searching) {
     values.push(`%${q}%`);
     having = `having coalesce(pa.actor_name, '') ilike $${values.length} or coalesce(owner.character_name, '') ilike $${values.length}`;
   }
@@ -2131,21 +2136,8 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
   const limitParamIndex = values.length - 1;
   const offsetParamIndex = values.length;
 
-  try {
-    const result = await db.query(`
-      with matched as (
-        select b.id,
-               a.id as actor_id,
-               pa.actor_name as raw_name,
-               coalesce(pa.actor_name, 'Base ' || b.id::text) as name,
-               coalesce(owner.character_name, '') as owner_name,
-               coalesce(a.map, '') as map,
-               a.transform
-        from dune.buildings b
-        join dune.building_instances bi on bi.building_id = b.id
-        join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
-        join dune.actors a on a.id = afe.actor_id
-        left join dune.permission_actor pa on pa.actor_id = a.id
+  const matchedOwnerSelect = searching ? "coalesce(owner.character_name, '') as owner_name,\n               " : "";
+  const matchedOwnerJoin = searching ? `
         left join lateral (
           select ps.character_name
           from dune.permission_actor_rank par
@@ -2154,9 +2146,40 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
           where par.permission_actor_id = a.id
           order by par.rank asc, ps.character_name asc
           limit 1
-        ) owner on true
+        ) owner on true` : "";
+  const matchedGroupByOwner = searching ? "owner.character_name, " : "";
+
+  const finalOwnerSelect = searching ? "p.owner_name," : "coalesce(owner.character_name, '') as owner_name,";
+  const finalOwnerJoin = searching ? "" : `
+      left join lateral (
+        select ps.character_name
+        from dune.permission_actor_rank par
+        join dune.actors player_a on player_a.id = par.player_id
+        join dune.player_state ps on ps.account_id = player_a.owner_account_id
+        where par.permission_actor_id = p.actor_id
+        order by par.rank asc, ps.character_name asc
+        limit 1
+      ) owner on true`;
+  const sharedOwnerRef = searching ? "p.owner_name" : "coalesce(owner.character_name, '')";
+
+  try {
+    const result = await db.query(`
+      with matched as (
+        select b.id,
+               a.id as actor_id,
+               max(bi.owner_entity_id) as owner_entity_id,
+               pa.actor_name as raw_name,
+               coalesce(pa.actor_name, 'Base ' || b.id::text) as name,
+               ${matchedOwnerSelect}coalesce(a.map, '') as map,
+               a.transform
+        from dune.buildings b
+        join dune.building_instances bi on bi.building_id = b.id
+        join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+        join dune.actors a on a.id = afe.actor_id
+        left join dune.permission_actor pa on pa.actor_id = a.id
+        ${matchedOwnerJoin}
         where a.transform is not null
-        group by b.id, a.id, pa.actor_name, owner.character_name, a.map, a.transform
+        group by b.id, a.id, pa.actor_name, ${matchedGroupByOwner}a.map, a.transform
         ${having}
       ),
       paged as (
@@ -2167,18 +2190,17 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
       )
       select p.id::text as base_id,
              p.name,
-             p.owner_name,
+             ${finalOwnerSelect}
              p.map,
              ((p.transform).location).x as x,
              ((p.transform).location).y as y,
              ((p.transform).location).z as z,
              p.total_count,
-             count(distinct bi.ctid)::int as piece_count,
-             count(distinct pl.id)::int as placeable_count,
+             (select count(*) from dune.building_instances bi where bi.building_id = p.id)::int as piece_count,
+             (select count(*) from dune.placeables pl where pl.owner_entity_id = p.owner_entity_id)::int as placeable_count,
              coalesce(shared.entries, '[]'::jsonb) as shared_with
       from paged p
-      join dune.building_instances bi on bi.building_id = p.id
-      left join dune.placeables pl on pl.owner_entity_id = bi.owner_entity_id
+      ${finalOwnerJoin}
       left join lateral (
         select jsonb_agg(jsonb_build_object('name', ps.character_name, 'rank', par.rank) order by par.rank asc, ps.character_name asc) as entries
         from dune.permission_actor_rank par
@@ -2186,21 +2208,22 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
         join dune.player_state ps on ps.account_id = player_a.owner_account_id
         where par.permission_actor_id = p.actor_id
           and par.rank <> 1
-          and ps.character_name is distinct from p.owner_name
+          and ps.character_name is distinct from ${sharedOwnerRef}
       ) shared on true
-      group by p.id, p.name, p.owner_name, p.map, p.transform, p.total_count, shared.entries
       order by lower(coalesce(p.name, '')), p.id`, values);
 
     const totalsResult = await db.query(`
-      select count(distinct b.id)::int as total_bases,
-             count(distinct bi.ctid)::int as total_pieces,
-             count(distinct pl.id)::int as total_placeables
-      from dune.buildings b
-      join dune.building_instances bi on bi.building_id = b.id
-      join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
-      join dune.actors a on a.id = afe.actor_id
-      left join dune.placeables pl on pl.owner_entity_id = bi.owner_entity_id
-      where a.transform is not null`);
+      with valid_bases as (
+        select distinct b.id as building_id, afe.entity_id as owner_entity_id
+        from dune.buildings b
+        join dune.building_instances bi on bi.building_id = b.id
+        join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+        join dune.actors a on a.id = afe.actor_id
+        where a.transform is not null
+      )
+      select (select count(*) from valid_bases)::int as total_bases,
+             (select count(*) from dune.building_instances bi join valid_bases vb on vb.building_id = bi.building_id)::int as total_pieces,
+             (select count(distinct pl.id) from dune.placeables pl join valid_bases vb on vb.owner_entity_id = pl.owner_entity_id)::int as total_placeables`);
 
     return {
       capabilities: { bases: true },

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2100,6 +2100,16 @@ export async function unsupportedPlayerFeature(db, id, feature) {
   return { capabilities: { [feature]: false }, rows: [], reason: `${feature} schema has not been detected in this database yet` };
 }
 
+const PERMISSION_RANK_LABELS = {
+  1: "Owner",
+  2: "Co-Owner",
+  3: "Associate"
+};
+
+function permissionRankLabel(rank) {
+  return PERMISSION_RANK_LABELS[rank] || `Rank ${rank}`;
+}
+
 export async function listBases(db, { q = "" } = {}) {
   const requiredTables = ["buildings", "building_instances", "actor_fgl_entities", "actors"];
   for (const table of requiredTables) {
@@ -2121,7 +2131,8 @@ export async function listBases(db, { q = "" } = {}) {
              ((a.transform).location).y as y,
              ((a.transform).location).z as z,
              count(distinct bi.ctid)::int as piece_count,
-             count(distinct p.id)::int as placeable_count
+             count(distinct p.id)::int as placeable_count,
+             coalesce(shared.entries, '[]'::jsonb) as shared_with
       from dune.buildings b
       join dune.building_instances bi on bi.building_id = b.id
       join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
@@ -2136,9 +2147,18 @@ export async function listBases(db, { q = "" } = {}) {
         order by par.rank asc, ps.character_name asc
         limit 1
       ) owner on true
+      left join lateral (
+        select jsonb_agg(jsonb_build_object('name', ps.character_name, 'rank', par.rank) order by par.rank asc, ps.character_name asc) as entries
+        from dune.permission_actor_rank par
+        join dune.actors player_a on player_a.id = par.player_id
+        join dune.player_state ps on ps.account_id = player_a.owner_account_id
+        where par.permission_actor_id = a.id
+          and par.rank <> 1
+          and ps.character_name is distinct from owner.character_name
+      ) shared on true
       left join dune.placeables p on p.owner_entity_id = bi.owner_entity_id
       where a.transform is not null
-      group by b.id, pa.actor_name, owner.character_name, a.map, a.transform
+      group by b.id, pa.actor_name, owner.character_name, a.map, a.transform, shared.entries
       ${having}
       order by lower(coalesce(pa.actor_name, '')), b.id
       limit 500`, values);
@@ -2150,7 +2170,12 @@ export async function listBases(db, { q = "" } = {}) {
         y: Number(row.y),
         z: Number(row.z),
         piece_count: Number(row.piece_count),
-        placeable_count: Number(row.placeable_count)
+        placeable_count: Number(row.placeable_count),
+        shared_with: (Array.isArray(row.shared_with) ? row.shared_with : []).map((entry) => ({
+          name: entry.name,
+          rank: entry.rank,
+          label: permissionRankLabel(entry.rank)
+        }))
       }))
     };
   } catch (error) {

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2152,6 +2152,10 @@ export async function listBases(db, { q = "" } = {}) {
   }
 }
 
+function quaternionYawDegrees(qz, qw) {
+  return (2 * Math.atan2(Number(qz) || 0, Number(qw) || 0)) * (180 / Math.PI);
+}
+
 export async function exportBase(db, id) {
   const baseId = intParam(id, "base id", 1);
   const requiredTables = ["buildings", "building_instances", "actor_fgl_entities", "actors"];
@@ -2178,27 +2182,68 @@ export async function exportBase(db, id) {
     group by b.id, pa.actor_name, a.map, a.transform`, [baseId]);
   if (!baseRow.rows.length) throw new UnsupportedCapabilityError(`Base ${baseId} was not found.`);
   const base = baseRow.rows[0];
+  const anchor = { x: Number(base.x), y: Number(base.y), z: Number(base.z) };
 
-  const pieceRows = await db.query("select * from dune.building_instances where building_id = $1", [baseId]);
+  // Blueprint import (blueprints.js) expects positions relative to a capture origin and a single
+  // yaw-degree rotation for instances, not the live tables' absolute world coords + quaternion.
+  // The anchor point is arbitrary (the base's own actor position) but consistent, so the exported
+  // pieces stay correctly positioned relative to each other when re-placed anywhere in-game.
+  // Rotation is captured yaw-only (Z axis) since every sampled live piece has qx=qy=0; pitch/roll
+  // on tilted geometry, if any exists, is lost.
+  const pieceRows = await db.query(`
+    select instance_id, building_type, transform
+    from dune.building_instances
+    where building_id = $1
+    order by instance_id`, [baseId]);
+  const instances = pieceRows.rows.map((row) => {
+    const t = row.transform || [];
+    return {
+      instance_id: row.instance_id,
+      building_type: row.building_type,
+      x: (Number(t[0]) || 0) - anchor.x,
+      y: (Number(t[1]) || 0) - anchor.y,
+      z: (Number(t[2]) || 0) - anchor.z,
+      rotation: quaternionYawDegrees(t[5], t[6])
+    };
+  });
+
   const placeableRows = (await tableExists(db, "placeables"))
     ? await db.query(`
-        select * from dune.placeables
-        where owner_entity_id = (select bi.owner_entity_id from dune.building_instances bi where bi.building_id = $1 limit 1)
-        order by id`, [baseId])
+        select p.id as placeable_id, p.building_type,
+               ((a.transform).location).x as x,
+               ((a.transform).location).y as y,
+               ((a.transform).location).z as z,
+               ((a.transform).rotation).z as qz,
+               ((a.transform).rotation).w as qw
+        from dune.placeables p
+        join dune.actors a on a.id = p.id
+        where p.owner_entity_id = (select bi.owner_entity_id from dune.building_instances bi where bi.building_id = $1 limit 1)
+          and a.transform is not null
+        order by p.id`, [baseId])
     : { rows: [] };
+  const placeables = placeableRows.rows.map((row) => ({
+    placeable_id: row.placeable_id,
+    building_type: row.building_type,
+    x: Number(row.x) - anchor.x,
+    y: Number(row.y) - anchor.y,
+    z: Number(row.z) - anchor.z,
+    rx: 0,
+    ry: 0,
+    rz: quaternionYawDegrees(row.qz, row.qw)
+  }));
 
   return {
     base_id: base.base_id,
     name: base.name,
     owner_name: base.owner_name,
     map: base.map,
-    x: Number(base.x),
-    y: Number(base.y),
-    z: Number(base.z),
-    piece_count: pieceRows.rows.length,
-    placeable_count: placeableRows.rows.length,
-    pieces: pieceRows.rows,
-    placeables: placeableRows.rows
+    x: anchor.x,
+    y: anchor.y,
+    z: anchor.z,
+    piece_count: instances.length,
+    placeable_count: placeables.length,
+    instances,
+    placeables
   };
 }
 

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2100,6 +2100,108 @@ export async function unsupportedPlayerFeature(db, id, feature) {
   return { capabilities: { [feature]: false }, rows: [], reason: `${feature} schema has not been detected in this database yet` };
 }
 
+export async function listBases(db, { q = "" } = {}) {
+  const requiredTables = ["buildings", "building_instances", "actor_fgl_entities", "actors"];
+  for (const table of requiredTables) {
+    if (!(await tableExists(db, table))) return unsupported("bases", requiredTables.map((t) => `dune.${t}`));
+  }
+  const values = [];
+  let having = "";
+  if (q) {
+    values.push(`%${q}%`);
+    having = `having coalesce(pa.actor_name, '') ilike $${values.length} or coalesce(max(ps.character_name), '') ilike $${values.length}`;
+  }
+  try {
+    const result = await db.query(`
+      select b.id::text as base_id,
+             coalesce(pa.actor_name, 'Base ' || b.id::text) as name,
+             coalesce(max(ps.character_name), '') as owner_name,
+             coalesce(a.map, '') as map,
+             ((a.transform).location).x as x,
+             ((a.transform).location).y as y,
+             ((a.transform).location).z as z,
+             count(distinct bi.ctid)::int as piece_count,
+             count(distinct p.id)::int as placeable_count
+      from dune.buildings b
+      join dune.building_instances bi on bi.building_id = b.id
+      join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+      join dune.actors a on a.id = afe.actor_id
+      left join dune.permission_actor pa on pa.actor_id = a.id
+      left join dune.permission_actor_rank par on par.permission_actor_id = a.id
+      left join dune.actors player_a on player_a.id = par.player_id
+      left join dune.player_state ps on ps.account_id = player_a.owner_account_id
+      left join dune.placeables p on p.owner_entity_id = bi.owner_entity_id
+      where a.transform is not null
+      group by b.id, pa.actor_name, a.map, a.transform
+      ${having}
+      order by lower(coalesce(pa.actor_name, '')), b.id
+      limit 500`, values);
+    return {
+      capabilities: { bases: true },
+      rows: result.rows.map((row) => ({
+        ...row,
+        x: Number(row.x),
+        y: Number(row.y),
+        z: Number(row.z),
+        piece_count: Number(row.piece_count),
+        placeable_count: Number(row.placeable_count)
+      }))
+    };
+  } catch (error) {
+    return { capabilities: { bases: false }, rows: [], reason: `Base list query is unsupported by this schema: ${error.message}` };
+  }
+}
+
+export async function exportBase(db, id) {
+  const baseId = intParam(id, "base id", 1);
+  const requiredTables = ["buildings", "building_instances", "actor_fgl_entities", "actors"];
+  for (const table of requiredTables) {
+    await requireCapability(await tableExists(db, table), `Base export requires dune.${requiredTables.join(", dune.")}.`);
+  }
+  const baseRow = await db.query(`
+    select b.id::text as base_id,
+           coalesce(pa.actor_name, 'Base ' || b.id::text) as name,
+           coalesce(max(ps.character_name), '') as owner_name,
+           coalesce(a.map, '') as map,
+           ((a.transform).location).x as x,
+           ((a.transform).location).y as y,
+           ((a.transform).location).z as z
+    from dune.buildings b
+    join dune.building_instances bi on bi.building_id = b.id
+    join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+    join dune.actors a on a.id = afe.actor_id
+    left join dune.permission_actor pa on pa.actor_id = a.id
+    left join dune.permission_actor_rank par on par.permission_actor_id = a.id
+    left join dune.actors player_a on player_a.id = par.player_id
+    left join dune.player_state ps on ps.account_id = player_a.owner_account_id
+    where b.id = $1
+    group by b.id, pa.actor_name, a.map, a.transform`, [baseId]);
+  if (!baseRow.rows.length) throw new UnsupportedCapabilityError(`Base ${baseId} was not found.`);
+  const base = baseRow.rows[0];
+
+  const pieceRows = await db.query("select * from dune.building_instances where building_id = $1", [baseId]);
+  const placeableRows = (await tableExists(db, "placeables"))
+    ? await db.query(`
+        select * from dune.placeables
+        where owner_entity_id = (select bi.owner_entity_id from dune.building_instances bi where bi.building_id = $1 limit 1)
+        order by id`, [baseId])
+    : { rows: [] };
+
+  return {
+    base_id: base.base_id,
+    name: base.name,
+    owner_name: base.owner_name,
+    map: base.map,
+    x: Number(base.x),
+    y: Number(base.y),
+    z: Number(base.z),
+    piece_count: pieceRows.rows.length,
+    placeable_count: placeableRows.rows.length,
+    pieces: pieceRows.rows,
+    placeables: placeableRows.rows
+  };
+}
+
 export async function listStorage(db) {
   if (!(await tableExists(db, "placeables"))) return unsupported("storage", ["dune.placeables"]);
   const result = await db.query(`

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2110,61 +2110,105 @@ function permissionRankLabel(rank) {
   return PERMISSION_RANK_LABELS[rank] || `Rank ${rank}`;
 }
 
-export async function listBases(db, { q = "" } = {}) {
+export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
   const requiredTables = ["buildings", "building_instances", "actor_fgl_entities", "actors"];
   for (const table of requiredTables) {
-    if (!(await tableExists(db, table))) return unsupported("bases", requiredTables.map((t) => `dune.${t}`));
+    if (!(await tableExists(db, table))) {
+      return { ...unsupported("bases", requiredTables.map((t) => `dune.${t}`)), totalCount: 0, totalBases: 0, totalPieces: 0, totalPlaceables: 0 };
+    }
   }
+  const safePageSize = intParam(pageSize, "pageSize", 1, 200);
+  const safePage = intParam(page, "page", 0);
+  const offset = safePage * safePageSize;
+
   const values = [];
   let having = "";
   if (q) {
     values.push(`%${q}%`);
     having = `having coalesce(pa.actor_name, '') ilike $${values.length} or coalesce(owner.character_name, '') ilike $${values.length}`;
   }
+  values.push(safePageSize, offset);
+  const limitParamIndex = values.length - 1;
+  const offsetParamIndex = values.length;
+
   try {
     const result = await db.query(`
-      select b.id::text as base_id,
-             coalesce(pa.actor_name, 'Base ' || b.id::text) as name,
-             coalesce(owner.character_name, '') as owner_name,
-             coalesce(a.map, '') as map,
-             ((a.transform).location).x as x,
-             ((a.transform).location).y as y,
-             ((a.transform).location).z as z,
+      with matched as (
+        select b.id,
+               a.id as actor_id,
+               pa.actor_name as raw_name,
+               coalesce(pa.actor_name, 'Base ' || b.id::text) as name,
+               coalesce(owner.character_name, '') as owner_name,
+               coalesce(a.map, '') as map,
+               a.transform
+        from dune.buildings b
+        join dune.building_instances bi on bi.building_id = b.id
+        join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+        join dune.actors a on a.id = afe.actor_id
+        left join dune.permission_actor pa on pa.actor_id = a.id
+        left join lateral (
+          select ps.character_name
+          from dune.permission_actor_rank par
+          join dune.actors player_a on player_a.id = par.player_id
+          join dune.player_state ps on ps.account_id = player_a.owner_account_id
+          where par.permission_actor_id = a.id
+          order by par.rank asc, ps.character_name asc
+          limit 1
+        ) owner on true
+        where a.transform is not null
+        group by b.id, a.id, pa.actor_name, owner.character_name, a.map, a.transform
+        ${having}
+      ),
+      paged as (
+        select *, count(*) over() as total_count
+        from matched
+        order by lower(coalesce(raw_name, '')), id
+        limit $${limitParamIndex} offset $${offsetParamIndex}
+      )
+      select p.id::text as base_id,
+             p.name,
+             p.owner_name,
+             p.map,
+             ((p.transform).location).x as x,
+             ((p.transform).location).y as y,
+             ((p.transform).location).z as z,
+             p.total_count,
              count(distinct bi.ctid)::int as piece_count,
-             count(distinct p.id)::int as placeable_count,
+             count(distinct pl.id)::int as placeable_count,
              coalesce(shared.entries, '[]'::jsonb) as shared_with
-      from dune.buildings b
-      join dune.building_instances bi on bi.building_id = b.id
-      join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
-      join dune.actors a on a.id = afe.actor_id
-      left join dune.permission_actor pa on pa.actor_id = a.id
-      left join lateral (
-        select ps.character_name
-        from dune.permission_actor_rank par
-        join dune.actors player_a on player_a.id = par.player_id
-        join dune.player_state ps on ps.account_id = player_a.owner_account_id
-        where par.permission_actor_id = a.id
-        order by par.rank asc, ps.character_name asc
-        limit 1
-      ) owner on true
+      from paged p
+      join dune.building_instances bi on bi.building_id = p.id
+      left join dune.placeables pl on pl.owner_entity_id = bi.owner_entity_id
       left join lateral (
         select jsonb_agg(jsonb_build_object('name', ps.character_name, 'rank', par.rank) order by par.rank asc, ps.character_name asc) as entries
         from dune.permission_actor_rank par
         join dune.actors player_a on player_a.id = par.player_id
         join dune.player_state ps on ps.account_id = player_a.owner_account_id
-        where par.permission_actor_id = a.id
+        where par.permission_actor_id = p.actor_id
           and par.rank <> 1
-          and ps.character_name is distinct from owner.character_name
+          and ps.character_name is distinct from p.owner_name
       ) shared on true
-      left join dune.placeables p on p.owner_entity_id = bi.owner_entity_id
-      where a.transform is not null
-      group by b.id, pa.actor_name, owner.character_name, a.map, a.transform, shared.entries
-      ${having}
-      order by lower(coalesce(pa.actor_name, '')), b.id
-      limit 500`, values);
+      group by p.id, p.name, p.owner_name, p.map, p.transform, p.total_count, shared.entries
+      order by lower(coalesce(p.name, '')), p.id`, values);
+
+    const totalsResult = await db.query(`
+      select count(distinct b.id)::int as total_bases,
+             count(distinct bi.ctid)::int as total_pieces,
+             count(distinct pl.id)::int as total_placeables
+      from dune.buildings b
+      join dune.building_instances bi on bi.building_id = b.id
+      join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+      join dune.actors a on a.id = afe.actor_id
+      left join dune.placeables pl on pl.owner_entity_id = bi.owner_entity_id
+      where a.transform is not null`);
+
     return {
       capabilities: { bases: true },
-      rows: result.rows.map((row) => ({
+      totalCount: result.rows[0] ? Number(result.rows[0].total_count) : 0,
+      totalBases: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_bases) : 0,
+      totalPieces: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_pieces) : 0,
+      totalPlaceables: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_placeables) : 0,
+      rows: result.rows.map(({ total_count, ...row }) => ({
         ...row,
         x: Number(row.x),
         y: Number(row.y),
@@ -2179,7 +2223,7 @@ export async function listBases(db, { q = "" } = {}) {
       }))
     };
   } catch (error) {
-    return { capabilities: { bases: false }, rows: [], reason: `Base list query is unsupported by this schema: ${error.message}` };
+    return { capabilities: { bases: false }, rows: [], totalCount: 0, totalBases: 0, totalPieces: 0, totalPlaceables: 0, reason: `Base list query is unsupported by this schema: ${error.message}` };
   }
 }
 

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2231,7 +2231,7 @@ function quaternionYawDegrees(qz, qw) {
   return (2 * Math.atan2(Number(qz) || 0, Number(qw) || 0)) * (180 / Math.PI);
 }
 
-export async function exportBase(db, id) {
+export async function exportBaseAsBlueprint(db, id) {
   const baseId = intParam(id, "base id", 1);
   const requiredTables = ["buildings", "building_instances", "actor_fgl_entities", "actors"];
   for (const table of requiredTables) {

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2110,7 +2110,18 @@ function permissionRankLabel(rank) {
   return PERMISSION_RANK_LABELS[rank] || `Rank ${rank}`;
 }
 
-export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
+const BASE_SORT_COLUMNS = {
+  base_id: { order: ["id"] },
+  name: { order: ["lower(coalesce(raw_name, ''))"] },
+  owner_name: { order: ["lower(coalesce(owner_name, ''))"], owner: true },
+  shared_with: { order: ["shared_count"], shared: true },
+  map: { order: ["lower(coalesce(map, ''))"] },
+  coordinates: { order: ["x", "y", "z"] },
+  piece_count: { order: ["piece_count"], pieces: true },
+  placeable_count: { order: ["placeable_count"], placeables: true }
+};
+
+export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColumn = "name", sortDirection = "asc" } = {}) {
   const requiredTables = ["buildings", "building_instances", "actor_fgl_entities", "actors"];
   for (const table of requiredTables) {
     if (!(await tableExists(db, table))) {
@@ -2120,12 +2131,16 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
   const safePageSize = intParam(pageSize, "pageSize", 1, 200);
   const safePage = intParam(page, "page", 0);
   const offset = safePage * safePageSize;
+  const safeSortColumn = Object.hasOwn(BASE_SORT_COLUMNS, sortColumn) ? sortColumn : "name";
+  const safeSortDirection = String(sortDirection).toLowerCase() === "desc" ? "desc" : "asc";
+  const sortSpec = BASE_SORT_COLUMNS[safeSortColumn];
 
   // Owner resolution (lowest-rank permission holder) is a per-base correlated LATERAL —
   // expensive at scale. When searching, the `having` clause needs it to filter on, so it
   // must run inside `matched` (before pagination) for every candidate base. When not
   // searching, defer it to the final SELECT so it only runs for the page being displayed.
   const searching = Boolean(q);
+  const resolveOwnerBeforePaging = searching || sortSpec.owner;
   const values = [];
   let having = "";
   if (searching) {
@@ -2136,8 +2151,8 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
   const limitParamIndex = values.length - 1;
   const offsetParamIndex = values.length;
 
-  const matchedOwnerSelect = searching ? "coalesce(owner.character_name, '') as owner_name,\n               " : "";
-  const matchedOwnerJoin = searching ? `
+  const matchedOwnerSelect = resolveOwnerBeforePaging ? "coalesce(owner.character_name, '') as owner_name,\n               " : "";
+  const matchedOwnerJoin = resolveOwnerBeforePaging ? `
         left join lateral (
           select ps.character_name
           from dune.permission_actor_rank par
@@ -2147,10 +2162,10 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
           order by par.rank asc, ps.character_name asc
           limit 1
         ) owner on true` : "";
-  const matchedGroupByOwner = searching ? "owner.character_name, " : "";
+  const matchedGroupByOwner = resolveOwnerBeforePaging ? "owner.character_name, " : "";
 
-  const finalOwnerSelect = searching ? "p.owner_name," : "coalesce(owner.character_name, '') as owner_name,";
-  const finalOwnerJoin = searching ? "" : `
+  const finalOwnerSelect = resolveOwnerBeforePaging ? "p.owner_name," : "coalesce(owner.character_name, '') as owner_name,";
+  const finalOwnerJoin = resolveOwnerBeforePaging ? "" : `
       left join lateral (
         select ps.character_name
         from dune.permission_actor_rank par
@@ -2160,7 +2175,18 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
         order by par.rank asc, ps.character_name asc
         limit 1
       ) owner on true`;
-  const sharedOwnerRef = searching ? "p.owner_name" : "coalesce(owner.character_name, '')";
+  const sharedOwnerRef = resolveOwnerBeforePaging ? "p.owner_name" : "coalesce(owner.character_name, '')";
+  const matchedSortSelect = [
+    "((a.transform).location).x as x",
+    "((a.transform).location).y as y",
+    "((a.transform).location).z as z",
+    sortSpec.pieces ? "(select count(*) from dune.building_instances count_bi where count_bi.building_id = b.id)::int as piece_count" : "",
+    sortSpec.placeables ? "(select count(*) from dune.placeables count_pl where count_pl.owner_entity_id in (select distinct bi2.owner_entity_id from dune.building_instances bi2 where bi2.building_id = b.id))::int as placeable_count" : "",
+    sortSpec.shared ? "(select count(*) from dune.permission_actor_rank count_par where count_par.permission_actor_id = a.id and count_par.rank <> 1)::int as shared_count" : ""
+  ].filter(Boolean).join(",\n               ");
+  const pagedOrder = [...sortSpec.order, ...(sortSpec.order.includes("id") ? [] : ["id"])].map((column) => `${column} ${safeSortDirection}`).join(", ");
+  const finalPieceCount = sortSpec.pieces ? "p.piece_count" : "(select count(*) from dune.building_instances bi where bi.building_id = p.id)::int";
+  const finalPlaceableCount = sortSpec.placeables ? "p.placeable_count" : "(select count(*) from dune.placeables pl where pl.owner_entity_id = p.owner_entity_id)::int";
 
   try {
     const result = await db.query(`
@@ -2171,7 +2197,8 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
                pa.actor_name as raw_name,
                coalesce(pa.actor_name, 'Base ' || b.id::text) as name,
                ${matchedOwnerSelect}coalesce(a.map, '') as map,
-               a.transform
+               a.transform,
+               ${matchedSortSelect}
         from dune.buildings b
         join dune.building_instances bi on bi.building_id = b.id
         join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
@@ -2183,21 +2210,23 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
         ${having}
       ),
       paged as (
-        select *, count(*) over() as total_count
+        select *,
+               count(*) over() as total_count,
+               row_number() over (order by ${pagedOrder}) as sort_position
         from matched
-        order by lower(coalesce(raw_name, '')), id
+        order by ${pagedOrder}
         limit $${limitParamIndex} offset $${offsetParamIndex}
       )
       select p.id::text as base_id,
              p.name,
              ${finalOwnerSelect}
              p.map,
-             ((p.transform).location).x as x,
-             ((p.transform).location).y as y,
-             ((p.transform).location).z as z,
+             p.x,
+             p.y,
+             p.z,
              p.total_count,
-             (select count(*) from dune.building_instances bi where bi.building_id = p.id)::int as piece_count,
-             (select count(*) from dune.placeables pl where pl.owner_entity_id = p.owner_entity_id)::int as placeable_count,
+             ${finalPieceCount} as piece_count,
+             ${finalPlaceableCount} as placeable_count,
              coalesce(shared.entries, '[]'::jsonb) as shared_with
       from paged p
       ${finalOwnerJoin}
@@ -2210,7 +2239,7 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
           and par.rank <> 1
           and ps.character_name is distinct from ${sharedOwnerRef}
       ) shared on true
-      order by lower(coalesce(p.name, '')), p.id`, values);
+      order by p.sort_position`, values);
 
     const totalsResult = await db.query(`
       with valid_bases as (
@@ -2231,7 +2260,7 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50 } = {}) {
       totalBases: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_bases) : 0,
       totalPieces: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_pieces) : 0,
       totalPlaceables: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_placeables) : 0,
-      rows: result.rows.map(({ total_count, ...row }) => ({
+      rows: result.rows.map(({ total_count, sort_position, ...row }) => ({
         ...row,
         x: Number(row.x),
         y: Number(row.y),

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2109,13 +2109,13 @@ export async function listBases(db, { q = "" } = {}) {
   let having = "";
   if (q) {
     values.push(`%${q}%`);
-    having = `having coalesce(pa.actor_name, '') ilike $${values.length} or coalesce(max(ps.character_name), '') ilike $${values.length}`;
+    having = `having coalesce(pa.actor_name, '') ilike $${values.length} or coalesce(owner.character_name, '') ilike $${values.length}`;
   }
   try {
     const result = await db.query(`
       select b.id::text as base_id,
              coalesce(pa.actor_name, 'Base ' || b.id::text) as name,
-             coalesce(max(ps.character_name), '') as owner_name,
+             coalesce(owner.character_name, '') as owner_name,
              coalesce(a.map, '') as map,
              ((a.transform).location).x as x,
              ((a.transform).location).y as y,
@@ -2127,12 +2127,18 @@ export async function listBases(db, { q = "" } = {}) {
       join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
       join dune.actors a on a.id = afe.actor_id
       left join dune.permission_actor pa on pa.actor_id = a.id
-      left join dune.permission_actor_rank par on par.permission_actor_id = a.id
-      left join dune.actors player_a on player_a.id = par.player_id
-      left join dune.player_state ps on ps.account_id = player_a.owner_account_id
+      left join lateral (
+        select ps.character_name
+        from dune.permission_actor_rank par
+        join dune.actors player_a on player_a.id = par.player_id
+        join dune.player_state ps on ps.account_id = player_a.owner_account_id
+        where par.permission_actor_id = a.id
+        order by par.rank asc, ps.character_name asc
+        limit 1
+      ) owner on true
       left join dune.placeables p on p.owner_entity_id = bi.owner_entity_id
       where a.transform is not null
-      group by b.id, pa.actor_name, a.map, a.transform
+      group by b.id, pa.actor_name, owner.character_name, a.map, a.transform
       ${having}
       order by lower(coalesce(pa.actor_name, '')), b.id
       limit 500`, values);
@@ -2165,7 +2171,7 @@ export async function exportBase(db, id) {
   const baseRow = await db.query(`
     select b.id::text as base_id,
            coalesce(pa.actor_name, 'Base ' || b.id::text) as name,
-           coalesce(max(ps.character_name), '') as owner_name,
+           coalesce(owner.character_name, '') as owner_name,
            coalesce(a.map, '') as map,
            ((a.transform).location).x as x,
            ((a.transform).location).y as y,
@@ -2175,11 +2181,17 @@ export async function exportBase(db, id) {
     join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
     join dune.actors a on a.id = afe.actor_id
     left join dune.permission_actor pa on pa.actor_id = a.id
-    left join dune.permission_actor_rank par on par.permission_actor_id = a.id
-    left join dune.actors player_a on player_a.id = par.player_id
-    left join dune.player_state ps on ps.account_id = player_a.owner_account_id
+    left join lateral (
+      select ps.character_name
+      from dune.permission_actor_rank par
+      join dune.actors player_a on player_a.id = par.player_id
+      join dune.player_state ps on ps.account_id = player_a.owner_account_id
+      where par.permission_actor_id = a.id
+      order by par.rank asc, ps.character_name asc
+      limit 1
+    ) owner on true
     where b.id = $1
-    group by b.id, pa.actor_name, a.map, a.transform`, [baseId]);
+    group by b.id, pa.actor_name, owner.character_name, a.map, a.transform`, [baseId]);
   if (!baseRow.rows.length) throw new UnsupportedCapabilityError(`Base ${baseId} was not found.`);
   const base = baseRow.rows[0];
   const anchor = { x: Number(base.x), y: Number(base.y), z: Number(base.z) };

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2175,7 +2175,8 @@ export async function exportBase(db, id) {
            coalesce(a.map, '') as map,
            ((a.transform).location).x as x,
            ((a.transform).location).y as y,
-           ((a.transform).location).z as z
+           ((a.transform).location).z as z,
+           max(bi.owner_entity_id) as owner_entity_id
     from dune.buildings b
     join dune.building_instances bi on bi.building_id = b.id
     join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
@@ -2229,9 +2230,9 @@ export async function exportBase(db, id) {
                ((a.transform).rotation).w as qw
         from dune.placeables p
         join dune.actors a on a.id = p.id
-        where p.owner_entity_id = (select bi.owner_entity_id from dune.building_instances bi where bi.building_id = $1 limit 1)
+        where p.owner_entity_id = $1
           and a.transform is not null
-        order by p.id`, [baseId])
+        order by p.id`, [base.owner_entity_id])
     : { rows: [] };
   const placeables = placeableRows.rows.map((row) => ({
     placeable_id: row.placeable_id,

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -379,6 +379,8 @@ async function handleApi(req, res) {
   if (path === "/api/players/search") return dbJson(res, () => duneDb.listPlayers(db, { q: url.searchParams.get("q") || "" }));
   if (path === "/api/guilds") return dbJson(res, () => duneDb.listGuilds(db, { q: url.searchParams.get("q") || "" }));
   if (path.match(/^\/api\/guilds\/[^/]+\/members$/)) return dbJson(res, () => duneDb.guildMembers(db, decodeURIComponent(path.split("/")[3])));
+  if (path === "/api/bases") return dbJson(res, () => duneDb.listBases(db, { q: url.searchParams.get("q") || "" }));
+  if (path.match(/^\/api\/bases\/[^/]+\/export$/) && req.method === "GET") return baseExportRoute(req, res, path);
   if (path === "/api/admin/items/catalog") return json(res, 200, { rows: listCatalogItems(config.repoRoot, { q: url.searchParams.get("q") || "", limit: url.searchParams.get("limit") || 500 }) });
   if (path === "/api/admin/items/search") return commandJson(res, "adminItemSearch", { q: url.searchParams.get("q") || "" });
   if (path === "/api/admin/items") return commandJson(res, url.searchParams.get("category") ? "adminItemListCategory" : "adminItemList", { category: url.searchParams.get("category") || "" });
@@ -1654,18 +1656,36 @@ async function storageGiveItemRoute(req, res, path) {
   }, { storageId });
 }
 
+function writeJsonAttachment(res, data, filename) {
+  res.writeHead(200, {
+    "content-type": "application/json; charset=utf-8",
+    "content-disposition": `attachment; filename="${filename}"`
+  });
+  res.end(JSON.stringify(data));
+}
+
 async function blueprintExportRoute(req, res, path) {
   const idPart = decodeURIComponent(path.split("/")[3]);
   const blueprintId = Number(idPart);
   if (!Number.isFinite(blueprintId) || blueprintId < 1) return json(res, 400, { error: "Invalid blueprint ID" });
   try {
     const data = await exportBlueprint(db, blueprintId);
-    const filename = data.name ? `${sanitizeBlueprintFilename(data.name)}.json` : `blueprint_${blueprintId}.json`;
-    res.writeHead(200, {
-      "content-type": "application/json; charset=utf-8",
-      "content-disposition": `attachment; filename="${filename}"`
-    });
-    res.end(JSON.stringify(data));
+    const filename = data.name ? `${sanitizeFilename(data.name, "blueprint")}.json` : `blueprint_${blueprintId}.json`;
+    writeJsonAttachment(res, data, filename);
+  } catch (error) {
+    const status = error.unsupported ? 501 : 500;
+    return json(res, status, { ok: false, error: redact(error.message || error) });
+  }
+}
+
+async function baseExportRoute(req, res, path) {
+  const idPart = decodeURIComponent(path.split("/")[3]);
+  const baseId = Number(idPart);
+  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  try {
+    const data = await duneDb.exportBase(db, baseId);
+    const filename = data.name ? `${sanitizeFilename(data.name, "base")}.json` : `base_${baseId}.json`;
+    writeJsonAttachment(res, data, filename);
   } catch (error) {
     const status = error.unsupported ? 501 : 500;
     return json(res, status, { ok: false, error: redact(error.message || error) });
@@ -1683,7 +1703,7 @@ async function blueprintBulkExportRoute(req, res) {
     const entries = [];
     for (const id of ids) {
       const data = await exportBlueprint(db, id);
-      const baseName = sanitizeBlueprintFilename(data.name || `blueprint_${id}`).replace(/\.json$/i, "") || `blueprint_${id}`;
+      const baseName = sanitizeFilename(data.name || `blueprint_${id}`, `blueprint_${id}`).replace(/\.json$/i, "") || `blueprint_${id}`;
       let filename = `${baseName}.json`;
       let suffix = 2;
       while (usedNames.has(filename.toLowerCase())) filename = `${baseName}_${suffix++}.json`;
@@ -1735,8 +1755,8 @@ async function blueprintImportRoute(req, res) {
   }
 }
 
-function sanitizeBlueprintFilename(s) {
-  return String(s).replace(/[\x00-\x1f\x7f<>:"/\\|?*]/g, "_").trim() || "blueprint";
+function sanitizeFilename(s, fallback = "export") {
+  return String(s).replace(/[\x00-\x1f\x7f<>:"/\\|?*]/g, "_").trim() || fallback;
 }
 
 async function blueprintsDeleteRoute(req, res, path) {

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -379,7 +379,11 @@ async function handleApi(req, res) {
   if (path === "/api/players/search") return dbJson(res, () => duneDb.listPlayers(db, { q: url.searchParams.get("q") || "" }));
   if (path === "/api/guilds") return dbJson(res, () => duneDb.listGuilds(db, { q: url.searchParams.get("q") || "" }));
   if (path.match(/^\/api\/guilds\/[^/]+\/members$/)) return dbJson(res, () => duneDb.guildMembers(db, decodeURIComponent(path.split("/")[3])));
-  if (path === "/api/bases") return dbJson(res, () => duneDb.listBases(db, { q: url.searchParams.get("q") || "" }));
+  if (path === "/api/bases") return dbJson(res, () => duneDb.listBases(db, {
+    q: url.searchParams.get("q") || "",
+    page: url.searchParams.get("page") || 0,
+    pageSize: url.searchParams.get("pageSize") || 50
+  }));
   if (path.match(/^\/api\/bases\/[^/]+\/export$/) && req.method === "GET") return baseExportRoute(req, res, path);
   if (path === "/api/admin/items/catalog") return json(res, 200, { rows: listCatalogItems(config.repoRoot, { q: url.searchParams.get("q") || "", limit: url.searchParams.get("limit") || 500 }) });
   if (path === "/api/admin/items/search") return commandJson(res, "adminItemSearch", { q: url.searchParams.get("q") || "" });

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -384,7 +384,7 @@ async function handleApi(req, res) {
     page: url.searchParams.get("page") || 0,
     pageSize: url.searchParams.get("pageSize") || 50
   }));
-  if (path.match(/^\/api\/bases\/[^/]+\/export$/) && req.method === "GET") return baseExportRoute(req, res, path);
+  if (path.match(/^\/api\/bases\/[^/]+\/export$/) && req.method === "GET") return baseBlueprintDownloadRoute(req, res, path);
   if (path === "/api/admin/items/catalog") return json(res, 200, { rows: listCatalogItems(config.repoRoot, { q: url.searchParams.get("q") || "", limit: url.searchParams.get("limit") || 500 }) });
   if (path === "/api/admin/items/search") return commandJson(res, "adminItemSearch", { q: url.searchParams.get("q") || "" });
   if (path === "/api/admin/items") return commandJson(res, url.searchParams.get("category") ? "adminItemListCategory" : "adminItemList", { category: url.searchParams.get("category") || "" });
@@ -1682,12 +1682,12 @@ async function blueprintExportRoute(req, res, path) {
   }
 }
 
-async function baseExportRoute(req, res, path) {
+async function baseBlueprintDownloadRoute(req, res, path) {
   const idPart = decodeURIComponent(path.split("/")[3]);
   const baseId = Number(idPart);
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
   try {
-    const data = await duneDb.exportBase(db, baseId);
+    const data = await duneDb.exportBaseAsBlueprint(db, baseId);
     const filename = data.name ? `${sanitizeFilename(data.name, "base")}.json` : `base_${baseId}.json`;
     writeJsonAttachment(res, data, filename);
   } catch (error) {

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -382,7 +382,9 @@ async function handleApi(req, res) {
   if (path === "/api/bases") return dbJson(res, () => duneDb.listBases(db, {
     q: url.searchParams.get("q") || "",
     page: url.searchParams.get("page") || 0,
-    pageSize: url.searchParams.get("pageSize") || 50
+    pageSize: url.searchParams.get("pageSize") || 50,
+    sortColumn: url.searchParams.get("sortColumn") || "name",
+    sortDirection: url.searchParams.get("sortDirection") || "asc"
   }));
   if (path.match(/^\/api\/bases\/[^/]+\/export$/) && req.method === "GET") return baseBlueprintDownloadRoute(req, res, path);
   if (path === "/api/admin/items/catalog") return json(res, 200, { rows: listCatalogItems(config.repoRoot, { q: url.searchParams.get("q") || "", limit: url.searchParams.get("limit") || 500 }) });

--- a/console/api/test/blueprints.test.js
+++ b/console/api/test/blueprints.test.js
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { exportBlueprint, importBlueprint, listBlueprints, blueprintCapabilities, deleteBlueprint } from "../src/blueprints.js";
+import { exportBaseAsBlueprint } from "../src/duneDb.js";
 
 const SAMPLE_INSTANCE = {
   building_type: "MTX_Smug_Foundation",
@@ -335,6 +336,46 @@ test("export blueprint returns full JSON structure", async () => {
   assert.equal(result.instances.length, 2);
   assert.equal(result.placeables.length, 1);
   assert.equal(result.pentashields.length, 1);
+});
+
+test("live base export can be imported without losing relative transforms", async () => {
+  const liveDb = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("from dune.buildings b")) {
+        return { rows: [{
+          base_id: "42",
+          name: "Round Trip Base",
+          owner_name: "Builder",
+          map: "Survival_1",
+          x: "1000",
+          y: "2000",
+          z: "3000",
+          owner_entity_id: "9001"
+        }] };
+      }
+      if (text.includes("select instance_id, building_type, transform")) {
+        return { rows: [{ instance_id: 7, building_type: "MTX_Smug_Foundation", transform: [1125, 2250, 3375, 0, 0, 0, 1] }] };
+      }
+      if (text.includes("select p.id as placeable_id")) {
+        assert.deepEqual(values, ["9001"]);
+        return { rows: [{ placeable_id: 9, building_type: "Generator_Placeable", x: 950, y: 2100, z: 3025, qz: 0, qw: 1 }] };
+      }
+      return { rows: [] };
+    }
+  };
+
+  const exported = await exportBaseAsBlueprint(liveDb, 42);
+  const { db, instances, placeables } = fakeBlueprintDb([]);
+  const imported = await importBlueprint(db, 123, exported);
+
+  assert.equal(imported.blueprintName, "Round Trip Base");
+  assert.equal(instances.length, 1);
+  assert.equal(instances[0].instance_id, 7);
+  assert.equal(instances[0].transform, "{125,250,375,0}");
+  assert.equal(placeables.length, 1);
+  assert.equal(placeables[0].placeable_id, 9);
+  assert.equal(placeables[0].transform, "{-50,100,25,0,0,0}");
 });
 
 test("export blueprint handles empty blueprint", async () => {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -837,7 +837,7 @@ test("list bases returns rows with piece and placeable counts and a total count"
       if (text.includes("total_bases")) {
         return { rows: [{ total_bases: "5", total_pieces: "700", total_placeables: "140" }] };
       }
-      if (text.includes("count(distinct bi.ctid)")) {
+      if (text.includes("from paged p")) {
         return { rows: [
           { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30", total_count: "1", piece_count: "589", placeable_count: "126", shared_with: [{ name: "Ally Two", rank: 2 }] }
         ] };
@@ -866,7 +866,7 @@ test("list bases excludes the owner from shared_with, coalesces missing entries,
       if (text.includes("total_bases")) {
         return { rows: [{ total_bases: "2", total_pieces: "601", total_placeables: "126" }] };
       }
-      if (text.includes("count(distinct bi.ctid)")) {
+      if (text.includes("from paged p")) {
         return { rows: [
           { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30", total_count: "2", piece_count: "589", placeable_count: "126", shared_with: [{ name: "Ally Two", rank: 2 }, { name: "Ally Three", rank: 7 }] },
           { base_id: "1007", name: "Sietch Two", owner_name: "Leader Two", map: "TheDeepDesert", x: "10", y: "20", z: "3", total_count: "2", piece_count: "12", placeable_count: "0", shared_with: null }
@@ -934,7 +934,7 @@ test("list bases resolves shared_with via the base's actor id, not its building 
   assert.ok(!baseQuery.text.includes("par.permission_actor_id = p.id"), "shared LATERAL must not regress to the building id");
 });
 
-test("list bases resolves the owner via the base's actor id, not its building id", async () => {
+test("list bases resolves the owner via the base's actor id, not its building id (no search)", async () => {
   const calls = [];
   const db = {
     query: async (text, values = []) => {
@@ -949,13 +949,45 @@ test("list bases resolves the owner via the base's actor id, not its building id
       return { rows: [] };
     }
   };
+  // Without a search term, owner resolution is deferred to the final SELECT (only run for
+  // the displayed page) instead of the matched CTE (run for every base) — see the fan-out/
+  // scaling fix in listBases. The final SELECT's owner LATERAL references p.actor_id, since
+  // `a` isn't in scope there.
   await listBases(db, {});
+  const baseQuery = calls.find((call) => call.text.includes("from dune.buildings b"));
+  assert.ok(baseQuery);
+  assert.match(baseQuery.text, /\) owner on true/);
+  const ownerLateral = baseQuery.text.slice(baseQuery.text.indexOf("left join lateral"), baseQuery.text.indexOf(") owner on true"));
+  assert.ok(ownerLateral.includes("where par.permission_actor_id = p.actor_id"), "owner LATERAL must resolve via the base's actor id");
+  assert.ok(ownerLateral.includes("order by par.rank asc"), "owner must be the lowest-rank (rank 1) member, not an arbitrary one");
+  assert.ok(!ownerLateral.includes("par.permission_actor_id = p.id"), "owner LATERAL must not regress to the building id");
+});
+
+test("list bases resolves the owner via the base's actor id, not its building id (searching)", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
+      }
+      if (text.includes("total_bases")) {
+        return { rows: [{ total_bases: "1", total_pieces: "1", total_placeables: "0" }] };
+      }
+      return { rows: [] };
+    }
+  };
+  // With a search term, the `having` clause needs the resolved owner name, so the owner
+  // LATERAL must still run inside the matched CTE (before pagination), referencing a.id.
+  await listBases(db, { q: "Sietch" });
   const baseQuery = calls.find((call) => call.text.includes("from dune.buildings b"));
   assert.ok(baseQuery);
   assert.match(baseQuery.text, /\) owner on true/);
   const ownerLateral = baseQuery.text.slice(baseQuery.text.indexOf("left join lateral"), baseQuery.text.indexOf(") owner on true"));
   assert.ok(ownerLateral.includes("where par.permission_actor_id = a.id"), "owner LATERAL must resolve via the base's actor id");
   assert.ok(ownerLateral.includes("order by par.rank asc"), "owner must be the lowest-rank (rank 1) member, not an arbitrary one");
+  assert.ok(!ownerLateral.includes("par.permission_actor_id = b.id"), "owner LATERAL must not regress to the building id");
 });
 
 test("list bases totals query uses the same base-inclusion criterion and placeable join as the main query", async () => {
@@ -974,7 +1006,10 @@ test("list bases totals query uses the same base-inclusion criterion and placeab
   const totalsQuery = calls.find((call) => call.text.includes("total_bases"));
   assert.ok(totalsQuery);
   assert.ok(totalsQuery.text.includes("where a.transform is not null"), "totals must use the same base-inclusion criterion as the paginated query");
-  assert.ok(totalsQuery.text.includes("left join dune.placeables pl on pl.owner_entity_id = bi.owner_entity_id"), "totals placeable join must match the main query's join key");
+  assert.ok(totalsQuery.text.includes("with valid_bases as"), "totals must dedup base/owner pairs before counting to avoid fan-out");
+  assert.ok(!totalsQuery.text.includes("left join dune.placeables pl on pl.owner_entity_id = bi.owner_entity_id"), "totals must not directly cross-join building_instances to placeables (causes fan-out)");
+  assert.ok(totalsQuery.text.includes("join valid_bases vb on vb.owner_entity_id = pl.owner_entity_id"), "placeable totals must count via the dedup'd owner_entity_id join, not a direct bi-to-pl join");
+  assert.ok(totalsQuery.text.includes("count(distinct pl.id)"), "placeable totals must stay deduped in case two bases ever share an owner entity");
 });
 
 test("list bases rejects invalid page or pageSize values", async () => {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -875,7 +875,10 @@ test("export base throws an unsupported error when required tables are missing",
   await assert.rejects(() => exportBase(db, 1006), UnsupportedCapabilityError);
 });
 
-test("export base returns base identity plus its piece and placeable rows", async () => {
+test("export base returns instances and placeables in blueprint-importable relative coordinates", async () => {
+  const anchor = { x: -165708.2808275, y: -220414.81625525, z: 23473.653477859374 };
+  const pieceTransform = [-167075.33, -217459.17, 22768.473, 0, 0, 0.81915206, 0.57357645];
+  const placeablePos = { x: -168670.68727685622, y: -218687.5419278533, z: 23154.388368606567, qz: 0.17364818, qw: 0.9848077 };
   const db = {
     query: async (text, values = []) => {
       if (text.includes("to_regclass")) {
@@ -884,14 +887,14 @@ test("export base returns base identity plus its piece and placeable rows", asyn
       }
       if (text.includes("from dune.buildings b")) {
         return { rows: [
-          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30" }
+          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "HaggaBasin", x: String(anchor.x), y: String(anchor.y), z: String(anchor.z) }
         ] };
       }
-      if (text.includes("from dune.building_instances where building_id")) {
-        return { rows: [{ building_id: 1006, owner_entity_id: "5198320676376814286" }, { building_id: 1006, owner_entity_id: "5198320676376814286" }] };
+      if (text.includes("select instance_id, building_type, transform")) {
+        return { rows: [{ instance_id: 2486, building_type: "Harkonnen_Outpost_Foundation", transform: pieceTransform }] };
       }
-      if (text.includes("from dune.placeables")) {
-        return { rows: [{ id: 1, owner_entity_id: "5198320676376814286" }] };
+      if (text.includes("select p.id as placeable_id")) {
+        return { rows: [{ placeable_id: 2582, building_type: "Hark_Deco_Plate_02_Placeable", x: placeablePos.x, y: placeablePos.y, z: placeablePos.z, qz: placeablePos.qz, qw: placeablePos.qw }] };
       }
       return { rows: [] };
     }
@@ -900,12 +903,31 @@ test("export base returns base identity plus its piece and placeable rows", asyn
   assert.equal(result.base_id, "1006");
   assert.equal(result.name, "Sietch One");
   assert.equal(result.owner_name, "Leader One");
-  assert.equal(result.map, "TheDeepDesert");
-  assert.equal(result.x, 100);
-  assert.equal(result.piece_count, 2);
+  assert.equal(result.map, "HaggaBasin");
+  assert.equal(result.piece_count, 1);
   assert.equal(result.placeable_count, 1);
-  assert.equal(result.pieces.length, 2);
-  assert.equal(result.placeables.length, 1);
+  assert.equal(result.pentashields, undefined);
+
+  const instance = result.instances[0];
+  assert.equal(instance.instance_id, 2486);
+  assert.equal(instance.building_type, "Harkonnen_Outpost_Foundation");
+  assert.equal(instance.provides_stability, undefined);
+  assert.ok(Math.abs(instance.x - (pieceTransform[0] - anchor.x)) < 1e-6);
+  assert.ok(Math.abs(instance.y - (pieceTransform[1] - anchor.y)) < 1e-6);
+  assert.ok(Math.abs(instance.z - (pieceTransform[2] - anchor.z)) < 1e-6);
+  const expectedInstanceRotation = 2 * Math.atan2(pieceTransform[5], pieceTransform[6]) * (180 / Math.PI);
+  assert.equal(instance.rotation, expectedInstanceRotation);
+  assert.ok(Math.abs(instance.rotation - 110) < 1);
+
+  const placeable = result.placeables[0];
+  assert.equal(placeable.placeable_id, 2582);
+  assert.equal(placeable.building_type, "Hark_Deco_Plate_02_Placeable");
+  assert.equal(placeable.rx, 0);
+  assert.equal(placeable.ry, 0);
+  assert.ok(Math.abs(placeable.x - (placeablePos.x - anchor.x)) < 1e-6);
+  const expectedPlaceableRotation = 2 * Math.atan2(placeablePos.qz, placeablePos.qw) * (180 / Math.PI);
+  assert.equal(placeable.rz, expectedPlaceableRotation);
+  assert.ok(Math.abs(placeable.rz - 20) < 1);
 });
 
 test("player profile includes faction and guild when addon tables are present", async () => {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { assertIdentifier, discoverDbConfig, isReadOnlySql, quoteQualified, redactDbError, rowsResult } from "../src/db.js";
-import { addCurrency, addFactionReputation, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, augmentInventoryItem, augmentNewestPlayerItem, changeDunePassword, completeJourneyNode, completeTutorial, deleteInventoryItem, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listGuilds, listPlayers, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerInventory, playerJourney, playerPosition, playerProfile, playerResearchItems, repairVehicleDecay, resetJourneyNode, resetTutorial, runSql, setLandsraadPlayerContribution, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError } from "../src/duneDb.js";
+import { addCurrency, addFactionReputation, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, augmentInventoryItem, augmentNewestPlayerItem, changeDunePassword, completeJourneyNode, completeTutorial, deleteInventoryItem, exportBase, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listBases, listGuilds, listPlayers, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerInventory, playerJourney, playerPosition, playerProfile, playerResearchItems, repairVehicleDecay, resetJourneyNode, resetTutorial, runSql, setLandsraadPlayerContribution, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError } from "../src/duneDb.js";
 
 test("discovers RedBlink Postgres defaults and env overrides", () => {
   assert.deepEqual(discoverDbConfig({}), {
@@ -814,6 +814,98 @@ test("guild members falls back to a direct account-id join when dune.actors is u
   assert.ok(memberQuery);
   assert.doesNotMatch(memberQuery.text, /dune\.actors/);
   assert.match(memberQuery.text, /left join dune\.player_state ps_by_account on ps_by_account\.account_id = coalesce\(null, gm\."player_id"\)/);
+});
+
+const BASE_REQUIRED_TABLES = ["dune.buildings", "dune.building_instances", "dune.actor_fgl_entities", "dune.actors"];
+
+test("list bases returns capability response when required tables are missing", async () => {
+  const db = {
+    query: async () => ({ rows: [{ exists: false }] })
+  };
+  const result = await listBases(db, {});
+  assert.equal(result.capabilities.bases, false);
+  assert.match(result.reason, /dune\.buildings/);
+});
+
+test("list bases returns rows with piece and placeable counts", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
+      }
+      if (text.includes("count(distinct bi.ctid)")) {
+        return { rows: [
+          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30", piece_count: "589", placeable_count: "126" }
+        ] };
+      }
+      return { rows: [] };
+    }
+  };
+  const result = await listBases(db, {});
+  assert.equal(result.capabilities.bases, true);
+  assert.deepEqual(result.rows, [
+    { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: 100, y: 200, z: 30, piece_count: 589, placeable_count: 126 }
+  ]);
+});
+
+test("list bases filters by name or owner name via a having clause", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
+      }
+      return { rows: [] };
+    }
+  };
+  await listBases(db, { q: "Sietch" });
+  const baseQuery = calls.find((call) => call.text.includes("from dune.buildings b"));
+  assert.ok(baseQuery);
+  assert.match(baseQuery.text, /having coalesce\(pa\.actor_name, ''\) ilike \$1 or coalesce\(max\(ps\.character_name\), ''\) ilike \$1/);
+  assert.deepEqual(baseQuery.values, ["%Sietch%"]);
+});
+
+test("export base throws an unsupported error when required tables are missing", async () => {
+  const db = {
+    query: async () => ({ rows: [{ exists: false }] })
+  };
+  await assert.rejects(() => exportBase(db, 1006), UnsupportedCapabilityError);
+});
+
+test("export base returns base identity plus its piece and placeable rows", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: [...BASE_REQUIRED_TABLES, "dune.placeables"].includes(name) }] };
+      }
+      if (text.includes("from dune.buildings b")) {
+        return { rows: [
+          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30" }
+        ] };
+      }
+      if (text.includes("from dune.building_instances where building_id")) {
+        return { rows: [{ building_id: 1006, owner_entity_id: "5198320676376814286" }, { building_id: 1006, owner_entity_id: "5198320676376814286" }] };
+      }
+      if (text.includes("from dune.placeables")) {
+        return { rows: [{ id: 1, owner_entity_id: "5198320676376814286" }] };
+      }
+      return { rows: [] };
+    }
+  };
+  const result = await exportBase(db, 1006);
+  assert.equal(result.base_id, "1006");
+  assert.equal(result.name, "Sietch One");
+  assert.equal(result.owner_name, "Leader One");
+  assert.equal(result.map, "TheDeepDesert");
+  assert.equal(result.x, 100);
+  assert.equal(result.piece_count, 2);
+  assert.equal(result.placeable_count, 1);
+  assert.equal(result.pieces.length, 2);
+  assert.equal(result.placeables.length, 1);
 });
 
 test("player profile includes faction and guild when addon tables are present", async () => {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -836,7 +836,7 @@ test("list bases returns rows with piece and placeable counts", async () => {
       }
       if (text.includes("count(distinct bi.ctid)")) {
         return { rows: [
-          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30", piece_count: "589", placeable_count: "126" }
+          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30", piece_count: "589", placeable_count: "126", shared_with: [{ name: "Ally Two", rank: 2 }] }
         ] };
       }
       return { rows: [] };
@@ -845,8 +845,33 @@ test("list bases returns rows with piece and placeable counts", async () => {
   const result = await listBases(db, {});
   assert.equal(result.capabilities.bases, true);
   assert.deepEqual(result.rows, [
-    { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: 100, y: 200, z: 30, piece_count: 589, placeable_count: 126 }
+    { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: 100, y: 200, z: 30, piece_count: 589, placeable_count: 126, shared_with: [{ name: "Ally Two", rank: 2, label: "Co-Owner" }] }
   ]);
+});
+
+test("list bases excludes the owner from shared_with, coalesces missing entries, and labels unmapped ranks", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
+      }
+      if (text.includes("count(distinct bi.ctid)")) {
+        return { rows: [
+          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30", piece_count: "589", placeable_count: "126", shared_with: [{ name: "Ally Two", rank: 2 }, { name: "Ally Three", rank: 7 }] },
+          { base_id: "1007", name: "Sietch Two", owner_name: "Leader Two", map: "TheDeepDesert", x: "10", y: "20", z: "3", piece_count: "12", placeable_count: "0", shared_with: null }
+        ] };
+      }
+      return { rows: [] };
+    }
+  };
+  const result = await listBases(db, {});
+  assert.deepEqual(result.rows[0].shared_with, [
+    { name: "Ally Two", rank: 2, label: "Co-Owner" },
+    { name: "Ally Three", rank: 7, label: "Rank 7" }
+  ]);
+  assert.ok(!result.rows[0].shared_with.some((entry) => entry.name === "Leader One"), "owner_name must not appear in shared_with");
+  assert.deepEqual(result.rows[1].shared_with, [], "null shared_with from the mock must coalesce to an empty array");
 });
 
 test("list bases filters by name or owner name via a having clause", async () => {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -864,7 +864,7 @@ test("list bases filters by name or owner name via a having clause", async () =>
   await listBases(db, { q: "Sietch" });
   const baseQuery = calls.find((call) => call.text.includes("from dune.buildings b"));
   assert.ok(baseQuery);
-  assert.match(baseQuery.text, /having coalesce\(pa\.actor_name, ''\) ilike \$1 or coalesce\(max\(ps\.character_name\), ''\) ilike \$1/);
+  assert.match(baseQuery.text, /having coalesce\(pa\.actor_name, ''\) ilike \$1 or coalesce\(owner\.character_name, ''\) ilike \$1/);
   assert.deepEqual(baseQuery.values, ["%Sietch%"]);
 });
 

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -827,16 +827,19 @@ test("list bases returns capability response when required tables are missing", 
   assert.match(result.reason, /dune\.buildings/);
 });
 
-test("list bases returns rows with piece and placeable counts", async () => {
+test("list bases returns rows with piece and placeable counts and a total count", async () => {
   const db = {
     query: async (text, values = []) => {
       if (text.includes("to_regclass")) {
         const name = String(values[0] || "");
         return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
       }
+      if (text.includes("total_bases")) {
+        return { rows: [{ total_bases: "5", total_pieces: "700", total_placeables: "140" }] };
+      }
       if (text.includes("count(distinct bi.ctid)")) {
         return { rows: [
-          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30", piece_count: "589", placeable_count: "126", shared_with: [{ name: "Ally Two", rank: 2 }] }
+          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30", total_count: "1", piece_count: "589", placeable_count: "126", shared_with: [{ name: "Ally Two", rank: 2 }] }
         ] };
       }
       return { rows: [] };
@@ -844,6 +847,10 @@ test("list bases returns rows with piece and placeable counts", async () => {
   };
   const result = await listBases(db, {});
   assert.equal(result.capabilities.bases, true);
+  assert.equal(result.totalCount, 1);
+  assert.equal(result.totalBases, 5);
+  assert.equal(result.totalPieces, 700);
+  assert.equal(result.totalPlaceables, 140);
   assert.deepEqual(result.rows, [
     { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: 100, y: 200, z: 30, piece_count: 589, placeable_count: 126, shared_with: [{ name: "Ally Two", rank: 2, label: "Co-Owner" }] }
   ]);
@@ -856,25 +863,31 @@ test("list bases excludes the owner from shared_with, coalesces missing entries,
         const name = String(values[0] || "");
         return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
       }
+      if (text.includes("total_bases")) {
+        return { rows: [{ total_bases: "2", total_pieces: "601", total_placeables: "126" }] };
+      }
       if (text.includes("count(distinct bi.ctid)")) {
         return { rows: [
-          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30", piece_count: "589", placeable_count: "126", shared_with: [{ name: "Ally Two", rank: 2 }, { name: "Ally Three", rank: 7 }] },
-          { base_id: "1007", name: "Sietch Two", owner_name: "Leader Two", map: "TheDeepDesert", x: "10", y: "20", z: "3", piece_count: "12", placeable_count: "0", shared_with: null }
+          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "TheDeepDesert", x: "100", y: "200", z: "30", total_count: "2", piece_count: "589", placeable_count: "126", shared_with: [{ name: "Ally Two", rank: 2 }, { name: "Ally Three", rank: 7 }] },
+          { base_id: "1007", name: "Sietch Two", owner_name: "Leader Two", map: "TheDeepDesert", x: "10", y: "20", z: "3", total_count: "2", piece_count: "12", placeable_count: "0", shared_with: null }
         ] };
       }
       return { rows: [] };
     }
   };
   const result = await listBases(db, {});
+  assert.equal(result.totalCount, 2);
+  assert.equal(result.totalBases, 2);
   assert.deepEqual(result.rows[0].shared_with, [
     { name: "Ally Two", rank: 2, label: "Co-Owner" },
     { name: "Ally Three", rank: 7, label: "Rank 7" }
   ]);
   assert.ok(!result.rows[0].shared_with.some((entry) => entry.name === "Leader One"), "owner_name must not appear in shared_with");
   assert.deepEqual(result.rows[1].shared_with, [], "null shared_with from the mock must coalesce to an empty array");
+  assert.ok(!("total_count" in result.rows[0]), "total_count must not leak onto individual rows");
 });
 
-test("list bases filters by name or owner name via a having clause", async () => {
+test("list bases filters by name or owner name via a having clause and paginates with limit/offset", async () => {
   const calls = [];
   const db = {
     query: async (text, values = []) => {
@@ -886,11 +899,99 @@ test("list bases filters by name or owner name via a having clause", async () =>
       return { rows: [] };
     }
   };
-  await listBases(db, { q: "Sietch" });
+  await listBases(db, { q: "Sietch", page: 2, pageSize: 25 });
   const baseQuery = calls.find((call) => call.text.includes("from dune.buildings b"));
   assert.ok(baseQuery);
   assert.match(baseQuery.text, /having coalesce\(pa\.actor_name, ''\) ilike \$1 or coalesce\(owner\.character_name, ''\) ilike \$1/);
-  assert.deepEqual(baseQuery.values, ["%Sietch%"]);
+  assert.match(baseQuery.text, /limit \$2 offset \$3/);
+  assert.deepEqual(baseQuery.values, ["%Sietch%", 25, 50]);
+  assert.ok(baseQuery.text.includes("order by lower(coalesce(raw_name, '')), id"), "paged CTE must sort by the raw (nullable) actor name, matching pre-pagination sort behavior");
+});
+
+test("list bases resolves shared_with via the base's actor id, not its building id", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
+      }
+      if (text.includes("total_bases")) {
+        return { rows: [{ total_bases: "1", total_pieces: "1", total_placeables: "0" }] };
+      }
+      return { rows: [] };
+    }
+  };
+  await listBases(db, {});
+  const baseQuery = calls.find((call) => call.text.includes("from dune.buildings b"));
+  assert.ok(baseQuery);
+  // matched CTE must carry the actor id through (a.id, distinct from the building id b.id)...
+  assert.ok(baseQuery.text.includes("a.id as actor_id"), "matched CTE must select the actor id");
+  assert.ok(baseQuery.text.includes("group by b.id, a.id, pa.actor_name"), "actor_id must be in matched's GROUP BY");
+  // ...and the shared-with LATERAL must filter on that actor id, never the building id.
+  assert.ok(baseQuery.text.includes("par.permission_actor_id = p.actor_id"), "shared LATERAL must join on the actor id");
+  assert.ok(!baseQuery.text.includes("par.permission_actor_id = p.id"), "shared LATERAL must not regress to the building id");
+});
+
+test("list bases resolves the owner via the base's actor id, not its building id", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
+      }
+      if (text.includes("total_bases")) {
+        return { rows: [{ total_bases: "1", total_pieces: "1", total_placeables: "0" }] };
+      }
+      return { rows: [] };
+    }
+  };
+  await listBases(db, {});
+  const baseQuery = calls.find((call) => call.text.includes("from dune.buildings b"));
+  assert.ok(baseQuery);
+  assert.match(baseQuery.text, /\) owner on true/);
+  const ownerLateral = baseQuery.text.slice(baseQuery.text.indexOf("left join lateral"), baseQuery.text.indexOf(") owner on true"));
+  assert.ok(ownerLateral.includes("where par.permission_actor_id = a.id"), "owner LATERAL must resolve via the base's actor id");
+  assert.ok(ownerLateral.includes("order by par.rank asc"), "owner must be the lowest-rank (rank 1) member, not an arbitrary one");
+});
+
+test("list bases totals query uses the same base-inclusion criterion and placeable join as the main query", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
+      }
+      return { rows: [] };
+    }
+  };
+  await listBases(db, {});
+  const totalsQuery = calls.find((call) => call.text.includes("total_bases"));
+  assert.ok(totalsQuery);
+  assert.ok(totalsQuery.text.includes("where a.transform is not null"), "totals must use the same base-inclusion criterion as the paginated query");
+  assert.ok(totalsQuery.text.includes("left join dune.placeables pl on pl.owner_entity_id = bi.owner_entity_id"), "totals placeable join must match the main query's join key");
+});
+
+test("list bases rejects invalid page or pageSize values", async () => {
+  const db = {
+    query: async (text, values = []) => {
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
+      }
+      return { rows: [] };
+    }
+  };
+  // Matches the tablePreview convention: intParam validation throws before the query runs,
+  // so it's caught by the HTTP layer's dbJson wrapper (server.js), not swallowed into a
+  // capabilities-false response here.
+  await assert.rejects(() => listBases(db, { pageSize: 0 }), /Invalid pageSize/);
+  await assert.rejects(() => listBases(db, { page: -1 }), /Invalid page/);
 });
 
 test("export base throws an unsupported error when required tables are missing", async () => {
@@ -898,6 +999,26 @@ test("export base throws an unsupported error when required tables are missing",
     query: async () => ({ rows: [{ exists: false }] })
   };
   await assert.rejects(() => exportBase(db, 1006), UnsupportedCapabilityError);
+});
+
+test("export base resolves the owner via the base's actor id", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: [...BASE_REQUIRED_TABLES, "dune.placeables"].includes(name) }] };
+      }
+      return { rows: [] };
+    }
+  };
+  // No matching base row in this mock, so exportBase throws after issuing the identity
+  // query below — that's fine, we only need to inspect the query text it sent.
+  await assert.rejects(() => exportBase(db, 1006), UnsupportedCapabilityError);
+  const baseQuery = calls.find((call) => call.text.includes("from dune.buildings b"));
+  assert.ok(baseQuery);
+  assert.ok(baseQuery.text.includes("where par.permission_actor_id = a.id"), "exportBase owner LATERAL must resolve via the base's actor id");
 });
 
 test("export base returns instances and placeables in blueprint-importable relative coordinates", async () => {
@@ -930,6 +1051,7 @@ test("export base returns instances and placeables in blueprint-importable relat
   const result = await exportBase(db, 1006);
   const placeableQuery = calls.find((call) => call.text.includes("select p.id as placeable_id"));
   assert.deepEqual(placeableQuery.values, [ownerEntityId]);
+  assert.ok(placeableQuery.text.includes("join dune.actors a on a.id = p.id"), "placeables share the actors id space directly, not via owner_entity_id");
   assert.equal(result.base_id, "1006");
   assert.equal(result.name, "Sietch One");
   assert.equal(result.owner_name, "Leader One");

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -879,15 +879,18 @@ test("export base returns instances and placeables in blueprint-importable relat
   const anchor = { x: -165708.2808275, y: -220414.81625525, z: 23473.653477859374 };
   const pieceTransform = [-167075.33, -217459.17, 22768.473, 0, 0, 0.81915206, 0.57357645];
   const placeablePos = { x: -168670.68727685622, y: -218687.5419278533, z: 23154.388368606567, qz: 0.17364818, qw: 0.9848077 };
+  const ownerEntityId = "918273645";
+  const calls = [];
   const db = {
     query: async (text, values = []) => {
+      calls.push({ text, values });
       if (text.includes("to_regclass")) {
         const name = String(values[0] || "");
         return { rows: [{ exists: [...BASE_REQUIRED_TABLES, "dune.placeables"].includes(name) }] };
       }
       if (text.includes("from dune.buildings b")) {
         return { rows: [
-          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "HaggaBasin", x: String(anchor.x), y: String(anchor.y), z: String(anchor.z) }
+          { base_id: "1006", name: "Sietch One", owner_name: "Leader One", map: "HaggaBasin", x: String(anchor.x), y: String(anchor.y), z: String(anchor.z), owner_entity_id: ownerEntityId }
         ] };
       }
       if (text.includes("select instance_id, building_type, transform")) {
@@ -900,6 +903,8 @@ test("export base returns instances and placeables in blueprint-importable relat
     }
   };
   const result = await exportBase(db, 1006);
+  const placeableQuery = calls.find((call) => call.text.includes("select p.id as placeable_id"));
+  assert.deepEqual(placeableQuery.values, [ownerEntityId]);
   assert.equal(result.base_id, "1006");
   assert.equal(result.name, "Sietch One");
   assert.equal(result.owner_name, "Leader One");

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -905,7 +905,47 @@ test("list bases filters by name or owner name via a having clause and paginates
   assert.match(baseQuery.text, /having coalesce\(pa\.actor_name, ''\) ilike \$1 or coalesce\(owner\.character_name, ''\) ilike \$1/);
   assert.match(baseQuery.text, /limit \$2 offset \$3/);
   assert.deepEqual(baseQuery.values, ["%Sietch%", 25, 50]);
-  assert.ok(baseQuery.text.includes("order by lower(coalesce(raw_name, '')), id"), "paged CTE must sort by the raw (nullable) actor name, matching pre-pagination sort behavior");
+  assert.ok(baseQuery.text.includes("order by lower(coalesce(raw_name, '')) asc, id asc"), "paged CTE must sort the complete matched result before pagination");
+});
+
+test("list bases applies requested sorting before pagination", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
+      }
+      return { rows: [] };
+    }
+  };
+  await listBases(db, { page: 1, pageSize: 25, sortColumn: "piece_count", sortDirection: "desc" });
+  const baseQuery = calls.find((call) => call.text.includes("from dune.buildings b"));
+  assert.ok(baseQuery);
+  assert.match(baseQuery.text, /as piece_count/);
+  assert.match(baseQuery.text, /row_number\(\) over \(order by piece_count desc, id desc\)/);
+  assert.match(baseQuery.text, /limit \$1 offset \$2/);
+  assert.deepEqual(baseQuery.values, [25, 25]);
+});
+
+test("list bases falls back to safe sorting for unsupported input", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) }] };
+      }
+      return { rows: [] };
+    }
+  };
+  await listBases(db, { sortColumn: "name desc; drop table dune.buildings", sortDirection: "sideways" });
+  const baseQuery = calls.find((call) => call.text.includes("from dune.buildings b"));
+  assert.ok(baseQuery);
+  assert.match(baseQuery.text, /row_number\(\) over \(order by lower\(coalesce\(raw_name, ''\)\) asc, id asc\)/);
+  assert.doesNotMatch(baseQuery.text, /drop table/i);
 });
 
 test("list bases resolves shared_with via the base's actor id, not its building id", async () => {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { assertIdentifier, discoverDbConfig, isReadOnlySql, quoteQualified, redactDbError, rowsResult } from "../src/db.js";
-import { addCurrency, addFactionReputation, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, augmentInventoryItem, augmentNewestPlayerItem, changeDunePassword, completeJourneyNode, completeTutorial, deleteInventoryItem, exportBase, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listBases, listGuilds, listPlayers, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerInventory, playerJourney, playerPosition, playerProfile, playerResearchItems, repairVehicleDecay, resetJourneyNode, resetTutorial, runSql, setLandsraadPlayerContribution, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError } from "../src/duneDb.js";
+import { addCurrency, addFactionReputation, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, augmentInventoryItem, augmentNewestPlayerItem, changeDunePassword, completeJourneyNode, completeTutorial, deleteInventoryItem, exportBaseAsBlueprint, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listBases, listGuilds, listPlayers, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerInventory, playerJourney, playerPosition, playerProfile, playerResearchItems, repairVehicleDecay, resetJourneyNode, resetTutorial, runSql, setLandsraadPlayerContribution, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError } from "../src/duneDb.js";
 
 test("discovers RedBlink Postgres defaults and env overrides", () => {
   assert.deepEqual(discoverDbConfig({}), {
@@ -998,7 +998,7 @@ test("export base throws an unsupported error when required tables are missing",
   const db = {
     query: async () => ({ rows: [{ exists: false }] })
   };
-  await assert.rejects(() => exportBase(db, 1006), UnsupportedCapabilityError);
+  await assert.rejects(() => exportBaseAsBlueprint(db, 1006), UnsupportedCapabilityError);
 });
 
 test("export base resolves the owner via the base's actor id", async () => {
@@ -1013,12 +1013,12 @@ test("export base resolves the owner via the base's actor id", async () => {
       return { rows: [] };
     }
   };
-  // No matching base row in this mock, so exportBase throws after issuing the identity
+  // No matching base row in this mock, so exportBaseAsBlueprint throws after issuing the identity
   // query below — that's fine, we only need to inspect the query text it sent.
-  await assert.rejects(() => exportBase(db, 1006), UnsupportedCapabilityError);
+  await assert.rejects(() => exportBaseAsBlueprint(db, 1006), UnsupportedCapabilityError);
   const baseQuery = calls.find((call) => call.text.includes("from dune.buildings b"));
   assert.ok(baseQuery);
-  assert.ok(baseQuery.text.includes("where par.permission_actor_id = a.id"), "exportBase owner LATERAL must resolve via the base's actor id");
+  assert.ok(baseQuery.text.includes("where par.permission_actor_id = a.id"), "exportBaseAsBlueprint owner LATERAL must resolve via the base's actor id");
 });
 
 test("export base returns instances and placeables in blueprint-importable relative coordinates", async () => {
@@ -1048,7 +1048,7 @@ test("export base returns instances and placeables in blueprint-importable relat
       return { rows: [] };
     }
   };
-  const result = await exportBase(db, 1006);
+  const result = await exportBaseAsBlueprint(db, 1006);
   const placeableQuery = calls.find((call) => call.text.includes("select p.id as placeable_id"));
   assert.deepEqual(placeableQuery.values, [ownerEntityId]);
   assert.ok(placeableQuery.text.includes("join dune.actors a on a.id = p.id"), "placeables share the actors id space directly, not via owner_entity_id");

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { Fragment, Suspense, lazy, useCallback, useEffect, useRef, useState } from "react";
-import { Archive, Database, ExternalLink, FileText, Gift, Heart, Home, Landmark, Map as MapIcon, MessageCircle, PackagePlus, RefreshCw, Server, Settings, Shield, Sparkles, Users } from "lucide-react";
+import { Archive, Building2, Database, ExternalLink, FileText, Gift, Heart, Home, Landmark, Map as MapIcon, MessageCircle, PackagePlus, RefreshCw, Server, Settings, Shield, Sparkles, Users } from "lucide-react";
 import { api, post, setCsrfToken } from "./api/client";
 import { serverApi } from "./api/server";
 import { updatesApi } from "./api/updates";
@@ -31,12 +31,13 @@ import {
 import { parseUpdateTask, stackVersionButtonLabel, stackVersionButtonTitle } from "./features/updates/updateUtils";
 import { formatUiSentence, stripAnsi, summarizeCommandText, titleCase } from "./lib/display";
 
-type Tab = "Home" | "Server Control" | "Services" | "Players" | "Guilds" | "Landsraad" | "Admin Tools" | "Live Map" | "Maps" | "Care Package" | "Addons" | "Database" | "Storage" | "Backups" | "Logs" | "Updates" | "Settings";
+type Tab = "Home" | "Server Control" | "Services" | "Players" | "Guilds" | "Bases" | "Landsraad" | "Admin Tools" | "Live Map" | "Maps" | "Care Package" | "Addons" | "Database" | "Storage" | "Backups" | "Logs" | "Updates" | "Settings";
 type SetupState = { files: Record<string, boolean>; config: Record<string, unknown> };
 let openConfirmDialog: ((request: ConfirmDialogRequest) => void) | null = null;
 
 const AddonsPanel = lazy(() => import("./features/addons/AddonsPanel").then((module) => ({ default: module.AddonsPanel })));
 const AdminToolsPanel = lazy(() => import("./features/adminTools/AdminToolsPanel").then((module) => ({ default: module.AdminToolsPanel })));
+const BasesPanel = lazy(() => import("./features/bases/BasesPanel").then((module) => ({ default: module.BasesPanel })));
 const BackupsPanel = lazy(() => import("./features/backups/BackupsPanel").then((module) => ({ default: module.BackupsPanel })));
 const CarePackagePanel = lazy(() => import("./features/carePackage/CarePackagePanel").then((module) => ({ default: module.CarePackagePanel })));
 const DatabasePanel = lazy(() => import("./features/database/DatabasePanel").then((module) => ({ default: module.DatabasePanel })));
@@ -109,6 +110,7 @@ const navGroups: { title: string; items: { tab: Tab; icon: React.ReactNode }[] }
       { tab: "Maps", icon: <MapIcon size={18} /> },
       { tab: "Players", icon: <Users size={18} /> },
       { tab: "Guilds", icon: <Shield size={18} /> },
+      { tab: "Bases", icon: <Building2 size={18} /> },
       { tab: "Live Map", icon: <MapIcon size={18} /> },
       { tab: "Landsraad", icon: <Landmark size={18} /> },
       { tab: "Admin Tools", icon: <PackagePlus size={18} /> },
@@ -547,6 +549,7 @@ export function App() {
         {!redeploySetupOpen && tab === "Services" && <LazyTabBoundary label="Loading Services"><ServicesPanel services={services} setServices={setServices} setTask={setTask} openLogs={(service) => { setRedeploySetupOpen(false); setSelectedLogService(service); setTab("Logs"); }} onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Players" && <LazyTabBoundary label="Loading Players"><PlayersPanel onError={setError} renderCharacterAdmin={(props) => <LazyTabBoundary label="Loading Player Details"><CharacterAdminUI {...props} onError={setError} confirmAction={confirmDialog} waitForTask={waitForTaskSilently} formatMutationResult={formatMutationResult} /></LazyTabBoundary>} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Guilds" && <LazyTabBoundary label="Loading Guilds"><GuildsPanel onError={setError} /></LazyTabBoundary>}
+        {!redeploySetupOpen && tab === "Bases" && <LazyTabBoundary label="Loading Bases"><BasesPanel onError={setError} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Landsraad" && <LazyTabBoundary label="Loading Landsraad"><LandsraadPanel onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Admin Tools" && <LazyTabBoundary label="Loading Admin Tools"><AdminToolsPanel onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Live Map" && <LazyTabBoundary label="Loading Live Map"><LiveMapPanel onError={setError} confirmAction={confirmDialog} waitForTask={waitForTaskSilently} taskTechnicalDetails={taskTechnicalDetails} /></LazyTabBoundary>}

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -1,0 +1,5 @@
+import { api } from "./client";
+
+export const basesApi = {
+  list: (q = "") => api<{ rows: Record<string, unknown>[]; capabilities: Record<string, unknown>; reason?: string }>(`/api/bases${q ? `?q=${encodeURIComponent(q)}` : ""}`)
+};

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -1,11 +1,13 @@
 import { api } from "./client";
 
 export const basesApi = {
-  list: (params: { q?: string; page?: number; pageSize?: number } = {}) => {
+  list: (params: { q?: string; page?: number; pageSize?: number; sortColumn?: string; sortDirection?: "asc" | "desc" } = {}) => {
     const search = new URLSearchParams();
     if (params.q) search.set("q", params.q);
     if (params.page) search.set("page", String(params.page));
     if (params.pageSize) search.set("pageSize", String(params.pageSize));
+    if (params.sortColumn) search.set("sortColumn", params.sortColumn);
+    if (params.sortDirection) search.set("sortDirection", params.sortDirection);
     const qs = search.toString();
     return api<{ rows: Record<string, unknown>[]; totalCount: number; totalBases: number; totalPieces: number; totalPlaceables: number; capabilities: Record<string, unknown>; reason?: string }>(`/api/bases${qs ? `?${qs}` : ""}`);
   }

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -1,5 +1,12 @@
 import { api } from "./client";
 
 export const basesApi = {
-  list: (q = "") => api<{ rows: Record<string, unknown>[]; capabilities: Record<string, unknown>; reason?: string }>(`/api/bases${q ? `?q=${encodeURIComponent(q)}` : ""}`)
+  list: (params: { q?: string; page?: number; pageSize?: number } = {}) => {
+    const search = new URLSearchParams();
+    if (params.q) search.set("q", params.q);
+    if (params.page) search.set("page", String(params.page));
+    if (params.pageSize) search.set("pageSize", String(params.pageSize));
+    const qs = search.toString();
+    return api<{ rows: Record<string, unknown>[]; totalCount: number; totalBases: number; totalPieces: number; totalPlaceables: number; capabilities: Record<string, unknown>; reason?: string }>(`/api/bases${qs ? `?${qs}` : ""}`);
+  }
 };

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -8,6 +8,8 @@ type BasesPanelProps = {
   onError: (text: string) => void;
 };
 
+type SharedWithEntry = { name: string; rank: number; label: string };
+
 type BaseRow = Record<string, unknown> & {
   base_id: string;
   name: string;
@@ -19,6 +21,7 @@ type BaseRow = Record<string, unknown> & {
   coordinates: string;
   piece_count: number;
   placeable_count: number;
+  shared_with: SharedWithEntry[];
 };
 
 const BASES_AUTO_REFRESH_MS = 10_000;
@@ -32,6 +35,23 @@ function withCoordinates(row: Record<string, unknown>): BaseRow {
   const y = Math.round(Number(row.y) || 0);
   const z = Math.round(Number(row.z) || 0);
   return { ...row, x, y, z, coordinates: `${x}, ${y}, ${z}` } as BaseRow;
+}
+
+function renderBaseCell(row: Record<string, unknown>, column: string) {
+  if (column !== "shared_with") {
+    const value = row[column];
+    if (Array.isArray(value)) return value.join(", ");
+    return value == null || value === "" ? "—" : String(value);
+  }
+  const sharedWith = Array.isArray(row.shared_with) ? (row.shared_with as SharedWithEntry[]) : [];
+  if (!sharedWith.length) return <span className="muted">—</span>;
+  return (
+    <span className="bases-shared-list">
+      {sharedWith.map((entry) => (
+        <span key={`${entry.name}-${entry.rank}`}>{entry.name} <em>({entry.label})</em></span>
+      ))}
+    </span>
+  );
 }
 
 export function BasesPanel({ onError }: BasesPanelProps) {
@@ -126,9 +146,10 @@ export function BasesPanel({ onError }: BasesPanelProps) {
       <div className="action-row bases-search-row"><input value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search base or owner name" /><button onClick={() => void load()}>Search</button></div>
       <DataTable
         rows={sort.sortedRows}
-        columns={["base_id", "name", "owner_name", "map", "coordinates", "piece_count", "placeable_count"]}
+        columns={["base_id", "name", "owner_name", "shared_with", "map", "coordinates", "piece_count", "placeable_count"]}
         tableClassName="bases-table"
         actionClassName="actions-column"
+        renderCell={renderBaseCell}
         action={(row) => {
           const base = row as BaseRow;
           const id = String(base.base_id);

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Download, Unlock } from "lucide-react";
+import { basesApi } from "../../api/bases";
+import { apiDownload } from "../../api/client";
+import { DataTable, useSortableRows } from "../../components/common/DataTable";
+
+type BasesPanelProps = {
+  onError: (text: string) => void;
+};
+
+type BaseRow = Record<string, unknown> & {
+  base_id: string;
+  name: string;
+  owner_name: string;
+  map: string;
+  x: number;
+  y: number;
+  z: number;
+  coordinates: string;
+  piece_count: number;
+  placeable_count: number;
+};
+
+const BASES_AUTO_REFRESH_MS = 10_000;
+
+function errorText(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function withCoordinates(row: Record<string, unknown>): BaseRow {
+  const x = Math.round(Number(row.x) || 0);
+  const y = Math.round(Number(row.y) || 0);
+  const z = Math.round(Number(row.z) || 0);
+  return { ...row, x, y, z, coordinates: `${x}, ${y}, ${z}` } as BaseRow;
+}
+
+export function BasesPanel({ onError }: BasesPanelProps) {
+  const [q, setQ] = useState("");
+  const [rows, setRows] = useState<BaseRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [exportingId, setExportingId] = useState("");
+  const refreshInFlight = useRef(false);
+  const qRef = useRef(q);
+  const sort = useSortableRows(rows);
+
+  useEffect(() => {
+    qRef.current = q;
+  }, [q]);
+
+  const load = useCallback(async (options: { silent?: boolean } = {}) => {
+    if (refreshInFlight.current) return;
+    refreshInFlight.current = true;
+    if (!options.silent) onError("");
+    try {
+      const result = await basesApi.list(qRef.current);
+      setRows((result.rows || []).map(withCoordinates));
+    } catch (error) {
+      if (!options.silent) onError(errorText(error));
+    } finally {
+      setLoading(false);
+      refreshInFlight.current = false;
+    }
+  }, [onError]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    const refresh = () => {
+      if (document.visibilityState === "hidden") return;
+      void load({ silent: true });
+    };
+
+    const interval = window.setInterval(refresh, BASES_AUTO_REFRESH_MS);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      window.clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [load]);
+
+  async function handleExport(row: BaseRow) {
+    const id = String(row.base_id);
+    setExportingId(id);
+    try {
+      const response = await apiDownload(`/api/bases/${encodeURIComponent(id)}/export`);
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = url;
+      anchor.download = row.name ? `${String(row.name).replace(/[^a-zA-Z0-9_-]/g, "_")}.json` : `base_${id}.json`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    } catch (error) {
+      onError(errorText(error));
+    } finally {
+      setExportingId("");
+    }
+  }
+
+  const totalBases = rows.length;
+  const totalPieces = rows.reduce((sum, row) => sum + Number(row.piece_count || 0), 0);
+  const totalPlaceables = rows.reduce((sum, row) => sum + Number(row.placeable_count || 0), 0);
+
+  return (
+    <section className="panel">
+      <div className="panel-title"><h2>Bases</h2><div className="action-row"><button onClick={() => void load()}>Refresh</button></div></div>
+      <p className="action-help-note">
+        Total Bases: {totalBases.toLocaleString()} · Total Building Pieces: {totalPieces.toLocaleString()} · Total Placeables: {totalPlaceables.toLocaleString()}
+      </p>
+      <div className="action-row bases-search-row"><input value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search base or owner name" /><button onClick={() => void load()}>Search</button></div>
+      <DataTable
+        rows={sort.sortedRows}
+        columns={["base_id", "name", "owner_name", "map", "coordinates", "piece_count", "placeable_count"]}
+        tableClassName="bases-table"
+        actionClassName="actions-column"
+        action={(row) => {
+          const base = row as BaseRow;
+          const id = String(base.base_id);
+          return <span className="icon-toggle-group">
+            <button className="icon-toggle-button" title="Export base" aria-label="Export base" disabled={exportingId === id} onClick={(event) => { event.stopPropagation(); void handleExport(base); }}><Download size={16} /></button>
+            <button className="icon-toggle-button" title="Coming soon" aria-label="Release claim" disabled><Unlock size={16} /></button>
+          </span>;
+        }}
+        sortColumn={sort.sortColumn}
+        sortDirection={sort.sortDirection}
+        onSort={sort.onSort}
+        rowKey={(row) => String(row.base_id)}
+        emptyMessage={loading ? "Loading bases..." : "No bases have been found yet."}
+      />
+    </section>
+  );
+}

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Download, Unlock } from "lucide-react";
 import { basesApi } from "../../api/bases";
 import { apiDownload } from "../../api/client";
@@ -24,7 +24,13 @@ type BaseRow = Record<string, unknown> & {
   shared_with: SharedWithEntry[];
 };
 
-const BASES_AUTO_REFRESH_MS = 10_000;
+const BASES_AUTO_REFRESH_MS = 15 * 60_000; // 15 minutes — listBases is expensive
+const BASES_AUTO_REFRESH_RETRY_MS = 60_000; // backoff if a due refresh hasn't landed yet (in-flight/failed)
+const BASES_RELATIVE_TIME_TICK_MS = 30_000; // UI-only re-render cadence for "time ago" text — never fetches
+
+type BasesCache = { rows: BaseRow[]; q: string; lastFetchedAt: number };
+
+let basesCache: BasesCache | null = null;
 
 function errorText(error: unknown) {
   return error instanceof Error ? error.message : String(error);
@@ -35,6 +41,22 @@ function withCoordinates(row: Record<string, unknown>): BaseRow {
   const y = Math.round(Number(row.y) || 0);
   const z = Math.round(Number(row.z) || 0);
   return { ...row, x, y, z, coordinates: `${x}, ${y}, ${z}` } as BaseRow;
+}
+
+function formatRelativeTime(fromMs: number, nowMs: number): string {
+  const diffSec = Math.max(0, Math.round((nowMs - fromMs) / 1000));
+  if (diffSec < 45) return "just now";
+  const diffMin = Math.round(diffSec / 60);
+  if (diffMin < 60) return `${diffMin} minute${diffMin === 1 ? "" : "s"} ago`;
+  const diffHr = Math.round(diffMin / 60);
+  return `${diffHr} hour${diffHr === 1 ? "" : "s"} ago`;
+}
+
+function matchesQuery(row: BaseRow, query: string) {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return true;
+  return String(row.name ?? "").toLowerCase().includes(needle)
+    || String(row.owner_name ?? "").toLowerCase().includes(needle);
 }
 
 function renderBaseCell(row: Record<string, unknown>, column: string) {
@@ -55,16 +77,17 @@ function renderBaseCell(row: Record<string, unknown>, column: string) {
 }
 
 export function BasesPanel({ onError }: BasesPanelProps) {
-  const [q, setQ] = useState("");
-  const [rows, setRows] = useState<BaseRow[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [q, setQ] = useState(() => basesCache?.q ?? "");
+  const [rows, setRows] = useState<BaseRow[]>(() => basesCache?.rows ?? []);
+  const [loading, setLoading] = useState(() => basesCache === null);
+  const [now, setNow] = useState(() => Date.now());
   const [exportingId, setExportingId] = useState("");
   const refreshInFlight = useRef(false);
-  const qRef = useRef(q);
-  const sort = useSortableRows(rows);
+  const filteredRows = useMemo(() => rows.filter((row) => matchesQuery(row, q)), [rows, q]);
+  const sort = useSortableRows(filteredRows);
 
   useEffect(() => {
-    qRef.current = q;
+    if (basesCache) basesCache.q = q;
   }, [q]);
 
   const load = useCallback(async (options: { silent?: boolean } = {}) => {
@@ -72,8 +95,10 @@ export function BasesPanel({ onError }: BasesPanelProps) {
     refreshInFlight.current = true;
     if (!options.silent) onError("");
     try {
-      const result = await basesApi.list(qRef.current);
-      setRows((result.rows || []).map(withCoordinates));
+      const result = await basesApi.list();
+      const nextRows = (result.rows || []).map(withCoordinates);
+      setRows(nextRows);
+      basesCache = { ...basesCache, rows: nextRows, q: basesCache?.q ?? "", lastFetchedAt: Date.now() };
     } catch (error) {
       if (!options.silent) onError(errorText(error));
     } finally {
@@ -83,26 +108,48 @@ export function BasesPanel({ onError }: BasesPanelProps) {
   }, [onError]);
 
   useEffect(() => {
-    void load();
-  }, [load]);
+    let cancelled = false;
+    let timeoutId: number | undefined;
 
-  useEffect(() => {
-    const refresh = () => {
-      if (document.visibilityState === "hidden") return;
-      void load({ silent: true });
+    const isStale = () => Date.now() - (basesCache?.lastFetchedAt ?? 0) >= BASES_AUTO_REFRESH_MS;
+
+    const refreshIfStale = async () => {
+      if (document.visibilityState === "hidden" || !isStale()) return;
+      await load({ silent: true });
     };
 
-    const interval = window.setInterval(refresh, BASES_AUTO_REFRESH_MS);
+    const scheduleNext = () => {
+      if (cancelled) return;
+      window.clearTimeout(timeoutId);
+      const last = basesCache?.lastFetchedAt ?? Date.now();
+      const dueIn = last + BASES_AUTO_REFRESH_MS - Date.now();
+      const delay = dueIn > 0 ? dueIn : BASES_AUTO_REFRESH_RETRY_MS;
+      timeoutId = window.setTimeout(() => { void runAndReschedule(refreshIfStale); }, delay);
+    };
+
+    const runAndReschedule = async (fn: () => Promise<void>) => {
+      await fn();
+      if (!cancelled) scheduleNext();
+    };
+
+    void runAndReschedule(basesCache === null ? () => load() : refreshIfStale);
+
     const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") refresh();
+      if (document.visibilityState === "visible") void runAndReschedule(refreshIfStale);
     };
-
     document.addEventListener("visibilitychange", onVisibilityChange);
+
     return () => {
-      window.clearInterval(interval);
+      cancelled = true;
+      window.clearTimeout(timeoutId);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
   }, [load]);
+
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), BASES_RELATIVE_TIME_TICK_MS);
+    return () => window.clearInterval(id);
+  }, []);
 
   async function handleExport(row: BaseRow) {
     const id = String(row.base_id);
@@ -136,14 +183,28 @@ export function BasesPanel({ onError }: BasesPanelProps) {
   const totalBases = rows.length;
   const totalPieces = rows.reduce((sum, row) => sum + Number(row.piece_count || 0), 0);
   const totalPlaceables = rows.reduce((sum, row) => sum + Number(row.placeable_count || 0), 0);
+  const lastFetchedAt = basesCache?.lastFetchedAt ?? null;
+  const filteredCount = filteredRows.length;
+  const rangeStart = filteredCount === 0 ? 0 : 1;
 
   return (
     <section className="panel">
-      <div className="panel-title"><h2>Bases</h2><div className="action-row"><button onClick={() => void load()}>Refresh</button></div></div>
+      <div className="panel-title">
+        <h2>Bases</h2>
+        <div className="action-row">
+          {lastFetchedAt !== null && (
+            <span className="muted">Refreshed {formatRelativeTime(lastFetchedAt, now)}</span>
+          )}
+          <button onClick={() => void load()}>Refresh</button>
+        </div>
+      </div>
       <p className="action-help-note">
         Total Bases: {totalBases.toLocaleString()} · Total Building Pieces: {totalPieces.toLocaleString()} · Total Placeables: {totalPlaceables.toLocaleString()}
       </p>
-      <div className="action-row bases-search-row"><input value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search base or owner name" /><button onClick={() => void load()}>Search</button></div>
+      <div className="action-row bases-search-row"><input value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search base or owner name" /></div>
+      <p className="action-help-note bases-row-count">
+        Showing {rangeStart}-{filteredCount} of {totalBases} rows.
+      </p>
       <DataTable
         rows={sort.sortedRows}
         columns={["base_id", "name", "owner_name", "shared_with", "map", "coordinates", "piece_count", "placeable_count"]}

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Download } from "lucide-react";
 import { basesApi } from "../../api/bases";
 import { apiDownload } from "../../api/client";
-import { DataTable, useSortableRows } from "../../components/common/DataTable";
+import { DataTable, type SortDirection } from "../../components/common/DataTable";
 
 type BasesPanelProps = {
   onError: (text: string) => void;
@@ -34,6 +34,8 @@ type BasesCache = {
   q: string;
   page: number;
   pageSize: number;
+  sortColumn: string;
+  sortDirection: SortDirection;
   rows: BaseRow[];
   totalCount: number;
   totalBases: number;
@@ -44,8 +46,8 @@ type BasesCache = {
 
 let basesCache: BasesCache | null = null;
 
-function sameView(cache: BasesCache | null, q: string, page: number, pageSize: number) {
-  return !!cache && cache.q === q && cache.page === page && cache.pageSize === pageSize;
+function sameView(cache: BasesCache | null, q: string, page: number, pageSize: number, sortColumn: string, sortDirection: SortDirection) {
+  return !!cache && cache.q === q && cache.page === page && cache.pageSize === pageSize && cache.sortColumn === sortColumn && cache.sortDirection === sortDirection;
 }
 
 function errorText(error: unknown) {
@@ -90,6 +92,8 @@ export function BasesPanel({ onError }: BasesPanelProps) {
   const [submittedQ, setSubmittedQ] = useState(() => basesCache?.q ?? "");
   const [page, setPage] = useState(() => basesCache?.page ?? 0);
   const [pageSize, setPageSize] = useState<number>(() => basesCache?.pageSize ?? BASES_DEFAULT_PAGE_SIZE);
+  const [sortColumn, setSortColumn] = useState(() => basesCache?.sortColumn ?? "name");
+  const [sortDirection, setSortDirection] = useState<SortDirection>(() => basesCache?.sortDirection ?? "asc");
   const [rows, setRows] = useState<BaseRow[]>(() => basesCache?.rows ?? []);
   const [totalCount, setTotalCount] = useState(() => basesCache?.totalCount ?? 0);
   const [totalBases, setTotalBases] = useState(() => basesCache?.totalBases ?? 0);
@@ -100,7 +104,6 @@ export function BasesPanel({ onError }: BasesPanelProps) {
   const [downloadingId, setDownloadingId] = useState("");
   const requestIdRef = useRef(0);
   const skipNextSearchReset = useRef(true);
-  const sort = useSortableRows(rows);
 
   useEffect(() => {
     if (skipNextSearchReset.current) {
@@ -119,7 +122,7 @@ export function BasesPanel({ onError }: BasesPanelProps) {
     setSubmittedQ("");
   }
 
-  const load = useCallback(async (params: { q: string; page: number; pageSize: number }, options: { silent?: boolean } = {}) => {
+  const load = useCallback(async (params: { q: string; page: number; pageSize: number; sortColumn: string; sortDirection: SortDirection }, options: { silent?: boolean } = {}) => {
     const requestId = ++requestIdRef.current;
     if (!options.silent) onError("");
     try {
@@ -135,6 +138,8 @@ export function BasesPanel({ onError }: BasesPanelProps) {
         q: params.q,
         page: params.page,
         pageSize: params.pageSize,
+        sortColumn: params.sortColumn,
+        sortDirection: params.sortDirection,
         rows: nextRows,
         totalCount: result.totalCount || 0,
         totalBases: result.totalBases || 0,
@@ -152,8 +157,8 @@ export function BasesPanel({ onError }: BasesPanelProps) {
   useEffect(() => {
     let cancelled = false;
     let timeoutId: number | undefined;
-    const params = { q: submittedQ, page, pageSize };
-    const cacheHit = sameView(basesCache, submittedQ, page, pageSize) ? basesCache : null;
+    const params = { q: submittedQ, page, pageSize, sortColumn, sortDirection };
+    const cacheHit = sameView(basesCache, submittedQ, page, pageSize, sortColumn, sortDirection) ? basesCache : null;
     const isStale = () => !cacheHit || Date.now() - cacheHit.lastFetchedAt >= BASES_AUTO_REFRESH_MS;
 
     if (cacheHit) {
@@ -196,7 +201,7 @@ export function BasesPanel({ onError }: BasesPanelProps) {
       window.clearTimeout(timeoutId);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [submittedQ, page, pageSize, load]);
+  }, [submittedQ, page, pageSize, sortColumn, sortDirection, load]);
 
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), BASES_RELATIVE_TIME_TICK_MS);
@@ -244,6 +249,16 @@ export function BasesPanel({ onError }: BasesPanelProps) {
     setPage(0);
   }
 
+  function handleSort(column: string) {
+    setPage(0);
+    if (column === sortColumn) {
+      setSortDirection((current) => current === "asc" ? "desc" : "asc");
+      return;
+    }
+    setSortColumn(column);
+    setSortDirection("asc");
+  }
+
   return (
     <section className="panel">
       <div className="panel-title">
@@ -252,7 +267,7 @@ export function BasesPanel({ onError }: BasesPanelProps) {
           {lastFetchedAt !== null && (
             <span className="muted">Refreshed {formatRelativeTime(lastFetchedAt, now)}</span>
           )}
-          <button onClick={() => void load({ q: submittedQ, page, pageSize })}>Refresh</button>
+          <button onClick={() => void load({ q: submittedQ, page, pageSize, sortColumn, sortDirection })}>Refresh</button>
         </div>
       </div>
       <p className="action-help-note">
@@ -289,7 +304,7 @@ export function BasesPanel({ onError }: BasesPanelProps) {
         </div>
       </div>
       <DataTable
-        rows={sort.sortedRows}
+        rows={rows}
         columns={["base_id", "name", "owner_name", "shared_with", "map", "coordinates", "piece_count", "placeable_count"]}
         tableClassName="bases-table"
         actionClassName="actions-column"
@@ -301,9 +316,9 @@ export function BasesPanel({ onError }: BasesPanelProps) {
             <button className="icon-toggle-button" title="Download Base as Blueprint" aria-label="Download Base as Blueprint" disabled={downloadingId === id} onClick={(event) => { event.stopPropagation(); void handleDownloadBlueprint(base); }}><Download size={16} /></button>
           </span>;
         }}
-        sortColumn={sort.sortColumn}
-        sortDirection={sort.sortDirection}
-        onSort={sort.onSort}
+        sortColumn={sortColumn}
+        sortDirection={sortDirection}
+        onSort={handleSort}
         rowKey={(row) => String(row.base_id)}
         emptyMessage="No bases have been found yet."
       />

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -103,6 +103,16 @@ export function BasesPanel({ onError }: BasesPanelProps) {
     }
   }
 
+  if (loading) {
+    return <section className="panel">
+      <div className="panel-title"><h2>Bases</h2></div>
+      <div className="loading-panel">
+        <span className="spinner" aria-hidden="true" />
+        <strong className="loading-dots">Loading Bases</strong>
+      </div>
+    </section>;
+  }
+
   const totalBases = rows.length;
   const totalPieces = rows.reduce((sum, row) => sum + Number(row.piece_count || 0), 0);
   const totalPlaceables = rows.reduce((sum, row) => sum + Number(row.placeable_count || 0), 0);
@@ -131,7 +141,7 @@ export function BasesPanel({ onError }: BasesPanelProps) {
         sortDirection={sort.sortDirection}
         onSort={sort.onSort}
         rowKey={(row) => String(row.base_id)}
-        emptyMessage={loading ? "Loading bases..." : "No bases have been found yet."}
+        emptyMessage="No bases have been found yet."
       />
     </section>
   );

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Download, Unlock } from "lucide-react";
 import { basesApi } from "../../api/bases";
 import { apiDownload } from "../../api/client";
@@ -27,10 +27,26 @@ type BaseRow = Record<string, unknown> & {
 const BASES_AUTO_REFRESH_MS = 15 * 60_000; // 15 minutes — listBases is expensive
 const BASES_AUTO_REFRESH_RETRY_MS = 60_000; // backoff if a due refresh hasn't landed yet (in-flight/failed)
 const BASES_RELATIVE_TIME_TICK_MS = 30_000; // UI-only re-render cadence for "time ago" text — never fetches
+const BASES_PAGE_SIZES = [25, 50, 100, 200] as const;
+const BASES_DEFAULT_PAGE_SIZE = 50;
 
-type BasesCache = { rows: BaseRow[]; q: string; lastFetchedAt: number };
+type BasesCache = {
+  q: string;
+  page: number;
+  pageSize: number;
+  rows: BaseRow[];
+  totalCount: number;
+  totalBases: number;
+  totalPieces: number;
+  totalPlaceables: number;
+  lastFetchedAt: number;
+};
 
 let basesCache: BasesCache | null = null;
+
+function sameView(cache: BasesCache | null, q: string, page: number, pageSize: number) {
+  return !!cache && cache.q === q && cache.page === page && cache.pageSize === pageSize;
+}
 
 function errorText(error: unknown) {
   return error instanceof Error ? error.message : String(error);
@@ -52,13 +68,6 @@ function formatRelativeTime(fromMs: number, nowMs: number): string {
   return `${diffHr} hour${diffHr === 1 ? "" : "s"} ago`;
 }
 
-function matchesQuery(row: BaseRow, query: string) {
-  const needle = query.trim().toLowerCase();
-  if (!needle) return true;
-  return String(row.name ?? "").toLowerCase().includes(needle)
-    || String(row.owner_name ?? "").toLowerCase().includes(needle);
-}
-
 function renderBaseCell(row: Record<string, unknown>, column: string) {
   if (column !== "shared_with") {
     const value = row[column];
@@ -78,64 +87,102 @@ function renderBaseCell(row: Record<string, unknown>, column: string) {
 
 export function BasesPanel({ onError }: BasesPanelProps) {
   const [q, setQ] = useState(() => basesCache?.q ?? "");
+  const [submittedQ, setSubmittedQ] = useState(() => basesCache?.q ?? "");
+  const [page, setPage] = useState(() => basesCache?.page ?? 0);
+  const [pageSize, setPageSize] = useState<number>(() => basesCache?.pageSize ?? BASES_DEFAULT_PAGE_SIZE);
   const [rows, setRows] = useState<BaseRow[]>(() => basesCache?.rows ?? []);
+  const [totalCount, setTotalCount] = useState(() => basesCache?.totalCount ?? 0);
+  const [totalBases, setTotalBases] = useState(() => basesCache?.totalBases ?? 0);
+  const [totalPieces, setTotalPieces] = useState(() => basesCache?.totalPieces ?? 0);
+  const [totalPlaceables, setTotalPlaceables] = useState(() => basesCache?.totalPlaceables ?? 0);
   const [loading, setLoading] = useState(() => basesCache === null);
   const [now, setNow] = useState(() => Date.now());
   const [exportingId, setExportingId] = useState("");
-  const refreshInFlight = useRef(false);
-  const filteredRows = useMemo(() => rows.filter((row) => matchesQuery(row, q)), [rows, q]);
-  const sort = useSortableRows(filteredRows);
+  const requestIdRef = useRef(0);
+  const skipNextSearchReset = useRef(true);
+  const sort = useSortableRows(rows);
 
   useEffect(() => {
-    if (basesCache) basesCache.q = q;
-  }, [q]);
+    if (skipNextSearchReset.current) {
+      skipNextSearchReset.current = false;
+      return;
+    }
+    setPage(0);
+  }, [submittedQ]);
 
-  const load = useCallback(async (options: { silent?: boolean } = {}) => {
-    if (refreshInFlight.current) return;
-    refreshInFlight.current = true;
+  function submitSearch() {
+    setSubmittedQ(q);
+  }
+
+  const load = useCallback(async (params: { q: string; page: number; pageSize: number }, options: { silent?: boolean } = {}) => {
+    const requestId = ++requestIdRef.current;
     if (!options.silent) onError("");
     try {
-      const result = await basesApi.list();
+      const result = await basesApi.list(params);
+      if (requestIdRef.current !== requestId) return;
       const nextRows = (result.rows || []).map(withCoordinates);
       setRows(nextRows);
-      basesCache = { ...basesCache, rows: nextRows, q: basesCache?.q ?? "", lastFetchedAt: Date.now() };
+      setTotalCount(result.totalCount || 0);
+      setTotalBases(result.totalBases || 0);
+      setTotalPieces(result.totalPieces || 0);
+      setTotalPlaceables(result.totalPlaceables || 0);
+      basesCache = {
+        q: params.q,
+        page: params.page,
+        pageSize: params.pageSize,
+        rows: nextRows,
+        totalCount: result.totalCount || 0,
+        totalBases: result.totalBases || 0,
+        totalPieces: result.totalPieces || 0,
+        totalPlaceables: result.totalPlaceables || 0,
+        lastFetchedAt: Date.now()
+      };
     } catch (error) {
-      if (!options.silent) onError(errorText(error));
+      if (requestIdRef.current === requestId && !options.silent) onError(errorText(error));
     } finally {
-      setLoading(false);
-      refreshInFlight.current = false;
+      if (requestIdRef.current === requestId) setLoading(false);
     }
   }, [onError]);
 
   useEffect(() => {
     let cancelled = false;
     let timeoutId: number | undefined;
+    const params = { q: submittedQ, page, pageSize };
+    const cacheHit = sameView(basesCache, submittedQ, page, pageSize) ? basesCache : null;
+    const isStale = () => !cacheHit || Date.now() - cacheHit.lastFetchedAt >= BASES_AUTO_REFRESH_MS;
 
-    const isStale = () => Date.now() - (basesCache?.lastFetchedAt ?? 0) >= BASES_AUTO_REFRESH_MS;
+    if (cacheHit) {
+      setRows(cacheHit.rows);
+      setTotalCount(cacheHit.totalCount);
+      setTotalBases(cacheHit.totalBases);
+      setTotalPieces(cacheHit.totalPieces);
+      setTotalPlaceables(cacheHit.totalPlaceables);
+      setLoading(false);
+    }
 
-    const refreshIfStale = async () => {
-      if (document.visibilityState === "hidden" || !isStale()) return;
-      await load({ silent: true });
-    };
-
-    const scheduleNext = () => {
+    const scheduleNext = (fromTime: number) => {
       if (cancelled) return;
       window.clearTimeout(timeoutId);
-      const last = basesCache?.lastFetchedAt ?? Date.now();
-      const dueIn = last + BASES_AUTO_REFRESH_MS - Date.now();
+      const dueIn = fromTime + BASES_AUTO_REFRESH_MS - Date.now();
       const delay = dueIn > 0 ? dueIn : BASES_AUTO_REFRESH_RETRY_MS;
-      timeoutId = window.setTimeout(() => { void runAndReschedule(refreshIfStale); }, delay);
+      timeoutId = window.setTimeout(() => { void tick(); }, delay);
     };
 
-    const runAndReschedule = async (fn: () => Promise<void>) => {
-      await fn();
-      if (!cancelled) scheduleNext();
+    const tick = async () => {
+      if (document.visibilityState !== "hidden") await load(params, { silent: true });
+      if (!cancelled) scheduleNext(basesCache?.lastFetchedAt ?? Date.now());
     };
 
-    void runAndReschedule(basesCache === null ? () => load() : refreshIfStale);
+    if (!cacheHit || isStale()) {
+      void load(params).then(() => { if (!cancelled) scheduleNext(Date.now()); });
+    } else {
+      scheduleNext(cacheHit.lastFetchedAt);
+    }
 
     const onVisibilityChange = () => {
-      if (document.visibilityState === "visible") void runAndReschedule(refreshIfStale);
+      if (document.visibilityState === "visible" && isStale()) {
+        void load(params, { silent: true }).then(() => { if (!cancelled) scheduleNext(Date.now()); });
+      }
     };
     document.addEventListener("visibilitychange", onVisibilityChange);
 
@@ -144,7 +191,7 @@ export function BasesPanel({ onError }: BasesPanelProps) {
       window.clearTimeout(timeoutId);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [load]);
+  }, [submittedQ, page, pageSize, load]);
 
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), BASES_RELATIVE_TIME_TICK_MS);
@@ -180,12 +227,17 @@ export function BasesPanel({ onError }: BasesPanelProps) {
     </section>;
   }
 
-  const totalBases = rows.length;
-  const totalPieces = rows.reduce((sum, row) => sum + Number(row.piece_count || 0), 0);
-  const totalPlaceables = rows.reduce((sum, row) => sum + Number(row.placeable_count || 0), 0);
   const lastFetchedAt = basesCache?.lastFetchedAt ?? null;
-  const filteredCount = filteredRows.length;
-  const rangeStart = filteredCount === 0 ? 0 : 1;
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const rangeStart = totalCount === 0 ? 0 : page * pageSize + 1;
+  const rangeEnd = totalCount === 0 ? 0 : rangeStart + rows.length - 1;
+  const hasPreviousPage = page > 0;
+  const hasNextPage = page + 1 < totalPages;
+
+  function changePageSize(nextSize: number) {
+    setPageSize(nextSize);
+    setPage(0);
+  }
 
   return (
     <section className="panel">
@@ -195,16 +247,41 @@ export function BasesPanel({ onError }: BasesPanelProps) {
           {lastFetchedAt !== null && (
             <span className="muted">Refreshed {formatRelativeTime(lastFetchedAt, now)}</span>
           )}
-          <button onClick={() => void load()}>Refresh</button>
+          <button onClick={() => void load({ q: submittedQ, page, pageSize })}>Refresh</button>
         </div>
       </div>
       <p className="action-help-note">
         Total Bases: {totalBases.toLocaleString()} · Total Building Pieces: {totalPieces.toLocaleString()} · Total Placeables: {totalPlaceables.toLocaleString()}
       </p>
-      <div className="action-row bases-search-row"><input value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search base or owner name" /></div>
-      <p className="action-help-note bases-row-count">
-        Showing {rangeStart}-{filteredCount} of {totalBases} rows.
-      </p>
+      <div className="action-row bases-search-row">
+        <input
+          value={q}
+          onChange={(event) => setQ(event.target.value)}
+          onKeyDown={(event) => { if (event.key === "Enter") submitSearch(); }}
+          placeholder="Search base or owner name"
+        />
+      </div>
+      <div className="panel-title bases-row-count">
+        <div className="action-row">
+          <button onClick={submitSearch}>Search</button>
+          <p className="action-help-note">
+            Showing {rangeStart}-{rangeEnd} of {totalCount} rows.
+          </p>
+        </div>
+        <div className="database-pagination-controls">
+          <label className="compact-select">
+            Rows
+            <select value={String(pageSize)} onChange={(event) => changePageSize(Number(event.target.value))}>
+              {BASES_PAGE_SIZES.map((size) => <option key={size} value={size}>{size}</option>)}
+            </select>
+          </label>
+          <button disabled={!hasPreviousPage} onClick={() => setPage(0)}>First</button>
+          <button disabled={!hasPreviousPage} onClick={() => setPage(page - 1)}>Previous</button>
+          <span className="muted database-page-indicator">Page {page + 1} of {totalPages}</span>
+          <button disabled={!hasNextPage} onClick={() => setPage(page + 1)}>Next</button>
+          <button disabled={!hasNextPage} onClick={() => setPage(totalPages - 1)}>Last</button>
+        </div>
+      </div>
       <DataTable
         rows={sort.sortedRows}
         columns={["base_id", "name", "owner_name", "shared_with", "map", "coordinates", "piece_count", "placeable_count"]}

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Download, Unlock } from "lucide-react";
+import { Download } from "lucide-react";
 import { basesApi } from "../../api/bases";
 import { apiDownload } from "../../api/client";
 import { DataTable, useSortableRows } from "../../components/common/DataTable";
@@ -97,7 +97,7 @@ export function BasesPanel({ onError }: BasesPanelProps) {
   const [totalPlaceables, setTotalPlaceables] = useState(() => basesCache?.totalPlaceables ?? 0);
   const [loading, setLoading] = useState(() => basesCache === null);
   const [now, setNow] = useState(() => Date.now());
-  const [exportingId, setExportingId] = useState("");
+  const [downloadingId, setDownloadingId] = useState("");
   const requestIdRef = useRef(0);
   const skipNextSearchReset = useRef(true);
   const sort = useSortableRows(rows);
@@ -112,6 +112,11 @@ export function BasesPanel({ onError }: BasesPanelProps) {
 
   function submitSearch() {
     setSubmittedQ(q);
+  }
+
+  function handleClearSearch() {
+    setQ("");
+    setSubmittedQ("");
   }
 
   const load = useCallback(async (params: { q: string; page: number; pageSize: number }, options: { silent?: boolean } = {}) => {
@@ -198,9 +203,9 @@ export function BasesPanel({ onError }: BasesPanelProps) {
     return () => window.clearInterval(id);
   }, []);
 
-  async function handleExport(row: BaseRow) {
+  async function handleDownloadBlueprint(row: BaseRow) {
     const id = String(row.base_id);
-    setExportingId(id);
+    setDownloadingId(id);
     try {
       const response = await apiDownload(`/api/bases/${encodeURIComponent(id)}/export`);
       const blob = await response.blob();
@@ -213,7 +218,7 @@ export function BasesPanel({ onError }: BasesPanelProps) {
     } catch (error) {
       onError(errorText(error));
     } finally {
-      setExportingId("");
+      setDownloadingId("");
     }
   }
 
@@ -264,6 +269,7 @@ export function BasesPanel({ onError }: BasesPanelProps) {
       <div className="panel-title bases-row-count">
         <div className="action-row">
           <button onClick={submitSearch}>Search</button>
+          <button onClick={handleClearSearch} disabled={!q && !submittedQ}>Clear</button>
           <p className="action-help-note">
             Showing {rangeStart}-{rangeEnd} of {totalCount} rows.
           </p>
@@ -292,8 +298,7 @@ export function BasesPanel({ onError }: BasesPanelProps) {
           const base = row as BaseRow;
           const id = String(base.base_id);
           return <span className="icon-toggle-group">
-            <button className="icon-toggle-button" title="Export base" aria-label="Export base" disabled={exportingId === id} onClick={(event) => { event.stopPropagation(); void handleExport(base); }}><Download size={16} /></button>
-            <button className="icon-toggle-button" title="Coming soon" aria-label="Release claim" disabled><Unlock size={16} /></button>
+            <button className="icon-toggle-button" title="Download Base as Blueprint" aria-label="Download Base as Blueprint" disabled={downloadingId === id} onClick={(event) => { event.stopPropagation(); void handleDownloadBlueprint(base); }}><Download size={16} /></button>
           </span>;
         }}
         sortColumn={sort.sortColumn}

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1678,6 +1678,25 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   overflow: hidden;
   text-overflow: ellipsis;
 }
+.bases-shared-list {
+  display: grid;
+  gap: 2px;
+  max-height: 4.2em;
+  overflow-wrap: anywhere;
+  overflow: hidden;
+  white-space: normal;
+  font-size: 11px;
+  line-height: 1.25;
+}
+.bases-shared-list span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.bases-shared-list em {
+  color: #ad9f89;
+  font-style: normal;
+}
 .inventory-augment-input-line {
   align-items: end;
   flex-wrap: nowrap;


### PR DESCRIPTION
## Summary

Add a new **Bases** tab under Arrakis Management to view and export player bases and their building pieces.

The new tab displays:
- Base ID, name, owner, and location (map + coordinates)
- Building piece and placeable object counts per base
- Search by base name or owner name
- One-click export to JSON for each base

## Changes

- **Backend** (`console/api/src/duneDb.js`): Added `listBases()` and `exportBase()` functions with proper owner resolution via rank-ordered LATERAL joins and distinct aggregate counts
- **Backend** (`console/api/src/server.js`): Added `/api/bases` and `/api/bases/:id/export` routes with CSRF protection
- **Frontend** (`console/web/src/features/bases/`): New `BasesPanel` component with search and export functionality
- **Tests** (`console/api/test/db.test.js`): Comprehensive test coverage for Bases queries including owner resolution and item counts

## Bug fixes (found in code review)

- Fixed non-deterministic `owner_entity_id` lookup in `exportBase`: now fetches and reuses the owner ID from the base identity query instead of re-deriving it with an unordered subquery
- Fixed owner name resolution in both `listBases` and `exportBase`: replaced `max(character_name)` aggregation with rank-ordered LATERAL subquery to consistently select the actual owner (lowest rank) rather than an arbitrary ranked member

## Testing

All backend tests pass (`node --test test/*.test.js`). Frontend tested in dev server with search, sort, and export functionality.

Refs: #85