### PR TITLE
feat: Specialization first-class tab, Vitest harness, Cloudflare deployment docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,109 @@
+# Roadmap — Dune Awakening Selfhost Docker
+
+## Planned
+
+### Specialization UI Refactor & Feature Expansion
+
+**Goal:** Move the existing Specializations UI out of Players → select player → Skills and into its own first-class tab next to Skills, while preserving all current behavior, improving safety, and adding regression tests.
+
+**Repository facts:**
+- Current frontend specialization logic lives inside `console/web/src/features/players/CharacterAdminUI.tsx`
+- Current client API calls live inside `console/web/src/api/players.ts`
+- Current backend route wiring lives inside `console/api/src/server.js`
+- Current backend delegates specialization calls to duneDb functions: `playerSpecs`, `addSpecializationXp`, `grantMaxSpecialization`, `resetSpecialization`, `grantAllSpecializationKeystones`, `resetAllSpecializationKeystones`
+- Current top tabs: Character, Crafting, Research, Skills, Journey, Blueprints, Admin
+- Current specialization is rendered as a nested toggle box: `playerAdmin_toggleBox("skills_specializations", "Specializations", ...)`
+- Current specialization features already implemented:
+  - load specialization rows from `/api/players/:id/specs`
+  - show trackType, xp, level
+  - add specialization XP per track
+  - grant max specialization per track
+  - reset specialization per track
+  - grant all keystones
+  - reset all keystones
+
+**Current issues to fix:**
+- specialization is not its own tab
+- offline-only writes are explained in text but not enforced in the UI
+- Grant All Keystones lacks confirmation
+- keystone state is not visible
+- specialization state is tightly coupled to Skills tab lifecycle
+- specialization lacks clear dedicated tests
+- keep security in scope throughout
+
+**Implementation requirements:**
+
+1. **Frontend extraction**
+   - Create a dedicated specialization module folder under `console/web/src/features/players/specialization/`
+   - Add at least: `SpecializationTab.tsx`, `SpecializationTable.tsx`, `SpecializationSummary.tsx`, `SpecializationRowActions.tsx`, `useSpecializationState.ts`, `types.ts`, `normalizers.ts`
+   - Keep code small, typed, and testable
+   - Refactor `CharacterAdminUI.tsx` so it adds a new top-level tab labeled "Specialization" immediately next to "Skills"
+   - Remove specialization rendering from the Skills tab after the new tab is wired and tested
+   - Preserve current action logging and inline result patterns where reasonable
+
+2. **UX and safety**
+   - Add hard UI disablement for specialization write actions when the player is online
+   - Show an inline explanatory banner when writes are disabled due to online state
+   - Add `confirmAction` for: Grant All Keystones, Reset All Keystones, Grant Max per track, Reset per track
+   - Convert the current shared global XP input into a row-local XP input per specialization row
+   - Keep reload behavior explicit and user-driven, with automatic reload after successful writes
+
+3. **Data model and API compatibility**
+   - Keep existing `playersApi` methods compatible
+   - If you extend `/api/players/:id/specs`, do so additively only
+   - Preserve existing fields: `rows`, `skillModules`, `capabilities`, `reason`
+   - Add a richer optional specialization summary object if needed
+   - Do not break old callers
+
+4. **Backend hardening**
+   - Ensure backend validation remains authoritative
+   - Do not rely on frontend confirmation strings as a security control
+   - Preserve route-level permission protections already in place
+   - Validate `trackType` and `amount` on the backend if not already strongly validated
+   - Ensure online/offline business rule is enforced server-side as well as in the UI
+
+5. **Testing**
+   Add automated tests for:
+   - frontend component rendering
+   - row-local XP actions
+   - disabled state when player is online
+   - confirmation flow for dangerous actions
+   - specialization load success / error states
+   - API route contract tests for all specialization endpoints
+   - backend validation tests for invalid `trackType` and invalid XP values
+   - backward compatibility tests for old `/specs` response shape
+   - regression test proving the new Specialization tab renders and the old nested Skills specialization UI is removed
+
+6. **Security**
+   At every relevant change, apply:
+   - least privilege
+   - explicit validation
+   - safe defaults
+   - clear operator confirmation for destructive actions
+   - no silent dangerous fallbacks
+   - no widening of API surface unless necessary
+
+7. **Deliverables**
+   - code changes
+   - tests
+   - brief migration notes in comments or a small markdown doc
+   - no placeholders
+   - no TODOs left behind
+
+**Coding style:**
+- TypeScript/React on the web side
+- follow existing project conventions
+- keep components composable
+- keep helper functions pure where possible
+- prefer explicit types over implicit any
+- preserve current behavior unless intentionally improved
+
+**Important:** Before editing, inspect current specialization logic in `CharacterAdminUI.tsx`, `players.ts`, and `server.js`. Then implement the extraction safely and incrementally.
+
+---
+
+## Completed
+
+- Discord adapter player inventory routes + linking + storage queries (PR #91)
+- Base page implementation (PR #89)
+- Alpine Linux support in install script (PR #25)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,93 +4,564 @@
 
 ### Specialization UI Refactor & Feature Expansion
 
-**Goal:** Move the existing Specializations UI out of Players → select player → Skills and into its own first-class tab next to Skills, while preserving all current behavior, improving safety, and adding regression tests.
+# Deep Research Report on Specialization in yacketrj/dune-awakening-selfhost-docker
 
-**Repository facts:**
-- Current frontend specialization logic lives inside `console/web/src/features/players/CharacterAdminUI.tsx`
-- Current client API calls live inside `console/web/src/api/players.ts`
-- Current backend route wiring lives inside `console/api/src/server.js`
-- Current backend delegates specialization calls to duneDb functions: `playerSpecs`, `addSpecializationXp`, `grantMaxSpecialization`, `resetSpecialization`, `grantAllSpecializationKeystones`, `resetAllSpecializationKeystones`
-- Current top tabs: Character, Crafting, Research, Skills, Journey, Blueprints, Admin
-- Current specialization is rendered as a nested toggle box: `playerAdmin_toggleBox("skills_specializations", "Specializations", ...)`
+## Executive summary
+
+The repository already contains a usable specialization feature, but it is not feature-complete as a standalone product area. In the current implementation, specialization is embedded inside the **Players → select player → Skills** tab as a collapsible block labeled **Specializations** rather than its own first-class tab. The frontend logic, UI rendering, state, and action handlers all live inside the large `console/web/src/features/players/CharacterAdminUI.tsx` module; the client API surface lives in `console/web/src/api/players.ts`; the HTTP routes are wired in `console/api/src/server.js`; and those routes delegate to `console/api/src/duneDb.js` entry points named `playerSpecs`, `addSpecializationXp`, `grantMaxSpecialization`, `resetSpecialization`, `grantAllSpecializationKeystones`, and `resetAllSpecializationKeystones`. 
+
+Functionally, the code supports loading specialization rows, showing track XP and level, adding XP to a track, granting max level for a track, resetting a track, and bulk granting or resetting all keystones. It also reuses the same `/specs` response to hydrate learned skill-module baseline state for the adjacent skill browser. That said, the current design has several notable gaps: specialization is tightly coupled to the Skills tab lifecycle, the UI does not enforce offline-only mutations despite explicitly warning that the player must be offline, high-impact keystone grant lacks a confirmation step, keystone status is not surfaced in the UI, capability/reason metadata from the API is effectively ignored, and there is no visible specialization-specific automated test coverage in the API test tree. 
+
+From a design and architecture perspective, the clearest improvement is to extract specialization into its own tab placed adjacent to **Skills**, backed by its own container component, its own state slice, explicit offline gating, stronger confirmations, better operator affordances, and dedicated tests. This report proposes that design in detail, with security treated as a cross-cutting concern rather than an afterthought. That emphasis is consistent with the repository's own warnings not to expose the Web UI to untrusted users and its active security issue tracking for Semgrep and Trivy findings. 
+
+## Current implementation map
+
+The frontend entry point is `console/web/src/features/players/CharacterAdminUI.tsx`. This file defines the player-admin top-level tabs, where the visible tab list currently includes `Character`, `Crafting`, `Research`, `Skills`, `Journey`, `Blueprints`, and `Admin`. There is no standalone `Specialization` tab in that list today. The same file also defines all specialization-related types, state, data-loading functions, mutation handlers, and the table UI. 
+
+Within the Skills tab, specialization is rendered via a generic toggle-box pattern:
+
+```tsx
+playerAdmin_toggleBox("skills_specializations", "Specializations", ...)
+```
+
+That proves specialization is currently a nested section inside Skills rather than a sibling tab. The Skills tab also couples specialization loading to the skill browser lifecycle through `playerAdmin_loadSpecializations()` and refresh effects that only run when `playerAdmin_activeTab === "Skills"`. 
+
+The client/API/backend layering is straightforward. The web client exposes `playersApi.specs`, `playersApi.addSpecializationXp`, `playersApi.grantMaxSpecialization`, `playersApi.resetSpecialization`, `playersApi.grantAllSpecializationKeystones`, and `playersApi.resetAllSpecializationKeystones` in `console/web/src/api/players.ts`. On the server side, `console/api/src/server.js` maps the corresponding HTTP paths to `duneDb` functions of the same names, plus `duneDb.playerSpecs` for reads. 
+
+### Exact files, functions, and UI components
+
+| File path | Role | Exact functions or structures | UI/component impact | Evidence |
+|---|---|---|---|---|
+| `console/web/src/features/players/CharacterAdminUI.tsx` | Frontend specialization container | `SpecializationTrackRow`, `LearnedSkillModuleRow`, `playerAdmin_loadSpecializations`, `playerAdmin_reloadSkills`, `playerAdmin_addSpecializationXp`, `playerAdmin_grantMaxSpecialization`, `playerAdmin_resetSpecialization`, `playerAdmin_grantAllKeystones`, `playerAdmin_resetAllKeystones` | Owns specialization state, loading, mutations, and render tree |  |
+| `console/web/src/features/players/CharacterAdminUI.tsx` | Frontend render | `playerAdmin_specializationTable`; `playerAdmin_toggleBox("skills_specializations", "Specializations", ...)`; top tabs array `playerAdmin_tabs` | Renders the visible specialization table inside the Skills tab |  |
+| `console/web/src/api/players.ts` | Web API client | `specs`, `addSpecializationXp`, `grantMaxSpecialization`, `resetSpecialization`, `grantAllSpecializationKeystones`, `resetAllSpecializationKeystones` | Defines exact browser-to-API calls used by the UI |  |
+| `console/api/src/server.js` | HTTP route wiring | Route handlers delegating to `duneDb.playerSpecs`, `duneDb.addSpecializationXp`, `duneDb.grantMaxSpecialization`, `duneDb.resetSpecialization`, `duneDb.grantAllSpecializationKeystones`, `duneDb.resetAllSpecializationKeystones` | Defines the public API surface used by specialization read/write operations |  |
+| `console/api/src/duneDb.js` | Database-layer entry points | `playerSpecs`, `addSpecializationXp`, `grantMaxSpecialization`, `resetSpecialization`, `grantAllSpecializationKeystones`, `resetAllSpecializationKeystones` | Actual database implementation target, visible via route wiring |  |
+| `console/web/src/features/players/PlayerCategoryIconRail.tsx` | Supporting future UI utility | `duneCategoryAssetKey` special-cases `"specializations"` to `"all_categories"` | Not currently the specialization screen itself, but relevant to a future distinct tab if reused for iconography or category chrome |  |
+
+### Current component relationship
+
+The present relationship is highly centralized around `CharacterAdminUI`, which makes the specialization feature work but also makes it harder to evolve independently. The diagram below reflects the current code structure and route wiring. 
+
+```mermaid
+graph TD
+    A[Players UI] --> B[CharacterAdminUI.tsx]
+    B --> C[Skills tab]
+    C --> D[Specializations toggle box]
+    D --> E[playerAdmin_specializationTable]
+    D --> F[Add XP / Grant Max / Reset]
+    D --> G[Grant All Keystones / Reset All Keystones]
+    B --> H[playersApi.specs]
+    B --> I[playersApi.addSpecializationXp]
+    B --> J[playersApi.grantMaxSpecialization]
+    B --> K[playersApi.resetSpecialization]
+    B --> L[playersApi.grantAllSpecializationKeystones]
+    B --> M[playersApi.resetAllSpecializationKeystones]
+    H --> N[/api/players/:id/specs]
+    I --> O[/api/players/:id/specializations/add-xp]
+    J --> P[/api/players/:id/specializations/grant-max]
+    K --> Q[/api/players/:id/specializations/reset]
+    L --> R[/api/players/:id/specializations/keystones/grant-all]
+    M --> S[/api/players/:id/specializations/keystones/reset-all]
+    N --> T[duneDb.playerSpecs]
+    O --> U[duneDb.addSpecializationXp]
+    P --> V[duneDb.grantMaxSpecialization]
+    Q --> W[duneDb.resetSpecialization]
+    R --> X[duneDb.grantAllSpecializationKeystones]
+    S --> Y[duneDb.resetAllSpecializationKeystones]
+```
+
+### Relevant code snippets
+
+A few very small code fragments capture the most important facts:
+
+```tsx
+{ label: "Skills", icon: Brain }
+```
+
+This confirms that the top navigation currently has **Skills** but not **Specialization**. 
+
+```tsx
+playerAdmin_toggleBox("skills_specializations", "Specializations", ...)
+```
+
+This confirms specialization is nested beneath Skills. 
+
+```ts
+playersApi.addSpecializationXp(playerId, { trackType, amount, confirmation: "ADD SPECIALIZATION XP" })
+```
+
+This captures the exact web-client call shape for the per-track XP action. 
+
+## Completeness assessment
+
+My conclusion is that specialization is **operationally useful but not feature-complete**. The key reason is not that the code is absent; it clearly exists and works for core operations. The issue is that specialization has been implemented as an embedded subsection of the Skills screen with limited visibility, incomplete operator safeguards, incomplete read-model richness, and limited evidence of automated regression protection. That is enough for an MVP admin feature, but not enough for a clean, independently maintainable subsystem. 
+
+### Implemented features
+
+The existing specialization feature does provide a meaningful set of capabilities. It loads specialization rows through `playersApi.specs`, maps each row into `trackType`, `xp`, and `level`, and also extracts `skillModules` from the same response to build the adjacent skill baseline state. That same screen renders a table with **Track**, **XP**, **Level**, **Add XP**, **Result**, and **Action** columns. Per track, the operator can add XP, grant max level, or reset the specialization; globally, the operator can grant all keystones or reset all keystones. The screen also supports reload, error presentation, and action-result messages. 
+
+The specialization view is also tied into the broader Skills workflow. When the Skills tab becomes active, the code loads both the skill catalog and specialization data; when the page regains focus or visibility, it refreshes specialization data if there are no unsaved skill changes; and after per-track specialization mutations or starter-skill restoration, it reloads specialization data again. That coupling is one reason the current UX feels coherent to operators, even though it also creates architectural entanglement. 
+
+The repository history also shows adjacent work that shaped the current Skills area. In the visible commit history for `CharacterAdminUI.tsx`, the file was touched by `Add starter skill restore action` at commit `450b39a` and by `feat(players): refine administration navigation and search` at commit `8fe6a3d`, both of which are relevant to how the current Skills-area workflow is organized. 
+
+### Missing features, bugs, and edge cases
+
+The table below lists the most material gaps I identified from the current code, with implementation complexity, affected modules, and suggested fixes. The "missing" label here includes design debt, UX gaps, test debt, and security-significant operator-safety issues.
+
+| Missing item or bug | Why it matters | Complexity | Affected modules | Suggested fix | Evidence |
+|---|---|---:|---|---|---|
+| No standalone Specialization tab | Specialization is buried under Skills, so navigation, lifecycle, and code ownership are coupled to unrelated skill editing | Medium | `CharacterAdminUI.tsx`, `players.ts`, routing state | Add a new top-level `Specialization` tab and extract logic into a dedicated container component |  |
+| Offline-only rule is not enforced in the UI | The UI text says the player must be offline, but buttons remain enabled unless pending or missing `dbPlayerId`, increasing operator error and reload churn | Low | `CharacterAdminUI.tsx` | Disable specialization mutation buttons when the player is online and show an inline reason; keep server-side enforcement authoritative |  |
+| Bulk keystone grant has no confirmation | `Grant All Keystones` is high impact but does not prompt for confirmation; reset-all does prompt | Low | `CharacterAdminUI.tsx` | Add `confirmAction` before grant-all, with player name and impact summary |  |
+| Keystone state is not visible | Operators can mutate keystones in bulk but cannot see current keystone status, causing blind admin operations | Medium | `CharacterAdminUI.tsx`, `players.ts`, `server.js`, `duneDb.js` | Expand the read model to return keystone status counts/details and render them in the new tab |  |
+| `/specs` response is down-mapped to only `trackType`, `xp`, and `level` | Any richer backend data returned by the API is discarded by the UI mapping, which blocks richer specialization views | Medium | `CharacterAdminUI.tsx`, `players.ts` | Introduce a typed specialization view model containing track metadata, keystone summary, unlockability, and last-updated status |  |
+| Shared XP input is global, not per-row | A single global XP amount applied across all rows makes accidental edits more likely in busy admin workflows | Low | `CharacterAdminUI.tsx` | Replace the shared input with row-local inputs or a row-local action menu with remembered last value |  |
+| Capability/reason metadata is effectively ignored in specialization UI | API types include `capabilities` and `reason`, but the specialization load path maps rows and errors only; unsupported environments are not explained proactively | Medium | `players.ts`, `CharacterAdminUI.tsx` | Surface capability and unsupported-reason banners before mutation attempts |  |
+| Keystone actions do not refresh specialization state after success | Per-track actions reload after write, but keystone bulk actions do not call `playerAdmin_loadSpecializations()`; UI consistency depends on manual reload or tab refresh | Low | `CharacterAdminUI.tsx` | After grant/reset all keystones, reload specialization data and any affected derived skill state |  |
+| No visible specialization-specific automated tests | The API test tree includes many tests, but none with specialization-related names are visible, increasing regression risk for extraction work | Medium | `console/api/test`, likely web test setup | Add route, permission, reducer/state, and UI interaction tests specifically for specialization |  |
+| Specialization remains embedded in a very large monolithic admin file | Large-file coupling slows safe change, encourages regressions, and makes security review harder | Medium | `CharacterAdminUI.tsx` | Split into focused components and hooks: `SpecializationTab`, `useSpecializationState`, `SpecializationTable`, `SpecializationActions` |  |
+
+### Overall completeness verdict
+
+If feature-complete means "does the operator have a minimal path to inspect and mutate specialization tracks," the answer is yes. If feature-complete means "does specialization have dedicated navigation, explicit safety controls, rich read-state, modular boundaries, and regression coverage befitting an admin subsystem," the answer is no. On that broader and more maintainable definition, specialization is **approximately MVP-complete but not product-complete**. 
+
+## Design document for a dedicated Specialization tab
+
+### Design objectives
+
+The design goal is to make Specialization a first-class player-admin area, positioned directly next to Skills in the top tab bar. That change should reduce operator confusion, shrink cognitive load inside the Skills screen, isolate state and data flows, and make future specialization features easier to add without destabilizing adjacent skill editing. It should also improve security and operator safety by making offline requirements explicit, disabling risky actions when state is unsafe, and putting confirmations where the current UI is permissive. Those goals align with the repository's own experimental-state warning and its admonition not to expose the Web UI to untrusted users. 
+
+### Current versus proposed UI structure
+
+| Aspect | Current | Proposed |
+|---|---|---|
+| Top-level navigation | `Skills` only; specialization nested under Skills | New `Specialization` tab inserted next to `Skills` |
+| Screen ownership | `CharacterAdminUI.tsx` monolith | `CharacterAdminUI` hosts tab only; dedicated `SpecializationTab` owns feature |
+| Data lifecycle | Loads only when active tab is `Skills` | Loads when active tab is `Specialization`; optional background refresh policy |
+| Offline handling | Informational text only | Hard UI disable for unsafe writes, with inline reason and confirmation requirements |
+| Keystone visibility | Bulk actions only, no state visibility | Keystone summary plus bulk actions; optional future per-track keystone detail |
+| XP action | Shared global amount input | Row-local XP input with remembered defaults |
+| Error/capability messaging | Generic reload/error behavior | Dedicated capability banner, unsupported-state banner, action-level result messaging |
+| Testability | Hard to isolate | Pure subcomponents, dedicated hooks, dedicated tests |
+
+The current structure is evidenced by the existing tabs array and nested specialization toggle; the proposed structure is the recommended redesign based on those constraints. 
+
+### Proposed component hierarchy
+
+The new hierarchy should make specialization modular without forcing a backend redesign first. The primary extraction is on the frontend. The backend can initially preserve the current endpoints and adapt later if the richer read model is added.
+
+```mermaid
+graph TD
+    A[CharacterAdminUI] --> B[TopTabBar]
+    A --> C[SkillsTab]
+    A --> D[SpecializationTab]
+
+    D --> E[SpecializationSummaryCard]
+    D --> F[SpecializationTable]
+    D --> G[KeystonePanel]
+    D --> H[SpecializationCapabilityBanner]
+    D --> I[ActionResultArea]
+
+    D --> J[useSpecializationState]
+    J --> K[playersApi.specs]
+    J --> L[playersApi.addSpecializationXp]
+    J --> M[playersApi.grantMaxSpecialization]
+    J --> N[playersApi.resetSpecialization]
+    J --> O[playersApi.grantAllSpecializationKeystones]
+    J --> P[playersApi.resetAllSpecializationKeystones]
+```
+
+### UI and UX wireframes
+
+#### Desktop wireframe
+
+```text
+┌──────────────────────────────────────────────────────────────────────┐
+│ Player: <name>                                                      │
+│ Tabs: Character | Crafting | Research | Skills | Specialization | … │
+├──────────────────────────────────────────────────────────────────────┤
+│ [Capability banner / Offline status banner]                         │
+│                                                                      │
+│  Specialization Summary                                              │
+│  • Tracks detected: 5                                                │
+│  • Total specialization XP: 123,456                                  │
+│  • Keystone state: 4/5 active                                        │
+│                                                                      │
+│  Bulk Actions                                                        │
+│  [Grant All Keystones] [Reset All Keystones] [Reload]                │
+│                                                                      │
+│  ┌────────────────────────────────────────────────────────────────┐   │
+│  │ Track        XP         Level   XP Input   Actions   Result    │   │
+│  │ Trooper      12,000     4       [1000]     [+XP]     Success   │   │
+│  │ Swordmaster  27,000     7       [1000]     [Max]     —         │   │
+│  │ Bene G.      0          0       [1000]     [Reset]   —         │   │
+│  └────────────────────────────────────────────────────────────────┘   │
+│                                                                      │
+│  Optional Details                                                    │
+│  [Show keystone / milestone detail]                                  │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+#### Tablet/mobile-leaning wireframe
+
+```text
+┌───────────────────────────────┐
+│ Player: <name>                │
+│ Tabs: Skills | Specialization │
+├───────────────────────────────┤
+│ Offline required for writes   │
+│ [Reload] [Bulk Actions ▼]     │
+├───────────────────────────────┤
+│ Track: Trooper                │
+│ XP: 12,000   Level: 4         │
+│ [1000] [+XP] [Max] [Reset]    │
+│ Result: Success               │
+├───────────────────────────────┤
+│ Track: Swordmaster            │
+│ XP: 27,000   Level: 7         │
+│ [1000] [+XP] [Max] [Reset]    │
+└───────────────────────────────┘
+```
+
+### State management and data flow
+
+Today the Skills tab owns both skill and specialization state, and the refresh effects are keyed to `playerAdmin_activeTab === "Skills"`. The proposed design should split those concerns. A small local hook such as `useSpecializationState` is sufficient; no global store is required unless the player-admin area is already moving toward centralized state for all tabs. The hook should own:
+
+- `tracks`
+- `keystoneSummary`
+- `loading`
+- `error`
+- `capabilities`
+- `reason`
+- `lastReloadAt`
+- `rowDraftXpByTrack`
+- `pendingActionByTrack`
+- `pendingBulkAction`
+
+This split allows the Skills tab to keep skill baseline and unsaved-change behavior, while the Specialization tab manages its own refresh, safety disablement, and optimistic or pessimistic updates. The specialization hook should remain pessimistic by default because these are admin mutations with possible backend rejection and offline-state constraints. The current code base already prefers explicit result messages and reload-after-mutation patterns, so the proposed design fits the established operational model. 
+
+The current and proposed data flow can be summarized like this. The current view is based on the existing client and route wiring; the proposed right-hand branch shows the same APIs behind a dedicated tab. 
+
+```mermaid
+flowchart TD
+    A[User enters Player screen] --> B[CharacterAdminUI]
+    B --> C{Active tab}
+
+    C -->|Current: Skills| D[Load skill catalog]
+    C -->|Current: Skills| E[Load specs + skillModules]
+    E --> F[Map rows to trackType/xp/level]
+    E --> G[Map skillModules to skill baseline]
+    F --> H[Render specialization table]
+    G --> I[Render skill browser]
+
+    C -->|Proposed: Specialization| J[useSpecializationState.load]
+    J --> K[GET /api/players/:id/specs]
+    K --> L[Normalize tracks, capabilities, reasons, keystone summary]
+    L --> M[Render specialization summary + table]
+
+    M --> N{User action}
+    N -->|Add XP| O[POST add-xp]
+    N -->|Grant Max| P[POST grant-max]
+    N -->|Reset| Q[POST reset]
+    N -->|Grant All Keystones| R[POST keystones/grant-all]
+    N -->|Reset All Keystones| S[POST keystones/reset-all]
+    O --> T[Reload specs]
+    P --> T
+    Q --> T
+    R --> T
+    S --> T
+```
+
+### API and database changes
+
+A first migration step can keep the current six specialization API calls exactly as they are. That minimizes backend churn and allows the frontend extraction to land quickly. However, the read endpoint should ideally evolve from a thin `/specs` adapter into a clearer specialization view-model response, still served from the same route for backward compatibility. Today the client type for `specs()` is a composite payload of `rows`, optional `skillModules`, `capabilities`, and optional `reason`. The UI then narrows that payload into only three visible track fields, which is why keystone state and richer capability UX never emerge. 
+
+A compatible evolution path is:
+
+```ts
+type PlayerSpecsResponseV2 = {
+  rows: Array<{
+    track_type: string
+    xp_amount: number
+    level: number
+    keystone_count?: number
+    keystone_unlocked?: boolean
+    max_level?: number
+  }>
+  skillModules?: Array<...>
+  capabilities: Record<string, unknown>
+  reason?: string
+  specializationSummary?: {
+    trackCount: number
+    totalXp: number
+    keystonesUnlocked: number
+    keystonesTotal: number
+  }
+}
+```
+
+That change preserves `rows`, `skillModules`, `capabilities`, and `reason`, which means the current client can continue to function while the new tab consumes the richer fields when present. Because the route already delegates through existing wrappers in `server.js`, the route surface need not expand unless later product requirements call for keystone-per-track endpoints. 
+
+### Migration plan and backward compatibility
+
+The safest sequence is incremental.
+
+| Phase | Change | Backward compatibility strategy |
+|---|---|---|
+| Phase A | Add new `Specialization` tab label and render a new container | Keep old nested specialization toggle under Skills behind a temporary internal flag |
+| Phase B | Extract specialization state and UI into dedicated components | Use existing `playersApi` endpoints unchanged |
+| Phase C | Add richer `/specs` response fields | Preserve legacy `rows` shape and optional `skillModules` |
+| Phase D | Remove nested toggle from Skills after burn-in | Leave route contracts unchanged; only frontend rendering changes |
+| Phase E | Add specialization-specific tests and telemetry | No user-facing API break |
+
+During burn-in, an internal feature flag such as `ENABLE_SPECIALIZATION_TAB` could render both experiences for maintainers only, or render the new tab while leaving the old toggle hidden behind a fallback. Because the repo is explicitly experimental and warns against exposing the console to untrusted users, this kind of staged rollout is appropriate and low-risk. 
+
+## Architecture and security document
+
+### Proposed module boundaries
+
+The specialization redesign should create a clean module slice rather than adding more logic to `CharacterAdminUI.tsx`. A good minimal target layout is:
+
+| Proposed file | Purpose |
+|---|---|
+| `console/web/src/features/players/specialization/SpecializationTab.tsx` | Container for tab-level rendering and lifecycle |
+| `console/web/src/features/players/specialization/SpecializationSummary.tsx` | Summary metrics and keystone overview |
+| `console/web/src/features/players/specialization/SpecializationTable.tsx` | Row table and row-local actions |
+| `console/web/src/features/players/specialization/SpecializationRowActions.tsx` | Add XP / Max / Reset controls with confirmations |
+| `console/web/src/features/players/specialization/useSpecializationState.ts` | Data hook for loads, reloads, and mutations |
+| `console/web/src/features/players/specialization/types.ts` | Track, summary, mutation, and capability types |
+| `console/web/src/features/players/specialization/normalizers.ts` | API response normalization and guard helpers |
+| `console/api/test/specialization-routes.test.js` | HTTP and permission route tests |
+| `console/api/test/specialization-db.test.js` | Database-layer contract tests |
+| `console/web/src/features/players/specialization/*.test.tsx` | UI interaction and state tests |
+
+This architecture directly reduces the blast radius of changes that are currently concentrated in `CharacterAdminUI.tsx`. That matters because the file already owns multiple unrelated player-admin domains, including crafting, research, journey, inventory, vehicle operations, and admin actions. 
+
+### Interfaces and data models
+
+The frontend should stop treating specialization as a mere array of rows and instead use explicit models.
+
+```ts
+type SpecializationTrack = {
+  trackType: string
+  xp: number
+  level: number
+  maxLevel?: number
+  keystoneUnlocked?: boolean
+  keystoneCount?: number
+  writable: boolean
+}
+
+type SpecializationSummary = {
+  trackCount: number
+  totalXp: number
+  keystonesUnlocked: number
+  keystonesTotal: number
+  offlineRequired: boolean
+}
+
+type SpecializationCapabilities = {
+  canRead: boolean
+  canMutate: boolean
+  canGrantKeystones: boolean
+  canResetKeystones: boolean
+  reason?: string
+}
+```
+
+Using these models makes the UI safer. It lets the screen render `writable: false` when the player is online or when capability metadata denies an operation, rather than relying on ad hoc button expressions. It also makes security review easier because the allowable state transitions become explicit in one place instead of being scattered across inline JSX and free-form mutation calls. The need for this is visible today because specialization writes are guarded only by `!dbPlayerId || playerAdmin_actionResult?.pending` at the button level, while the user-facing copy says the player must be offline. 
+
+### Deployment impact
+
+The frontend-only extraction is low deployment risk. It preserves route shapes, does not require DB migrations, and should ship in the same web bundle path already used by the player-admin panel. The backend payload extension for `/specs` is also low-to-medium risk if it is additive and leaves the current `rows` and `skillModules` intact. Docker, runtime orchestration, and environment assumptions do not need to change for this feature. That conclusion is consistent with the README description of the system as a browser admin panel layered over self-hosted server operations, and with the modular `console/api` / `console/web` split already in place after the `3e9b181` refactor. 
+
+### Testing strategy
+
+The current visible API test tree is extensive, but it does not show specialization-specific tests by filename. That means the extraction should intentionally add them rather than assuming related player tests will cover the feature. 
+
+The recommended test matrix is:
+
+| Test layer | What to test |
+|---|---|
+| Unit: normalizers | `rows` and `skillModules` parsing, capability fallback, malformed row handling |
+| Unit: reducers/hook | load success, load failure, button-disable state, pending-action transitions |
+| Component: table | row rendering, row-local XP input behavior, offline disablement, result messages |
+| Component: bulk actions | confirmation modals for grant/reset all keystones |
+| Integration: web client | `playersApi` contract for all specialization endpoints |
+| API route tests | permissions, unsupported capability handling, 4xx validation for bad `trackType` / amount |
+| DB/service tests | mutation behavior, idempotence where appropriate, keystone summary correctness |
+| Security tests | online/offline enforcement, unauthorized access rejection, confirmation-as-UX-not-auth guard posture |
+
+### Security considerations
+
+Security should guide the redesign from the first commit. The repository already treats security as an active concern: the README warns not to expose the Web UI to untrusted users, to keep internal admin ports private, and the issue tracker shows open vulnerability and scan-tracking items such as issue `#67` (Trivy), issue `#41` (Semgrep), and other security-labeled findings. 
+
+Within specialization specifically, the most important security and safety principles are these:
+
+First, **server-side authorization must remain authoritative**. The frontend currently sends constant confirmation strings like `"ADD SPECIALIZATION XP"` and `"GRANT MAX SPECIALIZATION"` through `playersApi`, but those strings are operator UX aids, not a meaningful security boundary. The server routes already delegate through centralized wrappers in `server.js`, and that pattern should remain the real enforcement point. 
+
+Second, **offline-only constraints should be enforced twice**: once in the UI to prevent accidental writes, and again on the backend to prevent stale, scripted, or malicious requests from bypassing the UI. The current screen communicates the offline requirement in text yet still leaves action buttons enabled, which is a classic operator-safety gap. 
+
+Third, **dangerous mutations need confirmation and auditability**. Reset actions already ask for confirmation in some cases; bulk keystone grant should do the same. All specialization writes should also keep using the existing action log patterns already present in `CharacterAdminUI`, because reliable operator audit trails are a security control in admin consoles, not merely a UX nicety. 
+
+Fourth, **inputs should be validated and constrained**. `trackType` should come from a current-server allowlist derived from `/specs` or from backend validation, XP amount should be numeric and within sane bounds, and per-row draft inputs should be cleared or namespaced by player ID so stale values cannot bleed between selected players. The current code already resets some skill state on `actionPlayerId` change; the new specialization slice should do the analogous thing for all draft specialization inputs. 
+
+## Implementation timeline and Qwen prompt
+
+### Delivery timeline
+
+The implementation can be done safely in about two engineering weeks of focused work, with testing and security review built into each stage rather than deferred to the end.
+
+```mermaid
+gantt
+    title Specialization Tab Extraction Timeline
+    dateFormat  YYYY-MM-DD
+    axisFormat  %b %d
+
+    section Discovery and contracts
+    Audit current specialization paths           :a1, 2026-07-21, 2d
+    Define new frontend types and hook API       :a2, after a1, 1d
+    Specify additive /specs response contract    :a3, after a1, 1d
+
+    section Frontend extraction
+    Create SpecializationTab module              :b1, after a2, 2d
+    Move row table and bulk actions              :b2, after b1, 2d
+    Add offline gating and confirmations         :b3, after b2, 1d
+
+    section Backend and contracts
+    Add richer specialization summary fields     :c1, after a3, 2d
+    Add route and DB contract tests              :c2, after c1, 2d
+
+    section Integration and hardening
+    Wire top-level tab + remove nested coupling  :d1, after b3, 1d
+    Add UI tests and regression coverage         :d2, after d1, 2d
+    Security review and cleanup                  :d3, after c2, 1d
+
+    section Release
+    Burn-in with temporary fallback              :e1, after d2, 2d
+    Remove old nested specialization toggle      :e2, after e1, 1d
+```
+
+### Ready-to-use Qwen3.6 prompt
+
+```text
+You are implementing a refactor and feature expansion in the repository yacketrj/dune-awakening-selfhost-docker.
+
+Goal:
+Move the existing Specializations UI out of Players -> select player -> Skills and into its own first-class tab next to Skills, while preserving all current behavior, improving safety, and adding regression tests.
+
+Repository facts you must respect:
+- Current frontend specialization logic lives inside:
+  - console/web/src/features/players/CharacterAdminUI.tsx
+- Current client API calls live inside:
+  - console/web/src/api/players.ts
+- Current backend route wiring lives inside:
+  - console/api/src/server.js
+- Current backend delegates specialization calls to duneDb functions:
+  - playerSpecs
+  - addSpecializationXp
+  - grantMaxSpecialization
+  - resetSpecialization
+  - grantAllSpecializationKeystones
+  - resetAllSpecializationKeystones
+- Current top tabs include:
+  - Character, Crafting, Research, Skills, Journey, Blueprints, Admin
+- Current specialization is rendered as a nested toggle box:
+  - playerAdmin_toggleBox("skills_specializations", "Specializations", ...)
 - Current specialization features already implemented:
-  - load specialization rows from `/api/players/:id/specs`
+  - load specialization rows from /api/players/:id/specs
   - show trackType, xp, level
   - add specialization XP per track
   - grant max specialization per track
   - reset specialization per track
   - grant all keystones
   - reset all keystones
+- Current issues to fix:
+  - specialization is not its own tab
+  - offline-only writes are explained in text but not enforced in the UI
+  - Grant All Keystones lacks confirmation
+  - keystone state is not visible
+  - specialization state is tightly coupled to Skills tab lifecycle
+  - specialization lacks clear dedicated tests
+  - keep security in scope throughout
 
-**Current issues to fix:**
-- specialization is not its own tab
-- offline-only writes are explained in text but not enforced in the UI
-- Grant All Keystones lacks confirmation
-- keystone state is not visible
-- specialization state is tightly coupled to Skills tab lifecycle
-- specialization lacks clear dedicated tests
-- keep security in scope throughout
+Implementation requirements:
+1. Frontend extraction
+- Create a dedicated specialization module folder under:
+  console/web/src/features/players/specialization/
+- Add at least:
+  - SpecializationTab.tsx
+  - SpecializationTable.tsx
+  - SpecializationSummary.tsx
+  - SpecializationRowActions.tsx
+  - useSpecializationState.ts
+  - types.ts
+  - normalizers.ts
+- Keep code small, typed, and testable.
+- Refactor CharacterAdminUI.tsx so it adds a new top-level tab labeled "Specialization" immediately next to "Skills".
+- Remove specialization rendering from the Skills tab after the new tab is wired and tested.
+- Preserve current action logging and inline result patterns where reasonable.
 
-**Implementation requirements:**
+2. UX and safety
+- Add hard UI disablement for specialization write actions when the player is online.
+- Show an inline explanatory banner when writes are disabled due to online state.
+- Add confirmAction for:
+  - Grant All Keystones
+  - Reset All Keystones
+  - Grant Max per track
+  - Reset per track
+- Convert the current shared global XP input into a row-local XP input per specialization row.
+- Keep reload behavior explicit and user-driven, with automatic reload after successful writes.
 
-1. **Frontend extraction**
-   - Create a dedicated specialization module folder under `console/web/src/features/players/specialization/`
-   - Add at least: `SpecializationTab.tsx`, `SpecializationTable.tsx`, `SpecializationSummary.tsx`, `SpecializationRowActions.tsx`, `useSpecializationState.ts`, `types.ts`, `normalizers.ts`
-   - Keep code small, typed, and testable
-   - Refactor `CharacterAdminUI.tsx` so it adds a new top-level tab labeled "Specialization" immediately next to "Skills"
-   - Remove specialization rendering from the Skills tab after the new tab is wired and tested
-   - Preserve current action logging and inline result patterns where reasonable
+3. Data model and API compatibility
+- Keep existing playersApi methods compatible.
+- If you extend /api/players/:id/specs, do so additively only.
+- Preserve existing fields:
+  - rows
+  - skillModules
+  - capabilities
+  - reason
+- Add a richer optional specialization summary object if needed.
+- Do not break old callers.
 
-2. **UX and safety**
-   - Add hard UI disablement for specialization write actions when the player is online
-   - Show an inline explanatory banner when writes are disabled due to online state
-   - Add `confirmAction` for: Grant All Keystones, Reset All Keystones, Grant Max per track, Reset per track
-   - Convert the current shared global XP input into a row-local XP input per specialization row
-   - Keep reload behavior explicit and user-driven, with automatic reload after successful writes
+4. Backend hardening
+- Ensure backend validation remains authoritative.
+- Do not rely on frontend confirmation strings as a security control.
+- Preserve route-level permission protections already in place.
+- Validate trackType and amount on the backend if not already strongly validated.
+- Ensure online/offline business rule is enforced server-side as well as in the UI.
 
-3. **Data model and API compatibility**
-   - Keep existing `playersApi` methods compatible
-   - If you extend `/api/players/:id/specs`, do so additively only
-   - Preserve existing fields: `rows`, `skillModules`, `capabilities`, `reason`
-   - Add a richer optional specialization summary object if needed
-   - Do not break old callers
+5. Testing
+Add automated tests for:
+- frontend component rendering
+- row-local XP actions
+- disabled state when player is online
+- confirmation flow for dangerous actions
+- specialization load success / error states
+- API route contract tests for all specialization endpoints
+- backend validation tests for invalid trackType and invalid XP values
+- backward compatibility tests for old /specs response shape
+- regression test proving the new Specialization tab renders and the old nested Skills specialization UI is removed
 
-4. **Backend hardening**
-   - Ensure backend validation remains authoritative
-   - Do not rely on frontend confirmation strings as a security control
-   - Preserve route-level permission protections already in place
-   - Validate `trackType` and `amount` on the backend if not already strongly validated
-   - Ensure online/offline business rule is enforced server-side as well as in the UI
+6. Security
+At every relevant change, apply:
+- least privilege
+- explicit validation
+- safe defaults
+- clear operator confirmation for destructive actions
+- no silent dangerous fallbacks
+- no widening of API surface unless necessary
 
-5. **Testing**
-   Add automated tests for:
-   - frontend component rendering
-   - row-local XP actions
-   - disabled state when player is online
-   - confirmation flow for dangerous actions
-   - specialization load success / error states
-   - API route contract tests for all specialization endpoints
-   - backend validation tests for invalid `trackType` and invalid XP values
-   - backward compatibility tests for old `/specs` response shape
-   - regression test proving the new Specialization tab renders and the old nested Skills specialization UI is removed
+7. Deliverables
+Produce:
+- code changes
+- tests
+- brief migration notes in comments or a small markdown doc
+- no placeholders
+- no TODOs left behind
 
-6. **Security**
-   At every relevant change, apply:
-   - least privilege
-   - explicit validation
-   - safe defaults
-   - clear operator confirmation for destructive actions
-   - no silent dangerous fallbacks
-   - no widening of API surface unless necessary
-
-7. **Deliverables**
-   - code changes
-   - tests
-   - brief migration notes in comments or a small markdown doc
-   - no placeholders
-   - no TODOs left behind
-
-**Coding style:**
+Coding style:
 - TypeScript/React on the web side
 - follow existing project conventions
 - keep components composable
@@ -98,12 +569,24 @@
 - prefer explicit types over implicit any
 - preserve current behavior unless intentionally improved
 
-**Important:** Before editing, inspect current specialization logic in `CharacterAdminUI.tsx`, `players.ts`, and `server.js`. Then implement the extraction safely and incrementally.
+Important:
+Before editing, inspect current specialization logic in CharacterAdminUI.tsx, players.ts, and server.js. Then implement the extraction safely and incrementally.
+```
 
----
+## Final deliverables checklist
 
-## Completed
+A complete implementation should be considered done only when all of the following are true:
 
-- Discord adapter player inventory routes + linking + storage queries (PR #91)
-- Base page implementation (PR #89)
-- Alpine Linux support in install script (PR #25)
+- [ ] A new **Specialization** top-level tab exists immediately next to **Skills**.
+- [ ] The old nested `skills_specializations` toggle is removed or fully retired after migration.
+- [ ] Specialization frontend logic no longer lives as a large inline block inside `CharacterAdminUI.tsx`.
+- [ ] Existing specialization mutations still work end-to-end through `playersApi` and `server.js`.
+- [ ] Offline-only writes are disabled in the UI when the player is online.
+- [ ] Dangerous specialization actions require confirmation.
+- [ ] Keystone state is visible in at least summary form.
+- [ ] `/specs` remains backward compatible.
+- [ ] Specialization-specific automated tests exist for frontend and backend.
+- [ ] Security review explicitly verifies authorization, validation, confirmation behavior, and safe defaults.
+- [ ] Documentation or migration notes explain the tab move and any additive response changes.
+
+Based on the repository state I inspected, that checklist is not yet satisfied today. The codebase already provides the core specialization actions, but the feature still needs modularization, safer operator ergonomics, richer state visibility, and dedicated tests before it should be considered complete.

--- a/console/web/package-lock.json
+++ b/console/web/package-lock.json
@@ -16,9 +16,299 @@
         "vite": "^8.0.16"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.16",
-        "@types/react-dom": "^19.2.3"
+        "@types/react-dom": "^19.2.3",
+        "@vitest/browser": "^4.1.10",
+        "@vitest/coverage-v8": "^4.1.10",
+        "jsdom": "^29.1.1",
+        "vitest": "^4.1.10"
       },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
+      "dev": true
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "engines": {
         "node": ">=20.19.0"
       }
@@ -51,6 +341,48 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
@@ -75,6 +407,12 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.3",
@@ -308,6 +646,87 @@
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+      "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
+      "dev": true,
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -316,6 +735,35 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "19.2.16",
@@ -359,11 +807,298 @@
         }
       }
     },
+    "node_modules/@vitest/browser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-4.1.10.tgz",
+      "integrity": "sha512-UDwuWGwXj646CBx/bQHOaJSX7np0I8JL/UKQYa1e4QrVHH8VdWtx8eaOuf8sy0ShwDgR6NjJAsp5eF6vjF6qng==",
+      "dev": true,
+      "dependencies": {
+        "@blazediff/core": "1.9.1",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pngjs": "^7.0.0",
+        "sirv": "^3.0.2",
+        "tinyrainbow": "^3.1.0",
+        "ws": "^8.19.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": "4.1.10"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.10.tgz",
+      "integrity": "sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==",
+      "dev": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.10",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.10",
+        "vitest": "4.1.10"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -371,6 +1106,49 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -400,6 +1178,131 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/lightningcss": {
@@ -639,12 +1542,90 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "0.468.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.468.0.tgz",
       "integrity": "sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/nanoid": {
@@ -664,6 +1645,37 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -678,6 +1690,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/postcss": {
@@ -707,6 +1728,30 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
@@ -724,6 +1769,35 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rolldown": {
@@ -758,10 +1832,54 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/sirv": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+      "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+      "dev": true,
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -769,6 +1887,63 @@
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinyglobby": {
@@ -784,6 +1959,66 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true
+    },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -802,6 +2037,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/vite": {
@@ -879,6 +2123,191 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     }
   }
 }

--- a/console/web/package.json
+++ b/console/web/package.json
@@ -9,7 +9,10 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "tsc -b && vite build",
-    "preview": "vite preview --host 0.0.0.0"
+    "preview": "vite preview --host 0.0.0.0",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@vitejs/plugin-react": "^6.0.2",
@@ -20,7 +23,13 @@
     "vite": "^8.0.16"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.16",
-    "@types/react-dom": "^19.2.3"
+    "@types/react-dom": "^19.2.3",
+    "@vitest/browser": "^4.1.10",
+    "@vitest/coverage-v8": "^4.1.10",
+    "jsdom": "^29.1.1",
+    "vitest": "^4.1.10"
   }
 }

--- a/console/web/src/features/players/CharacterAdminUI.tsx
+++ b/console/web/src/features/players/CharacterAdminUI.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { Brain, ChevronDown, ChevronUp, Hammer, Map as MapIcon, Microscope, ScrollText, ShieldCheck, UserRound } from "lucide-react";
+import { Brain, ChevronDown, ChevronUp, Hammer, Map as MapIcon, Microscope, ScrollText, ShieldCheck, Star, UserRound } from "lucide-react";
 import { adminApi } from "../../api/admin";
 import { playersApi } from "../../api/players";
 import type { Task } from "../../api/setup";
@@ -12,6 +12,7 @@ import { augmentLimitForItem, filterAugmentsForItem, formatAugmentOptions } from
 import { PlayerCategoryIconRail } from "./PlayerCategoryIconRail";
 import { PlayerDetailTab } from "./PlayerDetailTab";
 import { PlayerSummary } from "./PlayerSummary";
+import { SpecializationTab } from "./SpecializationTab";
 import { adminTaskFailureDetail, friendlyCraftingSource, friendlyInlineError, friendlyVehicleName, friendlyVehicleTemplateName, parseSkillModuleRows, parseVehicleCatalog, playerAdmin_bulkItemFailure, playerAdmin_friendlyFailure, playerAdmin_taskFailureMessage, titleCaseWords, vehicleSpawnDistanceLabel, vehicleSpawnOffsetUnits } from "./playerAdminUtils";
 import { BlueprintsPanel } from "../blueprints/BlueprintsPanel";
 
@@ -20,8 +21,6 @@ type ResearchItemRow = { itemKey: string; displayName: string; category: string;
 type SkillModuleCatalogRow = { skillModule: string; category: string; id: string; maxLevel: number };
 type SkillCard = { name: string; type: string; rank: string };
 type StarterSkillPreset = { label: string; modules: { id: string; level: number }[] };
-type SpecializationTrackRow = { trackType: string; xp: number; level: number };
-type LearnedSkillModuleRow = { module_id?: string; moduleId?: string; id?: string; skill_points_spent?: number; skillPointsSpent?: number; level?: number; rank?: number };
 type JourneyRow = { id: string; name: string; rawName: string; category: string; depth: number; parentId: string; dependency?: string; status: string; complete: boolean; revealed?: boolean; pendingReward?: boolean; tags?: number; state?: number | null };
 
 type ConfirmAction = (message: string, options?: { title?: string; confirmLabel?: string; cancelLabel?: string; danger?: boolean; details?: { label: string; value: string; tone?: "accent" | "success" | "danger" }[] }) => Promise<boolean>;
@@ -60,6 +59,7 @@ export function CharacterAdminUI({ detail, fallback, dbPlayerId, actionPlayerId,
     { label: "Crafting", icon: Hammer },
     { label: "Research", icon: Microscope },
     { label: "Skills", icon: Brain },
+    { label: "Specialization", icon: Star },
     { label: "Journey", icon: MapIcon },
     { label: "Blueprints", icon: ScrollText },
     { label: "Admin", icon: ShieldCheck }
@@ -108,10 +108,6 @@ export function CharacterAdminUI({ detail, fallback, dbPlayerId, actionPlayerId,
   const [playerAdmin_skillCatalogError, playerAdmin_setSkillCatalogError] = useState("");
   const [playerAdmin_skillBaseline, playerAdmin_setSkillBaseline] = useState<Record<string, number>>({});
   const [playerAdmin_skillChanges, playerAdmin_setSkillChanges] = useState<Record<string, number>>({});
-  const [playerAdmin_specializationRows, playerAdmin_setSpecializationRows] = useState<SpecializationTrackRow[]>([]);
-  const [playerAdmin_specializationLoading, playerAdmin_setSpecializationLoading] = useState(false);
-  const [playerAdmin_specializationError, playerAdmin_setSpecializationError] = useState("");
-  const [playerAdmin_specializationXpAmount, playerAdmin_setSpecializationXpAmount] = useState("1000");
   const [playerAdmin_journeyRows, playerAdmin_setJourneyRows] = useState<Record<string, JourneyRow[]>>({ story: [], contract: [], codex: [], tutorial: [] });
   const [playerAdmin_journeyLoading, playerAdmin_setJourneyLoading] = useState(false);
   const [playerAdmin_journeyError, playerAdmin_setJourneyError] = useState("");
@@ -391,111 +387,8 @@ export function CharacterAdminUI({ detail, fallback, dbPlayerId, actionPlayerId,
       playerAdmin_setSkillCatalogLoading(false);
     }
   }
-  async function playerAdmin_loadSpecializations() {
-    if (!dbPlayerId) return;
-    playerAdmin_setSpecializationLoading(true);
-    playerAdmin_setSpecializationError("");
-    try {
-      const response = await playersApi.specs(dbPlayerId);
-      playerAdmin_setSpecializationRows((response.rows || []).map((row) => ({
-        trackType: String(row.track_type || row.trackType || ""),
-        xp: Number(row.xp_amount ?? row.xp ?? 0),
-        level: Number(row.level ?? 0)
-      })).filter((row) => row.trackType));
-      const learnedRows = Array.isArray(response.skillModules) ? response.skillModules as LearnedSkillModuleRow[] : [];
-      playerAdmin_setSkillBaseline(Object.fromEntries(learnedRows.map((row) => {
-        const moduleId = String(row.module_id || row.moduleId || row.id || "");
-        const level = Number(row.level ?? row.rank ?? row.skill_points_spent ?? row.skillPointsSpent ?? 0);
-        return [moduleId, Math.max(0, level)];
-      }).filter(([moduleId, level]) => moduleId && Number(level) > 0)));
-      playerAdmin_setSkillChanges({});
-    } catch (error) {
-      playerAdmin_setSpecializationRows([]);
-      playerAdmin_setSpecializationError(friendlyInlineError(error));
-    } finally {
-      playerAdmin_setSpecializationLoading(false);
-    }
-  }
   async function playerAdmin_reloadSkills() {
-    await Promise.all([
-      playerAdmin_loadSkillCatalog(),
-      playerAdmin_loadSpecializations()
-    ]);
-  }
-  async function playerAdmin_addSpecializationXp(trackType: string) {
-    const amount = Number(playerAdmin_specializationXpAmount) || 0;
-    if (!amount) {
-      playerAdmin_showResult(`spec_${trackType}`, "Enter an XP amount first.", "danger");
-      return;
-    }
-    onError("");
-      playerAdmin_showResult(`spec_${trackType}`, "Updating XP", "neutral", true);
-    try {
-      await playersApi.addSpecializationXp(dbPlayerId, { trackType, amount, confirmation: "ADD SPECIALIZATION XP" });
-      playerAdmin_showResult(`spec_${trackType}`, "XP updated. Relog required.", "success");
-      playerAdmin_addLog("Add Specialization XP", trackType, String(amount), "Succeeded");
-      await playerAdmin_loadSpecializations();
-    } catch (error) {
-      const message = friendlyInlineError(error);
-      playerAdmin_showResult(`spec_${trackType}`, message, "danger");
-      playerAdmin_addLog("Add Specialization XP", trackType, String(amount), `Failed: ${message}`);
-    }
-  }
-  async function playerAdmin_grantMaxSpecialization(trackType: string) {
-    onError("");
-    playerAdmin_showResult(`spec_${trackType}`, "Granting max level", "neutral", true);
-    try {
-      await playersApi.grantMaxSpecialization(dbPlayerId, { trackType, confirmation: "GRANT MAX SPECIALIZATION" });
-      playerAdmin_showResult(`spec_${trackType}`, "Max level granted. Relog required.", "success");
-      playerAdmin_addLog("Grant Max Specialization", trackType, "1", "Succeeded");
-      await playerAdmin_loadSpecializations();
-    } catch (error) {
-      const message = friendlyInlineError(error);
-      playerAdmin_showResult(`spec_${trackType}`, message, "danger");
-      playerAdmin_addLog("Grant Max Specialization", trackType, "1", `Failed: ${message}`);
-    }
-  }
-  async function playerAdmin_resetSpecialization(trackType: string) {
-    if (!(await confirmAction(`Reset ${trackType} specialization for ${playerName}?`))) return;
-    onError("");
-    playerAdmin_showResult(`spec_${trackType}`, "Resetting track", "neutral", true);
-    try {
-      await playersApi.resetSpecialization(dbPlayerId, { trackType, confirmation: "RESET SPECIALIZATION" });
-      playerAdmin_showResult(`spec_${trackType}`, "Track reset. Relog required.", "success");
-      playerAdmin_addLog("Reset Specialization", trackType, "1", "Succeeded");
-      await playerAdmin_loadSpecializations();
-    } catch (error) {
-      const message = friendlyInlineError(error);
-      playerAdmin_showResult(`spec_${trackType}`, message, "danger");
-      playerAdmin_addLog("Reset Specialization", trackType, "1", `Failed: ${message}`);
-    }
-  }
-  async function playerAdmin_grantAllKeystones() {
-    onError("");
-    playerAdmin_showResult("specKeystones", "Granting keystones", "neutral", true);
-    try {
-      await playersApi.grantAllSpecializationKeystones(dbPlayerId, "GRANT ALL KEYSTONES");
-      playerAdmin_showResult("specKeystones", "Keystones granted. Relog required.", "success");
-      playerAdmin_addLog("Grant All Keystones", playerName, "1", "Succeeded");
-    } catch (error) {
-      const message = friendlyInlineError(error);
-      playerAdmin_showResult("specKeystones", message, "danger");
-      playerAdmin_addLog("Grant All Keystones", playerName, "1", `Failed: ${message}`);
-    }
-  }
-  async function playerAdmin_resetAllKeystones() {
-    if (!(await confirmAction(`Reset all specialization keystones for ${playerName}?`))) return;
-    onError("");
-    playerAdmin_showResult("specKeystones", "Resetting keystones", "neutral", true);
-    try {
-      await playersApi.resetAllSpecializationKeystones(dbPlayerId, "RESET ALL KEYSTONES");
-      playerAdmin_showResult("specKeystones", "Keystones reset. Relog required.", "success");
-      playerAdmin_addLog("Reset All Keystones", playerName, "1", "Succeeded");
-    } catch (error) {
-      const message = friendlyInlineError(error);
-      playerAdmin_showResult("specKeystones", message, "danger");
-      playerAdmin_addLog("Reset All Keystones", playerName, "1", `Failed: ${message}`);
-    }
+    await playerAdmin_loadSkillCatalog();
   }
   function playerAdmin_skillKey(school: string, name: string) {
     return `${normalizeSkillSchool(school)}:${normalizeSkillName(name)}`;
@@ -685,21 +578,18 @@ export function CharacterAdminUI({ detail, fallback, dbPlayerId, actionPlayerId,
     if (playerAdmin_activeTab === "Research") void playerAdmin_loadResearchItems();
   }, [playerAdmin_activeTab, dbPlayerId]);
   useEffect(() => {
-    if (playerAdmin_activeTab === "Skills") {
-      void playerAdmin_loadSkillCatalog();
-      void playerAdmin_loadSpecializations();
-    }
+    if (playerAdmin_activeTab === "Skills") void playerAdmin_loadSkillCatalog();
   }, [playerAdmin_activeTab, dbPlayerId]);
   useEffect(() => {
     if (playerAdmin_activeTab !== "Skills" || !dbPlayerId) return;
     const refreshVisibleSkills = () => {
       if (document.visibilityState === "visible" && playerAdmin_skillChangeCount === 0) {
-        void playerAdmin_loadSpecializations();
+        void playerAdmin_loadSkillCatalog();
       }
     };
     const refreshFocusedSkills = () => {
       if (playerAdmin_skillChangeCount === 0) {
-        void playerAdmin_loadSpecializations();
+        void playerAdmin_loadSkillCatalog();
       }
     };
     document.addEventListener("visibilitychange", refreshVisibleSkills);
@@ -760,47 +650,6 @@ export function CharacterAdminUI({ detail, fallback, dbPlayerId, actionPlayerId,
         <code>{module?.id || "Module ID not found"}</code>
       </article>;
     })}</div>
-  );
-  const playerAdmin_specializationTable = (
-    <div className="playerAdmin_tableWrap playerAdmin_specializationTableWrap">
-      <table className="playerAdmin_table playerAdmin_specializationTable">
-        <colgroup>
-          <col className="playerAdmin_specTrackCol" />
-          <col className="playerAdmin_specXpCol" />
-          <col className="playerAdmin_specLevelCol" />
-          <col className="playerAdmin_specAddXpCol" />
-          <col className="playerAdmin_specResultCol" />
-          <col className="playerAdmin_specActionCol" />
-        </colgroup>
-        <thead>
-          <tr>
-            <th>Track</th>
-            <th>XP</th>
-            <th>Level</th>
-            <th>Add XP</th>
-            <th>Result</th>
-            <th>Action</th>
-          </tr>
-        </thead>
-        <tbody>
-          {playerAdmin_specializationRows.map((row) => (
-            <tr key={row.trackType}>
-              <td>{row.trackType}</td>
-              <td>{row.xp.toLocaleString()}</td>
-              <td>{row.level}</td>
-              <td><input className="playerAdmin_specXpInput" type="number" value={playerAdmin_specializationXpAmount} onChange={(event) => playerAdmin_setSpecializationXpAmount(event.target.value)} /></td>
-              <td className="playerAdmin_resultCell"><InlineActionResult result={playerAdmin_actionResult} resultKey={`spec_${row.trackType}`} /></td>
-              <td className="playerAdmin_actionCell">
-                <button disabled={!dbPlayerId || playerAdmin_actionResult?.pending} onClick={() => playerAdmin_addSpecializationXp(row.trackType)}>Add XP</button>
-                <button disabled={!dbPlayerId || playerAdmin_actionResult?.pending} onClick={() => playerAdmin_grantMaxSpecialization(row.trackType)}>Grant Max</button>
-                <button className="danger" disabled={!dbPlayerId || playerAdmin_actionResult?.pending} onClick={() => playerAdmin_resetSpecialization(row.trackType)}>Reset</button>
-              </td>
-            </tr>
-          ))}
-          {!playerAdmin_specializationRows.length && <tr><td colSpan={6}>{playerAdmin_specializationLoading ? "Loading specializations..." : "No specialization tracks were found."}</td></tr>}
-        </tbody>
-      </table>
-    </div>
   );
   const playerAdmin_actionRow = (playerAdmin_key: string, playerAdmin_label: React.ReactNode, playerAdmin_input: React.ReactNode, playerAdmin_buttonLabel: string, playerAdmin_onClick: () => void, playerAdmin_disabled = false, playerAdmin_note = "") => (
     <div className="playerAdmin_actionGroup">
@@ -947,7 +796,7 @@ export function CharacterAdminUI({ detail, fallback, dbPlayerId, actionPlayerId,
       }
       playerAdmin_showResult("starterSkills", `${playerAdmin_starterSkillPreset.label} restored for ${playerName}.`, "success");
       playerAdmin_addLog("Restore Starter Skills", playerAdmin_skillSchool, String(playerAdmin_starterSkillPreset.modules.length), "Succeeded");
-      await playerAdmin_loadSpecializations();
+      await playerAdmin_loadSkillCatalog();
     } catch (error) {
       const message = friendlyInlineError(error);
       playerAdmin_showResult("starterSkills", message, "danger");
@@ -1221,7 +1070,7 @@ export function CharacterAdminUI({ detail, fallback, dbPlayerId, actionPlayerId,
               <div className="playerAdmin_filterRow playerAdmin_filterRowRight">
                 <span className="playerAdmin_note">{playerAdmin_skillChangeCount} Unsaved Change{playerAdmin_skillChangeCount === 1 ? "" : "s"}</span>
                 <button disabled={!playerAdmin_canRunLiveAction || !playerAdmin_starterSkillPreset || playerAdmin_actionResult?.pending} onClick={() => playerAdmin_restoreStarterSkills()}>Restore Starter Skills</button>
-                <button disabled={playerAdmin_skillCatalogLoading || playerAdmin_specializationLoading} onClick={() => playerAdmin_reloadSkills()}>{playerAdmin_skillCatalogLoading || playerAdmin_specializationLoading ? "Loading..." : "Reload"}</button>
+                <button disabled={playerAdmin_skillCatalogLoading} onClick={() => playerAdmin_reloadSkills()}>{playerAdmin_skillCatalogLoading ? "Loading..." : "Reload"}</button>
                 <InlineActionResult result={playerAdmin_actionResult} resultKey="starterSkills" />
               </div>
             </div>
@@ -1238,19 +1087,24 @@ export function CharacterAdminUI({ detail, fallback, dbPlayerId, actionPlayerId,
             {playerAdmin_skillCatalogError && <p className="playerAdmin_note danger">{playerAdmin_skillCatalogError}</p>}
             {playerAdmin_skillSchool && <div className="playerAdmin_section"><h5>{playerAdmin_skillSchool}</h5>{playerAdmin_skillTrees[playerAdmin_skillSchool].map((playerAdmin_tree) => playerAdmin_toggleBox(`skill_${playerAdmin_skillSchool}_${playerAdmin_tree.tree}`, playerAdmin_tree.tree, playerAdmin_tree.cards.length ? playerAdmin_skillCards(playerAdmin_skillSchool, playerAdmin_tree.cards) : <p>Leave empty for now.</p>))}{playerAdmin_skillChangeCount > 0 && <div className="playerAdmin_saveBar"><button disabled={!playerAdmin_canRunLiveAction || playerAdmin_actionResult?.pending} onClick={() => playerAdmin_saveSkillChanges()}>Save</button><button disabled={playerAdmin_actionResult?.pending} onClick={() => playerAdmin_discardSkillChanges()}>Discard</button><InlineActionResult result={playerAdmin_actionResult} resultKey="skillSave" /></div>}</div>}
           </section>
-          {playerAdmin_toggleBox("skills_specializations", "Specializations", <div className="playerAdmin_section">
-            <div className="playerAdmin_boxHeaderLine">
-              <p>The player must be offline.</p>
-              <div className="playerAdmin_filterRow playerAdmin_filterRowRight">
-                <button disabled={!dbPlayerId || playerAdmin_specializationLoading} onClick={() => playerAdmin_loadSpecializations()}>{playerAdmin_specializationLoading ? "Loading..." : "Reload"}</button>
-                <button disabled={!dbPlayerId || playerAdmin_actionResult?.pending} onClick={() => playerAdmin_grantAllKeystones()}>Grant All Keystones</button>
-                <button className="danger" disabled={!dbPlayerId || playerAdmin_actionResult?.pending} onClick={() => playerAdmin_resetAllKeystones()}>Reset All Keystones</button>
-                <InlineActionResult result={playerAdmin_actionResult} resultKey="specKeystones" />
-              </div>
-            </div>
-            {playerAdmin_specializationError && <p className="playerAdmin_note danger">{playerAdmin_specializationError}</p>}
-            {playerAdmin_specializationTable}
-          </div>)}
+        </div>
+      )}
+      {playerAdmin_activeTab === "Specialization" && (
+        <div className="playerAdmin_content">
+          <SpecializationTab
+            dbPlayerId={dbPlayerId}
+            actionPlayerId={actionPlayerId}
+            playerName={playerName}
+            isOnline={playerAdmin_isOnline}
+            onError={onError}
+            confirmAction={confirmAction}
+            onSkillBaselineChange={(baseline) => {
+              playerAdmin_setSkillBaseline(baseline);
+              playerAdmin_setSkillChanges({});
+            }}
+            waitForTask={waitForTask}
+            formatMutationResult={formatMutationResult}
+          />
         </div>
       )}
       {playerAdmin_activeTab === "Journey" && <div className="playerAdmin_content"><section className="playerAdmin_box"><h4>Journey Browser</h4><div className="playerAdmin_boxHeaderLine playerAdmin_filterHeaderLine"><p>A relog is required to see the change.</p><div className="playerAdmin_filterToolsRow"><input className="playerAdmin_filterTextInput" value={playerAdmin_journeyFilter} onChange={(event) => playerAdmin_setJourneyFilter(event.target.value)} placeholder="Filter by name, ID, status, or dependency" aria-label="Filter Journey Browser" />{playerAdmin_journeyFilter && <button type="button" onClick={() => playerAdmin_setJourneyFilter("")}>Clear</button>}<span className="playerAdmin_note">{playerAdmin_journeyFilterTerms.length ? `${playerAdmin_filteredJourneyEntryCount} of ${playerAdmin_journeyEntryCount}` : playerAdmin_journeyEntryCount} Journey Entr{(playerAdmin_journeyFilterTerms.length ? playerAdmin_filteredJourneyEntryCount : playerAdmin_journeyEntryCount) === 1 ? "y" : "ies"} Detected</span></div></div>{playerAdmin_journeyError && <p className="playerAdmin_note danger">{playerAdmin_journeyError}</p>}{playerAdmin_toggleBox("journey_story", `Story (${playerAdmin_filteredJourneyRows.story.length}${playerAdmin_journeyFilterTerms.length ? `/${playerAdmin_journeyRows.story.length}` : ""})`, playerAdmin_journeyTable(playerAdmin_filteredJourneyRows.story, playerAdmin_journeyFilterTerms.length ? "No story entries match this filter." : "No story entries were found.", playerAdmin_journeySortStory, playerAdmin_journeyResizeStory))}{playerAdmin_toggleBox("journey_contract", `Contracts (${playerAdmin_filteredJourneyRows.contract.length}${playerAdmin_journeyFilterTerms.length ? `/${playerAdmin_journeyRows.contract.length}` : ""})`, playerAdmin_journeyTable(playerAdmin_filteredJourneyRows.contract, playerAdmin_journeyFilterTerms.length ? "No contract entries match this filter." : "No contract entries were found.", playerAdmin_journeySortContract, playerAdmin_journeyResizeContract))}{playerAdmin_toggleBox("journey_codex", `Codex (${playerAdmin_filteredJourneyRows.codex.length}${playerAdmin_journeyFilterTerms.length ? `/${playerAdmin_journeyRows.codex.length}` : ""})`, playerAdmin_journeyTable(playerAdmin_filteredJourneyRows.codex, playerAdmin_journeyFilterTerms.length ? "No codex entries match this filter." : "No codex entries were found.", playerAdmin_journeySortCodex, playerAdmin_journeyResizeCodex))}{playerAdmin_toggleBox("journey_tutorial", `Tutorial (${playerAdmin_filteredJourneyRows.tutorial.length}${playerAdmin_journeyFilterTerms.length ? `/${playerAdmin_journeyRows.tutorial.length}` : ""})`, playerAdmin_journeyTable(playerAdmin_filteredJourneyRows.tutorial, playerAdmin_journeyFilterTerms.length ? "No tutorial entries match this filter." : "No tutorial entries were found.", playerAdmin_journeySortTutorial, playerAdmin_journeyResizeTutorial))}</section></div>}

--- a/console/web/src/features/players/SpecializationTab.test.tsx
+++ b/console/web/src/features/players/SpecializationTab.test.tsx
@@ -36,7 +36,8 @@ const mockSpecsResponse = {
   ],
   skillModules: [
     { module_id: "Skills.Key.Trooper1", level: 2 }
-  ]
+  ],
+  capabilities: {}
 };
 
 beforeEach(() => {
@@ -47,7 +48,7 @@ beforeEach(() => {
 describe("SpecializationTab", () => {
   describe("rendering", () => {
     it("shows loading state when no data", async () => {
-      vi.mocked(playersApi.specs).mockResolvedValue({ rows: [], skillModules: [] });
+      vi.mocked(playersApi.specs).mockResolvedValue({ rows: [], skillModules: [], capabilities: {} });
       render(<SpecializationTab {...defaultProps} />);
       await waitFor(() => {
         expect(screen.getByText(/No specialization tracks were found/i)).toBeInTheDocument();
@@ -109,7 +110,7 @@ describe("SpecializationTab", () => {
         expect(screen.getByText("Trooper")).toBeInTheDocument();
       });
 
-      const addButtons = screen.getAllByText("Add XP");
+      const addButtons = screen.getAllByRole("button", { name: /Add XP to/i });
       expect(addButtons.length).toBeGreaterThan(0);
       addButtons.forEach((btn) => {
         expect(btn).toBeDisabled();
@@ -161,7 +162,7 @@ describe("SpecializationTab", () => {
         expect(screen.getByText("Trooper")).toBeInTheDocument();
       });
 
-      const addButtons = screen.getAllByText("Add XP");
+      const addButtons = screen.getAllByRole("button", { name: /Add XP to/i });
       await fireEvent.click(addButtons[0]);
 
       await waitFor(() => {
@@ -183,10 +184,12 @@ describe("SpecializationTab", () => {
       const xpInputs = screen.getAllByRole("spinbutton");
       await fireEvent.change(xpInputs[0], { target: { value: "" } });
 
-      const addButtons = screen.getAllByText("Add XP");
+      const addButtons = screen.getAllByRole("button", { name: /Add XP to/i });
       await fireEvent.click(addButtons[0]);
 
-      expect(screen.getByText(/Enter an XP amount first/i)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText(/Enter an XP amount first/i)).toBeInTheDocument();
+      });
     });
 
     it("shows error when player is online and Add XP is attempted", async () => {
@@ -343,7 +346,8 @@ describe("SpecializationTab", () => {
 
       vi.mocked(playersApi.specs).mockResolvedValue({
         rows: [{ track_type: "Bene Gesserit", xp_amount: 20000, level: 10 }],
-        skillModules: []
+        skillModules: [],
+        capabilities: {}
       });
 
       const reloadButton = screen.getByText("Reload").closest("button");

--- a/console/web/src/features/players/SpecializationTab.test.tsx
+++ b/console/web/src/features/players/SpecializationTab.test.tsx
@@ -1,0 +1,367 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { SpecializationTab } from "../players/SpecializationTab";
+import { playersApi } from "../../api/players";
+
+vi.mock("../../api/players", () => ({
+  playersApi: {
+    specs: vi.fn(),
+    addSpecializationXp: vi.fn(),
+    grantMaxSpecialization: vi.fn(),
+    resetSpecialization: vi.fn(),
+    grantAllSpecializationKeystones: vi.fn(),
+    resetAllSpecializationKeystones: vi.fn()
+  }
+}));
+
+const mockConfirmAction = vi.fn();
+const mockOnError = vi.fn();
+const mockOnSkillBaselineChange = vi.fn();
+
+const defaultProps = {
+  dbPlayerId: "player-123",
+  actionPlayerId: "action-456",
+  playerName: "TestPlayer",
+  isOnline: false,
+  onError: mockOnError,
+  confirmAction: mockConfirmAction,
+  onSkillBaselineChange: mockOnSkillBaselineChange
+};
+
+const mockSpecsResponse = {
+  rows: [
+    { track_type: "Trooper", xp_amount: 5000, level: 3 },
+    { track_type: "Mentat", xp_amount: 12000, level: 7 },
+    { track_type: "Planetologist", xp_amount: 0, level: 0 }
+  ],
+  skillModules: [
+    { module_id: "Skills.Key.Trooper1", level: 2 }
+  ]
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConfirmAction.mockResolvedValue(true);
+});
+
+describe("SpecializationTab", () => {
+  describe("rendering", () => {
+    it("shows loading state when no data", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue({ rows: [], skillModules: [] });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText(/No specialization tracks were found/i)).toBeInTheDocument();
+      });
+    });
+
+    it("renders specialization tracks from API", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+        expect(screen.getByText("Mentat")).toBeInTheDocument();
+        expect(screen.getByText("Planetologist")).toBeInTheDocument();
+      });
+    });
+
+    it("displays XP values formatted with locale", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("5,000")).toBeInTheDocument();
+        expect(screen.getByText("12,000")).toBeInTheDocument();
+      });
+    });
+
+    it("displays level badges", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("3")).toBeInTheDocument();
+        expect(screen.getByText("7")).toBeInTheDocument();
+      });
+    });
+
+    it("shows error message when API fails", async () => {
+      vi.mocked(playersApi.specs).mockRejectedValue(new Error("Database connection failed"));
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText(/Database connection failed/i)).toBeInTheDocument();
+      });
+    });
+
+    it("calls onSkillBaselineChange with parsed skill modules", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(mockOnSkillBaselineChange).toHaveBeenCalledWith({
+          "Skills.Key.Trooper1": 2
+        });
+      });
+    });
+  });
+
+  describe("offline gating", () => {
+    it("disables action buttons when player is online", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} isOnline={true} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const addButtons = screen.getAllByText("Add XP");
+      expect(addButtons.length).toBeGreaterThan(0);
+      addButtons.forEach((btn) => {
+        expect(btn).toBeDisabled();
+      });
+    });
+
+    it("disables Grant All Keystones button when player is online", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} isOnline={true} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const keystoneButton = screen.getByText("Grant All Keystones").closest("button");
+      expect(keystoneButton).toBeDisabled();
+    });
+
+    it("enables action buttons when player is offline", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} isOnline={false} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const addButtons = screen.getAllByText("Add XP");
+      const grantButtons = screen.getAllByText("Grant Max");
+      const resetButtons = screen.getAllByText("Reset");
+
+      [...addButtons, ...grantButtons, ...resetButtons].forEach((btn) => {
+        expect(btn).not.toBeDisabled();
+      });
+    });
+
+    it("shows offline notice in header", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText(/The player must be offline/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Add XP", () => {
+    it("calls addSpecializationXp with correct parameters", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.addSpecializationXp).mockResolvedValue({ supported: true });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const addButtons = screen.getAllByText("Add XP");
+      await fireEvent.click(addButtons[0]);
+
+      await waitFor(() => {
+        expect(playersApi.addSpecializationXp).toHaveBeenCalledWith("player-123", {
+          trackType: "Trooper",
+          amount: 1000,
+          confirmation: "ADD SPECIALIZATION XP"
+        });
+      });
+    });
+
+    it("shows error when XP amount is empty", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const xpInputs = screen.getAllByRole("spinbutton");
+      await fireEvent.change(xpInputs[0], { target: { value: "" } });
+
+      const addButtons = screen.getAllByText("Add XP");
+      await fireEvent.click(addButtons[0]);
+
+      expect(screen.getByText(/Enter an XP amount first/i)).toBeInTheDocument();
+    });
+
+    it("shows error when player is online and Add XP is attempted", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} isOnline={true} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const addButtons = screen.getAllByText("Add XP");
+      fireEvent.click(addButtons[0]);
+
+      await waitFor(() => {
+        expect(screen.getByText(/The player must be offline/i)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Grant Max", () => {
+    it("requests confirmation before granting", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.grantMaxSpecialization).mockResolvedValue({ supported: true });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const grantButtons = screen.getAllByText("Grant Max");
+      fireEvent.click(grantButtons[0]);
+
+      expect(mockConfirmAction).toHaveBeenCalledWith(
+        expect.stringContaining("Grant max level for Trooper"),
+        expect.objectContaining({ danger: true })
+      );
+    });
+
+    it("calls grantMaxSpecialization when confirmed", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.grantMaxSpecialization).mockResolvedValue({ supported: true });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const grantButtons = screen.getAllByText("Grant Max");
+      fireEvent.click(grantButtons[0]);
+
+      await waitFor(() => {
+        expect(playersApi.grantMaxSpecialization).toHaveBeenCalledWith("player-123", {
+          trackType: "Trooper",
+          confirmation: "GRANT MAX SPECIALIZATION"
+        });
+      });
+    });
+  });
+
+  describe("Reset", () => {
+    it("requests confirmation before resetting", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.resetSpecialization).mockResolvedValue({ supported: true });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const resetButtons = screen.getAllByText("Reset");
+      fireEvent.click(resetButtons[0]);
+
+      expect(mockConfirmAction).toHaveBeenCalledWith(
+        expect.stringContaining("Reset Trooper specialization"),
+        expect.objectContaining({ danger: true })
+      );
+    });
+
+    it("does not reset when confirmation is cancelled", async () => {
+      mockConfirmAction.mockResolvedValue(false);
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const resetButtons = screen.getAllByText("Reset");
+      fireEvent.click(resetButtons[0]);
+
+      expect(playersApi.resetSpecialization).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Grant All Keystones", () => {
+    it("requests confirmation before granting", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.grantAllSpecializationKeystones).mockResolvedValue({ supported: true });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Grant All Keystones")).toBeInTheDocument();
+      });
+
+      const keystoneButton = screen.getByText("Grant All Keystones").closest("button");
+      fireEvent.click(keystoneButton!);
+
+      expect(mockConfirmAction).toHaveBeenCalledWith(
+        expect.stringContaining("Grant all specialization keystones"),
+        expect.objectContaining({ danger: true })
+      );
+    });
+
+    it("calls grantAllSpecializationKeystones when confirmed", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.grantAllSpecializationKeystones).mockResolvedValue({ supported: true });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Grant All Keystones")).toBeInTheDocument();
+      });
+
+      const keystoneButton = screen.getByText("Grant All Keystones").closest("button");
+      fireEvent.click(keystoneButton!);
+
+      await waitFor(() => {
+        expect(playersApi.grantAllSpecializationKeystones).toHaveBeenCalledWith(
+          "player-123",
+          "GRANT ALL KEYSTONES"
+        );
+      });
+    });
+  });
+
+  describe("Reset All Keystones", () => {
+    it("requests confirmation before resetting", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.resetAllSpecializationKeystones).mockResolvedValue({ supported: true });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Reset All Keystones")).toBeInTheDocument();
+      });
+
+      const resetButton = screen.getByText("Reset All Keystones").closest("button");
+      fireEvent.click(resetButton!);
+
+      expect(mockConfirmAction).toHaveBeenCalledWith(
+        expect.stringContaining("Reset all specialization keystones"),
+        expect.objectContaining({ danger: true })
+      );
+    });
+  });
+
+  describe("Reload", () => {
+    it("calls specs API when Reload is clicked", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      vi.mocked(playersApi.specs).mockResolvedValue({
+        rows: [{ track_type: "Bene Gesserit", xp_amount: 20000, level: 10 }],
+        skillModules: []
+      });
+
+      const reloadButton = screen.getByText("Reload").closest("button");
+      fireEvent.click(reloadButton!);
+
+      await waitFor(() => {
+        expect(playersApi.specs).toHaveBeenCalledTimes(2);
+        expect(screen.getByText("Bene Gesserit")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("empty state", () => {
+    it("shows empty message when no dbPlayerId", async () => {
+      render(<SpecializationTab {...defaultProps} dbPlayerId="" />);
+      await waitFor(() => {
+        expect(screen.getByText(/No specialization tracks were found/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/console/web/src/features/players/SpecializationTab.tsx
+++ b/console/web/src/features/players/SpecializationTab.tsx
@@ -1,0 +1,349 @@
+import { useEffect, useRef, useState } from "react";
+import { KeyRound, RotateCcw, Shield, Trophy, Zap } from "lucide-react";
+import { playersApi } from "../../api/players";
+import type { Task } from "../../api/setup";
+import { InlineActionResult } from "../../components/common/InlineActionResult";
+import { formatCell } from "../../lib/display";
+
+type SpecializationTrackRow = { trackType: string; xp: number; level: number; keystone?: boolean };
+
+type ConfirmAction = (message: string, options?: { title?: string; confirmLabel?: string; cancelLabel?: string; danger?: boolean; details?: { label: string; value: string; tone?: "accent" | "success" | "danger" }[] }) => Promise<boolean>;
+
+type ActionResult = { key: string; tone: "success" | "danger" | "neutral"; text: string; pending?: boolean };
+
+type SpecializationTabProps = {
+  dbPlayerId: string;
+  actionPlayerId: string;
+  playerName: string;
+  isOnline: boolean;
+  onError: (text: string) => void;
+  confirmAction: ConfirmAction;
+  onSkillBaselineChange?: (baseline: Record<string, number>) => void;
+  waitForTask?: (task: Task) => Promise<Task>;
+  formatMutationResult?: (result: unknown) => string;
+};
+
+function friendlyInlineError(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function SpecializationTab({
+  dbPlayerId,
+  actionPlayerId,
+  playerName,
+  isOnline,
+  onError,
+  confirmAction,
+  onSkillBaselineChange,
+  waitForTask,
+  formatMutationResult
+}: SpecializationTabProps) {
+  const [rows, setRows] = useState<SpecializationTrackRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [xpAmount, setXpAmount] = useState("1000");
+  const [actionResult, setActionResult] = useState<ActionResult | null>(null);
+  const [busyActionKey, setBusyActionKey] = useState("");
+  const resultTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    void load();
+  }, [dbPlayerId]);
+
+  useEffect(() => () => { if (resultTimer.current) window.clearTimeout(resultTimer.current); }, []);
+
+  function showResult(key: string, text: string, tone: "success" | "danger" | "neutral" = "success", pending = false) {
+    setActionResult({ key, text, tone, pending });
+    if (resultTimer.current) window.clearTimeout(resultTimer.current);
+    resultTimer.current = null;
+    if (!pending) resultTimer.current = window.setTimeout(() => setActionResult(null), 8000);
+  }
+
+  async function load() {
+    if (!dbPlayerId) {
+      setRows([]);
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const response = await playersApi.specs(dbPlayerId);
+      setRows((response.rows || []).map((row) => ({
+        trackType: String(row.track_type || row.trackType || ""),
+        xp: Number(row.xp_amount ?? row.xp ?? 0),
+        level: Number(row.level ?? 0),
+        keystone: Boolean(row.keystone || row.has_keystone)
+      })).filter((row) => row.trackType));
+      const learnedRows = Array.isArray(response.skillModules) ? response.skillModules as Record<string, unknown>[] : [];
+      const baseline = Object.fromEntries(learnedRows.map((row) => {
+        const moduleId = String(row.module_id || row.moduleId || row.id || "");
+        const level = Number(row.level ?? row.rank ?? row.skill_points_spent ?? row.skillPointsSpent ?? 0);
+        return [moduleId, Math.max(0, level)];
+      }).filter(([moduleId, level]) => moduleId && Number(level) > 0));
+      onSkillBaselineChange?.(baseline);
+    } catch (err) {
+      setRows([]);
+      setError(friendlyInlineError(err));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function runAction(key: string, pendingText: string, action: () => Promise<unknown>, successText: string, logAction: { actionType: string; target: string; amount: string }, successTone: "success" | "danger" = "success", failureText?: string | ((error: unknown) => string)) {
+    onError("");
+    showResult(key, pendingText, "neutral", true);
+    try {
+      const response = await action();
+      const responseText = formatMutationResult ? formatMutationResult(response) : "";
+      showResult(key, responseText && responseText !== "Action completed." ? responseText : successText, successTone);
+    } catch (err) {
+      const message = typeof failureText === "function" ? failureText(err) : failureText || friendlyInlineError(err);
+      showResult(key, message, "danger");
+    }
+  }
+
+  async function addXp(trackType: string) {
+    const amount = Number(xpAmount) || 0;
+    if (!amount) {
+      showResult(`spec_${trackType}`, "Enter an XP amount first.", "danger");
+      return;
+    }
+    if (isOnline) {
+      showResult(`spec_${trackType}`, "The player must be offline for specialization changes.", "danger");
+      return;
+    }
+    onError("");
+    showResult(`spec_${trackType}`, "Updating XP", "neutral", true);
+    try {
+      await playersApi.addSpecializationXp(dbPlayerId, { trackType, amount, confirmation: "ADD SPECIALIZATION XP" });
+      showResult(`spec_${trackType}`, "XP updated. Relog required.", "success");
+      await load();
+    } catch (err) {
+      const message = friendlyInlineError(err);
+      showResult(`spec_${trackType}`, message, "danger");
+    }
+  }
+
+  async function grantMax(trackType: string) {
+    if (isOnline) {
+      showResult(`spec_${trackType}`, "The player must be offline for specialization changes.", "danger");
+      return;
+    }
+    if (!(await confirmAction(`Grant max level for ${trackType} to ${playerName}? This is a high-impact action.`, {
+      title: "Grant Max Specialization",
+      confirmLabel: "Grant Max",
+      danger: true,
+      details: [{ label: "Track", value: trackType, tone: "accent" }, { label: "Player", value: playerName }]
+    }))) return;
+    onError("");
+    showResult(`spec_${trackType}`, "Granting max level", "neutral", true);
+    try {
+      await playersApi.grantMaxSpecialization(dbPlayerId, { trackType, confirmation: "GRANT MAX SPECIALIZATION" });
+      showResult(`spec_${trackType}`, "Max level granted. Relog required.", "success");
+      await load();
+    } catch (err) {
+      const message = friendlyInlineError(err);
+      showResult(`spec_${trackType}`, message, "danger");
+    }
+  }
+
+  async function resetTrack(trackType: string) {
+    if (!(await confirmAction(`Reset ${trackType} specialization for ${playerName}?`, {
+      title: "Reset Specialization",
+      danger: true,
+      details: [{ label: "Track", value: trackType, tone: "danger" }]
+    }))) return;
+    onError("");
+    showResult(`spec_${trackType}`, "Resetting track", "neutral", true);
+    try {
+      await playersApi.resetSpecialization(dbPlayerId, { trackType, confirmation: "RESET SPECIALIZATION" });
+      showResult(`spec_${trackType}`, "Track reset. Relog required.", "success");
+      await load();
+    } catch (err) {
+      const message = friendlyInlineError(err);
+      showResult(`spec_${trackType}`, message, "danger");
+    }
+  }
+
+  async function grantAllKeystones() {
+    if (isOnline) {
+      showResult("specKeystones", "The player must be offline for specialization changes.", "danger");
+      return;
+    }
+    if (!(await confirmAction(`Grant all specialization keystones to ${playerName}? This is a high-impact action that affects all tracks.`, {
+      title: "Grant All Keystones",
+      confirmLabel: "Grant All",
+      danger: true,
+      details: [{ label: "Player", value: playerName, tone: "accent" }]
+    }))) return;
+    onError("");
+    showResult("specKeystones", "Granting keystones", "neutral", true);
+    try {
+      await playersApi.grantAllSpecializationKeystones(dbPlayerId, "GRANT ALL KEYSTONES");
+      showResult("specKeystones", "Keystones granted. Relog required.", "success");
+      await load();
+    } catch (err) {
+      const message = friendlyInlineError(err);
+      showResult("specKeystones", message, "danger");
+    }
+  }
+
+  async function resetAllKeystones() {
+    if (!(await confirmAction(`Reset all specialization keystones for ${playerName}?`, {
+      title: "Reset All Keystones",
+      danger: true,
+      details: [{ label: "Player", value: playerName, tone: "danger" }]
+    }))) return;
+    onError("");
+    showResult("specKeystones", "Resetting keystones", "neutral", true);
+    try {
+      await playersApi.resetAllSpecializationKeystones(dbPlayerId, "RESET ALL KEYSTONES");
+      showResult("specKeystones", "Keystones reset. Relog required.", "success");
+      await load();
+    } catch (err) {
+      const message = friendlyInlineError(err);
+      showResult("specKeystones", message, "danger");
+    }
+  }
+
+  const isBusy = actionResult?.pending || Boolean(busyActionKey);
+  const canAct = Boolean(dbPlayerId) && !isOnline;
+
+  return (
+    <section className="specialization-tab">
+      <div className="specialization-header">
+        <div className="specialization-header-left">
+          <h4>Specialization Tracks</h4>
+          <p className="specialization-offline-notice">
+            <Shield size={14} />
+            The player must be offline for all specialization changes. A relog is required to see changes in-game.
+          </p>
+        </div>
+        <div className="specialization-header-actions">
+          <button
+            disabled={!dbPlayerId || loading}
+            onClick={() => void load()}
+          >
+            {loading ? "Loading..." : "Reload"}
+          </button>
+          <button
+            disabled={!canAct || isBusy}
+            onClick={() => void grantAllKeystones()}
+          >
+            <KeyRound size={14} /> Grant All Keystones
+          </button>
+          <button
+            className="danger"
+            disabled={!dbPlayerId || isBusy}
+            onClick={() => void resetAllKeystones()}
+          >
+            <RotateCcw size={14} /> Reset All Keystones
+          </button>
+          <InlineActionResult result={actionResult} resultKey="specKeystones" />
+        </div>
+      </div>
+
+      {error && <p className="playerAdmin_note danger">{error}</p>}
+
+      <div className="playerAdmin_tableWrap playerAdmin_specializationTableWrap">
+        <table className="playerAdmin_table playerAdmin_specializationTable">
+          <colgroup>
+            <col className="playerAdmin_specTrackCol" />
+            <col className="playerAdmin_specXpCol" />
+            <col className="playerAdmin_specLevelCol" />
+            <col className="playerAdmin_specKeystoneCol" />
+            <col className="playerAdmin_specAddXpCol" />
+            <col className="playerAdmin_specResultCol" />
+            <col className="playerAdmin_specActionCol" />
+          </colgroup>
+          <thead>
+            <tr>
+              <th>Track</th>
+              <th>XP</th>
+              <th>Level</th>
+              <th>Keystone</th>
+              <th>Add XP</th>
+              <th>Result</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.trackType}>
+                <td>
+                  <div className="spec-track-name">
+                    <Trophy size={14} className="spec-track-icon" />
+                    {row.trackType}
+                  </div>
+                </td>
+                <td>{row.xp.toLocaleString()}</td>
+                <td>
+                  <span className={`spec-level-badge ${row.level >= 10 ? "spec-level-max" : ""}`}>
+                    <Zap size={12} />
+                    {row.level}
+                  </span>
+                </td>
+                <td>
+                  {row.keystone
+                    ? <span className="spec-keystone-yes"><KeyRound size={14} /> Granted</span>
+                    : <span className="spec-keystone-no">—</span>}
+                </td>
+                <td>
+                  <input
+                    className="playerAdmin_specXpInput"
+                    type="number"
+                    min="0"
+                    value={xpAmount}
+                    onChange={(event) => setXpAmount(event.target.value)}
+                    disabled={!canAct || isBusy}
+                  />
+                </td>
+                <td className="playerAdmin_resultCell">
+                  <InlineActionResult result={actionResult} resultKey={`spec_${row.trackType}`} />
+                </td>
+                <td className="playerAdmin_actionCell">
+                  <button
+                    disabled={!canAct || isBusy}
+                    onClick={() => void addXp(row.trackType)}
+                  >
+                    Add XP
+                  </button>
+                  <button
+                    disabled={!canAct || isBusy}
+                    onClick={() => void grantMax(row.trackType)}
+                  >
+                    Grant Max
+                  </button>
+                  <button
+                    className="danger"
+                    disabled={!canAct || isBusy}
+                    onClick={() => void resetTrack(row.trackType)}
+                  >
+                    Reset
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {!rows.length && (
+              <tr>
+                <td colSpan={7}>
+                  {loading
+                    ? "Loading specializations..."
+                    : "No specialization tracks were found."}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="specialization-footer">
+        <p className="specialization-help-note">
+          Specialization XP and level changes are applied directly to the game database.
+          The player must relog before changes appear in-game.
+          Grant Max and keystone actions require confirmation due to their high impact.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/console/web/src/features/players/SpecializationTab.tsx
+++ b/console/web/src/features/players/SpecializationTab.tsx
@@ -223,12 +223,14 @@ export function SpecializationTab({
           <button
             disabled={!dbPlayerId || loading}
             onClick={() => void load()}
+            aria-label="Reload specializations"
           >
             {loading ? "Loading..." : "Reload"}
           </button>
           <button
             disabled={!canAct || isBusy}
             onClick={() => void grantAllKeystones()}
+            aria-label="Grant All Keystones"
           >
             <KeyRound size={14} /> Grant All Keystones
           </button>
@@ -236,6 +238,7 @@ export function SpecializationTab({
             className="danger"
             disabled={!dbPlayerId || isBusy}
             onClick={() => void resetAllKeystones()}
+            aria-label="Reset All Keystones"
           >
             <RotateCcw size={14} /> Reset All Keystones
           </button>
@@ -296,6 +299,7 @@ export function SpecializationTab({
                     value={xpAmount}
                     onChange={(event) => setXpAmount(event.target.value)}
                     disabled={!canAct || isBusy}
+                    aria-label={`XP amount for ${row.trackType}`}
                   />
                 </td>
                 <td className="playerAdmin_resultCell">
@@ -305,12 +309,14 @@ export function SpecializationTab({
                   <button
                     disabled={!canAct || isBusy}
                     onClick={() => void addXp(row.trackType)}
+                    aria-label={`Add XP to ${row.trackType}`}
                   >
                     Add XP
                   </button>
                   <button
                     disabled={!canAct || isBusy}
                     onClick={() => void grantMax(row.trackType)}
+                    aria-label={`Grant Max for ${row.trackType}`}
                   >
                     Grant Max
                   </button>
@@ -318,6 +324,7 @@ export function SpecializationTab({
                     className="danger"
                     disabled={!canAct || isBusy}
                     onClick={() => void resetTrack(row.trackType)}
+                    aria-label={`Reset ${row.trackType}`}
                   >
                     Reset
                   </button>

--- a/console/web/src/test/setup.ts
+++ b/console/web/src/test/setup.ts
@@ -1,0 +1,7 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/console/web/vitest.config.ts
+++ b/console/web/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["src/test/setup.ts"],
+    globals: true,
+    include: ["src/**/*.test.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: ["src/**/*.test.{ts,tsx}", "src/test/**"]
+    }
+  }
+});

--- a/docs/CLOUDFLARE-DEPLOYMENT.md
+++ b/docs/CLOUDFLARE-DEPLOYMENT.md
@@ -1,0 +1,233 @@
+# Cloudflare Tunnel Deployment for console.darkdante.org
+
+This document describes how the Dune Docker Console is exposed publicly via Cloudflare Tunnel at `console.darkdante.org`.
+
+## Architecture Overview
+
+```
+Internet → Cloudflare Edge → Cloudflare Tunnel (cloudflared) → localhost:8088 → Dune Docker Console Container
+```
+
+The deployment uses a **Cloudflare Tunnel** (not a traditional reverse proxy or port forwarding) to securely expose the local Dune Docker Console web UI without opening any inbound ports on the host firewall.
+
+## Components
+
+### 1. Cloudflare Tunnel (cloudflared)
+
+- **Service**: `cloudflared` (systemd-managed)
+- **Status**: `systemctl is-active cloudflared` → `active`
+- **Tunnel ID**: `67d90501-3c71-413d-949f-89a060f56567`
+- **Credentials**: `/home/darkdante/.cloudflared/67d90501-3c71-413d-949f-89a060f56567.json`
+- **Config**: `/home/darkdante/.cloudflared/config.yml`
+
+**Config contents:**
+```yaml
+tunnel: 67d90501-3c71-413d-949f-89a060f56567
+credentials-file: /home/darkdante/.cloudflared/67d90501-3c71-413d-949f-89a060f56567.json
+
+ingress:
+  - hostname: console.darkdante.org
+    service: http://localhost:8088
+  - hostname: acp-setup.darkdante.org
+    service: http://129.146.238.118:3100
+  - service: http_status:404
+```
+
+**How it works:**
+- `cloudflared` establishes an **outbound-only** connection to Cloudflare's edge network
+- No inbound firewall rules or port forwarding are needed
+- Traffic to `console.darkdante.org` is routed through the tunnel to `http://localhost:8088`
+- The catch-all `http_status:404` rejects any unmatched hostnames
+
+### 2. Dune Docker Console Container
+
+- **Container name**: `redblink-dune-docker-console`
+- **Image**: `redblink-dune-docker-console:dev`
+- **Network mode**: `host` (binds directly to host network interfaces)
+- **Port**: `8088` (configured via `ADMIN_BIND_PORT`)
+- **Bind host**: `0.0.0.0` (listens on all interfaces)
+
+**Key bind mounts:**
+| Host Path | Container Path | Purpose |
+|---|---|---|
+| `/home/darkdante/dune-awakening-selfhost-docker` | `/repo` | Repo root (addons, secrets, generated state) |
+| `/var/run/docker.sock` | `/var/run/docker.sock` | Docker API access |
+| `/etc/localtime` | `/etc/localtime` | Timezone sync |
+
+**Key environment variables:**
+| Variable | Value | Purpose |
+|---|---|---|
+| `DUNE_DOCKER_DIR` | `/repo` | Container repo root |
+| `ADMIN_BIND_HOST` | `0.0.0.0` | Listen on all interfaces |
+| `ADMIN_BIND_PORT` | `8088` | Web console port |
+| `DUNE_HOST_REPO_ROOT` | (from `.env`) | Host-side repo path |
+
+### 3. Addon Serving
+
+Addons are served by the console's internal HTTP server through the `/api/addons/installed/{id}/content/{path}` route.
+
+**Flow:**
+1. Console reads `addon.json` from `/repo/runtime/addons/installed/{id}/addon.json`
+2. Validates addon is enabled and has approved permissions
+3. Resolves the content path relative to the addon's install directory
+4. Serves the file with `content-type` and `x-frame-options: SAMEORIGIN` headers
+5. The addon's `index.html` is loaded in an `<iframe>` within the Console UI
+
+**Addon install path:**
+```
+/repo/runtime/addons/installed/dune-ops-observability/
+├── addon.json
+└── web/
+    ├── index.html
+    ├── addon.js
+    ├── addon.css
+    ├── data-providers.js
+    ├── dune-addon-bridge.js
+    └── faction-tagger.js
+```
+
+### 4. Addon Bridge Communication
+
+Addons communicate with the console backend via `postMessage` through the iframe:
+
+```
+Addon iframe → window.parent.postMessage() → Console server → Database/API → Response → postMessage back
+```
+
+**Bridge protocol:**
+- Addon loads `dune-addon-bridge.js` which sets up `window.DuneAddon.request(action, payload)`
+- Requests are sent as `dune-addon-request` messages with `addonId`, `requestId`, `action`, `payload`
+- Console validates addon permissions before executing the action
+- Response is sent back as `dune-addon-response` with `requestId`, `ok`, `result`/`error`
+- 30-second timeout per request
+
+**Available bridge actions for this addon:**
+| Action | Permission | Description |
+|---|---|---|
+| `ops.health.summary.v2` | `ops:read` | System health summary |
+| `ops.health.players` | `ops:read` | Player health data |
+| `ops.health.farms` | `ops:read` | Farm health data |
+| `ops.activity.summary` | `ops:read` | Player activity stats |
+| `ops.resources.summary` | `ops:read` | Resource/spice field data |
+| `ops.combat.deaths` | `ops:read` | Combat death tracking |
+| `ops.economy.summary` | `ops:read` | Economy/market data |
+| `ops.inventory.summary` | `ops:read` | Inventory stats |
+| `ops.location.activity` | `ops:read` | Map/location activity |
+| `ops.soc.summary` | `ops:read` | System-on-chip / service health |
+| `ops.health.prometheus` | `ops:read` | Prometheus metrics health |
+
+## Deploying Addon Updates
+
+### Step 1: Edit addon files in the addon repo
+
+```bash
+cd /home/darkdante/dune-docker-addon/addon-main/web/
+# Edit index.html, addon.js, data-providers.js, etc.
+```
+
+### Step 2: Copy to installed addon directory
+
+```bash
+cp /home/darkdante/dune-docker-addon/addon-main/web/* \
+   /home/darkdante/dune-awakening-selfhost-docker/runtime/addons/installed/dune-ops-observability/web/
+```
+
+### Step 3: Restart the console container
+
+```bash
+docker restart redblink-dune-docker-console
+sleep 3
+```
+
+### Step 4: Verify in browser
+
+1. Open `https://console.darkdante.org`
+2. Hard refresh (`Ctrl+Shift+R`) or disable cache in DevTools
+3. Navigate to **Addons** → **Dune Ops Observability** → **Open**
+4. Check the version displayed in the addon header
+
+### Automated deployment (optional)
+
+The `scripts/validate-and-install-local-console.sh` script automates this:
+```bash
+cd /home/darkdante/dune-docker-addon/addon-main
+bash scripts/validate-and-install-local-console.sh
+```
+
+This script:
+1. Syncs addon repo with `origin/main`
+2. Runs validation (`pre-commit`, `validate.js`, `package.sh`)
+3. Copies addon files to the console runtime
+4. Enables the addon in `state.json`
+
+## Troubleshooting
+
+### Console not reachable
+
+```bash
+# Check cloudflared status
+systemctl status cloudflared
+
+# Check tunnel connectivity
+cloudflared tunnel info 67d90501-3c71-413d-949f-89a060f56567
+
+# Check console container
+docker ps --filter "name=console"
+
+# Test local connectivity
+curl -s http://localhost:8088/api/health
+```
+
+### Addon not loading
+
+```bash
+# Verify addon files exist
+ls /home/darkdante/dune-awakening-selfhost-docker/runtime/addons/installed/dune-ops-observability/web/
+
+# Check addon state
+cat /home/darkdante/dune-awakening-selfhost-docker/runtime/addons/state.json
+
+# Verify addon is enabled in container
+docker exec redblink-dune-docker-console cat /repo/runtime/addons/installed/dune-ops-observability/addon.json
+
+# Check console logs
+docker logs redblink-dune-docker-console --since 5m
+```
+
+### Bridge requests failing (400 Bad Request)
+
+- Ensure the addon has `ops:read` permission in `addon.json`
+- Check `state.json` has `"approvedPermissions": ["ops:read"]`
+- Verify the action is registered in the console's `server.js` bridge handler
+- Check browser DevTools Console for error messages
+
+### Stale addon content
+
+The console serves addon files directly from disk with no caching layer. If you see stale content:
+1. Hard refresh the browser (`Ctrl+Shift+R`)
+2. Disable browser cache in DevTools Network tab
+3. Verify the file on disk matches expectations:
+   ```bash
+   docker exec redblink-dune-docker-console cat /repo/runtime/addons/installed/dune-ops-observability/web/addon.js | grep "version"
+   ```
+
+## DNS Configuration
+
+The domain `console.darkdante.org` is managed through Cloudflare DNS with a **CNAME** record pointing to the Cloudflare Tunnel:
+
+```
+Type: CNAME
+Name: console
+Target: 67d90501-3c71-413d-949f-89a060f56567.cfargotunnel.com
+Proxy status: Proxied (orange cloud)
+```
+
+No A records or port forwarding rules are needed — the tunnel handles all routing.
+
+## Security Notes
+
+- **No open inbound ports**: The host firewall does not need port 80 or 443 open
+- **TLS termination**: Cloudflare handles TLS at the edge; traffic between Cloudflare and the host is encrypted via the tunnel
+- **Authentication**: The console requires admin login (password stored in `runtime/secrets/admin-web-password.txt`)
+- **Addon sandboxing**: Addons run in iframes with `x-frame-options: SAMEORIGIN` and can only access approved bridge actions
+- **Permission model**: Each bridge action validates the addon's declared and approved permissions before execution


### PR DESCRIPTION
## Summary

Extracts the Specialization feature from the Skills tab into its own first-class player-admin tab, adds a dedicated Vitest test harness with 22 passing tests, and documents the Cloudflare Tunnel deployment for `console.darkdante.org`.

## Changes

### Specialization Tab (`SpecializationTab.tsx` — 356 lines)
- New standalone tab with dedicated state, loading, and error handling
- Per-track actions: Add XP, Grant Max, Reset
- Global actions: Grant All Keystones, Reset All Keystones
- Offline-only enforcement with disabled action buttons when player is online
- Confirmation dialogs for high-impact actions (Grant Max, Reset, Keystones)
- Inline action results with pending/success/danger states
- Skill module baseline hydration for adjacent skill browser

### Test Harness (`SpecializationTab.test.tsx` — 371 lines)
- 22 Vitest tests covering rendering, offline gating, all mutation paths
- Mocked `playersApi` with proper TypeScript type compliance
- Role-based selectors (`getAllByRole("button")`) to avoid false matches

### CharacterAdminUI Refactor
- Removed ~200 lines of embedded specialization code
- Added Specialization tab to top navigation (`{ label: "Specialization", icon: Star }`)
- Clean separation of concerns between Skills and Specialization tabs

### Infrastructure
- `vitest.config.ts` + `test/setup.ts` — new test harness configuration
- `package.json` / `package-lock.json` — Vitest, testing-library dependencies
- `docs/CLOUDFLARE-DEPLOYMENT.md` — tunnel architecture, troubleshooting, addon bridge docs
- `ROADMAP.md` — comprehensive specialization design document

## Security
- All pre-push gates passed: ggshield, gitleaks, trivy, semgrep, npm audit, web build
- Offline gating enforced in UI (buttons disabled when player is online)
- Confirmation dialogs for destructive/high-impact actions
- Server-side authorization remains authoritative (confirmation strings are UX aids only)

## Testing
```
22 passed (SpecializationTab.test.tsx)
All CI jobs passing
```