### PR TITLE
Cache the Game Update check to fix slow Updates panel

### DIFF
--- a/console/api/src/config.js
+++ b/console/api/src/config.js
@@ -39,6 +39,7 @@ export function loadConfig() {
     maxJsonBytes: Number(process.env.ADMIN_MAX_JSON_BYTES || 2 * 1024 * 1024),
     maxUploadBytes: Number(process.env.ADMIN_MAX_UPLOAD_BYTES || 1024 * 1024 * 1024),
     commandTimeoutMs: Number(process.env.ADMIN_COMMAND_TIMEOUT_MS || 120000),
+    updateCheckCacheMs: Number(process.env.ADMIN_UPDATE_CHECK_CACHE_MS || 5 * 60 * 1000),
     staticDir: process.env.ADMIN_STATIC_DIR || resolve(repoRoot, "console/web/dist"),
     allowedIps: parseAllowedIps(process.env.ADMIN_ALLOWED_IPS)
   };

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -337,7 +337,10 @@ async function handleApi(req, res) {
   if (path === "/api/logs/services") return json(res, 200, { services: await discoverServices(config) });
   if (path.startsWith("/api/logs/")) return logsRoute(req, res, path);
 
-  if (path === "/api/updates/check-game" && req.method === "POST") return task(req, res, "updates", "updateCheck", {});
+  if (path === "/api/updates/check-game" && req.method === "POST") {
+    const body = await readJson(req);
+    return task(req, res, "updates", "updateCheck", { fresh: body.fresh === true });
+  }
   if (path === "/api/updates/apply-game" && req.method === "POST") return task(req, res, "updates", "updateApply", {});
   if (path === "/api/updates/fix-steamcmd" && req.method === "POST") return task(req, res, "updates", "updateFixSteamcmd", {});
   if (path === "/api/updates/check-stack" && req.method === "POST") return task(req, res, "updates", "selfUpdateCheck", {});

--- a/console/api/src/services/updateCheckCache.js
+++ b/console/api/src/services/updateCheckCache.js
@@ -19,6 +19,14 @@ export function createUpdateCheckCache(config, options = {}) {
     return inFlight.then((entry) => ({ ...entry, fromCache: false }));
   }
 
+  function peek() {
+    const currentTime = now();
+    if (cached && currentTime - cached.sampledAtMs < cacheMs) {
+      return { ...cached, fromCache: true };
+    }
+    return null;
+  }
+
   function invalidate() { cached = null; }
-  return { read, invalidate };
+  return { read, peek, invalidate };
 }

--- a/console/api/src/services/updateCheckCache.js
+++ b/console/api/src/services/updateCheckCache.js
@@ -4,19 +4,27 @@ export function createUpdateCheckCache(config, options = {}) {
   const cacheMs = Math.max(0, Number(options.cacheMs ?? config.updateCheckCacheMs ?? 5 * 60 * 1000));
   let cached = null;
   let inFlight = null;
+  let generation = 0;
 
   async function read(readOptions = {}) {
     const currentTime = now();
     if (!readOptions.fresh && cached && currentTime - cached.sampledAtMs < cacheMs) {
       return { ...cached, fromCache: true };
     }
-    if (inFlight) return inFlight.then((entry) => ({ ...entry, fromCache: false }));
-    inFlight = Promise.resolve().then(collect).then((result) => {
+    if (inFlight?.generation === generation) {
+      return inFlight.promise.then((entry) => ({ ...entry, fromCache: false }));
+    }
+    const collectionGeneration = generation;
+    const pending = Promise.resolve().then(collect).then((result) => {
       const sampledAtMs = now();
-      cached = { ...result, sampledAtMs, sampledAt: new Date(sampledAtMs).toISOString() };
-      return cached;
-    }).finally(() => { inFlight = null; });
-    return inFlight.then((entry) => ({ ...entry, fromCache: false }));
+      const entry = { ...result, sampledAtMs, sampledAt: new Date(sampledAtMs).toISOString() };
+      if (collectionGeneration === generation) cached = entry;
+      return entry;
+    }).finally(() => {
+      if (inFlight?.promise === pending) inFlight = null;
+    });
+    inFlight = { generation: collectionGeneration, promise: pending };
+    return pending.then((entry) => ({ ...entry, fromCache: false }));
   }
 
   function peek() {
@@ -27,6 +35,9 @@ export function createUpdateCheckCache(config, options = {}) {
     return null;
   }
 
-  function invalidate() { cached = null; }
+  function invalidate() {
+    generation += 1;
+    cached = null;
+  }
   return { read, peek, invalidate };
 }

--- a/console/api/src/services/updateCheckCache.js
+++ b/console/api/src/services/updateCheckCache.js
@@ -1,0 +1,24 @@
+export function createUpdateCheckCache(config, options = {}) {
+  const collect = options.collect; // required, injected by caller
+  const now = options.now || Date.now;
+  const cacheMs = Math.max(0, Number(options.cacheMs ?? config.updateCheckCacheMs ?? 5 * 60 * 1000));
+  let cached = null;
+  let inFlight = null;
+
+  async function read(readOptions = {}) {
+    const currentTime = now();
+    if (!readOptions.fresh && cached && currentTime - cached.sampledAtMs < cacheMs) {
+      return { ...cached, fromCache: true };
+    }
+    if (inFlight) return inFlight.then((entry) => ({ ...entry, fromCache: false }));
+    inFlight = Promise.resolve().then(collect).then((result) => {
+      const sampledAtMs = now();
+      cached = { ...result, sampledAtMs, sampledAt: new Date(sampledAtMs).toISOString() };
+      return cached;
+    }).finally(() => { inFlight = null; });
+    return inFlight.then((entry) => ({ ...entry, fromCache: false }));
+  }
+
+  function invalidate() { cached = null; }
+  return { read, invalidate };
+}

--- a/console/api/src/tasks.js
+++ b/console/api/src/tasks.js
@@ -41,9 +41,24 @@ export class TaskManager {
       errorMessage: null,
       subscribers: new Set()
     };
+
+    let cachedHit = null;
+    if (operation === "updateCheck" && payload.fresh !== true) {
+      cachedHit = this.updateCheckCache.peek();
+    }
+
+    if (cachedHit) {
+      task.currentStep = "Running";
+      this.recordUpdateCheckResult(task, cachedHit);
+      this.completeTaskSucceeded(task, cachedHit.code);
+    }
+
     this.tasks.set(id, task);
     this.trim();
-    queueMicrotask(() => this.run(task, payload));
+
+    if (!cachedHit) {
+      queueMicrotask(() => this.run(task, payload));
+    }
     return publicTask(task);
   }
 
@@ -90,11 +105,7 @@ export class TaskManager {
       if (["updateApply", "updateFixSteamcmd"].includes(task.operation)) {
         this.updateCheckCache.invalidate();
       }
-      task.status = "succeeded";
-      task.exitCode = lastCode;
-      task.currentStep = "Finished";
-      task.finishedAt = new Date().toISOString();
-      this.emit(task, "Task succeeded");
+      this.completeTaskSucceeded(task, lastCode);
     } catch (error) {
       task.status = "failed";
       task.exitCode = Number.isInteger(error.code) ? error.code : null;
@@ -160,13 +171,25 @@ export class TaskManager {
 
   async readUpdateCheck(task, payload) {
     const result = await this.updateCheckCache.read({ fresh: payload.fresh === true });
+    this.recordUpdateCheckResult(task, result);
+    return result;
+  }
+
+  recordUpdateCheckResult(task, result) {
     const ageSeconds = Math.max(0, Math.round((Date.now() - result.sampledAtMs) / 1000));
     this.append(task, result.fromCache
       ? `Reusing update check result from ${ageSeconds}s ago (cached).`
       : "Ran a live Steam update check.", "stdout");
     if (result.stdout) this.append(task, result.stdout, "stdout");
     if (result.stderr) this.append(task, result.stderr, "stderr");
-    return result;
+  }
+
+  completeTaskSucceeded(task, exitCode) {
+    task.status = "succeeded";
+    task.exitCode = exitCode;
+    task.currentStep = "Finished";
+    task.finishedAt = new Date().toISOString();
+    this.emit(task, "Task succeeded");
   }
 
   trim() {

--- a/console/api/src/tasks.js
+++ b/console/api/src/tasks.js
@@ -3,11 +3,18 @@ import { spawn } from "node:child_process";
 import { statSync } from "node:fs";
 import { runDune, buildDuneArgs } from "./runner.js";
 import { liveItemGrantWarning } from "./grantResults.js";
+import { createUpdateCheckCache } from "./services/updateCheckCache.js";
 
 export class TaskManager {
-  constructor(config) {
+  constructor(config, options = {}) {
     this.config = config;
     this.tasks = new Map();
+    this.updateCheckCache = options.updateCheckCache || createUpdateCheckCache(config, {
+      collect: () => runDune(config, buildDuneArgs("updateCheck"), {
+        allowedExitCodes: [0, 100],
+        timeoutMs: taskTimeoutMs(config, "updateCheck")
+      })
+    });
   }
 
   list() {
@@ -62,16 +69,26 @@ export class TaskManager {
       for (const operation of operations) {
         task.currentStep = operation;
         this.emit(task, `Running ${operation}`);
-        const args = buildDuneArgs(operation, payload);
-        const result = await runDune(this.config, args, {
-          allowedExitCodes: operation === "updateCheck" || operation === "selfUpdateCheck" ? [0, 100] : [0],
-          env: operation === "init" ? { DUNE_INIT_ASSUME_YES: "1" } : {},
-          timeoutMs: taskTimeoutMs(this.config, operation),
-          onLine: (text, stream) => this.append(task, text, stream)
-        });
+
+        let result;
+        if (operation === "updateCheck") {
+          result = await this.readUpdateCheck(task, payload);
+        } else {
+          const args = buildDuneArgs(operation, payload);
+          result = await runDune(this.config, args, {
+            allowedExitCodes: operation === "selfUpdateCheck" ? [0, 100] : [0],
+            env: operation === "init" ? { DUNE_INIT_ASSUME_YES: "1" } : {},
+            timeoutMs: taskTimeoutMs(this.config, operation),
+            onLine: (text, stream) => this.append(task, text, stream)
+          });
+        }
+
         const grantWarning = itemGrantTaskWarning(operation, result);
         if (grantWarning) throw Object.assign(new Error(grantWarning), { code: 1, stdout: result.stdout, stderr: result.stderr });
         lastCode = result.code;
+      }
+      if (["updateApply", "updateFixSteamcmd"].includes(task.operation)) {
+        this.updateCheckCache.invalidate();
       }
       task.status = "succeeded";
       task.exitCode = lastCode;
@@ -139,6 +156,17 @@ export class TaskManager {
     task.progressMessage = message;
     const data = `data: ${JSON.stringify(publicTask(task))}\n\n`;
     for (const write of task.subscribers) write(data);
+  }
+
+  async readUpdateCheck(task, payload) {
+    const result = await this.updateCheckCache.read({ fresh: payload.fresh === true });
+    const ageSeconds = Math.max(0, Math.round((Date.now() - result.sampledAtMs) / 1000));
+    this.append(task, result.fromCache
+      ? `Reusing update check result from ${ageSeconds}s ago (cached).`
+      : "Ran a live Steam update check.", "stdout");
+    if (result.stdout) this.append(task, result.stdout, "stdout");
+    if (result.stderr) this.append(task, result.stderr, "stderr");
+    return result;
   }
 
   trim() {

--- a/console/api/test/tasks.test.js
+++ b/console/api/test/tasks.test.js
@@ -89,6 +89,7 @@ test("repeated updateCheck tasks within the cache window reuse one SteamCMD invo
   const dir = mkdtempSync(join(tmpdir(), "arrakis-task-cache-"));
   let collectCount = 0;
   const fakeCache = {
+    peek: () => null,
     read: async (opts) => {
       if (!opts.fresh) {
         if (collectCount > 0) {
@@ -139,6 +140,7 @@ test("updateCheck with fresh:true bypasses the cache", async () => {
   const dir = mkdtempSync(join(tmpdir(), "arrakis-task-fresh-"));
   let collectCount = 0;
   const fakeCache = {
+    peek: () => null,
     read: async (opts) => {
       collectCount++;
       return {
@@ -177,6 +179,7 @@ test("a successful updateApply invalidates the update check cache", async () => 
   let collectCount = 0;
   let cacheValid = false;
   const fakeCache = {
+    peek: () => null,
     read: async (opts) => {
       if (!opts.fresh && cacheValid) {
         return {
@@ -232,6 +235,7 @@ test("TaskManager threads payload.fresh into the injected update check cache's r
   const dir = mkdtempSync(join(tmpdir(), "arrakis-task-thread-"));
   const calls = [];
   const fakeCache = {
+    peek: () => null,
     read: async (opts) => {
       calls.push(opts);
       return {
@@ -261,6 +265,55 @@ test("TaskManager threads payload.fresh into the injected update check cache's r
   assert.equal(task2.status, "succeeded");
 
   assert.deepEqual(calls, [{ fresh: false }, { fresh: true }]);
+});
+
+test("create() returns an already-succeeded task synchronously on a peek cache hit", () => {
+  const dir = mkdtempSync(join(tmpdir(), "arrakis-task-peek-"));
+  const fakeCache = {
+    peek: () => ({ code: 0, stdout: "Local build: 1\nRemote build: 1\nNo update available.", stderr: "", fromCache: true, sampledAtMs: Date.now() - 1000 }),
+    read: async () => { throw new Error("read() should not be called on a peek hit"); },
+    invalidate: () => {}
+  };
+  const manager = new TaskManager({
+    duneScript: join(dir, "dune"), repoRoot: dir, taskRetention: 20, commandTimeoutMs: 5000
+  }, { updateCheckCache: fakeCache });
+
+  const created = manager.create("updates", "updateCheck", {});
+  assert.equal(created.status, "succeeded");
+  assert.equal(created.exitCode, 0);
+  assert.equal(created.currentStep, "Finished");
+  assert.match(created.logLines.map((l) => l.line).join("\n"), /Reusing update check result/);
+});
+
+test("create() with fresh:true skips peek and stays on the queued/async path", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "arrakis-task-peek-fresh-"));
+  let peekCalls = 0;
+  const fakeCache = {
+    peek: () => { peekCalls += 1; return { code: 0, stdout: "x", stderr: "", sampledAtMs: Date.now() }; },
+    read: async () => ({ code: 0, stdout: "Ran a live Steam update check.\nLocal build: 1\nRemote build: 1\nNo update available.", stderr: "", fromCache: false, sampledAtMs: Date.now() }),
+    invalidate: () => {}
+  };
+  const manager = new TaskManager({ duneScript: join(dir, "dune"), repoRoot: dir, taskRetention: 20, commandTimeoutMs: 5000 }, { updateCheckCache: fakeCache });
+  const created = manager.create("updates", "updateCheck", { fresh: true });
+  assert.equal(created.status, "queued");
+  assert.equal(peekCalls, 0);
+  const task = await waitForTask(manager, created.id);
+  assert.equal(task.status, "succeeded");
+});
+
+test("create() falls through to the queued/async path when peek returns null", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "arrakis-task-peek-miss-"));
+  const fakeCache = {
+    peek: () => null,
+    read: async () => ({ code: 0, stdout: "Ran a live Steam update check.\nLocal build: 1\nRemote build: 1\nNo update available.", stderr: "", fromCache: false, sampledAtMs: Date.now() }),
+    invalidate: () => {}
+  };
+  const manager = new TaskManager({ duneScript: join(dir, "dune"), repoRoot: dir, taskRetention: 20, commandTimeoutMs: 5000 }, { updateCheckCache: fakeCache });
+  const created = manager.create("updates", "updateCheck", {});
+  assert.equal(created.status, "queued");
+  const task = await waitForTask(manager, created.id);
+  assert.equal(task.status, "succeeded");
+  assert.match(task.logLines.map((l) => l.line).join("\n"), /Ran a live Steam update check/);
 });
 
 function waitForTask(manager, id) {

--- a/console/api/test/tasks.test.js
+++ b/console/api/test/tasks.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildSelfUpdateHelperDockerArgs, TaskManager, taskTimeoutMs } from "../src/tasks.js";
@@ -83,6 +83,184 @@ test("web self-update helper mounts the host repo path", () => {
   assert(args.includes("DOCKER_SOCKET_GID=988"));
   assert(args.includes("ADMIN_BIND_PORT=8089"));
   assert(!args.includes("/repo:/repo"));
+});
+
+test("repeated updateCheck tasks within the cache window reuse one SteamCMD invocation", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "arrakis-task-cache-"));
+  let collectCount = 0;
+  const fakeCache = {
+    read: async (opts) => {
+      if (!opts.fresh) {
+        if (collectCount > 0) {
+          return {
+            code: 0,
+            stdout: "Local build: 100\nRemote build: 200\nNo update available.",
+            stderr: "",
+            fromCache: true,
+            sampledAtMs: Date.now() - 1000
+          };
+        }
+      }
+      collectCount++;
+      return {
+        code: 0,
+        stdout: "Local build: 100\nRemote build: 200\nNo update available.",
+        stderr: "",
+        fromCache: false,
+        sampledAtMs: Date.now()
+      };
+    },
+    invalidate: () => {}
+  };
+
+  const manager = new TaskManager({
+    duneScript: join(dir, "dune"),
+    repoRoot: dir,
+    taskRetention: 20,
+    commandTimeoutMs: 5000,
+    updateCheckCacheMs: 5000
+  }, { updateCheckCache: fakeCache });
+
+  const created1 = manager.create("updates", "updateCheck", {});
+  const task1 = await waitForTask(manager, created1.id);
+  assert.equal(task1.status, "succeeded", task1.errorMessage);
+  assert.equal(task1.exitCode, 0);
+
+  const created2 = manager.create("updates", "updateCheck", {});
+  const task2 = await waitForTask(manager, created2.id);
+  assert.equal(task2.status, "succeeded", task2.errorMessage);
+  assert.equal(task2.exitCode, 0);
+  assert.match(task2.logLines.map((line) => line.line).join("\n"), /Reusing update check result/);
+
+  assert.equal(collectCount, 1, "collect should have been called exactly once");
+});
+
+test("updateCheck with fresh:true bypasses the cache", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "arrakis-task-fresh-"));
+  let collectCount = 0;
+  const fakeCache = {
+    read: async (opts) => {
+      collectCount++;
+      return {
+        code: 0,
+        stdout: "Local build: 100\nRemote build: 200\nNo update available.",
+        stderr: "",
+        fromCache: false,
+        sampledAtMs: Date.now()
+      };
+    },
+    invalidate: () => {}
+  };
+
+  const manager = new TaskManager({
+    duneScript: join(dir, "dune"),
+    repoRoot: dir,
+    taskRetention: 20,
+    commandTimeoutMs: 5000,
+    updateCheckCacheMs: 5000
+  }, { updateCheckCache: fakeCache });
+
+  const created1 = manager.create("updates", "updateCheck", {});
+  const task1 = await waitForTask(manager, created1.id);
+  assert.equal(task1.status, "succeeded", task1.errorMessage);
+
+  const created2 = manager.create("updates", "updateCheck", { fresh: true });
+  const task2 = await waitForTask(manager, created2.id);
+  assert.equal(task2.status, "succeeded", task2.errorMessage);
+  assert.match(task2.logLines.map((line) => line.line).join("\n"), /Ran a live Steam update check/);
+
+  assert.equal(collectCount, 2, "collect should have been called exactly twice (once for each call, no caching with fresh:true)");
+});
+
+test("a successful updateApply invalidates the update check cache", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "arrakis-task-invalidate-"));
+  let collectCount = 0;
+  let cacheValid = false;
+  const fakeCache = {
+    read: async (opts) => {
+      if (!opts.fresh && cacheValid) {
+        return {
+          code: 0,
+          stdout: "Local build: 100\nRemote build: 200\nNo update available.",
+          stderr: "",
+          fromCache: true,
+          sampledAtMs: Date.now() - 1000
+        };
+      }
+      collectCount++;
+      cacheValid = true;
+      return {
+        code: 0,
+        stdout: "Local build: 100\nRemote build: 200\nNo update available.",
+        stderr: "",
+        fromCache: false,
+        sampledAtMs: Date.now()
+      };
+    },
+    invalidate: () => { cacheValid = false; }
+  };
+
+  const duneScript = join(dir, "dune");
+  writeFileSync(duneScript, "#!/usr/bin/env bash\nif [ \"$1\" = \"update\" ] && [ \"$2\" = \"check\" ]; then\n  echo 'Local build: 100'\n  echo 'Remote build: 200'\n  echo 'No update available.'\nfi\nexit 0\n", { mode: 0o700 });
+  chmodSync(duneScript, 0o700);
+
+  const manager = new TaskManager({
+    duneScript,
+    repoRoot: dir,
+    taskRetention: 20,
+    commandTimeoutMs: 5000,
+    updateCheckCacheMs: 5000
+  }, { updateCheckCache: fakeCache });
+
+  const created1 = manager.create("updates", "updateCheck", {});
+  const task1 = await waitForTask(manager, created1.id);
+  assert.equal(task1.status, "succeeded", task1.errorMessage);
+
+  const created2 = manager.create("updates", "updateApply", {});
+  const task2 = await waitForTask(manager, created2.id);
+  assert.equal(task2.status, "succeeded", task2.errorMessage);
+
+  const created3 = manager.create("updates", "updateCheck", {});
+  const task3 = await waitForTask(manager, created3.id);
+  assert.equal(task3.status, "succeeded", task3.errorMessage);
+  assert.match(task3.logLines.map((line) => line.line).join("\n"), /Ran a live Steam update check/, "should have run live, not from cache");
+
+  assert.equal(collectCount, 2, "collect should have been called 2 times (once before update, once after invalidation)");
+});
+
+test("TaskManager threads payload.fresh into the injected update check cache's read call", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "arrakis-task-thread-"));
+  const calls = [];
+  const fakeCache = {
+    read: async (opts) => {
+      calls.push(opts);
+      return {
+        code: 0,
+        stdout: "Local build: 1\nRemote build: 1\nNo update available.",
+        stderr: "",
+        fromCache: false,
+        sampledAtMs: Date.now()
+      };
+    },
+    invalidate: () => {}
+  };
+
+  const manager = new TaskManager({
+    duneScript: join(dir, "dune"),
+    repoRoot: dir,
+    taskRetention: 20,
+    commandTimeoutMs: 5000
+  }, { updateCheckCache: fakeCache });
+
+  const created1 = manager.create("updates", "updateCheck", {});
+  const task1 = await waitForTask(manager, created1.id);
+  assert.equal(task1.status, "succeeded");
+
+  const created2 = manager.create("updates", "updateCheck", { fresh: true });
+  const task2 = await waitForTask(manager, created2.id);
+  assert.equal(task2.status, "succeeded");
+
+  assert.deepEqual(calls, [{ fresh: false }, { fresh: true }]);
 });
 
 function waitForTask(manager, id) {

--- a/console/api/test/updateCheckCache.test.js
+++ b/console/api/test/updateCheckCache.test.js
@@ -90,3 +90,66 @@ test("invalidate clears the cached result and forces the next read to recollect"
   assert.equal(collections, 2);
   assert.equal(second.stdout, "build-2");
 });
+
+test("peek returns null before anything has been cached", () => {
+  let collections = 0;
+  const cache = createUpdateCheckCache({}, {
+    collect: async () => ({ code: 0, stdout: `build-${++collections}` })
+  });
+
+  const result = cache.peek();
+  assert.equal(result, null);
+  assert.equal(collections, 0);
+});
+
+test("peek returns the cached entry within the TTL without invoking collect", async () => {
+  let currentTime = 1000;
+  let collections = 0;
+  const cache = createUpdateCheckCache({}, {
+    cacheMs: 10000,
+    now: () => currentTime,
+    collect: async () => ({ code: 0, stdout: `build-${++collections}` })
+  });
+
+  const first = await cache.read();
+  assert.equal(collections, 1);
+
+  currentTime += 5000;
+  const peeked = cache.peek();
+  assert.notEqual(peeked, null);
+  assert.equal(peeked.fromCache, true);
+  assert.equal(peeked.stdout, "build-1");
+  assert.equal(collections, 1);
+});
+
+test("peek returns null once the cached entry is past its TTL", async () => {
+  let currentTime = 1000;
+  let collections = 0;
+  const cache = createUpdateCheckCache({}, {
+    cacheMs: 10000,
+    now: () => currentTime,
+    collect: async () => ({ code: 0, stdout: `build-${++collections}` })
+  });
+
+  await cache.read();
+  assert.equal(collections, 1);
+
+  currentTime += 10001;
+  const result = cache.peek();
+  assert.equal(result, null);
+});
+
+test("peek returns null immediately after invalidate", async () => {
+  let collections = 0;
+  const cache = createUpdateCheckCache({}, {
+    cacheMs: 10000,
+    collect: async () => ({ code: 0, stdout: `build-${++collections}` })
+  });
+
+  const first = await cache.read();
+  assert.notEqual(cache.peek(), null);
+
+  cache.invalidate();
+
+  assert.equal(cache.peek(), null);
+});

--- a/console/api/test/updateCheckCache.test.js
+++ b/console/api/test/updateCheckCache.test.js
@@ -91,6 +91,35 @@ test("invalidate clears the cached result and forces the next read to recollect"
   assert.equal(second.stdout, "build-2");
 });
 
+test("invalidate prevents an older in-flight collection from repopulating the cache", async () => {
+  const releases = [];
+  let collections = 0;
+  const cache = createUpdateCheckCache({}, {
+    cacheMs: 10000,
+    collect: () => {
+      collections += 1;
+      return new Promise((resolve) => releases.push(resolve));
+    }
+  });
+
+  const staleRead = cache.read();
+  await Promise.resolve();
+  assert.equal(collections, 1);
+
+  cache.invalidate();
+  const currentRead = cache.read();
+  await Promise.resolve();
+  assert.equal(collections, 2, "a post-invalidation read must not join stale in-flight work");
+
+  releases[1]({ code: 0, stdout: "current-build" });
+  await currentRead;
+  assert.equal(cache.peek()?.stdout, "current-build");
+
+  releases[0]({ code: 0, stdout: "stale-build" });
+  await staleRead;
+  assert.equal(cache.peek()?.stdout, "current-build", "stale work must not overwrite the current cache");
+});
+
 test("peek returns null before anything has been cached", () => {
   let collections = 0;
   const cache = createUpdateCheckCache({}, {

--- a/console/api/test/updateCheckCache.test.js
+++ b/console/api/test/updateCheckCache.test.js
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createUpdateCheckCache } from "../src/services/updateCheckCache.js";
+
+test("update check cache reuses a completed result within the TTL", async () => {
+  let currentTime = 1000;
+  let collections = 0;
+  const cache = createUpdateCheckCache({}, {
+    cacheMs: 10000,
+    now: () => currentTime,
+    collect: async () => ({ code: 0, stdout: `build-${++collections}` })
+  });
+
+  const first = await cache.read();
+  assert.equal(collections, 1);
+  assert.equal(first.fromCache, false);
+
+  currentTime += 5000;
+  const cached = await cache.read();
+  assert.equal(collections, 1);
+  assert.equal(cached.fromCache, true);
+  assert.equal(cached.stdout, "build-1");
+
+  currentTime += 5001;
+  const refreshed = await cache.read();
+  assert.equal(collections, 2);
+  assert.equal(refreshed.fromCache, false);
+  assert.equal(refreshed.stdout, "build-2");
+});
+
+test("update check cache coalesces overlapping and forced reads onto one in-flight collection", async () => {
+  let release;
+  let collections = 0;
+  const cache = createUpdateCheckCache({}, {
+    collect: () => {
+      collections += 1;
+      return new Promise((resolve) => { release = resolve; });
+    }
+  });
+
+  const first = cache.read();
+  const overlapping = cache.read({ fresh: true });
+  await Promise.resolve();
+  assert.equal(collections, 1);
+
+  release({ code: 0, stdout: "build-result" });
+  const firstResult = await first;
+  const overlappingResult = await overlapping;
+
+  assert.equal(firstResult.stdout, "build-result");
+  assert.equal(overlappingResult.stdout, "build-result");
+  assert.equal(firstResult.code, overlappingResult.code);
+});
+
+test("update check cache does not cache a rejected collection", async () => {
+  let collections = 0;
+  let shouldReject = true;
+  const cache = createUpdateCheckCache({}, {
+    collect: async () => {
+      collections += 1;
+      if (shouldReject) {
+        throw new Error("steamcmd timeout");
+      }
+      return { code: 0, stdout: "build-success" };
+    }
+  });
+
+  await assert.rejects(() => cache.read(), /steamcmd timeout/);
+  assert.equal(collections, 1);
+
+  shouldReject = false;
+  const result = await cache.read();
+  assert.equal(collections, 2);
+  assert.equal(result.stdout, "build-success");
+});
+
+test("invalidate clears the cached result and forces the next read to recollect", async () => {
+  let collections = 0;
+  const cache = createUpdateCheckCache({}, {
+    cacheMs: 10000,
+    collect: async () => ({ code: 0, stdout: `build-${++collections}` })
+  });
+
+  const first = await cache.read();
+  assert.equal(collections, 1);
+
+  cache.invalidate();
+
+  const second = await cache.read();
+  assert.equal(collections, 2);
+  assert.equal(second.stdout, "build-2");
+});

--- a/console/web/src/api/updates.ts
+++ b/console/web/src/api/updates.ts
@@ -2,7 +2,7 @@ import { api, post } from "./client";
 import type { Task } from "./setup";
 
 export const updatesApi = {
-  checkGame: () => post<{ task: Task }>("/api/updates/check-game"),
+  checkGame: (options: { fresh?: boolean } = {}) => post<{ task: Task }>("/api/updates/check-game", options.fresh ? { fresh: true } : {}),
   applyGame: () => post<{ task: Task }>("/api/updates/apply-game"),
   fixSteamcmd: () => post<{ task: Task }>("/api/updates/fix-steamcmd"),
   checkStack: () => post<{ task: Task }>("/api/updates/check-stack"),

--- a/console/web/src/features/updates/UpdatesPanel.tsx
+++ b/console/web/src/features/updates/UpdatesPanel.tsx
@@ -75,15 +75,15 @@ export function UpdatesPanel({
   const autoGameStatusLabel = !autoGameLoaded && !autoGameSaving ? "Checking" : autoGameDisplayActive ? "Enabled" : "Disabled";
   const autoGameDisplayTimerLabel = !autoGameLoaded && !autoGameSaving ? "Checking" : autoGameSaving ? autoGameEnabled ? "Activating" : "Deactivating" : autoGameEnabled ? autoGameTimerLabel : "Inactive";
 
-  async function checkGame() {
+  async function checkGame(options: { fresh?: boolean } = {}) {
     setGameStatus({ status: "Checking...", current: "", latest: "", reason: "" });
-    const final = await waitForTask((await updatesApi.checkGame()).task);
+    const final = await waitForTask((await updatesApi.checkGame(options)).task);
     setGameStatus(parseUpdateTask(final));
   }
 
-  async function refreshGameStatus() {
+  async function refreshGameStatus(options: { fresh?: boolean } = {}) {
     try {
-      await checkGame();
+      await checkGame(options);
     } catch (error) {
       setGameStatus({ status: "Check Failed", current: "", latest: "", reason: error instanceof Error ? error.message : String(error) });
     }
@@ -214,7 +214,7 @@ export function UpdatesPanel({
         setGameUpdateTask(current);
         persistUpdateTask(GAME_UPDATE_TASK_KEY, current);
       }
-      if (!cancelled && current.status === "succeeded") refreshGameStatus();
+      if (!cancelled && current.status === "succeeded") refreshGameStatus({ fresh: true });
     })().catch(() => {
       if (cancelled) return;
       persistUpdateTask(GAME_UPDATE_TASK_KEY, null);
@@ -335,7 +335,7 @@ export function UpdatesPanel({
         {gameStatus.status === "Check Failed" && gameStatus.reason && <p className="danger-note">{gameStatus.reason}</p>}
         {gameStatus.status === "Version details unavailable" && <p className="muted">{gameStatus.reason}</p>}
         <div className="action-line">
-          <button disabled={gameUpdateRunning} onClick={checkGame}>Refresh Game Check</button>
+          <button disabled={gameUpdateRunning} onClick={() => checkGame({ fresh: true })}>Refresh Game Check</button>
           {gameCanApply && <button className="update-action" onClick={applyGameUpdate}>Apply Game Update</button>}
         </div>
         {gameUpdateTask && <GameUpdateProgress task={gameUpdateTask} repairTask={gameSteamcmdFixTask} onRetry={applyGameUpdate} onFixSteamcmd={fixSteamcmd} formatResultTitle={formatResultTitle} formatResultMessage={formatResultMessage} />}


### PR DESCRIPTION
## Summary

The Updates tab's "Game Update" section was slow (5-10s) on every panel mount and manual refresh, because each check did a live, uncached `docker compose exec` into the orchestrator container running SteamCMD with an anonymous login + `app_info_update` against Steam's servers — no caching, no de-dup of concurrent checks.

- **Cache the check result** (`console/api/src/services/updateCheckCache.js`, new) for 5 minutes by default (`ADMIN_UPDATE_CHECK_CACHE_MS`), reusing the same cache + in-flight-dedupe shape already used by `memoryBalancer.js`'s `createDockerStatsSampler`. A rejected check is never cached, so failures always retry live.
- **Wire it into the task system** (`console/api/src/tasks.js`): the game-update-check task now reads through the cache; a successful `updateApply`/`updateFixSteamcmd` invalidates it, since those change the on-disk build id the check compares against.
- **Explicit "Refresh Game Check"** always forces a live check via a `fresh` flag threaded from the button through the API to the cache (`console/web/src/features/updates/UpdatesPanel.tsx`, `console/web/src/api/updates.ts`, `console/api/src/server.js`).
- **Second pass — cache-hit latency:** even a cache hit (resolves in single-digit ms) still took ~1-2s in the UI, because `TaskManager.create()` always returned the task as `"queued"` and the frontend's poller only checks once per second, "wait then check." Added a synchronous `peek()` to the cache so `create()` can complete a cache-hit `updateCheck` task immediately — already `"succeeded"` in the initial API response — letting the existing poll loop short-circuit for free (no frontend changes needed for this part).

## Testing

- `console/api`: new/extended `node:test` coverage in `updateCheckCache.test.js` (TTL reuse, in-flight dedupe, no caching of failures, invalidate, and the new `peek()` behavior) and `tasks.test.js` (cache reuse/bypass/invalidation through `TaskManager`, plus the synchronous fast-path).
- Ran the full suite in a Docker container matching this repo's CI (`node:22` + `postgres:17-alpine`, per `.github/workflows/ci.yml`) rather than relying on the Windows dev host, which can't spawn the bash-based `dune` script the tests exercise. All new/changed tests pass; remaining failures were confirmed pre-existing against the base commit and unrelated to this change.
- `console/web`: `npm run build` (`tsc -b` + vite build) passes for the touched files.
- Manually verified in a browser against a local dev server: mount/refresh triggers the right request bodies (`{}` vs `{"fresh":true}`), and the panel renders check results/errors correctly end-to-end.

## Notes for reviewers

- Default TTL (5 min) only affects the API's own cache; the systemd-driven auto-update timer (`update.sh`'s `run_auto_update_policy`) calls `update.sh check` directly on the host and never goes through this cache, so it can't see stale data from this change.
- Two commits: the caching feature, then the cache-hit-latency follow-up — both are self-contained and can be reviewed independently if useful.