### PR TITLE
fix: resolve partition PvP/PvE combat state consistently across all publishers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,14 @@ jobs:
         run: bash tests/ready-configured-ports-test.sh
       - name: Test database updater role restoration
         run: bash tests/update-db-role-privilege-test.sh
+      - name: Test partition combat-state resolver
+        run: python3 runtime/scripts/test_partition_combat_state.py
+      - name: Test combat-state publishers
+        run: |
+          runtime/tests/test-deepdesert-combat-state-publication.sh
+          runtime/tests/test-deepdesert-overrides-combat-state-publication.sh
+          runtime/tests/test-deepdesert-startup-publisher-consistency.sh
+          runtime/tests/test-sietch-combat-state-publication.sh
 
   container-lifecycle:
     runs-on: ubuntu-latest

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2380,6 +2380,33 @@ export async function liveMapServices(db, map = "") {
   return { capabilities: { services: true, farmState: hasFarm }, rows: result.rows };
 }
 
+// Partition topology rows for combat-state resolution. Returns
+// `dune.world_partition` metadata (partition id, dimension index, database
+// label) joined with `farm_state` runtime availability. These fields are
+// descriptive metadata only — callers must resolve PvP/PvE combat state via
+// `services/mapCombatState.js`, never by inferring it from the columns
+// returned here.
+export async function mapCombatPartitionRows(db, map) {
+  if (!(await tableExists(db, "world_partition"))) return unsupportedMap("combatState", ["dune.world_partition"]);
+  const hasFarm = await tableExists(db, "farm_state");
+  const values = [];
+  const where = mapFilterClause(map, values, "wp");
+  const result = await db.query(`
+    select wp.partition_id::text as partition_id,
+           coalesce(wp.map, '') as map,
+           coalesce(wp.dimension_index, 0) as dimension_index,
+           coalesce(wp.label, '') as database_label,
+           coalesce(wp.server_id, '') as server_id,
+           coalesce(wp.blocked, false) as blocked,
+           ${hasFarm ? "coalesce(fs.alive, false)" : "false"} as alive,
+           ${hasFarm ? "coalesce(fs.ready, false)" : "false"} as ready
+    from dune.world_partition wp
+    ${hasFarm ? "left join dune.farm_state fs on fs.server_id = wp.server_id" : ""}
+    where 1=1 ${where}
+    order by wp.dimension_index, wp.partition_id`, values);
+  return { capabilities: { combatState: true, farmState: hasFarm }, rows: result.rows };
+}
+
 export async function liveMapMarkers(db, map = "") {
   const [players, vehicles, bases, storage] = await Promise.all([
     liveMapPlayers(db, map),

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -39,6 +39,7 @@ import { persistSpicefieldOverride } from "./services/spicefieldOverrides.js";
 import { applySavedLandsraadMilestonePreset, createLandsraadMilestoneReconciler, readLandsraadMilestonePreset, saveLandsraadMilestonePreset } from "./services/landsraadMilestones.js";
 import { exportBlueprint, importBlueprint, listBlueprints, deleteBlueprint } from "./blueprints.js";
 import { createZipArchive } from "./services/zipArchive.js";
+import { resolveMapCombatState } from "./services/mapCombatState.js";
 import { grantAddonItem } from "./addonItemGrants.js";
 import { EDA_EXCHANGE_BOT_ADDON_ID, ADDON_SCHEDULER_PERMISSION, createAddonJobScheduler, probeBuybackEligibility, readBuybackSchedule, saveBuybackSchedule } from "./addonJobs.js";
 import { createPublicDirectoryReporter, normalizeDiscordInvite, readDirectorySettings } from "./services/publicDirectory.js";
@@ -573,6 +574,7 @@ async function handleApi(req, res) {
   if (path === "/api/maps/memory") return commandJson(res, "memoryStatus");
   if (path.match(/^\/api\/maps\/spicefields\/[^/]+$/) && req.method === "PATCH") return mapsSpicefieldUpdateRoute(req, res, path);
   if (path === "/api/maps/spicefields") return dbJson(res, () => duneDb.listSpicefieldTypes(db));
+  if (path === "/api/maps/combat-state") return mapCombatStateRoute(res, url);
   if (path === "/api/maps/choam-terminals" && req.method === "POST") return mapsChoamTerminalInstallRoute(req, res);
   if (path === "/api/maps/choam-terminals" && req.method === "DELETE") return mapsChoamTerminalRemoveRoute(req, res);
   if (path === "/api/maps/choam-terminals") return dbJson(res, () => choamTerminalOverview(db));
@@ -1406,6 +1408,32 @@ async function memoryBalancerRoute(req, res) {
   const state = await memoryBalancer.setEnabled(enabled);
   audit(config, req, "maps.memory.balancer", { enabled });
   return json(res, 200, state);
+}
+
+// Read-only, aggregate-only PvP/PvE combat state for a map's partitions.
+// Resolved from the effective UserGame.ini configuration via
+// services/mapCombatState.js — never from database labels, dimension
+// index, display names, or lifecycle mode. See docs on
+// services/mapCombatState.js for the full contract.
+async function mapCombatStateRoute(res, url) {
+  const map = String(url.searchParams.get("map") || "").trim();
+  if (!map) return json(res, 400, { error: "map query parameter is required." });
+  return dbJson(res, async () => {
+    const partitionResult = await duneDb.mapCombatPartitionRows(db, map);
+    if (partitionResult.capabilities?.combatState === false) {
+      return { map, mapState: "UNKNOWN", partitions: [], reason: partitionResult.reason };
+    }
+    const partitionRows = partitionResult.rows.map((row) => ({
+      partitionId: row.partition_id,
+      dimensionIndex: row.dimension_index,
+      databaseLabel: row.database_label || null,
+      serverId: row.server_id || "",
+      ready: Boolean(row.ready),
+      alive: Boolean(row.alive),
+      blocked: Boolean(row.blocked)
+    }));
+    return resolveMapCombatState(config, map, partitionRows);
+  });
 }
 
 async function mapSettingsRoute(req, res) {

--- a/console/api/src/services/mapCombatState.js
+++ b/console/api/src/services/mapCombatState.js
@@ -1,0 +1,200 @@
+// Canonical, read-only resolver for map/partition PvP-PvE combat state.
+//
+// This module is the single reusable source of truth consumed by the Web
+// Console, Discord bridge, Prometheus exporter, RabbitMQ publication, and
+// any other read-only integration that needs to report whether a partition
+// (and, in aggregate, a map) is currently PvP, PvE, MIXED, in CONFLICT, or
+// UNKNOWN.
+//
+// Combat state is resolved exclusively from the effective, merged
+// UserGame.ini configuration for the partition (via
+// `runtime/scripts/usersettings.py partition-combat-state`). It must never
+// be inferred from:
+//   - map names
+//   - dimension indexes
+//   - database labels (`world_partition.label`)
+//   - display names
+//   - service/container names
+//   - lifecycle modes ("dynamic" / "always-on" / etc.)
+//   - client-side badges
+//
+// Those signals remain valid as *descriptive metadata* attached alongside
+// the resolved state, never as a substitute for it.
+//
+// Runtime availability (whether a server process is currently up) is a
+// separate dimension from configured combat state and is reported
+// independently — an offline partition retains its configured PvP/PvE
+// designation.
+
+import { runDune } from "../runner.js";
+
+export const PARTITION_COMBAT_STATES = ["PVP", "PVE", "CONFLICT", "UNKNOWN"];
+export const MAP_COMBAT_STATES = ["PVP", "PVE", "MIXED", "CONFLICT", "UNKNOWN"];
+export const RUNTIME_STATUSES = ["RUNNING", "STARTING", "OFFLINE", "STOPPED", "UNASSIGNED", "UNKNOWN"];
+
+function validateMapNameForCombatState(value) {
+  const raw = String(value || "").trim();
+  if (/^[A-Za-z0-9_:-]{1,80}$/.test(raw)) return raw;
+  throw new Error("Invalid map name");
+}
+
+function validatePartitionIdForCombatState(value) {
+  const raw = String(value ?? "").trim();
+  if (/^\d{1,9}$/.test(raw) && Number(raw) > 0) return raw;
+  throw new Error("Invalid partition id");
+}
+
+/**
+ * Resolve runtime availability for a partition from world_partition /
+ * farm_state fields. This is metadata about whether a server process is
+ * currently up — it must never be blended into the combat-state itself.
+ *
+ * @param {{ serverId?: string, ready?: boolean, alive?: boolean, blocked?: boolean }} row
+ * @returns {"RUNNING"|"STARTING"|"OFFLINE"|"STOPPED"|"UNASSIGNED"|"UNKNOWN"}
+ */
+export function resolveRuntimeStatus(row = {}) {
+  const hasServer = Boolean(String(row.serverId || "").trim());
+  if (row.blocked === true) return "STOPPED";
+  if (!hasServer) return "UNASSIGNED";
+  if (row.alive === true && row.ready === true) return "RUNNING";
+  if (row.alive === true) return "STARTING";
+  if (hasServer) return "OFFLINE";
+  return "UNKNOWN";
+}
+
+/**
+ * Call the canonical Python resolver for a single partition and parse its
+ * structured JSON result. Throws if the underlying `usersettings.py`
+ * invocation fails; callers should catch and surface an UNKNOWN/error state
+ * rather than letting a resolver failure silently look like PVE.
+ *
+ * @param {object} config - server config (repoRoot, duneScript, commandTimeoutMs)
+ * @param {string} mapName
+ * @param {string} partitionId
+ * @returns {Promise<{
+ *   map: string,
+ *   partitionId: string,
+ *   configuredState: "PVP"|"PVE"|"CONFLICT"|"UNKNOWN",
+ *   configuredSource: string,
+ *   materializedState: "PVP"|"PVE"|"CONFLICT"|"UNKNOWN"|null,
+ *   materializedSource: string|null,
+ *   securityZonesEnabled: boolean,
+ *   restartRequired: boolean,
+ *   configurationDrift: boolean,
+ *   warnings: string[],
+ *   unresolvedFields: string[]
+ * }>}
+ */
+export async function resolvePartitionCombatStateFromRuntime(config, mapName, partitionId) {
+  const map = validateMapNameForCombatState(mapName);
+  const id = validatePartitionIdForCombatState(partitionId);
+  const args = ["usersettings", "partition-combat-state", map, id];
+  const result = await runDune(config, args, { timeoutMs: 8000, env: config.env });
+  const parsed = JSON.parse(result.stdout || "{}");
+  if (!PARTITION_COMBAT_STATES.includes(parsed.configuredState)) {
+    throw new Error(`Resolver returned unrecognized configuredState: ${parsed.configuredState}`);
+  }
+  return parsed;
+}
+
+/**
+ * Aggregate independently-resolved partition combat states into a single
+ * map-level combat state. Mirrors the Python `aggregate_map_combat_state`
+ * implementation exactly (both must be kept in sync).
+ *
+ * @param {string[]} partitionStates
+ * @returns {"PVP"|"PVE"|"MIXED"|"CONFLICT"|"UNKNOWN"}
+ */
+export function aggregateMapCombatState(partitionStates) {
+  const states = Array.isArray(partitionStates) ? partitionStates : [];
+  if (!states.length) return "UNKNOWN";
+  if (states.some((state) => state === "CONFLICT")) return "CONFLICT";
+  const determinable = new Set(states.filter((state) => state === "PVP" || state === "PVE"));
+  if (determinable.size === 0) return "UNKNOWN";
+  if (determinable.size === 1) return determinable.has("PVP") ? "PVP" : "PVE";
+  return "MIXED";
+}
+
+/**
+ * Build the full structured combat-state result for every partition of a
+ * map, plus the map-level aggregate. Partitions come from
+ * `dune.world_partition` rows supplied by the caller (already joined with
+ * `farm_state` for runtime metadata) — this function does not query the
+ * database directly so it stays testable and reusable by non-DB callers
+ * (e.g. the Discord bridge, RabbitMQ publisher).
+ *
+ * @param {object} config
+ * @param {Array<{
+ *   partitionId: string|number,
+ *   map: string,
+ *   dimensionIndex?: number,
+ *   databaseLabel?: string,
+ *   serverId?: string,
+ *   ready?: boolean,
+ *   alive?: boolean,
+ *   blocked?: boolean
+ * }>} partitionRows
+ * @returns {Promise<{
+ *   map: string,
+ *   mapState: "PVP"|"PVE"|"MIXED"|"CONFLICT"|"UNKNOWN",
+ *   partitions: Array<object>
+ * }>}
+ */
+export async function resolveMapCombatState(config, mapName, partitionRows) {
+  const map = validateMapNameForCombatState(mapName);
+  const rows = Array.isArray(partitionRows) ? partitionRows : [];
+
+  const partitions = await Promise.all(rows.map(async (row) => {
+    const partitionId = String(row.partitionId ?? "").trim();
+    const runtimeStatus = resolveRuntimeStatus(row);
+    const base = {
+      map,
+      partitionId,
+      dimensionIndex: row.dimensionIndex ?? null,
+      databaseLabel: row.databaseLabel ?? null,
+      runtimeStatus,
+    };
+
+    if (!partitionId) {
+      return {
+        ...base,
+        configuredState: "UNKNOWN",
+        materializedState: null,
+        source: "missing-partition-id",
+        securityZonesEnabled: false,
+        restartRequired: false,
+        configurationDrift: false,
+        warnings: ["Partition has no partition id; combat state cannot be resolved."],
+      };
+    }
+
+    try {
+      const resolved = await resolvePartitionCombatStateFromRuntime(config, map, partitionId);
+      return {
+        ...base,
+        configuredState: resolved.configuredState,
+        materializedState: resolved.materializedState,
+        source: resolved.configuredSource,
+        securityZonesEnabled: resolved.securityZonesEnabled,
+        restartRequired: resolved.restartRequired,
+        configurationDrift: resolved.configurationDrift,
+        warnings: resolved.warnings,
+      };
+    } catch (error) {
+      return {
+        ...base,
+        configuredState: "UNKNOWN",
+        materializedState: null,
+        source: "resolver-error",
+        securityZonesEnabled: false,
+        restartRequired: false,
+        configurationDrift: false,
+        warnings: [`Combat state could not be resolved: ${error.message || error}`],
+      };
+    }
+  }));
+
+  const mapState = aggregateMapCombatState(partitions.map((p) => p.configuredState));
+
+  return { map, mapState, partitions };
+}

--- a/console/api/src/services/mapCombatState.js
+++ b/console/api/src/services/mapCombatState.js
@@ -1,10 +1,8 @@
 // Canonical, read-only resolver for map/partition PvP-PvE combat state.
 //
-// This module is the single reusable source of truth consumed by the Web
-// Console, Discord bridge, Prometheus exporter, RabbitMQ publication, and
-// any other read-only integration that needs to report whether a partition
-// (and, in aggregate, a map) is currently PvP, PvE, MIXED, in CONFLICT, or
-// UNKNOWN.
+// This module is the Console/API adapter for the canonical resolver in
+// runtime/scripts/usersettings.py. Runtime publishers call those same Python
+// resolver helpers directly so every path uses the effective configuration.
 //
 // Combat state is resolved exclusively from the effective, merged
 // UserGame.ini configuration for the partition (via
@@ -97,6 +95,29 @@ export async function resolvePartitionCombatStateFromRuntime(config, mapName, pa
   return parsed;
 }
 
+/** Resolve several partitions with one usersettings.py process. */
+export async function resolvePartitionCombatStatesFromRuntime(config, mapName, partitionIds) {
+  const map = validateMapNameForCombatState(mapName);
+  const ids = [...new Set((Array.isArray(partitionIds) ? partitionIds : [])
+    .map((partitionId) => validatePartitionIdForCombatState(partitionId)))];
+  if (!ids.length) return new Map();
+  const result = await runDune(config, ["usersettings", "partition-combat-states", map, ...ids], { timeoutMs: 8000, env: config.env });
+  const parsed = JSON.parse(result.stdout || "{}");
+  if (!Array.isArray(parsed.partitions)) throw new Error("Resolver returned no partition results");
+  const byPartition = new Map();
+  for (const partition of parsed.partitions) {
+    const id = validatePartitionIdForCombatState(partition.partitionId);
+    if (!PARTITION_COMBAT_STATES.includes(partition.configuredState)) {
+      throw new Error(`Resolver returned unrecognized configuredState: ${partition.configuredState}`);
+    }
+    byPartition.set(id, partition);
+  }
+  for (const id of ids) {
+    if (!byPartition.has(id)) throw new Error(`Resolver omitted partition ${id}`);
+  }
+  return byPartition;
+}
+
 /**
  * Aggregate independently-resolved partition combat states into a single
  * map-level combat state. Mirrors the Python `aggregate_map_combat_state`
@@ -121,7 +142,7 @@ export function aggregateMapCombatState(partitionStates) {
  * `dune.world_partition` rows supplied by the caller (already joined with
  * `farm_state` for runtime metadata) — this function does not query the
  * database directly so it stays testable and reusable by non-DB callers
- * (e.g. the Discord bridge, RabbitMQ publisher).
+ * without coupling database access into the resolver.
  *
  * @param {object} config
  * @param {Array<{
@@ -143,8 +164,16 @@ export function aggregateMapCombatState(partitionStates) {
 export async function resolveMapCombatState(config, mapName, partitionRows) {
   const map = validateMapNameForCombatState(mapName);
   const rows = Array.isArray(partitionRows) ? partitionRows : [];
+  const ids = rows.map((row) => String(row.partitionId ?? "").trim()).filter(Boolean);
+  let resolvedByPartition = new Map();
+  let resolverError = null;
+  try {
+    resolvedByPartition = await resolvePartitionCombatStatesFromRuntime(config, map, ids);
+  } catch (error) {
+    resolverError = error;
+  }
 
-  const partitions = await Promise.all(rows.map(async (row) => {
+  const partitions = rows.map((row) => {
     const partitionId = String(row.partitionId ?? "").trim();
     const runtimeStatus = resolveRuntimeStatus(row);
     const base = {
@@ -168,8 +197,8 @@ export async function resolveMapCombatState(config, mapName, partitionRows) {
       };
     }
 
-    try {
-      const resolved = await resolvePartitionCombatStateFromRuntime(config, map, partitionId);
+    const resolved = resolvedByPartition.get(partitionId);
+    if (resolved) {
       return {
         ...base,
         configuredState: resolved.configuredState,
@@ -180,19 +209,18 @@ export async function resolveMapCombatState(config, mapName, partitionRows) {
         configurationDrift: resolved.configurationDrift,
         warnings: resolved.warnings,
       };
-    } catch (error) {
-      return {
-        ...base,
-        configuredState: "UNKNOWN",
-        materializedState: null,
-        source: "resolver-error",
-        securityZonesEnabled: false,
-        restartRequired: false,
-        configurationDrift: false,
-        warnings: [`Combat state could not be resolved: ${error.message || error}`],
-      };
     }
-  }));
+    return {
+      ...base,
+      configuredState: "UNKNOWN",
+      materializedState: null,
+      source: "resolver-error",
+      securityZonesEnabled: false,
+      restartRequired: false,
+      configurationDrift: false,
+      warnings: [`Combat state could not be resolved: ${resolverError?.message || resolverError || "partition result missing"}`],
+    };
+  });
 
   const mapState = aggregateMapCombatState(partitions.map((p) => p.configuredState));
 

--- a/console/api/test/mapCombatState.test.js
+++ b/console/api/test/mapCombatState.test.js
@@ -1,0 +1,251 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  aggregateMapCombatState,
+  resolveRuntimeStatus,
+  resolvePartitionCombatStateFromRuntime,
+  resolveMapCombatState,
+  PARTITION_COMBAT_STATES,
+  MAP_COMBAT_STATES
+} from "../src/services/mapCombatState.js";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+// ─── Pure aggregation tests (no subprocess) ────────────────────────────────
+
+test("map aggregation: PVP + PVP -> PVP", () => {
+  assert.equal(aggregateMapCombatState(["PVP", "PVP"]), "PVP");
+});
+
+test("map aggregation: PVE + PVE -> PVE", () => {
+  assert.equal(aggregateMapCombatState(["PVE", "PVE"]), "PVE");
+});
+
+test("map aggregation: PVP + PVE -> MIXED", () => {
+  assert.equal(aggregateMapCombatState(["PVP", "PVE"]), "MIXED");
+});
+
+test("map aggregation: PVP + CONFLICT -> CONFLICT", () => {
+  assert.equal(aggregateMapCombatState(["PVP", "CONFLICT"]), "CONFLICT");
+});
+
+test("map aggregation: no partitions -> UNKNOWN", () => {
+  assert.equal(aggregateMapCombatState([]), "UNKNOWN");
+});
+
+test("map aggregation: all UNKNOWN -> UNKNOWN", () => {
+  assert.equal(aggregateMapCombatState(["UNKNOWN", "UNKNOWN"]), "UNKNOWN");
+});
+
+test("map aggregation is order-independent and dedupes determinable votes", () => {
+  assert.equal(aggregateMapCombatState(["PVP", "PVP", "PVP"]), "PVP");
+  assert.equal(aggregateMapCombatState(["PVE", "PVP", "PVE"]), "MIXED");
+});
+
+test("exported state enums match the documented contract", () => {
+  assert.deepEqual(PARTITION_COMBAT_STATES, ["PVP", "PVE", "CONFLICT", "UNKNOWN"]);
+  assert.deepEqual(MAP_COMBAT_STATES, ["PVP", "PVE", "MIXED", "CONFLICT", "UNKNOWN"]);
+});
+
+// ─── Runtime status tests (no subprocess) ──────────────────────────────────
+
+test("runtime status: no server assigned -> UNASSIGNED", () => {
+  assert.equal(resolveRuntimeStatus({}), "UNASSIGNED");
+});
+
+test("runtime status: blocked partition -> STOPPED regardless of server assignment", () => {
+  assert.equal(resolveRuntimeStatus({ serverId: "abc", blocked: true }), "STOPPED");
+});
+
+test("runtime status: assigned, alive and ready -> RUNNING", () => {
+  assert.equal(resolveRuntimeStatus({ serverId: "abc", alive: true, ready: true }), "RUNNING");
+});
+
+test("runtime status: assigned and alive but not ready -> STARTING", () => {
+  assert.equal(resolveRuntimeStatus({ serverId: "abc", alive: true, ready: false }), "STARTING");
+});
+
+test("runtime status: assigned but not alive -> OFFLINE", () => {
+  assert.equal(resolveRuntimeStatus({ serverId: "abc", alive: false, ready: false }), "OFFLINE");
+});
+
+test("configured combat state must be retained while runtime is offline", () => {
+  // This directly encodes the requirement that combat state and runtime
+  // availability are separate dimensions: an OFFLINE partition must not
+  // erase or reset its configured PvP/PvE designation.
+  const runtimeStatus = resolveRuntimeStatus({ serverId: "abc", alive: false, ready: false });
+  assert.equal(runtimeStatus, "OFFLINE");
+  // The combat state itself is resolved independently (see the
+  // subprocess-backed tests below) and is never derived from runtimeStatus.
+});
+
+// ─── Subprocess-backed integration tests against the real resolver ────────
+
+function buildSandbox() {
+  const dir = mkdtempSync(join(tmpdir(), "dune-map-combat-state-"));
+  const generated = join(dir, "runtime", "generated");
+  mkdirSync(generated, { recursive: true });
+  const fakeBin = join(dir, "bin");
+  mkdirSync(fakeBin, { recursive: true });
+
+  // runDune requires config.duneScript to exist on disk, even though
+  // "usersettings" operations are routed to python3 + usersettings.py
+  // directly. A minimal placeholder is sufficient.
+  const duneScript = join(dir, "dune");
+  writeFileSync(duneScript, "#!/usr/bin/env bash\nexit 0\n");
+  chmodSync(duneScript, 0o755);
+
+  const config = {
+    repoRoot,
+    duneScript,
+    commandTimeoutMs: 8000
+  };
+
+  const env = {
+    DUNE_USERSETTINGS_CONFIG: join(generated, "usersettings.json"),
+    DUNE_GAMEPLAY_PROFILE: join(generated, "gameplay-profile.ini"),
+    DUNE_USERSETTINGS_GAME_ROOT: join(dir, "runtime", "game")
+  };
+
+  return { dir, config, env };
+}
+
+function writeProfile(env, lines) {
+  writeFileSync(env.DUNE_GAMEPLAY_PROFILE, lines.join("\n") + "\n");
+}
+
+test("resolver: explicit partition PvP selector resolves to PVP end-to-end", async () => {
+  const { config, env } = buildSandbox();
+  writeProfile(env, [
+    "[Partition:Survival_1:1:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PvpEnabledPartitions=1"
+  ]);
+
+  const result = await resolvePartitionCombatStateFromRuntime(
+    { ...config, env },
+    "Survival_1",
+    "1"
+  );
+  assert.equal(result.configuredState, "PVP");
+  assert.equal(result.configuredSource, "partition-pvp-selector");
+});
+
+test("resolver: explicit partition PvE selector resolves to PVE end-to-end", async () => {
+  const { config, env } = buildSandbox();
+  writeProfile(env, [
+    "[Partition:Survival_1:1:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PveEnabledPartitions=1"
+  ]);
+
+  const result = await resolvePartitionCombatStateFromRuntime(
+    { ...config, env },
+    "Survival_1",
+    "1"
+  );
+  assert.equal(result.configuredState, "PVE");
+  assert.equal(result.configuredSource, "partition-pve-selector");
+});
+
+test("resolver: conflicting partition selectors resolve to CONFLICT with a warning", async () => {
+  const { config, env } = buildSandbox();
+  writeProfile(env, [
+    "[Partition:Survival_1:1:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PvpEnabledPartitions=1",
+    "+m_PveEnabledPartitions=1"
+  ]);
+
+  const result = await resolvePartitionCombatStateFromRuntime(
+    { ...config, env },
+    "Survival_1",
+    "1"
+  );
+  assert.equal(result.configuredState, "CONFLICT");
+  assert.equal(result.configuredSource, "partition-selectors");
+  assert.ok(result.warnings.some((w) => /both PvP and PvE selectors/.test(w)));
+});
+
+test("resolver: default configuration (no overrides) falls back to legacy flags", async () => {
+  const { config, env } = buildSandbox();
+  // No profile file at all -> falls back to defaults: legacy_pvp_enabled
+  // default False, server_pve default True -> PVE via legacy-flags.
+  const result = await resolvePartitionCombatStateFromRuntime(
+    { ...config, env },
+    "Survival_1",
+    "1"
+  );
+  assert.equal(result.configuredState, "PVE");
+  assert.equal(result.configuredSource, "legacy-flags");
+});
+
+test("resolver: database labels, dimension index, and display names are not consulted", async () => {
+  // The resolver call signature only accepts map + partitionId. There is
+  // no parameter through which a label, dimension index, or display name
+  // could influence the result — this test documents that contract by
+  // asserting two partitions with different ids but identical UserGame.ini
+  // partition-selector configuration produce identical combat states.
+  const { config, env } = buildSandbox();
+  writeProfile(env, [
+    "[Partition:DeepDesert_1:8:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PvpEnabledPartitions=8",
+    "[Partition:DeepDesert_1:9:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PvpEnabledPartitions=9"
+  ]);
+
+  const partitionEight = await resolvePartitionCombatStateFromRuntime({ ...config, env }, "DeepDesert_1", "8");
+  const partitionNine = await resolvePartitionCombatStateFromRuntime({ ...config, env }, "DeepDesert_1", "9");
+  assert.equal(partitionEight.configuredState, "PVP");
+  assert.equal(partitionNine.configuredState, "PVP");
+});
+
+test("resolveMapCombatState aggregates a dual Deep Desert (PVP + PVE) to MIXED", async () => {
+  const { config, env } = buildSandbox();
+  writeProfile(env, [
+    "[Partition:DeepDesert_1:8:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PvpEnabledPartitions=8",
+    "[Partition:DeepDesert_1:9:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PveEnabledPartitions=9"
+  ]);
+
+  const result = await resolveMapCombatState({ ...config, env }, "DeepDesert_1", [
+    { partitionId: "8", dimensionIndex: 0, databaseLabel: "PvP" },
+    { partitionId: "9", dimensionIndex: 1, databaseLabel: "PvE" }
+  ]);
+
+  assert.equal(result.mapState, "MIXED");
+  assert.equal(result.partitions.find((p) => p.partitionId === "8").configuredState, "PVP");
+  assert.equal(result.partitions.find((p) => p.partitionId === "9").configuredState, "PVE");
+});
+
+test("resolveMapCombatState retains configured state for offline partitions", async () => {
+  const { config, env } = buildSandbox();
+  writeProfile(env, [
+    "[Partition:DeepDesert_1:8:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PvpEnabledPartitions=8",
+    "[Partition:DeepDesert_1:9:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PveEnabledPartitions=9"
+  ]);
+
+  const result = await resolveMapCombatState({ ...config, env }, "DeepDesert_1", [
+    { partitionId: "8", dimensionIndex: 0, serverId: "", ready: false, alive: false },
+    { partitionId: "9", dimensionIndex: 1, serverId: "", ready: false, alive: false }
+  ]);
+
+  assert.equal(result.mapState, "MIXED");
+  for (const partition of result.partitions) {
+    assert.equal(partition.runtimeStatus, "UNASSIGNED");
+    assert.ok(["PVP", "PVE"].includes(partition.configuredState));
+  }
+});
+
+test("resolveMapCombatState treats a partition with no partition id as UNKNOWN without throwing", async () => {
+  const { config, env } = buildSandbox();
+  const result = await resolveMapCombatState({ ...config, env }, "DeepDesert_1", [
+    { partitionId: "", dimensionIndex: 0 }
+  ]);
+  assert.equal(result.partitions[0].configuredState, "UNKNOWN");
+  assert.equal(result.mapState, "UNKNOWN");
+});

--- a/console/api/test/mapCombatState.test.js
+++ b/console/api/test/mapCombatState.test.js
@@ -8,6 +8,7 @@ import {
   aggregateMapCombatState,
   resolveRuntimeStatus,
   resolvePartitionCombatStateFromRuntime,
+  resolvePartitionCombatStatesFromRuntime,
   resolveMapCombatState,
   PARTITION_COMBAT_STATES,
   MAP_COMBAT_STATES
@@ -199,6 +200,51 @@ test("resolver: database labels, dimension index, and display names are not cons
   const partitionNine = await resolvePartitionCombatStateFromRuntime({ ...config, env }, "DeepDesert_1", "9");
   assert.equal(partitionEight.configuredState, "PVP");
   assert.equal(partitionNine.configuredState, "PVP");
+});
+
+test("batch resolver returns multiple partition states from one command", async () => {
+  const { config, env } = buildSandbox();
+  writeProfile(env, [
+    "[Partition:DeepDesert_1:8:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PvpEnabledPartitions=8",
+    "[Partition:DeepDesert_1:9:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PveEnabledPartitions=9"
+  ]);
+
+  const result = await resolvePartitionCombatStatesFromRuntime(
+    { ...config, env },
+    "DeepDesert_1",
+    ["8", "9", "8"]
+  );
+  assert.equal(result.size, 2);
+  assert.equal(result.get("8").configuredState, "PVP");
+  assert.equal(result.get("9").configuredState, "PVE");
+});
+
+test("resolver compares materialized boolean spellings semantically", async () => {
+  const { config, env } = buildSandbox();
+  writeProfile(env, []);
+  const settingsDir = join(env.DUNE_USERSETTINGS_GAME_ROOT, "deepdesert-1-8", "Saved", "UserSettings");
+  mkdirSync(settingsDir, { recursive: true });
+  writeFileSync(join(settingsDir, "UserGame.ini"), [
+    "[/Script/DuneSandbox.PvpPveSettings]",
+    "m_bShouldForceEnablePvpOnAllPartitions=false",
+    "[/Script/DuneSandbox.DuneGameMode]",
+    "bPvPEnabled=0",
+    "bServerPVE=yes",
+    "[/Script/DuneSandbox.SecurityZonesSubsystem]",
+    "m_bAreSecurityZonesEnabled=on"
+  ].join("\n"));
+
+  const result = await resolvePartitionCombatStateFromRuntime(
+    { ...config, env },
+    "DeepDesert_1",
+    "8"
+  );
+  assert.equal(result.configuredState, "PVE");
+  assert.equal(result.materializedState, "PVE");
+  assert.equal(result.configurationDrift, false);
+  assert.equal(result.restartRequired, false);
 });
 
 test("resolveMapCombatState aggregates a dual Deep Desert (PVP + PVE) to MIXED", async () => {

--- a/console/web/src/api/maps.ts
+++ b/console/web/src/api/maps.ts
@@ -56,6 +56,32 @@ export type SpicefieldTypeRow = {
   global_spawn_weight: number | null;
 };
 
+export type PartitionCombatState = "PVP" | "PVE" | "CONFLICT" | "UNKNOWN";
+export type MapCombatState = "PVP" | "PVE" | "MIXED" | "CONFLICT" | "UNKNOWN";
+export type PartitionRuntimeStatus = "RUNNING" | "STARTING" | "OFFLINE" | "STOPPED" | "UNASSIGNED" | "UNKNOWN";
+
+export type PartitionCombatStateRow = {
+  map: string;
+  partitionId: string;
+  dimensionIndex: number | null;
+  databaseLabel: string | null;
+  runtimeStatus: PartitionRuntimeStatus;
+  configuredState: PartitionCombatState;
+  materializedState: PartitionCombatState | null;
+  source: string;
+  securityZonesEnabled: boolean;
+  restartRequired: boolean;
+  configurationDrift: boolean;
+  warnings: string[];
+};
+
+export type MapCombatStateResult = {
+  map: string;
+  mapState: MapCombatState;
+  partitions: PartitionCombatStateRow[];
+  reason?: string;
+};
+
 export type ChoamTradeCenter = { key: string; name: string };
 export type ChoamSietch = { partition_id: string; dimension_index: number; label: string };
 export type ChoamTerminalPlacement = {
@@ -117,5 +143,6 @@ export const mapsApi = {
   sietchDimensions: (map = "Survival_1", ids = false) => api<{ stdout: string }>(`/api/sietches/dimensions?map=${encodeURIComponent(map)}${ids ? "&ids=1" : ""}`),
   updateSietches: (body: Record<string, unknown>) => post<{ task: Task }>("/api/sietches/update", body),
   deepdesert: () => api<{ stdout: string }>("/api/deepdesert"),
-  updateDeepdesert: (body: { action: string; confirmation: string }) => post<{ task: Task }>("/api/deepdesert/update", body)
+  updateDeepdesert: (body: { action: string; confirmation: string }) => post<{ task: Task }>("/api/deepdesert/update", body),
+  combatState: (map: string) => api<MapCombatStateResult>(`/api/maps/combat-state?map=${encodeURIComponent(map)}`)
 };

--- a/console/web/src/features/maps/MapsPanel.combatState.test.ts
+++ b/console/web/src/features/maps/MapsPanel.combatState.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { deepDesertPartitionName } from "./MapsPanel";
+import type { PartitionCombatStateRow } from "../../api/maps";
+
+// Regression coverage for the fix to deepDesertPartitionName: it must
+// resolve PvP/PvE labeling from the server-resolved combat state (backed by
+// the effective UserGame.ini configuration), never from `row.dimension`.
+// Previously dimension 0 was hard-labeled "Deep Desert PvP" and dimension 1
+// "Deep Desert PvE" regardless of actual partition configuration.
+
+function combatRow(overrides: Partial<PartitionCombatStateRow> = {}): PartitionCombatStateRow {
+  return {
+    map: "DeepDesert_1",
+    partitionId: "8",
+    dimensionIndex: 0,
+    databaseLabel: "DeepDesert_0",
+    runtimeStatus: "RUNNING",
+    configuredState: "PVE",
+    materializedState: "PVE",
+    source: "legacy-flags",
+    securityZonesEnabled: true,
+    restartRequired: false,
+    configurationDrift: false,
+    warnings: [],
+    ...overrides
+  };
+}
+
+describe("deepDesertPartitionName", () => {
+  it("uses a real database label when present and not purely numeric", () => {
+    const name = deepDesertPartitionName({ label: "Custom Sietch Name", dimension: 0 });
+    expect(name).toBe("Custom Sietch Name");
+  });
+
+  it("falls back to a neutral instance name with no combat state supplied", () => {
+    const name = deepDesertPartitionName({ label: "", dimension: 0 });
+    expect(name).toBe("Deep Desert 1");
+  });
+
+  it("does NOT label dimension 0 as PvP when the resolved combat state is PVE", () => {
+    const name = deepDesertPartitionName(
+      { label: "", dimension: 0 },
+      combatRow({ dimensionIndex: 0, configuredState: "PVE" })
+    );
+    expect(name).toContain("PvE");
+    expect(name).not.toContain("PvP");
+  });
+
+  it("does NOT label dimension 1 as PvE when the resolved combat state is PVP", () => {
+    const name = deepDesertPartitionName(
+      { label: "", dimension: 1 },
+      combatRow({ dimensionIndex: 1, partitionId: "9", configuredState: "PVP" })
+    );
+    expect(name).toContain("PvP");
+    expect(name).not.toContain("PvE");
+  });
+
+  it("surfaces a CONFLICT combat state instead of guessing PvP or PvE", () => {
+    const name = deepDesertPartitionName(
+      { label: "", dimension: 0 },
+      combatRow({ configuredState: "CONFLICT" })
+    );
+    expect(name).toMatch(/conflicting/i);
+    expect(name).not.toContain("(PvP)");
+    expect(name).not.toContain("(PvE)");
+  });
+
+  it("does not append a PvP/PvE suffix when combat state is UNKNOWN", () => {
+    const name = deepDesertPartitionName(
+      { label: "", dimension: 0 },
+      combatRow({ configuredState: "UNKNOWN" })
+    );
+    expect(name).toBe("Deep Desert 1");
+  });
+
+  it("a purely numeric database label is treated as non-descriptive and ignored", () => {
+    const name = deepDesertPartitionName(
+      { label: "0", dimension: 0 },
+      combatRow({ configuredState: "PVP" })
+    );
+    expect(name).toContain("PvP");
+  });
+});

--- a/console/web/src/features/maps/MapsPanel.combatState.test.ts
+++ b/console/web/src/features/maps/MapsPanel.combatState.test.ts
@@ -32,6 +32,14 @@ describe("deepDesertPartitionName", () => {
     expect(name).toBe("Custom Sietch Name");
   });
 
+  it("prefers resolved combat state over a stale database label", () => {
+    const name = deepDesertPartitionName(
+      { label: "Deep Desert PvP", dimension: 0 },
+      combatRow({ configuredState: "PVE" })
+    );
+    expect(name).toBe("Deep Desert 1 (PvE)");
+  });
+
   it("falls back to a neutral instance name with no combat state supplied", () => {
     const name = deepDesertPartitionName({ label: "", dimension: 0 });
     expect(name).toBe("Deep Desert 1");

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -1,6 +1,6 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import { ChevronDown, ChevronUp, Download, Grid2X2, List, Lock } from "lucide-react";
-import { mapsApi, type ChoamTerminalOverview, type ChoamTradeCenter, type LiveMapMemoryRow, type MapRuntimeSettings, type MemoryBalancerState, type SpicefieldTypeRow, type UserSettingField, type UserSettingsSchema } from "../../api/maps";
+import { mapsApi, type ChoamTerminalOverview, type ChoamTradeCenter, type LiveMapMemoryRow, type MapCombatStateResult, type MapRuntimeSettings, type MemoryBalancerState, type PartitionCombatStateRow, type SpicefieldTypeRow, type UserSettingField, type UserSettingsSchema } from "../../api/maps";
 import { setupApi, type Task } from "../../api/setup";
 import { SecretInput } from "../../components/SecretInput";
 import { KeyValueGrid, StatusPill, TechnicalDetails } from "../../components/common/DisplayPrimitives";
@@ -237,6 +237,7 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
   const [startupParallelism, setStartupParallelism] = useState("1");
   const [runtimeSettingsSaving, setRuntimeSettingsSaving] = useState(false);
   const [runtimeSettingsResult, setRuntimeSettingsResult] = useState<HomeTaskResult | null>(null);
+  const [combatStateByMap, setCombatStateByMap] = useState<Record<string, MapCombatStateResult>>({});
   const [sietchesText, setSietchesText] = useState("");
   const [sietchDimensionsText, setSietchDimensionsText] = useState("");
   const [sietchDimensionIdsText, setSietchDimensionIdsText] = useState("");
@@ -548,6 +549,20 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       }
     }
   }
+  async function loadCombatState(map: string) {
+    // Combat state (PvP/PvE/MIXED/CONFLICT/UNKNOWN) is resolved server-side
+    // from the effective UserGame.ini configuration — never inferred here
+    // from dimension index, database labels, or display names. See
+    // console/api/src/services/mapCombatState.js for the resolver.
+    try {
+      const result = await mapsApi.combatState(map);
+      setCombatStateByMap((current) => ({ ...current, [map]: result }));
+    } catch {
+      // Combat state is supplementary metadata for this panel; a failure
+      // to resolve it must not block or error the rest of the Maps tab.
+      // Partition rows simply render without a combat-state badge.
+    }
+  }
   async function loadLiveMemory() {
     const result = await mapsApi.liveMemory();
     const now = Date.now();
@@ -696,6 +711,8 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     run(loadRuntimeSettings);
     run(loadSietches);
     run(loadSpicefields);
+    void loadCombatState("Survival_1").catch(() => {});
+    void loadCombatState("DeepDesert_1").catch(() => {});
   }, []);
   useEffect(() => {
     const persisted = loadPersistedMapsTask();
@@ -804,6 +821,8 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       if (document.visibilityState !== "visible") return;
       void refreshMapRuntime().catch(() => {});
       void loadSietches({ preserveDrafts: true }).catch(() => {});
+      void loadCombatState("Survival_1").catch(() => {});
+      void loadCombatState("DeepDesert_1").catch(() => {});
     }, MAP_RUNTIME_REFRESH_MS);
     return () => window.clearInterval(id);
   }, []);
@@ -813,6 +832,8 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       void refreshMapRuntime().catch(() => {});
       void loadLiveMemory().catch(() => {});
       void loadSietches({ preserveDrafts: true }).catch(() => {});
+      void loadCombatState("Survival_1").catch(() => {});
+      void loadCombatState("DeepDesert_1").catch(() => {});
     };
     window.addEventListener("focus", refreshVisibleMaps);
     document.addEventListener("visibilitychange", refreshVisibleMaps);
@@ -1493,9 +1514,11 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
             const childMapSettingsResultActive = Boolean(childResultActive && mapsResult && mapsResultScope === "maps" && isMapSettingsResult(mapsResult));
             const childForceDespawnResultActive = Boolean(childResultActive && mapsResult && mapsResultScope === "maps" && isForceDespawnResult(mapsResult) && !isDeepDesertDualResult(mapsResult));
             const childForceSpawnResultActive = Boolean(childResultActive && mapsResult && mapsResultScope === "maps" && isForceSpawnResult(mapsResult));
-            return <Fragment key={`deepdesert-${String(deepRow.partitionId || deepRow.dimension || "")}`}><tr className="sietch-child-row"><td><span className="sietch-child-name">{deepDesertPartitionName(deepRow)}</span><span className="sietch-child-meta">Partition {String(deepRow.partitionId || "Unknown")} / Dimension {String(deepRow.dimension || "Unknown")}</span></td><td><MapRuntimeStatus value={childStatus} /></td><td>Dual</td><td><MemoryUsageBar row={childMemoryRow} fallback={liveMemoryFallback({ ...row, status: childStatus })} configuredLimit={deepMemory} /></td><td className="actions-column"><button className="stable-action-button" onClick={() => selectDeepDesertPartition(deepRow)}>{childSelected ? "Close" : "Edit"}</button></td></tr>
+            const childCombatRow = combatStateByMap["DeepDesert_1"]?.partitions.find((p) => p.partitionId === String(deepRow.partitionId || "")) || null;
+            const childName = deepDesertPartitionName(deepRow, childCombatRow);
+            return <Fragment key={`deepdesert-${String(deepRow.partitionId || deepRow.dimension || "")}`}><tr className="sietch-child-row"><td><span className="sietch-child-name">{childName}</span><span className="sietch-child-meta">Partition {String(deepRow.partitionId || "Unknown")} / Dimension {String(deepRow.dimension || "Unknown")}{childCombatRow?.configurationDrift ? " / Restart required to apply saved PvP-PvE settings" : ""}</span></td><td><MapRuntimeStatus value={childStatus} /></td><td>Dual</td><td><MemoryUsageBar row={childMemoryRow} fallback={liveMemoryFallback({ ...row, status: childStatus })} configuredLimit={deepMemory} /></td><td className="actions-column"><button className="stable-action-button" onClick={() => selectDeepDesertPartition(deepRow)}>{childSelected ? "Close" : "Edit"}</button></td></tr>
               {childSelected && <tr className="inline-edit-row"><td colSpan={5}><section className="inline-edit-panel">
-                <div className="panel-title"><h4>Edit {deepDesertPartitionName(deepRow)}</h4></div>
+                <div className="panel-title"><h4>Edit {childName}</h4></div>
                 <KeyValueGrid items={[["Partition", deepRow.partitionId], ["Dimension", deepRow.dimension], ["Status", childStatus], ["Memory", deepMemory]]} />
                 <div className="action-line">
                   <label className="memory-number-field">Memory<input type="number" min="0.01" step="0.01" inputMode="decimal" value={memory} onChange={(event) => setMemory(event.target.value)} placeholder="8" /></label>
@@ -2001,13 +2024,23 @@ function partitionMemoryValue(memoryText: string, partitionId: string, fallback:
   return String(row?.memory || fallback || "");
 }
 
-function deepDesertPartitionName(row: Record<string, unknown>) {
+// `combatRow`, when available, comes from the /api/maps/combat-state
+// resolver (see console/api/src/services/mapCombatState.js), which derives
+// PvP/PvE state from the partition's effective UserGame.ini configuration.
+// This function must NOT infer PvP/PvE from `row.dimension` — dimension
+// index is positional metadata only and does not determine combat state
+// (see the "Dual Deep Desert" resolver contract).
+export function deepDesertPartitionName(row: Record<string, unknown>, combatRow?: PartitionCombatStateRow | null) {
   const label = String(row.label || "").trim();
   if (label && !/^[-\d\s]+$/.test(label)) return label;
   const dimension = Number(row.dimension);
-  if (dimension === 0) return "Deep Desert PvP";
-  if (dimension === 1) return "Deep Desert PvE";
-  return `Deep Desert ${Number.isFinite(dimension) ? dimension + 1 : "Instance"}`;
+  const suffix = Number.isFinite(dimension) ? ` ${dimension + 1}` : "";
+  if (combatRow) {
+    if (combatRow.configuredState === "PVP") return `Deep Desert${suffix} (PvP)`;
+    if (combatRow.configuredState === "PVE") return `Deep Desert${suffix} (PvE)`;
+    if (combatRow.configuredState === "CONFLICT") return `Deep Desert${suffix} (Conflicting PvP/PvE config)`;
+  }
+  return `Deep Desert${suffix || " Instance"}`;
 }
 
 type UserGameTarget = { key: string; map: string; partitionId: string; label: string };

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -711,7 +711,6 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     run(loadRuntimeSettings);
     run(loadSietches);
     run(loadSpicefields);
-    void loadCombatState("Survival_1").catch(() => {});
     void loadCombatState("DeepDesert_1").catch(() => {});
   }, []);
   useEffect(() => {
@@ -821,7 +820,6 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       if (document.visibilityState !== "visible") return;
       void refreshMapRuntime().catch(() => {});
       void loadSietches({ preserveDrafts: true }).catch(() => {});
-      void loadCombatState("Survival_1").catch(() => {});
       void loadCombatState("DeepDesert_1").catch(() => {});
     }, MAP_RUNTIME_REFRESH_MS);
     return () => window.clearInterval(id);
@@ -832,7 +830,6 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       void refreshMapRuntime().catch(() => {});
       void loadLiveMemory().catch(() => {});
       void loadSietches({ preserveDrafts: true }).catch(() => {});
-      void loadCombatState("Survival_1").catch(() => {});
       void loadCombatState("DeepDesert_1").catch(() => {});
     };
     window.addEventListener("focus", refreshVisibleMaps);
@@ -2031,8 +2028,6 @@ function partitionMemoryValue(memoryText: string, partitionId: string, fallback:
 // index is positional metadata only and does not determine combat state
 // (see the "Dual Deep Desert" resolver contract).
 export function deepDesertPartitionName(row: Record<string, unknown>, combatRow?: PartitionCombatStateRow | null) {
-  const label = String(row.label || "").trim();
-  if (label && !/^[-\d\s]+$/.test(label)) return label;
   const dimension = Number(row.dimension);
   const suffix = Number.isFinite(dimension) ? ` ${dimension + 1}` : "";
   if (combatRow) {
@@ -2040,6 +2035,8 @@ export function deepDesertPartitionName(row: Record<string, unknown>, combatRow?
     if (combatRow.configuredState === "PVE") return `Deep Desert${suffix} (PvE)`;
     if (combatRow.configuredState === "CONFLICT") return `Deep Desert${suffix} (Conflicting PvP/PvE config)`;
   }
+  const label = String(row.label || "").trim();
+  if (!combatRow && label && !/^[-\d\s]+$/.test(label)) return label;
   return `Deep Desert${suffix || " Instance"}`;
 }
 

--- a/runtime/scripts/publish-deepdesert-overrides.sh
+++ b/runtime/scripts/publish-deepdesert-overrides.sh
@@ -242,7 +242,11 @@ publish_snapshot_once() {
   python3 - <<'PY'
 import json
 import subprocess
+import sys
 import time
+
+sys.path.insert(0, "runtime/scripts")
+import usersettings  # noqa: E402
 
 query = """
 select wp.partition_id,
@@ -270,43 +274,93 @@ result = subprocess.run(
     capture_output=True,
 )
 
-defaults = {
-    "Difficulty": "Custom",
-    "CoreSettings": {
-        "serverDisplayName": "",
-        "doubleDifficultyLoot": False,
-    },
-    "SurvivalSettings": {
-        "hydrationEnabled": True,
-        "sandstormEnabled": 1,
-        "sandStormAutoSpawn": True,
-        "sandStormCoriolisAutoSpawnEnabled": True,
-        "sandStormTreasureEnabled": 1,
-        "sandwormEnabled": 1,
-        "sandwormSpawnType": None,
-        "sandwormDangerZonesEnabled": True,
-        "vehicleSandwormCollisionInteraction": False,
-        "vehicleSandwormInvulnerabilitySecondsOnExit": 900,
-        "vehicleSandwormInvulnerabilitySecondsOnServerRestart": 7200,
-    },
-    "CombatSettings": {
-        "securityZonesForceEnablePvp": False,
-        "areSecurityZonesEnabled": True,
-        "shouldForceEnablePvpOnAllPartitions": False,
-        "itemDeteriorationUpdateRate": 1,
-        "vehicleDurabilityDamageMultiplier": 1,
-        "inventoryDecayedMaxDurabilityThreshold": 0.2,
-    },
-    "HarvestingSettings": {
-        "miningOutputMultiplier": 1,
-        "vehicleMiningOutputMultiplier": 1,
-        "securityZonesPvpResourceMultiplier": 2.5,
-    },
-    "PersistenceSettings": {
-        "buildingBlueprintMaxExtensions": 4,
-        "baseBackupMaxExtensions": 8,
-    },
-}
+usersettings_config = usersettings.load_config()
+
+
+def combat_settings_for_partition(partition_id: str) -> dict:
+    """Resolve this partition's PvP/PvE combat state via the canonical
+    resolver (the same merged UserGame.ini logic used by
+    `usersettings.py partition-values`), instead of publishing a single
+    hard-coded CombatSettings block for every Deep Desert partition.
+
+    This mirrors publish-deepdesert-state.sh's and publish-sietch-overrides.sh's
+    identical fix. This script was the third, previously-unfixed sibling
+    publisher with this exact bug: it publishes to the SAME RabbitMQ
+    target (completions/server_state.DeepDesert_1, via the
+    deepdesertOverrideFilteredState filter exchange) as
+    publish-deepdesert-state.sh, and spawn-server.sh runs both scripts
+    back-to-back at Deep Desert startup (state.sh then overrides.sh) --
+    so this script's previously-generic, identical-for-every-partition
+    payload was silently overwriting the correct, per-partition-resolved
+    payload publish-deepdesert-state.sh had just published moments
+    earlier. Only fields with a known, real source are published here;
+    when the partition's combat state cannot be determined
+    (UNKNOWN/CONFLICT), the PvP/PvE-affecting fields are omitted entirely
+    rather than publishing a guessed value.
+    """
+    values = usersettings.merged_partition_values(
+        usersettings_config, "DeepDesert_1", str(partition_id)
+    )
+    resolved = usersettings.resolve_partition_combat_state(values)
+
+    # Field values are serialized as strings ("True"/"False"), matching
+    # publish-deepdesert-state.sh's and publish-sietch-overrides.sh's
+    # snapshot-publish convention for this exact field set (see #106 for
+    # the pre-existing, deliberately-not-fixed-here string/bool
+    # inconsistency between the snapshot-publish and forward-relay code
+    # paths in the Sietch script -- this function only needs to match its
+    # own snapshot-publish sibling, not resolve that separate finding).
+    settings = {
+        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
+        "itemDeteriorationUpdateRate": "1.0",
+        "vehicleDurabilityDamageMultiplier": "1.0",
+        "inventoryDecayedMaxDurabilityThreshold": "0.2",
+    }
+    if resolved["state"] in ("PVP", "PVE"):
+        # shouldForceEnablePvpOnAllPartitions reflects the actual resolved
+        # force-all flag only when it is what determined this partition's
+        # state; otherwise it is omitted rather than defaulted to False,
+        # since a wrong False would misrepresent a force-all-PvP server.
+        settings["shouldForceEnablePvpOnAllPartitions"] = (
+            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
+        )
+    # When state is CONFLICT or UNKNOWN, PvP/PvE-affecting fields are
+    # intentionally omitted rather than publishing a guessed value.
+    return settings
+
+
+def gameplay_settings_for_partition(partition_id: str, display_name: str) -> dict:
+    return {
+        "Difficulty": "Custom",
+        "CoreSettings": {
+            "serverDisplayName": display_name,
+            "doubleDifficultyLoot": False,
+        },
+        "SurvivalSettings": {
+            "hydrationEnabled": True,
+            "sandstormEnabled": 1,
+            "sandStormAutoSpawn": True,
+            "sandStormCoriolisAutoSpawnEnabled": True,
+            "sandStormTreasureEnabled": 1,
+            "sandwormEnabled": 1,
+            "sandwormSpawnType": None,
+            "sandwormDangerZonesEnabled": True,
+            "vehicleSandwormCollisionInteraction": False,
+            "vehicleSandwormInvulnerabilitySecondsOnExit": 900,
+            "vehicleSandwormInvulnerabilitySecondsOnServerRestart": 7200,
+        },
+        "CombatSettings": combat_settings_for_partition(partition_id),
+        "HarvestingSettings": {
+            "miningOutputMultiplier": 1,
+            "vehicleMiningOutputMultiplier": 1,
+            "securityZonesPvpResourceMultiplier": 2.5,
+        },
+        "PersistenceSettings": {
+            "buildingBlueprintMaxExtensions": 4,
+            "baseBackupMaxExtensions": 8,
+        },
+    }
+
 
 for line in result.stdout.splitlines():
     if not line.strip():
@@ -318,8 +372,6 @@ for line in result.stdout.splitlines():
         continue
     is_ready = ready.lower() in ("t", "true", "1")
     display_name = label if is_ready else ""
-    settings = json.loads(json.dumps(defaults))
-    settings["CoreSettings"]["serverDisplayName"] = display_name
     payload = {
         "reportTimestamp": int(time.time()),
         "partitionId": int(partition_id),
@@ -333,7 +385,7 @@ for line in result.stdout.splitlines():
         "playerHardCapOverride": -1,
         "wauCapCurve": -1,
         "players": [],
-        "serverGameplaySettings": settings,
+        "serverGameplaySettings": gameplay_settings_for_partition(partition_id, display_name),
     }
     print(json.dumps(payload, separators=(",", ":")))
 PY

--- a/runtime/scripts/publish-deepdesert-overrides.sh
+++ b/runtime/scripts/publish-deepdesert-overrides.sh
@@ -301,31 +301,18 @@ def combat_settings_for_partition(partition_id: str) -> dict:
     values = usersettings.merged_partition_values(
         usersettings_config, "DeepDesert_1", str(partition_id)
     )
-    resolved = usersettings.resolve_partition_combat_state(values)
+    publication = usersettings.combat_settings_for_publication(values, string_values=True)
 
     # Field values are serialized as strings ("True"/"False"), matching
     # publish-deepdesert-state.sh's and publish-sietch-overrides.sh's
-    # snapshot-publish convention for this exact field set (see #106 for
-    # the pre-existing, deliberately-not-fixed-here string/bool
-    # inconsistency between the snapshot-publish and forward-relay code
-    # paths in the Sietch script -- this function only needs to match its
-    # own snapshot-publish sibling, not resolve that separate finding).
+    # snapshot-publish convention for this exact field set. Forwarded live
+    # payloads retain their existing native boolean convention.
     settings = {
-        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
         "itemDeteriorationUpdateRate": "1.0",
         "vehicleDurabilityDamageMultiplier": "1.0",
         "inventoryDecayedMaxDurabilityThreshold": "0.2",
     }
-    if resolved["state"] in ("PVP", "PVE"):
-        # shouldForceEnablePvpOnAllPartitions reflects the actual resolved
-        # force-all flag only when it is what determined this partition's
-        # state; otherwise it is omitted rather than defaulted to False,
-        # since a wrong False would misrepresent a force-all-PvP server.
-        settings["shouldForceEnablePvpOnAllPartitions"] = (
-            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
-        )
-    # When state is CONFLICT or UNKNOWN, PvP/PvE-affecting fields are
-    # intentionally omitted rather than publishing a guessed value.
+    settings.update(publication["settings"])
     return settings
 
 

--- a/runtime/scripts/publish-deepdesert-state.sh
+++ b/runtime/scripts/publish-deepdesert-state.sh
@@ -74,8 +74,12 @@ publish_snapshot_once() {
   python3 - <<'PY'
 import json
 import subprocess
+import sys
 import time
 from pathlib import Path
+
+sys.path.insert(0, "runtime/scripts")
+import usersettings  # noqa: E402
 
 config_path = Path("runtime/generated/sietch-config.json")
 config = json.loads(config_path.read_text()) if config_path.exists() else {"partitions": {}}
@@ -107,18 +111,50 @@ result = subprocess.run(
     capture_output=True,
 )
 
-defaults = {
-    "Difficulty": "Custom",
-    "CoreSettings": {
-        "serverDisplayName": "",
-        "doubleDifficultyLoot": "False",
-    },
-    "CombatSettings": {
-        "securityZonesForceEnablePvp": "False",
-        "areSecurityZonesEnabled": "True",
-        "shouldForceEnablePvpOnAllPartitions": "False",
-    },
-}
+usersettings_config = usersettings.load_config()
+
+
+def combat_settings_for_partition(partition_id: str) -> dict:
+    """Resolve this partition's PvP/PvE combat state via the canonical
+    resolver (the same merged UserGame.ini logic used by
+    `usersettings.py partition-values`), instead of publishing a single
+    hard-coded CombatSettings block for every partition.
+
+    Only fields with a known, real source are published. When the
+    partition's combat state cannot be determined (UNKNOWN/CONFLICT), the
+    PvP/PvE-affecting fields are omitted entirely rather than publishing a
+    guessed value, so downstream consumers cannot mistake an unresolved
+    state for an accurate partition-specific reading.
+    """
+    values = usersettings.merged_partition_values(
+        usersettings_config, "DeepDesert_1", str(partition_id)
+    )
+    resolved = usersettings.resolve_partition_combat_state(values)
+
+    settings = {
+        "Difficulty": "Custom",
+        "CoreSettings": {
+            "serverDisplayName": "",
+            "doubleDifficultyLoot": "False",
+        },
+        "CombatSettings": {
+            "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
+        },
+    }
+
+    if resolved["state"] in ("PVP", "PVE"):
+        # shouldForceEnablePvpOnAllPartitions reflects the actual resolved
+        # force-all flag only when it is what determined this partition's
+        # state; otherwise it is left unset rather than defaulted to False,
+        # since a wrong "False" would misrepresent a force-all-PvP server.
+        settings["CombatSettings"]["shouldForceEnablePvpOnAllPartitions"] = (
+            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
+        )
+    # When state is CONFLICT or UNKNOWN, PvP/PvE-affecting fields are
+    # intentionally omitted — see docstring above.
+
+    return settings
+
 
 for line in result.stdout.splitlines():
     if not line.strip():
@@ -131,6 +167,7 @@ for line in result.stdout.splitlines():
     display_name = partitions.get(partition_id, {}).get("display_name", "")
     if not display_name:
         display_name = "Deep Desert" if not label else f"Deep Desert {label}"
+    combat_settings = combat_settings_for_partition(partition_id)
     payload = {
         "reportTimestamp": int(time.time()),
         "partitionId": int(partition_id),
@@ -144,7 +181,7 @@ for line in result.stdout.splitlines():
         "playerHardCapOverride": -1,
         "wauCapCurve": -1,
         "players": [],
-        "serverGameplaySettings": json.loads(json.dumps(defaults)),
+        "serverGameplaySettings": combat_settings,
     }
     payload["serverGameplaySettings"]["CoreSettings"]["serverDisplayName"] = display_name
     print(json.dumps(payload, separators=(",", ":")))

--- a/runtime/scripts/publish-deepdesert-state.sh
+++ b/runtime/scripts/publish-deepdesert-state.sh
@@ -129,7 +129,7 @@ def combat_settings_for_partition(partition_id: str) -> dict:
     values = usersettings.merged_partition_values(
         usersettings_config, "DeepDesert_1", str(partition_id)
     )
-    resolved = usersettings.resolve_partition_combat_state(values)
+    publication = usersettings.combat_settings_for_publication(values, string_values=True)
 
     settings = {
         "Difficulty": "Custom",
@@ -137,21 +137,8 @@ def combat_settings_for_partition(partition_id: str) -> dict:
             "serverDisplayName": "",
             "doubleDifficultyLoot": "False",
         },
-        "CombatSettings": {
-            "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
-        },
+        "CombatSettings": publication["settings"],
     }
-
-    if resolved["state"] in ("PVP", "PVE"):
-        # shouldForceEnablePvpOnAllPartitions reflects the actual resolved
-        # force-all flag only when it is what determined this partition's
-        # state; otherwise it is left unset rather than defaulted to False,
-        # since a wrong "False" would misrepresent a force-all-PvP server.
-        settings["CombatSettings"]["shouldForceEnablePvpOnAllPartitions"] = (
-            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
-        )
-    # When state is CONFLICT or UNKNOWN, PvP/PvE-affecting fields are
-    # intentionally omitted — see docstring above.
 
     return settings
 

--- a/runtime/scripts/publish-sietch-overrides.sh
+++ b/runtime/scripts/publish-sietch-overrides.sh
@@ -304,8 +304,12 @@ publish_snapshot_once() {
 import json
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
+
+sys.path.insert(0, "runtime/scripts")
+import usersettings  # noqa: E402
 
 config_path = Path("runtime/generated/sietch-config.json")
 config = json.loads(config_path.read_text()) if config_path.exists() else {"partitions": {}}
@@ -339,43 +343,69 @@ result = subprocess.run(
     capture_output=True,
 )
 
-defaults = {
-    "Difficulty": "Custom",
-    "CoreSettings": {
-        "serverDisplayName": "",
-        "doubleDifficultyLoot": "False",
-    },
-    "SurvivalSettings": {
-        "hydrationEnabled": "True",
-        "sandstormEnabled": "0",
-        "sandStormAutoSpawn": "True",
-        "sandStormCoriolisAutoSpawnEnabled": "True",
-        "sandStormTreasureEnabled": "1",
-        "sandwormEnabled": "1",
-        "sandwormSpawningType": "0",
-        "sandwormDangerZonesEnabled": "True",
-        "vehicleSandwormCollisionInteraction": "False",
-        "vehicleSandwormInvulnerabilitySecondsOnExit": "900.0",
-        "vehicleSandwormInvulnerabilitySecondsOnServerRestart": "7200.0",
-    },
-    "CombatSettings": {
-        "securityZonesForceEnablePvp": "False",
-        "areSecurityZonesEnabled": "True",
-        "shouldForceEnablePvpOnAllPartitions": "False",
+usersettings_config = usersettings.load_config()
+
+
+def combat_settings_for_partition(partition_id: str) -> dict:
+    """Resolve this partition's PvP/PvE combat state via the canonical
+    resolver (the same merged UserGame.ini logic used by
+    `usersettings.py partition-values`) instead of publishing a single
+    hard-coded CombatSettings block for every Survival_1 partition/Sietch.
+
+    PvP/PvE-affecting fields are omitted entirely when the partition's
+    combat state cannot be determined (UNKNOWN/CONFLICT), rather than
+    publishing a guessed value.
+    """
+    values = usersettings.merged_partition_values(
+        usersettings_config, "Survival_1", str(partition_id)
+    )
+    resolved = usersettings.resolve_partition_combat_state(values)
+
+    settings = {
+        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
         "itemDeteriorationUpdateRate": "1.0",
         "vehicleDurabilityDamageMultiplier": "1.0",
         "inventoryDecayedMaxDurabilityThreshold": "0.2",
-    },
-    "HarvestingSettings": {
-        "miningOutputMultiplier": "1.0",
-        "vehicleMiningOutputMultiplier": "1.0",
-        "securityZonesPvpResourceMultiplier": "2.5",
-    },
-    "PersistenceSettings": {
-        "buildingBlueprintMaxExtensions": "4",
-        "baseBackupMaxExtensions": "8",
-    },
-}
+    }
+    if resolved["state"] in ("PVP", "PVE"):
+        settings["shouldForceEnablePvpOnAllPartitions"] = (
+            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
+        )
+    return settings
+
+
+def gameplay_settings_for_partition(partition_id: str) -> dict:
+    return {
+        "Difficulty": "Custom",
+        "CoreSettings": {
+            "serverDisplayName": "",
+            "doubleDifficultyLoot": "False",
+        },
+        "SurvivalSettings": {
+            "hydrationEnabled": "True",
+            "sandstormEnabled": "0",
+            "sandStormAutoSpawn": "True",
+            "sandStormCoriolisAutoSpawnEnabled": "True",
+            "sandStormTreasureEnabled": "1",
+            "sandwormEnabled": "1",
+            "sandwormSpawningType": "0",
+            "sandwormDangerZonesEnabled": "True",
+            "vehicleSandwormCollisionInteraction": "False",
+            "vehicleSandwormInvulnerabilitySecondsOnExit": "900.0",
+            "vehicleSandwormInvulnerabilitySecondsOnServerRestart": "7200.0",
+        },
+        "CombatSettings": combat_settings_for_partition(partition_id),
+        "HarvestingSettings": {
+            "miningOutputMultiplier": "1.0",
+            "vehicleMiningOutputMultiplier": "1.0",
+            "securityZonesPvpResourceMultiplier": "2.5",
+        },
+        "PersistenceSettings": {
+            "buildingBlueprintMaxExtensions": "4",
+            "baseBackupMaxExtensions": "8",
+        },
+    }
+
 
 for line in result.stdout.splitlines():
     if not line.strip():
@@ -399,7 +429,7 @@ for line in result.stdout.splitlines():
         "playerHardCapOverride": -1,
         "wauCapCurve": -1,
         "players": [],
-        "serverGameplaySettings": json.loads(json.dumps(defaults)),
+        "serverGameplaySettings": gameplay_settings_for_partition(partition_id),
     }
     if game_addr:
         payload["ip"] = game_addr
@@ -434,8 +464,12 @@ forward_batch_once() {
 import json
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
+
+sys.path.insert(0, "runtime/scripts")
+import usersettings  # noqa: E402
 
 messages = json.loads(os.environ["FILTER_MESSAGES"])
 config_path = Path(os.environ["FILTER_CONFIG_PATH"])
@@ -472,6 +506,23 @@ for line in endpoint_rows_raw.splitlines():
     partition_id, game_addr, game_port = line.split("\t", 2)
     endpoint_by_partition[partition_id] = (game_addr, game_port)
 
+usersettings_config = usersettings.load_config()
+
+
+def resolved_force_all_pvp_flag(partition_id: str):
+    """Resolve shouldForceEnablePvpOnAllPartitions from the canonical
+    resolver rather than silently defaulting a missing field to False.
+    Returns None when the partition's combat state cannot be determined,
+    so the caller can omit the field entirely instead of guessing."""
+    values = usersettings.merged_partition_values(
+        usersettings_config, "Survival_1", str(partition_id)
+    )
+    resolved = usersettings.resolve_partition_combat_state(values)
+    if resolved["state"] not in ("PVP", "PVE"):
+        return None
+    return resolved["source"] == "force-pvp-all-partitions"
+
+
 latest_by_partition = {}
 for message in messages:
     payload = json.loads(message["payload"])
@@ -507,7 +558,11 @@ for offset, partition_id in enumerate(sorted(latest_by_partition, key=lambda val
     core["serverDisplayName"] = display_name
     combat = gameplay.setdefault("CombatSettings", {})
     if combat.get("shouldForceEnablePvpOnAllPartitions") in ("", None):
-        combat["shouldForceEnablePvpOnAllPartitions"] = False
+        resolved_flag = resolved_force_all_pvp_flag(partition_id)
+        if resolved_flag is not None:
+            combat["shouldForceEnablePvpOnAllPartitions"] = resolved_flag
+        else:
+            combat.pop("shouldForceEnablePvpOnAllPartitions", None)
     payload["reportTimestamp"] = max(base_timestamp + offset, int(payload.get("reportTimestamp", 0) or 0) + 1)
     print(json.dumps(payload, separators=(",", ":")))
 PY

--- a/runtime/scripts/publish-sietch-overrides.sh
+++ b/runtime/scripts/publish-sietch-overrides.sh
@@ -359,18 +359,14 @@ def combat_settings_for_partition(partition_id: str) -> dict:
     values = usersettings.merged_partition_values(
         usersettings_config, "Survival_1", str(partition_id)
     )
-    resolved = usersettings.resolve_partition_combat_state(values)
+    publication = usersettings.combat_settings_for_publication(values, string_values=True)
 
     settings = {
-        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
         "itemDeteriorationUpdateRate": "1.0",
         "vehicleDurabilityDamageMultiplier": "1.0",
         "inventoryDecayedMaxDurabilityThreshold": "0.2",
     }
-    if resolved["state"] in ("PVP", "PVE"):
-        settings["shouldForceEnablePvpOnAllPartitions"] = (
-            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
-        )
+    settings.update(publication["settings"])
     return settings
 
 
@@ -517,10 +513,8 @@ def resolved_force_all_pvp_flag(partition_id: str):
     values = usersettings.merged_partition_values(
         usersettings_config, "Survival_1", str(partition_id)
     )
-    resolved = usersettings.resolve_partition_combat_state(values)
-    if resolved["state"] not in ("PVP", "PVE"):
-        return None
-    return resolved["source"] == "force-pvp-all-partitions"
+    publication = usersettings.combat_settings_for_publication(values)
+    return publication["settings"].get("shouldForceEnablePvpOnAllPartitions")
 
 
 latest_by_partition = {}

--- a/runtime/scripts/test_partition_combat_state.py
+++ b/runtime/scripts/test_partition_combat_state.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Unit tests for the partition combat-state resolver in usersettings.py.
+
+Run directly:
+    python3 runtime/scripts/test_partition_combat_state.py
+
+Or via unittest discovery:
+    python3 -m unittest discover -s runtime/scripts -p "test_*.py"
+"""
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import usersettings  # noqa: E402
+
+
+def values(
+    force_pvp_all_partitions="False",
+    partition_pvp_enabled="False",
+    partition_pve_enabled="False",
+    legacy_pvp_enabled="False",
+    server_pve="True",
+    security_zones_enabled="True",
+):
+    return {
+        "force_pvp_all_partitions": force_pvp_all_partitions,
+        "partition_pvp_enabled": partition_pvp_enabled,
+        "partition_pve_enabled": partition_pve_enabled,
+        "legacy_pvp_enabled": legacy_pvp_enabled,
+        "server_pve": server_pve,
+        "security_zones_enabled": security_zones_enabled,
+    }
+
+
+class BoolNormalizationTests(unittest.TestCase):
+    def test_recognizes_true_variants(self):
+        for text in ("1", "true", "True", " TRUE ", "yes", "Yes", "on", "ON"):
+            self.assertTrue(usersettings.bool_or_none(text), msg=text)
+
+    def test_recognizes_false_variants(self):
+        for text in ("0", "false", "False", " FALSE ", "no", "No", "off", "OFF"):
+            self.assertFalse(usersettings.bool_or_none(text), msg=text)
+
+    def test_unknown_and_missing_values_are_none(self):
+        for text in (None, "", "  ", "maybe", "null", "unset"):
+            self.assertIsNone(usersettings.bool_or_none(text), msg=repr(text))
+
+
+class PartitionResolverPrecedenceTests(unittest.TestCase):
+    def test_partition_pvp_true_pve_false_is_pvp(self):
+        result = usersettings.resolve_partition_combat_state(
+            values(partition_pvp_enabled="True", partition_pve_enabled="False")
+        )
+        self.assertEqual(result["state"], "PVP")
+        self.assertEqual(result["source"], "partition-pvp-selector")
+
+    def test_partition_pvp_false_pve_true_is_pve(self):
+        result = usersettings.resolve_partition_combat_state(
+            values(partition_pvp_enabled="False", partition_pve_enabled="True")
+        )
+        self.assertEqual(result["state"], "PVE")
+        self.assertEqual(result["source"], "partition-pve-selector")
+
+    def test_partition_pvp_true_and_pve_true_is_conflict(self):
+        result = usersettings.resolve_partition_combat_state(
+            values(partition_pvp_enabled="True", partition_pve_enabled="True")
+        )
+        self.assertEqual(result["state"], "CONFLICT")
+        self.assertEqual(result["source"], "partition-selectors")
+        self.assertIn(
+            "Partition is explicitly included in both PvP and PvE selectors.",
+            result["warnings"],
+        )
+
+    def test_force_all_pvp_conflicts_with_partition_pve(self):
+        result = usersettings.resolve_partition_combat_state(
+            values(force_pvp_all_partitions="True", partition_pve_enabled="True")
+        )
+        self.assertEqual(result["state"], "CONFLICT")
+        self.assertEqual(result["source"], "force-all-vs-partition")
+        self.assertIn(
+            "Global force-PvP conflicts with the partition PvE selector.",
+            result["warnings"],
+        )
+
+    def test_force_all_pvp_true_no_pve_conflict_is_pvp(self):
+        result = usersettings.resolve_partition_combat_state(
+            values(force_pvp_all_partitions="True")
+        )
+        self.assertEqual(result["state"], "PVP")
+        self.assertEqual(result["source"], "force-pvp-all-partitions")
+
+    def test_legacy_pvp_true_server_pve_false_is_pvp(self):
+        result = usersettings.resolve_partition_combat_state(
+            values(legacy_pvp_enabled="True", server_pve="False")
+        )
+        self.assertEqual(result["state"], "PVP")
+        self.assertEqual(result["source"], "legacy-flags")
+
+    def test_legacy_pvp_false_server_pve_true_is_pve(self):
+        result = usersettings.resolve_partition_combat_state(
+            values(legacy_pvp_enabled="False", server_pve="True")
+        )
+        self.assertEqual(result["state"], "PVE")
+        self.assertEqual(result["source"], "legacy-flags")
+
+    def test_unresolved_configuration_is_unknown(self):
+        result = usersettings.resolve_partition_combat_state(
+            values(legacy_pvp_enabled="maybe", server_pve="unset")
+        )
+        self.assertEqual(result["state"], "UNKNOWN")
+        self.assertEqual(result["source"], "unresolved")
+        self.assertIn("legacy_pvp_enabled", result["unresolvedFields"])
+        self.assertIn("server_pve", result["unresolvedFields"])
+
+    def test_unresolved_does_not_default_to_pve(self):
+        # legacy_pvp_enabled unresolved, server_pve True alone must NOT
+        # resolve to PVE — both legacy fields must be determinable.
+        result = usersettings.resolve_partition_combat_state(
+            values(legacy_pvp_enabled="maybe", server_pve="True")
+        )
+        self.assertEqual(result["state"], "UNKNOWN")
+
+    def test_security_zones_disabled_adds_warning_without_changing_state(self):
+        result = usersettings.resolve_partition_combat_state(
+            values(partition_pvp_enabled="True", security_zones_enabled="False")
+        )
+        self.assertEqual(result["state"], "PVP")
+        self.assertFalse(result["securityZonesEnabled"])
+        self.assertIn(
+            "Security zones are disabled; PvP and abilities may be available everywhere.",
+            result["warnings"],
+        )
+
+    def test_explicit_partition_selector_overrides_legacy_flags(self):
+        # partition_pve_enabled=True should win even though legacy flags
+        # would otherwise resolve to PVP.
+        result = usersettings.resolve_partition_combat_state(
+            values(
+                partition_pve_enabled="True",
+                legacy_pvp_enabled="True",
+                server_pve="False",
+            )
+        )
+        self.assertEqual(result["state"], "PVE")
+        self.assertEqual(result["source"], "partition-pve-selector")
+
+    def test_boolean_normalization_case_insensitive_with_whitespace(self):
+        result = usersettings.resolve_partition_combat_state(
+            values(partition_pvp_enabled="  TRUE  ", partition_pve_enabled="No")
+        )
+        self.assertEqual(result["state"], "PVP")
+
+
+class MapAggregationTests(unittest.TestCase):
+    def test_all_pvp_is_pvp(self):
+        self.assertEqual(usersettings.aggregate_map_combat_state(["PVP", "PVP"]), "PVP")
+
+    def test_all_pve_is_pve(self):
+        self.assertEqual(usersettings.aggregate_map_combat_state(["PVE", "PVE"]), "PVE")
+
+    def test_mixed_pvp_and_pve_is_mixed(self):
+        self.assertEqual(usersettings.aggregate_map_combat_state(["PVP", "PVE"]), "MIXED")
+
+    def test_any_conflict_forces_conflict(self):
+        self.assertEqual(usersettings.aggregate_map_combat_state(["PVP", "CONFLICT"]), "CONFLICT")
+        self.assertEqual(usersettings.aggregate_map_combat_state(["CONFLICT"]), "CONFLICT")
+
+    def test_no_partitions_is_unknown(self):
+        self.assertEqual(usersettings.aggregate_map_combat_state([]), "UNKNOWN")
+
+    def test_all_unknown_is_unknown(self):
+        self.assertEqual(usersettings.aggregate_map_combat_state(["UNKNOWN", "UNKNOWN"]), "UNKNOWN")
+
+    def test_unknown_mixed_with_determinable_does_not_force_unknown(self):
+        # One PVP + one UNKNOWN partition should still register as PVP,
+        # since UNKNOWN partitions abstain from the vote rather than
+        # forcing ambiguity onto the whole map.
+        self.assertEqual(usersettings.aggregate_map_combat_state(["PVP", "UNKNOWN"]), "PVP")
+
+
+class MetadataIndependenceTests(unittest.TestCase):
+    """Confirm the resolver never reads dimension index, labels, display
+    names, service/container names, or lifecycle mode — only the six
+    UserGame.ini-derived fields matter."""
+
+    def test_identical_config_different_metadata_yields_identical_state(self):
+        base = values(partition_pvp_enabled="True", partition_pve_enabled="False")
+        result_a = usersettings.resolve_partition_combat_state(base)
+        result_b = usersettings.resolve_partition_combat_state(
+            {**base, "dimension_index": 1, "label": "PvE", "display_name": "Sietch Abbir"}
+        )
+        self.assertEqual(result_a["state"], result_b["state"])
+        self.assertEqual(result_a["source"], result_b["source"])
+
+    def test_dimension_zero_is_not_assumed_pvp(self):
+        # A dimension-0 partition configured for PVE must resolve to PVE,
+        # not PVP, proving dimension index plays no role.
+        result = usersettings.resolve_partition_combat_state(
+            {
+                **values(partition_pvp_enabled="False", partition_pve_enabled="True"),
+                "dimension_index": 0,
+            }
+        )
+        self.assertEqual(result["state"], "PVE")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/runtime/scripts/test_partition_combat_state.py
+++ b/runtime/scripts/test_partition_combat_state.py
@@ -183,6 +183,34 @@ class MapAggregationTests(unittest.TestCase):
         self.assertEqual(usersettings.aggregate_map_combat_state(["PVP", "UNKNOWN"]), "PVP")
 
 
+class PublicationCombatSettingsTests(unittest.TestCase):
+    def test_selector_states_do_not_misuse_force_all_field(self):
+        pvp = usersettings.combat_settings_for_publication(
+            values(partition_pvp_enabled="True"), string_values=True
+        )
+        pve = usersettings.combat_settings_for_publication(
+            values(partition_pve_enabled="True"), string_values=True
+        )
+        self.assertEqual(pvp["resolved"]["state"], "PVP")
+        self.assertEqual(pve["resolved"]["state"], "PVE")
+        self.assertEqual(pvp["settings"], pve["settings"])
+        self.assertEqual(pvp["settings"]["shouldForceEnablePvpOnAllPartitions"], "False")
+
+    def test_force_all_pvp_is_published_as_true(self):
+        publication = usersettings.combat_settings_for_publication(
+            values(force_pvp_all_partitions="True")
+        )
+        self.assertEqual(publication["resolved"]["state"], "PVP")
+        self.assertIs(publication["settings"]["shouldForceEnablePvpOnAllPartitions"], True)
+
+    def test_unknown_state_omits_force_all_field(self):
+        publication = usersettings.combat_settings_for_publication(
+            values(legacy_pvp_enabled="maybe", server_pve="unset")
+        )
+        self.assertEqual(publication["resolved"]["state"], "UNKNOWN")
+        self.assertNotIn("shouldForceEnablePvpOnAllPartitions", publication["settings"])
+
+
 class MetadataIndependenceTests(unittest.TestCase):
     """Confirm the resolver never reads dimension index, labels, display
     names, service/container names, or lifecycle mode — only the six

--- a/runtime/scripts/usersettings.py
+++ b/runtime/scripts/usersettings.py
@@ -2233,6 +2233,270 @@ def materialize(map_name: str, saved_dir: str, partition_id: str | None = None) 
     return 0
 
 
+# ─── Partition combat-state resolver ────────────────────────────────────────
+#
+# Resolves the effective PvP/PvE combat state of a map partition from the
+# same merged UserGame.ini configuration fields that generate the partition
+# runtime files (see `merged_partition_values` / PARTITION_FIELDS above).
+#
+# This resolver intentionally does NOT use database dimension indexes,
+# database labels, display names, service names, container names, or
+# lifecycle modes as inputs. Those remain descriptive metadata only and are
+# attached by callers (e.g. the Console API) alongside this resolver's
+# output, never as a substitute for it.
+
+PARTITION_COMBAT_STATES = ("PVP", "PVE", "CONFLICT", "UNKNOWN")
+MAP_COMBAT_STATES = ("PVP", "PVE", "MIXED", "CONFLICT", "UNKNOWN")
+
+# Fields compared between the persisted profile ("configured") and the
+# materialized runtime UserGame.ini ("materialized") to detect drift/pending
+# restarts. Order is not significant.
+COMBAT_STATE_FIELDS = (
+    "force_pvp_all_partitions",
+    "partition_pvp_enabled",
+    "partition_pve_enabled",
+    "legacy_pvp_enabled",
+    "server_pve",
+    "security_zones_enabled",
+)
+
+
+def bool_or_none(value) -> bool | None:
+    """Tri-state boolean normalization.
+
+    Recognizes 1/true/yes/on as True and 0/false/no/off as False
+    (case-insensitive, surrounding whitespace ignored). Anything else
+    (including None/empty) returns None so that callers can distinguish
+    "explicitly false" from "unknown/unsupported" rather than silently
+    coercing incomplete configuration into a false reading.
+    """
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "on"}:
+        return True
+    if text in {"0", "false", "no", "off"}:
+        return False
+    return None
+
+
+def resolve_partition_combat_state(values: dict) -> dict:
+    """Resolve a single partition's PvP/PvE combat state.
+
+    `values` must contain (or omit, for UNKNOWN) the keys:
+      force_pvp_all_partitions, partition_pvp_enabled, partition_pve_enabled,
+      legacy_pvp_enabled, server_pve, security_zones_enabled
+
+    Returns a dict with keys: state, source, securityZonesEnabled, warnings,
+    unresolvedFields. `state` is one of PARTITION_COMBAT_STATES.
+
+    Precedence (highest to lowest):
+      1. partition_pvp_enabled AND partition_pve_enabled       -> CONFLICT
+      2. force_pvp_all_partitions AND partition_pve_enabled    -> CONFLICT
+      3. force_pvp_all_partitions                              -> PVP
+      4. partition_pvp_enabled                                 -> PVP
+      5. partition_pve_enabled                                 -> PVE
+      6. legacy_pvp_enabled AND NOT server_pve                 -> PVP
+      7. NOT legacy_pvp_enabled AND server_pve                 -> PVE
+      8. otherwise                                              -> UNKNOWN
+
+    Explicit partition selectors (rules 1, 2, 4, 5) always take precedence
+    over the legacy compatibility fields (rules 6, 7). Unresolved (None)
+    values never satisfy a positive comparison, so missing/unsupported
+    configuration cannot be mistaken for an explicit selection.
+    """
+    force_all_pvp = bool_or_none(values.get("force_pvp_all_partitions"))
+    partition_pvp = bool_or_none(values.get("partition_pvp_enabled"))
+    partition_pve = bool_or_none(values.get("partition_pve_enabled"))
+    legacy_pvp = bool_or_none(values.get("legacy_pvp_enabled"))
+    server_pve = bool_or_none(values.get("server_pve"))
+    security_zones_enabled = bool_or_none(values.get("security_zones_enabled"))
+
+    unresolved_fields = [
+        key for key, raw in (
+            ("force_pvp_all_partitions", values.get("force_pvp_all_partitions")),
+            ("partition_pvp_enabled", values.get("partition_pvp_enabled")),
+            ("partition_pve_enabled", values.get("partition_pve_enabled")),
+            ("legacy_pvp_enabled", values.get("legacy_pvp_enabled")),
+            ("server_pve", values.get("server_pve")),
+            ("security_zones_enabled", values.get("security_zones_enabled")),
+        )
+        if bool_or_none(raw) is None
+    ]
+
+    warnings: list[str] = []
+
+    if partition_pvp is True and partition_pve is True:
+        return {
+            "state": "CONFLICT",
+            "source": "partition-selectors",
+            "securityZonesEnabled": bool(security_zones_enabled),
+            "warnings": ["Partition is explicitly included in both PvP and PvE selectors."],
+            "unresolvedFields": unresolved_fields,
+        }
+
+    if force_all_pvp is True and partition_pve is True:
+        return {
+            "state": "CONFLICT",
+            "source": "force-all-vs-partition",
+            "securityZonesEnabled": bool(security_zones_enabled),
+            "warnings": ["Global force-PvP conflicts with the partition PvE selector."],
+            "unresolvedFields": unresolved_fields,
+        }
+
+    if security_zones_enabled is False:
+        warnings.append("Security zones are disabled; PvP and abilities may be available everywhere.")
+
+    if force_all_pvp is True:
+        return {
+            "state": "PVP",
+            "source": "force-pvp-all-partitions",
+            "securityZonesEnabled": bool(security_zones_enabled),
+            "warnings": warnings,
+            "unresolvedFields": unresolved_fields,
+        }
+
+    if partition_pvp is True:
+        return {
+            "state": "PVP",
+            "source": "partition-pvp-selector",
+            "securityZonesEnabled": bool(security_zones_enabled),
+            "warnings": warnings,
+            "unresolvedFields": unresolved_fields,
+        }
+
+    if partition_pve is True:
+        return {
+            "state": "PVE",
+            "source": "partition-pve-selector",
+            "securityZonesEnabled": bool(security_zones_enabled),
+            "warnings": warnings,
+            "unresolvedFields": unresolved_fields,
+        }
+
+    if legacy_pvp is True and server_pve is False:
+        return {
+            "state": "PVP",
+            "source": "legacy-flags",
+            "securityZonesEnabled": bool(security_zones_enabled),
+            "warnings": warnings,
+            "unresolvedFields": unresolved_fields,
+        }
+
+    if legacy_pvp is False and server_pve is True:
+        return {
+            "state": "PVE",
+            "source": "legacy-flags",
+            "securityZonesEnabled": bool(security_zones_enabled),
+            "warnings": warnings,
+            "unresolvedFields": unresolved_fields,
+        }
+
+    return {
+        "state": "UNKNOWN",
+        "source": "unresolved",
+        "securityZonesEnabled": bool(security_zones_enabled),
+        "warnings": warnings,
+        "unresolvedFields": unresolved_fields,
+    }
+
+
+def aggregate_map_combat_state(partition_states: list) -> str:
+    """Aggregate independently-resolved partition states into a map state.
+
+      every partition PVP                -> PVP
+      every partition PVE                 -> PVE
+      at least one PVP and one PVE        -> MIXED
+      any partition CONFLICT              -> CONFLICT
+      no configured/determinable states   -> UNKNOWN
+
+    UNKNOWN partitions are excluded from the PVP/PVE/MIXED vote (they are
+    "undeterminable", not a vote for either side) but do not by themselves
+    force the map to UNKNOWN unless every partition is UNKNOWN.
+    """
+    if not partition_states:
+        return "UNKNOWN"
+    if any(state == "CONFLICT" for state in partition_states):
+        return "CONFLICT"
+    determinable = {state for state in partition_states if state in ("PVP", "PVE")}
+    if not determinable:
+        return "UNKNOWN"
+    if determinable == {"PVP"}:
+        return "PVP"
+    if determinable == {"PVE"}:
+        return "PVE"
+    return "MIXED"
+
+
+def materialized_partition_combat_values(map_name: str, partition_id: str) -> dict | None:
+    """Read the effective combat-relevant fields from the live/materialized
+    UserGame.ini for a partition, if that runtime file exists. Returns None
+    when no materialized file is present (e.g. the partition has never been
+    started), which callers must not treat as UNKNOWN/false — it simply
+    means there is nothing materialized to compare against yet.
+    """
+    target_map = canonical_map(map_name)
+    path = live_usergame_path(target_map, str(partition_id))
+    if not path.exists():
+        return None
+
+    pvp_pve_section = "/Script/DuneSandbox.PvpPveSettings"
+    game_mode_section = "/Script/DuneSandbox.DuneGameMode"
+    security_zones_section = "/Script/DuneSandbox.SecurityZonesSubsystem"
+
+    force_all = read_ini_value(path, pvp_pve_section, "m_bShouldForceEnablePvpOnAllPartitions")
+    partition_pvp = read_ini_array_contains(path, pvp_pve_section, "m_PvpEnabledPartitions", str(partition_id))
+    partition_pve = read_ini_array_contains(path, pvp_pve_section, "m_PveEnabledPartitions", str(partition_id))
+    legacy_pvp = read_ini_value(path, game_mode_section, "bPvPEnabled")
+    server_pve = read_ini_value(path, game_mode_section, "bServerPVE")
+    security_zones = read_ini_value(path, security_zones_section, "m_bAreSecurityZonesEnabled")
+
+    return {
+        "force_pvp_all_partitions": force_all if force_all is not None else "False",
+        "partition_pvp_enabled": "True" if partition_pvp else "False",
+        "partition_pve_enabled": "True" if partition_pve else "False",
+        "legacy_pvp_enabled": legacy_pvp if legacy_pvp is not None else "False",
+        "server_pve": server_pve if server_pve is not None else "True",
+        "security_zones_enabled": security_zones if security_zones is not None else "True",
+    }
+
+
+def partition_combat_state_command(map_name: str, partition_id: str) -> int:
+    """Print a structured JSON combat-state result for one partition,
+    comparing the persisted/configured settings against the materialized
+    runtime UserGame.ini (when present)."""
+    config = load_config()
+    target_map = canonical_map(map_name)
+    target_partition = str(partition_id)
+
+    configured_values = merged_partition_values(config, target_map, target_partition)
+    configured_result = resolve_partition_combat_state(configured_values)
+
+    materialized_values = materialized_partition_combat_values(target_map, target_partition)
+    materialized_result = resolve_partition_combat_state(materialized_values) if materialized_values is not None else None
+
+    configuration_drift = materialized_values is not None and any(
+        str(materialized_values.get(field, "")) != str(configured_values.get(field, ""))
+        for field in COMBAT_STATE_FIELDS
+    )
+
+    payload = {
+        "map": target_map,
+        "partitionId": target_partition,
+        "configuredState": configured_result["state"],
+        "configuredSource": configured_result["source"],
+        "materializedState": materialized_result["state"] if materialized_result else None,
+        "materializedSource": materialized_result["source"] if materialized_result else None,
+        "securityZonesEnabled": configured_result["securityZonesEnabled"],
+        "restartRequired": configuration_drift,
+        "configurationDrift": configuration_drift,
+        "warnings": configured_result["warnings"],
+        "unresolvedFields": configured_result["unresolvedFields"],
+    }
+    print(json.dumps(payload, separators=(",", ":")))
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if len(argv) < 2:
         return 2
@@ -2278,6 +2542,8 @@ def main(argv: list[str]) -> int:
         return print_usergame_rows(merged_map_values(config, canonical_map(argv[2])), MAP_FIELDS)
     if command == "partition-values" and len(argv) == 4:
         return print_usergame_rows(merged_partition_values(config, canonical_map(argv[2]), argv[3]), PARTITION_FIELDS)
+    if command == "partition-combat-state" and len(argv) == 4:
+        return partition_combat_state_command(argv[2], argv[3])
     if command == "partition-engine-values" and len(argv) == 4:
         return print_rows(merged_partition_engine_values(config, canonical_map(argv[2]), argv[3]), PARTITION_ENGINE_FIELDS)
     if command == "engine-set" and len(argv) == 4:

--- a/runtime/scripts/usersettings.py
+++ b/runtime/scripts/usersettings.py
@@ -2401,6 +2401,32 @@ def resolve_partition_combat_state(values: dict) -> dict:
     }
 
 
+def combat_settings_for_publication(values: dict, string_values: bool = False) -> dict:
+    """Return only combat fields supported by the Funcom state payload.
+
+    Partition selector membership is intentionally not folded into
+    shouldForceEnablePvpOnAllPartitions: that field describes the global
+    force-all switch, not whether this particular partition resolved to PvP.
+    The resolved state is returned alongside the supported settings for UI,
+    diagnostics, and tests that need the full distinction.
+    """
+    resolved = resolve_partition_combat_state(values)
+
+    def output_bool(value: bool):
+        if string_values:
+            return "True" if value else "False"
+        return value
+
+    settings = {
+        "areSecurityZonesEnabled": output_bool(resolved["securityZonesEnabled"]),
+    }
+    if resolved["state"] in ("PVP", "PVE"):
+        settings["shouldForceEnablePvpOnAllPartitions"] = output_bool(
+            resolved["source"] == "force-pvp-all-partitions"
+        )
+    return {"resolved": resolved, "settings": settings}
+
+
 def aggregate_map_combat_state(partition_states: list) -> str:
     """Aggregate independently-resolved partition states into a map state.
 
@@ -2461,26 +2487,23 @@ def materialized_partition_combat_values(map_name: str, partition_id: str) -> di
     }
 
 
-def partition_combat_state_command(map_name: str, partition_id: str) -> int:
-    """Print a structured JSON combat-state result for one partition,
-    comparing the persisted/configured settings against the materialized
-    runtime UserGame.ini (when present)."""
-    config = load_config()
+def partition_combat_state_payload(map_name: str, partition_id: str, profile: dict | None = None) -> dict:
+    """Build one structured combat-state result without reloading config."""
     target_map = canonical_map(map_name)
     target_partition = str(partition_id)
 
-    configured_values = merged_partition_values(config, target_map, target_partition)
+    configured_values = profile_partition_values(profile if profile is not None else read_profile(), target_map, target_partition)
     configured_result = resolve_partition_combat_state(configured_values)
 
     materialized_values = materialized_partition_combat_values(target_map, target_partition)
     materialized_result = resolve_partition_combat_state(materialized_values) if materialized_values is not None else None
 
     configuration_drift = materialized_values is not None and any(
-        str(materialized_values.get(field, "")) != str(configured_values.get(field, ""))
+        bool_or_none(materialized_values.get(field)) != bool_or_none(configured_values.get(field))
         for field in COMBAT_STATE_FIELDS
     )
 
-    payload = {
+    return {
         "map": target_map,
         "partitionId": target_partition,
         "configuredState": configured_result["state"],
@@ -2492,6 +2515,30 @@ def partition_combat_state_command(map_name: str, partition_id: str) -> int:
         "configurationDrift": configuration_drift,
         "warnings": configured_result["warnings"],
         "unresolvedFields": configured_result["unresolvedFields"],
+    }
+
+
+def partition_combat_state_command(map_name: str, partition_id: str) -> int:
+    """Print a structured combat-state result for one partition."""
+    payload = partition_combat_state_payload(map_name, partition_id, read_profile())
+    print(json.dumps(payload, separators=(",", ":")))
+    return 0
+
+
+def partition_combat_states_command(map_name: str, partition_ids: list[str]) -> int:
+    """Resolve several partitions in one process and one profile read path."""
+    profile = read_profile()
+    target_map = canonical_map(map_name)
+    partitions = [
+        partition_combat_state_payload(target_map, partition_id, profile)
+        for partition_id in partition_ids
+    ]
+    payload = {
+        "map": target_map,
+        "mapState": aggregate_map_combat_state(
+            [partition["configuredState"] for partition in partitions]
+        ),
+        "partitions": partitions,
     }
     print(json.dumps(payload, separators=(",", ":")))
     return 0
@@ -2544,6 +2591,8 @@ def main(argv: list[str]) -> int:
         return print_usergame_rows(merged_partition_values(config, canonical_map(argv[2]), argv[3]), PARTITION_FIELDS)
     if command == "partition-combat-state" and len(argv) == 4:
         return partition_combat_state_command(argv[2], argv[3])
+    if command == "partition-combat-states" and len(argv) >= 4:
+        return partition_combat_states_command(argv[2], argv[3:])
     if command == "partition-engine-values" and len(argv) == 4:
         return print_rows(merged_partition_engine_values(config, canonical_map(argv[2]), argv[3]), PARTITION_ENGINE_FIELDS)
     if command == "engine-set" and len(argv) == 4:

--- a/runtime/tests/test-deepdesert-combat-state-publication.sh
+++ b/runtime/tests/test-deepdesert-combat-state-publication.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Regression test for runtime/scripts/publish-deepdesert-state.sh:
+#
+#   Previously, every Deep Desert partition was published to RabbitMQ with
+#   an identical, hard-coded CombatSettings block, regardless of that
+#   partition's actual configured PvP/PvE state. This test proves the
+#   script's combat-settings resolution now diverges correctly between a
+#   PvP-configured partition and a PvE-configured partition, and that it
+#   uses the canonical `usersettings.py` resolver rather than a fixed
+#   defaults dict.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  grep -Fq -- "$pattern" "$file" || fail "$file missing: $pattern"
+}
+
+assert_not_python_pattern() {
+  local file="$1"
+  local pattern="$2"
+  if grep -Pzoq -- "$pattern" "$file"; then
+    fail "$file unexpectedly still contains fixed-defaults pattern"
+  fi
+}
+
+SCRIPT="runtime/scripts/publish-deepdesert-state.sh"
+
+# ─── Static checks: the script must call the canonical resolver ───────────
+
+assert_contains "$SCRIPT" "import usersettings"
+assert_contains "$SCRIPT" "usersettings.resolve_partition_combat_state"
+assert_contains "$SCRIPT" "usersettings.merged_partition_values"
+assert_contains "$SCRIPT" "def combat_settings_for_partition"
+
+# The old bug: one fixed defaults dict, built once outside the per-line
+# loop, reused verbatim for every partition regardless of its
+# configuration. Guard against regressing to that shape by asserting the
+# loop body calls the per-partition resolver function rather than reusing
+# a single pre-built dict via json.loads(json.dumps(defaults)).
+assert_not_python_pattern "$SCRIPT" 'json\.loads\(json\.dumps\(defaults\)\)'
+
+# ─── Behavioral check: two partitions with different configured combat
+#     state must resolve to different CombatSettings payloads ─────────────
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+GENERATED_DIR="$TMP_DIR/runtime/generated"
+mkdir -p "$GENERATED_DIR"
+
+PROFILE_PATH="$GENERATED_DIR/gameplay-profile.ini"
+cat > "$PROFILE_PATH" <<'INI'
+[Partition:DeepDesert_1:8:/Script/DuneSandbox.PvpPveSettings]
++m_PvpEnabledPartitions=8
+[Partition:DeepDesert_1:9:/Script/DuneSandbox.PvpPveSettings]
++m_PveEnabledPartitions=9
+INI
+
+RESULT="$(DUNE_GAMEPLAY_PROFILE="$PROFILE_PATH" DUNE_USERSETTINGS_CONFIG="$GENERATED_DIR/usersettings.json" python3 - <<'PY'
+import sys
+sys.path.insert(0, "runtime/scripts")
+import usersettings
+
+config = usersettings.load_config()
+
+
+def combat_settings_for_partition(partition_id):
+    values = usersettings.merged_partition_values(config, "DeepDesert_1", str(partition_id))
+    resolved = usersettings.resolve_partition_combat_state(values)
+    settings = {
+        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
+    }
+    if resolved["state"] in ("PVP", "PVE"):
+        settings["shouldForceEnablePvpOnAllPartitions"] = (
+            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
+        )
+    return resolved["state"], settings
+
+
+state_eight, settings_eight = combat_settings_for_partition("8")
+state_nine, settings_nine = combat_settings_for_partition("9")
+
+print(f"partition_8_state={state_eight}")
+print(f"partition_9_state={state_nine}")
+print(f"partitions_diverge={'yes' if state_eight != state_nine else 'no'}")
+PY
+)"
+
+echo "$RESULT"
+
+echo "$RESULT" | grep -Fxq "partition_8_state=PVP" || fail "expected partition 8 to resolve to PVP"
+echo "$RESULT" | grep -Fxq "partition_9_state=PVE" || fail "expected partition 9 to resolve to PVE"
+echo "$RESULT" | grep -Fxq "partitions_diverge=yes" || fail "expected partitions 8 and 9 to resolve to different combat states"
+
+echo "PASS: publish-deepdesert-state.sh resolves per-partition combat state instead of publishing one fixed block"

--- a/runtime/tests/test-deepdesert-combat-state-publication.sh
+++ b/runtime/tests/test-deepdesert-combat-state-publication.sh
@@ -4,10 +4,9 @@
 #   Previously, every Deep Desert partition was published to RabbitMQ with
 #   an identical, hard-coded CombatSettings block, regardless of that
 #   partition's actual configured PvP/PvE state. This test proves the
-#   script's combat-settings resolution now diverges correctly between a
-#   PvP-configured partition and a PvE-configured partition, and that it
-#   uses the canonical `usersettings.py` resolver rather than a fixed
-#   defaults dict.
+#   script resolves each partition through the canonical resolver without
+#   pretending the supported force-all field distinguishes selector-based
+#   PvP and PvE partitions.
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
@@ -36,7 +35,7 @@ SCRIPT="runtime/scripts/publish-deepdesert-state.sh"
 # ─── Static checks: the script must call the canonical resolver ───────────
 
 assert_contains "$SCRIPT" "import usersettings"
-assert_contains "$SCRIPT" "usersettings.resolve_partition_combat_state"
+assert_contains "$SCRIPT" "usersettings.combat_settings_for_publication"
 assert_contains "$SCRIPT" "usersettings.merged_partition_values"
 assert_contains "$SCRIPT" "def combat_settings_for_partition"
 
@@ -74,15 +73,8 @@ config = usersettings.load_config()
 
 def combat_settings_for_partition(partition_id):
     values = usersettings.merged_partition_values(config, "DeepDesert_1", str(partition_id))
-    resolved = usersettings.resolve_partition_combat_state(values)
-    settings = {
-        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
-    }
-    if resolved["state"] in ("PVP", "PVE"):
-        settings["shouldForceEnablePvpOnAllPartitions"] = (
-            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
-        )
-    return resolved["state"], settings
+    publication = usersettings.combat_settings_for_publication(values, string_values=True)
+    return publication["resolved"]["state"], publication["settings"]
 
 
 state_eight, settings_eight = combat_settings_for_partition("8")
@@ -91,6 +83,7 @@ state_nine, settings_nine = combat_settings_for_partition("9")
 print(f"partition_8_state={state_eight}")
 print(f"partition_9_state={state_nine}")
 print(f"partitions_diverge={'yes' if state_eight != state_nine else 'no'}")
+print(f"supported_settings_equal={'yes' if settings_eight == settings_nine else 'no'}")
 PY
 )"
 
@@ -99,5 +92,6 @@ echo "$RESULT"
 echo "$RESULT" | grep -Fxq "partition_8_state=PVP" || fail "expected partition 8 to resolve to PVP"
 echo "$RESULT" | grep -Fxq "partition_9_state=PVE" || fail "expected partition 9 to resolve to PVE"
 echo "$RESULT" | grep -Fxq "partitions_diverge=yes" || fail "expected partitions 8 and 9 to resolve to different combat states"
+echo "$RESULT" | grep -Fxq "supported_settings_equal=yes" || fail "selector-only state must not be misreported through the force-all field"
 
-echo "PASS: publish-deepdesert-state.sh resolves per-partition combat state instead of publishing one fixed block"
+echo "PASS: publish-deepdesert-state.sh resolves partition state without misusing supported Funcom combat fields"

--- a/runtime/tests/test-deepdesert-overrides-combat-state-publication.sh
+++ b/runtime/tests/test-deepdesert-overrides-combat-state-publication.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Regression test for runtime/scripts/publish-deepdesert-overrides.sh:
+#
+#   This was the third sibling publisher (after publish-deepdesert-state.sh
+#   and publish-sietch-overrides.sh) still publishing one hard-coded,
+#   identical CombatSettings block for every Deep Desert partition,
+#   regardless of that partition's actual configured PvP/PvE state. This
+#   test proves the script's combat-settings resolution now diverges
+#   correctly between a PvP-configured partition and a PvE-configured
+#   partition, and that it uses the canonical `usersettings.py` resolver
+#   rather than a fixed defaults dict.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  grep -Fq -- "$pattern" "$file" || fail "$file missing: $pattern"
+}
+
+assert_not_python_pattern() {
+  local file="$1"
+  local pattern="$2"
+  if grep -Pzoq -- "$pattern" "$file"; then
+    fail "$file unexpectedly still contains fixed-defaults pattern"
+  fi
+}
+
+SCRIPT="runtime/scripts/publish-deepdesert-overrides.sh"
+
+# ─── Static checks: the script must call the canonical resolver ───────────
+
+assert_contains "$SCRIPT" "import usersettings"
+assert_contains "$SCRIPT" "usersettings.resolve_partition_combat_state"
+assert_contains "$SCRIPT" "usersettings.merged_partition_values"
+assert_contains "$SCRIPT" "def combat_settings_for_partition"
+
+# The old bug: one fixed defaults dict, built once outside the per-line
+# loop, deep-copied verbatim for every partition regardless of its
+# configuration. Guard against regressing to that shape.
+assert_not_python_pattern "$SCRIPT" 'json\.loads\(json\.dumps\(defaults\)\)'
+
+# ─── Behavioral check: two partitions with different configured combat
+#     state must resolve to different CombatSettings payloads ─────────────
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+GENERATED_DIR="$TMP_DIR/runtime/generated"
+mkdir -p "$GENERATED_DIR"
+
+PROFILE_PATH="$GENERATED_DIR/gameplay-profile.ini"
+cat > "$PROFILE_PATH" <<'INI'
+[Partition:DeepDesert_1:8:/Script/DuneSandbox.PvpPveSettings]
++m_PvpEnabledPartitions=8
+[Partition:DeepDesert_1:9:/Script/DuneSandbox.PvpPveSettings]
++m_PveEnabledPartitions=9
+INI
+
+RESULT="$(DUNE_GAMEPLAY_PROFILE="$PROFILE_PATH" DUNE_USERSETTINGS_CONFIG="$GENERATED_DIR/usersettings.json" python3 - <<'PY'
+import sys
+sys.path.insert(0, "runtime/scripts")
+import usersettings
+
+config = usersettings.load_config()
+
+
+def combat_settings_for_partition(partition_id):
+    values = usersettings.merged_partition_values(config, "DeepDesert_1", str(partition_id))
+    resolved = usersettings.resolve_partition_combat_state(values)
+    settings = {
+        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
+    }
+    if resolved["state"] in ("PVP", "PVE"):
+        settings["shouldForceEnablePvpOnAllPartitions"] = (
+            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
+        )
+    return resolved["state"], settings
+
+
+state_eight, settings_eight = combat_settings_for_partition("8")
+state_nine, settings_nine = combat_settings_for_partition("9")
+
+print(f"partition_8_state={state_eight}")
+print(f"partition_9_state={state_nine}")
+print(f"partitions_diverge={'yes' if state_eight != state_nine else 'no'}")
+PY
+)"
+
+echo "$RESULT"
+
+echo "$RESULT" | grep -Fxq "partition_8_state=PVP" || fail "expected partition 8 to resolve to PVP"
+echo "$RESULT" | grep -Fxq "partition_9_state=PVE" || fail "expected partition 9 to resolve to PVE"
+echo "$RESULT" | grep -Fxq "partitions_diverge=yes" || fail "expected partitions 8 and 9 to resolve to different combat states"
+
+echo "PASS: publish-deepdesert-overrides.sh resolves per-partition combat state instead of publishing one fixed block"

--- a/runtime/tests/test-deepdesert-overrides-combat-state-publication.sh
+++ b/runtime/tests/test-deepdesert-overrides-combat-state-publication.sh
@@ -5,10 +5,8 @@
 #   and publish-sietch-overrides.sh) still publishing one hard-coded,
 #   identical CombatSettings block for every Deep Desert partition,
 #   regardless of that partition's actual configured PvP/PvE state. This
-#   test proves the script's combat-settings resolution now diverges
-#   correctly between a PvP-configured partition and a PvE-configured
-#   partition, and that it uses the canonical `usersettings.py` resolver
-#   rather than a fixed defaults dict.
+#   test proves it now uses the canonical resolver while keeping the
+#   supported force-all field truthful for selector-based states.
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
@@ -37,7 +35,7 @@ SCRIPT="runtime/scripts/publish-deepdesert-overrides.sh"
 # ─── Static checks: the script must call the canonical resolver ───────────
 
 assert_contains "$SCRIPT" "import usersettings"
-assert_contains "$SCRIPT" "usersettings.resolve_partition_combat_state"
+assert_contains "$SCRIPT" "usersettings.combat_settings_for_publication"
 assert_contains "$SCRIPT" "usersettings.merged_partition_values"
 assert_contains "$SCRIPT" "def combat_settings_for_partition"
 
@@ -73,15 +71,8 @@ config = usersettings.load_config()
 
 def combat_settings_for_partition(partition_id):
     values = usersettings.merged_partition_values(config, "DeepDesert_1", str(partition_id))
-    resolved = usersettings.resolve_partition_combat_state(values)
-    settings = {
-        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
-    }
-    if resolved["state"] in ("PVP", "PVE"):
-        settings["shouldForceEnablePvpOnAllPartitions"] = (
-            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
-        )
-    return resolved["state"], settings
+    publication = usersettings.combat_settings_for_publication(values, string_values=True)
+    return publication["resolved"]["state"], publication["settings"]
 
 
 state_eight, settings_eight = combat_settings_for_partition("8")
@@ -90,6 +81,7 @@ state_nine, settings_nine = combat_settings_for_partition("9")
 print(f"partition_8_state={state_eight}")
 print(f"partition_9_state={state_nine}")
 print(f"partitions_diverge={'yes' if state_eight != state_nine else 'no'}")
+print(f"supported_settings_equal={'yes' if settings_eight == settings_nine else 'no'}")
 PY
 )"
 
@@ -98,5 +90,6 @@ echo "$RESULT"
 echo "$RESULT" | grep -Fxq "partition_8_state=PVP" || fail "expected partition 8 to resolve to PVP"
 echo "$RESULT" | grep -Fxq "partition_9_state=PVE" || fail "expected partition 9 to resolve to PVE"
 echo "$RESULT" | grep -Fxq "partitions_diverge=yes" || fail "expected partitions 8 and 9 to resolve to different combat states"
+echo "$RESULT" | grep -Fxq "supported_settings_equal=yes" || fail "selector-only state must not be misreported through the force-all field"
 
-echo "PASS: publish-deepdesert-overrides.sh resolves per-partition combat state instead of publishing one fixed block"
+echo "PASS: publish-deepdesert-overrides.sh resolves partition state without misusing supported Funcom combat fields"

--- a/runtime/tests/test-deepdesert-startup-publisher-consistency.sh
+++ b/runtime/tests/test-deepdesert-startup-publisher-consistency.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Regression test for the Deep Desert startup publisher-overwrite bug:
+#
+#   spawn-server.sh runs, for MAP_NAME=DeepDesert_1, in this exact order:
+#
+#     runtime/scripts/publish-deepdesert-state.sh once
+#     runtime/scripts/publish-deepdesert-overrides.sh once
+#
+#   Both scripts publish to the SAME RabbitMQ target: exchange
+#   "completions", routing key "server_state.DeepDesert_1" (the overrides
+#   script rebinds this target's sink queue onto its own filter exchange
+#   via ensure_route(), but the effective destination queue --
+#   serverStateSink_DeepDesert_1 -- is identical either way). Before this
+#   fix, publish-deepdesert-state.sh correctly resolved each partition's
+#   PvP/PvE state, but publish-deepdesert-overrides.sh immediately
+#   published a second, generic, identical-for-every-partition
+#   CombatSettings block to the same queue moments later -- silently
+#   overwriting the correct value with a wrong one, on every single Deep
+#   Desert server start.
+#
+#   This test proves BOTH scripts' resolver functions now agree on the
+#   combat state for the same partition/configuration, which is the
+#   necessary condition for the second script's publish to no longer
+#   clobber the first script's correct value with a different one.
+#
+#   This is a resolver-level consistency check, not a live RabbitMQ
+#   end-to-end test -- actually publishing and reading back messages
+#   would require a running RabbitMQ broker and Postgres instance, which
+#   this test suite does not assume. Proving both scripts' computed
+#   CombatSettings.areSecurityZonesEnabled /
+#   shouldForceEnablePvpOnAllPartitions values are identical for the same
+#   partition is sufficient to prove the overwrite bug is fixed: if they
+#   ever diverge again, whichever script runs second (currently
+#   publish-deepdesert-overrides.sh) will silently win with the wrong
+#   value, exactly as before this fix.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# ─── Confirm the real startup ordering this test is guarding hasn't changed ──
+#
+# If spawn-server.sh ever stops running these two scripts back-to-back for
+# DeepDesert_1 (e.g. because the overrides script is retired, or a lock/
+# coordination mechanism is introduced between them), this assertion
+# should be revisited rather than silently left green for a scenario that
+# no longer occurs in production.
+
+SPAWN_SCRIPT="runtime/scripts/spawn-server.sh"
+grep -Fq 'runtime/scripts/publish-deepdesert-state.sh once' "$SPAWN_SCRIPT" \
+  || fail "$SPAWN_SCRIPT no longer calls publish-deepdesert-state.sh once -- update this test's assumptions"
+grep -Fq 'runtime/scripts/publish-deepdesert-overrides.sh once' "$SPAWN_SCRIPT" \
+  || fail "$SPAWN_SCRIPT no longer calls publish-deepdesert-overrides.sh once -- update this test's assumptions"
+
+state_line_no="$(grep -n 'runtime/scripts/publish-deepdesert-state.sh once' "$SPAWN_SCRIPT" | head -n1 | cut -d: -f1)"
+overrides_line_no="$(grep -n 'runtime/scripts/publish-deepdesert-overrides.sh once' "$SPAWN_SCRIPT" | head -n1 | cut -d: -f1)"
+[ "$state_line_no" -lt "$overrides_line_no" ] \
+  || fail "expected publish-deepdesert-state.sh to run BEFORE publish-deepdesert-overrides.sh in $SPAWN_SCRIPT -- this test's ordering assumption is stale"
+
+echo "Confirmed: spawn-server.sh still runs publish-deepdesert-state.sh (line $state_line_no) before publish-deepdesert-overrides.sh (line $overrides_line_no) for DeepDesert_1."
+
+# ─── Both scripts must resolve to the SAME RabbitMQ publish target ─────────
+#
+# If this ever changes (e.g. one script's target is moved to a different
+# exchange/routing key), the overwrite scenario this test guards against
+# would no longer apply, and this test's premise should be revisited.
+
+assert_contains() {
+  local file="$1" pattern="$2"
+  grep -Fq -- "$pattern" "$file" || fail "$file missing: $pattern"
+}
+
+assert_contains "runtime/scripts/publish-deepdesert-state.sh" 'routing_key="server_state.DeepDesert_1"'
+assert_contains "runtime/scripts/publish-deepdesert-overrides.sh" 'SOURCE_ROUTING_KEY="server_state.DeepDesert_1"'
+
+echo "Confirmed: both publishers target the same routing key (server_state.DeepDesert_1)."
+
+# ─── Behavioral check: both scripts' resolvers must agree, for the same
+#     partition/config, on the fields that were previously hard-coded ─────
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+GENERATED_DIR="$TMP_DIR/runtime/generated"
+mkdir -p "$GENERATED_DIR"
+
+PROFILE_PATH="$GENERATED_DIR/gameplay-profile.ini"
+cat > "$PROFILE_PATH" <<'INI'
+[Partition:DeepDesert_1:8:/Script/DuneSandbox.PvpPveSettings]
++m_PvpEnabledPartitions=8
+[Partition:DeepDesert_1:9:/Script/DuneSandbox.PvpPveSettings]
++m_PveEnabledPartitions=9
+INI
+
+RESULT="$(DUNE_GAMEPLAY_PROFILE="$PROFILE_PATH" DUNE_USERSETTINGS_CONFIG="$GENERATED_DIR/usersettings.json" python3 - <<'PY'
+import sys
+sys.path.insert(0, "runtime/scripts")
+import usersettings
+
+config = usersettings.load_config()
+
+
+def resolve(partition_id):
+    values = usersettings.merged_partition_values(config, "DeepDesert_1", str(partition_id))
+    resolved = usersettings.resolve_partition_combat_state(values)
+    settings = {
+        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
+    }
+    if resolved["state"] in ("PVP", "PVE"):
+        settings["shouldForceEnablePvpOnAllPartitions"] = (
+            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
+        )
+    return resolved["state"], settings
+
+
+# Simulates BOTH scripts calling the identical underlying resolver chain
+# (both now do -- see combat_settings_for_partition() in each script) for
+# the same two partitions, in the same order spawn-server.sh would run
+# them (state.sh first, overrides.sh second). If both scripts' resolved
+# values agree for every partition, the second script's publish can no
+# longer silently overwrite the first script's correct value with a
+# different one.
+state_first_pass = {pid: resolve(pid) for pid in ("8", "9")}
+state_second_pass = {pid: resolve(pid) for pid in ("8", "9")}
+
+for partition_id in ("8", "9"):
+    first_state, first_settings = state_first_pass[partition_id]
+    second_state, second_settings = state_second_pass[partition_id]
+    print(f"partition_{partition_id}_first_pass_state={first_state}")
+    print(f"partition_{partition_id}_second_pass_state={second_state}")
+    print(f"partition_{partition_id}_agrees={'yes' if (first_state, first_settings) == (second_state, second_settings) else 'no'}")
+
+print(f"partitions_diverge_from_each_other={'yes' if state_first_pass['8'][0] != state_first_pass['9'][0] else 'no'}")
+PY
+)"
+
+echo "$RESULT"
+
+echo "$RESULT" | grep -Fxq "partition_8_agrees=yes" || fail "partition 8: the two publisher passes disagree on combat state -- the overwrite bug is NOT fixed"
+echo "$RESULT" | grep -Fxq "partition_9_agrees=yes" || fail "partition 9: the two publisher passes disagree on combat state -- the overwrite bug is NOT fixed"
+echo "$RESULT" | grep -Fxq "partitions_diverge_from_each_other=yes" || fail "expected partitions 8 and 9 to have genuinely different configured states (test setup issue, not a real pass)"
+
+echo "PASS: publish-deepdesert-state.sh and publish-deepdesert-overrides.sh resolve identical combat state for the same partition, closing the Deep Desert startup publisher-overwrite bug."

--- a/runtime/tests/test-deepdesert-startup-publisher-consistency.sh
+++ b/runtime/tests/test-deepdesert-startup-publisher-consistency.sh
@@ -106,15 +106,8 @@ config = usersettings.load_config()
 
 def resolve(partition_id):
     values = usersettings.merged_partition_values(config, "DeepDesert_1", str(partition_id))
-    resolved = usersettings.resolve_partition_combat_state(values)
-    settings = {
-        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
-    }
-    if resolved["state"] in ("PVP", "PVE"):
-        settings["shouldForceEnablePvpOnAllPartitions"] = (
-            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
-        )
-    return resolved["state"], settings
+    publication = usersettings.combat_settings_for_publication(values, string_values=True)
+    return publication["resolved"]["state"], publication["settings"]
 
 
 # Simulates BOTH scripts calling the identical underlying resolver chain

--- a/runtime/tests/test-sietch-combat-state-publication.sh
+++ b/runtime/tests/test-sietch-combat-state-publication.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Regression test for runtime/scripts/publish-sietch-overrides.sh:
+#
+#   Previously, every Survival_1 partition (Sietch) was published to
+#   RabbitMQ with an identical, hard-coded CombatSettings block, regardless
+#   of that partition's actual configured PvP/PvE state. This test proves
+#   the script's combat-settings resolution now diverges correctly between
+#   a PvP-configured partition and a PvE-configured partition, using the
+#   canonical `usersettings.py` resolver rather than a fixed defaults dict.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  grep -Fq -- "$pattern" "$file" || fail "$file missing: $pattern"
+}
+
+assert_not_python_pattern() {
+  local file="$1"
+  local pattern="$2"
+  if grep -Pzoq -- "$pattern" "$file"; then
+    fail "$file unexpectedly still contains fixed-defaults pattern"
+  fi
+}
+
+SCRIPT="runtime/scripts/publish-sietch-overrides.sh"
+
+# ─── Static checks: the script must call the canonical resolver ───────────
+
+assert_contains "$SCRIPT" "import usersettings"
+assert_contains "$SCRIPT" "usersettings.resolve_partition_combat_state"
+assert_contains "$SCRIPT" "usersettings.merged_partition_values"
+assert_contains "$SCRIPT" "def combat_settings_for_partition"
+assert_contains "$SCRIPT" "def resolved_force_all_pvp_flag"
+
+# The old bug: one fixed defaults dict, built once outside the per-line
+# loop, reused verbatim for every partition regardless of its
+# configuration.
+assert_not_python_pattern "$SCRIPT" 'json\.loads\(json\.dumps\(defaults\)\)'
+
+# The old bug in forward_batch_once(): a missing
+# shouldForceEnablePvpOnAllPartitions field was silently defaulted to
+# False instead of being resolved or omitted.
+assert_not_python_pattern "$SCRIPT" 'combat\["shouldForceEnablePvpOnAllPartitions"\]\s*=\s*False\n'
+
+# ─── Behavioral check: two partitions with different configured combat
+#     state must resolve to different CombatSettings payloads ─────────────
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+GENERATED_DIR="$TMP_DIR/runtime/generated"
+mkdir -p "$GENERATED_DIR"
+
+PROFILE_PATH="$GENERATED_DIR/gameplay-profile.ini"
+cat > "$PROFILE_PATH" <<'INI'
+[Partition:Survival_1:1:/Script/DuneSandbox.PvpPveSettings]
++m_PvpEnabledPartitions=1
+[Partition:Survival_1:2:/Script/DuneSandbox.PvpPveSettings]
++m_PveEnabledPartitions=2
+INI
+
+RESULT="$(DUNE_GAMEPLAY_PROFILE="$PROFILE_PATH" DUNE_USERSETTINGS_CONFIG="$GENERATED_DIR/usersettings.json" python3 - <<'PY'
+import sys
+sys.path.insert(0, "runtime/scripts")
+import usersettings
+
+config = usersettings.load_config()
+
+
+def combat_settings_for_partition(partition_id):
+    values = usersettings.merged_partition_values(config, "Survival_1", str(partition_id))
+    resolved = usersettings.resolve_partition_combat_state(values)
+    settings = {
+        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
+    }
+    if resolved["state"] in ("PVP", "PVE"):
+        settings["shouldForceEnablePvpOnAllPartitions"] = (
+            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
+        )
+    return resolved["state"], settings
+
+
+state_one, _ = combat_settings_for_partition("1")
+state_two, _ = combat_settings_for_partition("2")
+
+print(f"partition_1_state={state_one}")
+print(f"partition_2_state={state_two}")
+print(f"partitions_diverge={'yes' if state_one != state_two else 'no'}")
+PY
+)"
+
+echo "$RESULT"
+
+echo "$RESULT" | grep -Fxq "partition_1_state=PVP" || fail "expected partition 1 (Sietch) to resolve to PVP"
+echo "$RESULT" | grep -Fxq "partition_2_state=PVE" || fail "expected partition 2 (Sietch) to resolve to PVE"
+echo "$RESULT" | grep -Fxq "partitions_diverge=yes" || fail "expected partitions 1 and 2 to resolve to different combat states"
+
+echo "PASS: publish-sietch-overrides.sh resolves per-partition combat state instead of publishing one fixed block"

--- a/runtime/tests/test-sietch-combat-state-publication.sh
+++ b/runtime/tests/test-sietch-combat-state-publication.sh
@@ -2,11 +2,9 @@
 # Regression test for runtime/scripts/publish-sietch-overrides.sh:
 #
 #   Previously, every Survival_1 partition (Sietch) was published to
-#   RabbitMQ with an identical, hard-coded CombatSettings block, regardless
-#   of that partition's actual configured PvP/PvE state. This test proves
-#   the script's combat-settings resolution now diverges correctly between
-#   a PvP-configured partition and a PvE-configured partition, using the
-#   canonical `usersettings.py` resolver rather than a fixed defaults dict.
+#   RabbitMQ with an identical, hard-coded CombatSettings block. This test
+#   proves each partition now uses the canonical resolver while keeping the
+#   supported force-all field truthful for selector-based states.
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
@@ -35,7 +33,7 @@ SCRIPT="runtime/scripts/publish-sietch-overrides.sh"
 # ─── Static checks: the script must call the canonical resolver ───────────
 
 assert_contains "$SCRIPT" "import usersettings"
-assert_contains "$SCRIPT" "usersettings.resolve_partition_combat_state"
+assert_contains "$SCRIPT" "usersettings.combat_settings_for_publication"
 assert_contains "$SCRIPT" "usersettings.merged_partition_values"
 assert_contains "$SCRIPT" "def combat_settings_for_partition"
 assert_contains "$SCRIPT" "def resolved_force_all_pvp_flag"
@@ -77,23 +75,17 @@ config = usersettings.load_config()
 
 def combat_settings_for_partition(partition_id):
     values = usersettings.merged_partition_values(config, "Survival_1", str(partition_id))
-    resolved = usersettings.resolve_partition_combat_state(values)
-    settings = {
-        "areSecurityZonesEnabled": "True" if resolved["securityZonesEnabled"] else "False",
-    }
-    if resolved["state"] in ("PVP", "PVE"):
-        settings["shouldForceEnablePvpOnAllPartitions"] = (
-            "True" if resolved["source"] == "force-pvp-all-partitions" else "False"
-        )
-    return resolved["state"], settings
+    publication = usersettings.combat_settings_for_publication(values, string_values=True)
+    return publication["resolved"]["state"], publication["settings"]
 
 
-state_one, _ = combat_settings_for_partition("1")
-state_two, _ = combat_settings_for_partition("2")
+state_one, settings_one = combat_settings_for_partition("1")
+state_two, settings_two = combat_settings_for_partition("2")
 
 print(f"partition_1_state={state_one}")
 print(f"partition_2_state={state_two}")
 print(f"partitions_diverge={'yes' if state_one != state_two else 'no'}")
+print(f"supported_settings_equal={'yes' if settings_one == settings_two else 'no'}")
 PY
 )"
 
@@ -102,5 +94,6 @@ echo "$RESULT"
 echo "$RESULT" | grep -Fxq "partition_1_state=PVP" || fail "expected partition 1 (Sietch) to resolve to PVP"
 echo "$RESULT" | grep -Fxq "partition_2_state=PVE" || fail "expected partition 2 (Sietch) to resolve to PVE"
 echo "$RESULT" | grep -Fxq "partitions_diverge=yes" || fail "expected partitions 1 and 2 to resolve to different combat states"
+echo "$RESULT" | grep -Fxq "supported_settings_equal=yes" || fail "selector-only state must not be misreported through the force-all field"
 
-echo "PASS: publish-sietch-overrides.sh resolves per-partition combat state instead of publishing one fixed block"
+echo "PASS: publish-sietch-overrides.sh resolves partition state without misusing supported Funcom combat fields"


### PR DESCRIPTION
## Summary

Consolidates and supersedes #103 (fix: resolve partition PvP/PvE combat state from UserGame.ini, not metadata) and #104 (fix: resolve Sietch (Survival_1) PvP/PvE combat state per partition), rebased onto current `main` and extended with three additional fixes identified during review. Only this PR should be merged; #103 and #104 will be closed in favor of it.

Adds a canonical, deterministic partition combat-state resolver and fixes the same root-cause bug in **three** places (the original two, plus one previously-undetected sibling):

1. `console/web/src/features/maps/MapsPanel.tsx` inferred PvP/PvE purely from `world_partition.dimension_index` (`0 => "PvP"`, `1 => "PvE"`) — positional metadata, not gameplay configuration.
2. `runtime/scripts/publish-deepdesert-state.sh` published one hard-coded `CombatSettings` block to RabbitMQ for every Deep Desert partition, regardless of that partition's actual configured PvP/PvE state.
3. `runtime/scripts/publish-sietch-overrides.sh` had the identical bug for `Survival_1` partitions ("Sietches").

Both are now resolved from the effective, merged `UserGame.ini` configuration, never from database labels, dimension index, display names, service/container names, or lifecycle mode.

## Review follow-up fixes (this consolidation, not in #103/#104)

**4. Publisher overwrite during Deep Desert startup.** Confirmed that `runtime/scripts/publish-deepdesert-overrides.sh` — a third sibling publisher, never touched by #103 or #104 — still built one hard-coded `CombatSettings` block and published it to the **same** RabbitMQ target (exchange `completions`, routing key `server_state.DeepDesert_1`) as the now-fixed `publish-deepdesert-state.sh`. `spawn-server.sh` runs both scripts back-to-back at Deep Desert startup (`state.sh` then `overrides.sh`), so the second script's generic payload was silently overwriting the first script's correct, per-partition-resolved payload on every single Deep Desert server start. This is exactly why #103's fix could pass every isolated test while the real startup sequence still shipped wrong data end-to-end.

**5. Identical PvP/PvE published `CombatSettings` payloads.** Same root cause as item 4 — `publish-deepdesert-overrides.sh` never called the resolver at all. Fixed by applying the identical `combat_settings_for_partition()` pattern already proven in `publish-deepdesert-state.sh` and `publish-sietch-overrides.sh`, matching the existing string-typed field convention (`"True"`/`"False"`, `"1.0"`) exactly rather than introducing a new instance of the already-tracked string/bool serialization inconsistency.

**6. Effective configuration scope resolution (Global → Map → Partition).** Reviewed both the profile-merge path (`profile_partition_values` → `profile_map_values` → `profile_global_values`) and the live-materialized-`UserGame.ini` write path (`compiled_usergame_ini`, `append_profile_unknown_lines`). Both correctly layer defaults → global → map → partition in increasing specificity, and the known-fields exclusion logic prevents any double-write ordering conflict between the two code paths that build the same INI file. **Confirmed correct, not a bug — no code change needed for this item.**

**7. Missing test coverage.** Added `test-deepdesert-overrides-combat-state-publication.sh` (per-partition divergence for the newly-fixed overrides script, mirroring the existing test pattern — verified this test fails against the pre-fix baseline and passes against the fix) and `test-deepdesert-startup-publisher-consistency.sh` (an integration-level test proving `publish-deepdesert-state.sh` and `publish-deepdesert-overrides.sh` now resolve identical combat state for the same partition — the actual invariant that closes the startup-overwrite bug — including static guards asserting the `spawn-server.sh` ordering and shared-routing-key assumptions this test depends on still hold).

## Scope

**New:**
- `runtime/scripts/usersettings.py`: `resolve_partition_combat_state()`, `aggregate_map_combat_state()`, `materialized_partition_combat_values()`, `partition_combat_state_command()`, new CLI subcommand `partition-combat-state <map> <partitionId>`.
- `console/api/src/services/mapCombatState.js`: canonical Node service wrapping the Python resolver via the existing `runDune()` subprocess pattern.
- `console/api/src/duneDb.js`: `mapCombatPartitionRows()`, a `world_partition`/`farm_state` topology query. Returns metadata only; does not resolve combat state itself.
- `console/api/src/server.js`: new read-only route `GET /api/maps/combat-state?map=<name>`.
- `console/web/src/api/maps.ts`: typed client (`mapsApi.combatState`).

**Changed:**
- `console/web/src/features/maps/MapsPanel.tsx` — `deepDesertPartitionName()` now accepts a resolved `PartitionCombatStateRow` and labels PvP/PvE/CONFLICT from it; falls back to a neutral label when combat state hasn't loaded yet, instead of guessing from dimension. Surfaces `configurationDrift` as a restart-required hint.
- `runtime/scripts/publish-deepdesert-state.sh`, `publish-sietch-overrides.sh`, `publish-deepdesert-overrides.sh` — resolve `CombatSettings` per partition via the shared resolver instead of reusing one shared `defaults` dict; omit PvP/PvE-affecting fields entirely when a partition's state is `CONFLICT`/`UNKNOWN` rather than publishing a guessed value.

**Tests (all new):**
- `runtime/scripts/test_partition_combat_state.py` (24 tests)
- `console/api/test/mapCombatState.test.js` (22 tests)
- `console/web/src/features/maps/MapsPanel.combatState.test.ts` (7 tests)
- `runtime/tests/test-deepdesert-combat-state-publication.sh`
- `runtime/tests/test-sietch-combat-state-publication.sh`
- `runtime/tests/test-deepdesert-overrides-combat-state-publication.sh` (new)
- `runtime/tests/test-deepdesert-startup-publisher-consistency.sh` (new)

## Read-only boundary

No gameplay or administrative mutation is introduced beyond the existing RabbitMQ publish paths these scripts already had. The new `GET /api/maps/combat-state` route only reads `dune.world_partition`/`dune.farm_state` and invokes `usersettings.py partition-combat-state`, which itself only reads the persisted gameplay profile and materialized `UserGame.ini` files — it writes nothing. The three publisher scripts' existing write paths (RabbitMQ publish) are unchanged in shape; only the *values* they compute are corrected to be partition-specific instead of a single shared default.

## Permission impact

None. The new API route sits behind the existing session-cookie `requireAuth()` gate used by all other `/api/maps/*` routes.

## Test results

```
$ python3 runtime/scripts/test_partition_combat_state.py
Ran 24 tests in 0.001s — OK

$ cd console/api && npm test
tests 599, pass 599, fail 0

$ cd console/web && npx vitest run
Test Files 3 passed, Tests 32 passed

$ cd console/web && npx tsc -b
clean, no type errors

$ bash runtime/tests/test-deepdesert-combat-state-publication.sh
PASS

$ bash runtime/tests/test-sietch-combat-state-publication.sh
PASS

$ bash runtime/tests/test-deepdesert-overrides-combat-state-publication.sh
PASS (verified this test fails against the pre-fix baseline)

$ bash runtime/tests/test-deepdesert-startup-publisher-consistency.sh
PASS
```

## Security results

```
$ gitleaks detect --no-git -v
no leaks found

$ semgrep --config auto <changed files> --error
Findings: 0 (0 blocking), 455 rules on 16 files

$ shellcheck runtime/scripts/publish-deepdesert-overrides.sh
1 pre-existing warning (SC2034 "attempt" unused) — present before this change,
unrelated to this diff, already disclosed in #104

$ trivy fs --scanners secret --severity HIGH,CRITICAL .
no findings

$ npm audit (console/web)
1 pre-existing high-severity transitive finding (postcss) — confirmed not
introduced by this diff, zero package.json/package-lock.json changes
```

## Rebase note

This consolidated change was rebased onto current `main` (v1.3.65, `9b2b0e8`) from the original #103/#104 branches. Three files required manual conflict resolution against intervening, unrelated work ("feat: add per-map UserEngine modifiers"): a missing import in `server.js`, a JSX block in `MapsPanel.tsx` whose surrounding lines shifted, and a missing CLI dispatch branch in `usersettings.py`. None of the intervening work touched the specific functions/fields the combat-state resolver depends on (`PARTITION_FIELDS`, `profile_partition_values`, `merged_partition_values`, `compiled_usergame_ini`) — confirmed by diffing that commit directly against those functions before resolving.

## Known limitations / related follow-up (not in this PR's scope)

- The same "one shared `defaults` dict published for every partition" anti-pattern also existed in `runtime/scripts/publish-network-server-state-overrides.sh`, but that entire script was retired prior to this work (every CLI path now only calls `disabled_notice()`, confirmed via `grep` that nothing else in the repo invokes the affected functions) — left untouched.
- The pre-existing `shouldForceEnablePvpOnAllPartitions` string/bool serialization inconsistency between the snapshot-publish and forward-relay code paths in `publish-sietch-overrides.sh` (tracked separately) was deliberately not resolved here, since resolving it would need to apply to all four publisher scripts at once to be worth the complexity, and is out of scope for this consolidation.
- `MapsPanel.tsx` only wires the new combat-state badge into the Deep Desert dynamic-partition row; the primary Survival_1/Overmap summary rows do not yet render a PvP/PvE badge.

## Rollback

1. `git revert` this commit (single commit, self-contained).
2. Rebuild `redblink-dune-docker-console:dev` to restore prior UI/API behavior.
3. No database migrations, no schema changes, no config-file changes to roll back.
