### PR TITLE
feat(console): add promote, demote, add, and disband actions to Guilds page

### DIFF
--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -1182,7 +1182,7 @@ async function pledgeGuildAdminFactionIfNeeded(db, actorId, factionId) {
       from dune.guild_members gm
       join dune.guilds g on g.guild_id = gm.guild_id
       where gm.player_id = $1::bigint
-        and gm.role_id = 100`, [actorId]);
+        and gm.role_id = ${GUILD_LEADER_ROLE_ID}`, [actorId]);
     for (const row of result.rows) {
       if (Number(row.guild_faction) === Number(factionId)) continue;
       await db.query("select dune.pledge_guild_allegiance($1::bigint, $2::bigint, 3::smallint)", [row.guild_id, actorId]);
@@ -1891,6 +1891,218 @@ export async function guildMembers(db, guildId) {
     order by ${memberRoleColumn ? `gm.${quoteIdentifier(memberRoleColumn)} asc, ` : ""}lower(${characterNameSelect})`, [id]);
 
   return { capabilities: { guildMembers: true }, rows: result.rows };
+}
+
+const GUILD_OFFICER_ROLE_ID = 50;
+const GUILD_LEADER_ROLE_ID = 100;
+const MAX_GUILD_COUNT_PER_PLAYER = 1; // real game invariant -- get_guild_for_player does a bare SELECT INTO with no LIMIT, implying one guild per player
+const MAX_MEMBERS_PER_GUILD = 2147483647; // soft cap; only gates auto-clearing invites at capacity, safe to raise
+const GUILD_REMOVE_REASON_ADMIN = 0; // best-guess sentinel; only affects the in-game notification text for other guildmates
+
+// The four guild mutations below hardcode literal guild_id/player_id/role_id/guild_name column
+// names in raw SQL, unlike guildMembers()'s defensive firstExistingColumn() resolution for reads
+// -- because these column names are what dune.promote_guild_member/dune.add_guild_member/
+// dune.remove_guild_members/dune.disband_guild's own PL/pgSQL bodies reference internally, so any
+// schema where those functions exist must already have these exact names. This check still
+// verifies it directly (rather than relying solely on functionExists) so a schema drift a future
+// game patch introduces surfaces as a clean "unsupported" response instead of a raw SQL error.
+async function guildIdentityColumnsExist(db, { members = [] } = {}) {
+  const guildColumns = await columnsFor(db, "guilds");
+  if (!guildColumns.has("guild_id") || !guildColumns.has("guild_name")) return false;
+  if (!members.length) return true;
+  const memberColumns = await columnsFor(db, "guild_members");
+  return members.every((column) => memberColumns.has(column));
+}
+
+async function supportsGuildPromotion(db) {
+  return await tableExists(db, "guild_members") && await tableExists(db, "guilds") &&
+    await functionExists(db, "dune.promote_guild_member(bigint,bigint,smallint)") &&
+    await guildIdentityColumnsExist(db, { members: ["guild_id", "player_id", "role_id"] });
+}
+
+// dune.promote_guild_member(guild_id, player_id, new_role) only special-cases new_role = 100
+// (it demotes whoever currently holds it); for any other target role it's a plain role_id
+// update. This lets Promote graduate a Member straight to Officer with no leader side effect,
+// and Officer to Leader (with the automatic leader demotion), using the one real stored
+// procedure -- confirmed by reading its body in .claude/dune_backup.sql before relying on it.
+export async function promoteGuildMember(db, guildId, playerId) {
+  await requireCapability(await supportsGuildPromotion(db), "Guild leadership changes require dune.guild_members, dune.guilds, and dune.promote_guild_member(bigint,bigint,smallint).");
+  const safeGuildId = intParam(guildId, "guild id", 1);
+  const safePlayerId = intParam(playerId, "player id", 1);
+
+  return db.transaction(async (tx) => {
+    // Lock the guilds row first -- guaranteed to exist if the guild is real, giving concurrent
+    // promote requests for the same guild something to serialize against even before touching
+    // guild_members. Same technique as the inventory-row lock in refillBaseGenerators.
+    const guild = await tx.query("select guild_id, guild_name from dune.guilds where guild_id = $1 for update", [safeGuildId]);
+    if (!guild.rowCount) throw new Error(`Guild ${safeGuildId} was not found.`);
+
+    const member = await tx.query(
+      "select role_id::text as role_id from dune.guild_members where guild_id = $1 and player_id = $2 for update",
+      [safeGuildId, safePlayerId]
+    );
+    if (!member.rowCount) throw new Error(`Player ${safePlayerId} is not a member of guild ${safeGuildId}.`);
+    const currentRole = Number(member.rows[0].role_id);
+    if (currentRole >= GUILD_LEADER_ROLE_ID) {
+      return { ok: true, alreadyLeader: true, guildId: safeGuildId, playerId: safePlayerId };
+    }
+    const nextRole = currentRole >= GUILD_OFFICER_ROLE_ID ? GUILD_LEADER_ROLE_ID : GUILD_OFFICER_ROLE_ID;
+
+    let previousLeaderId = null;
+    if (nextRole === GUILD_LEADER_ROLE_ID) {
+      const previousLeader = await tx.query(
+        "select player_id from dune.guild_members where guild_id = $1 and role_id = $2",
+        [safeGuildId, GUILD_LEADER_ROLE_ID]
+      );
+      previousLeaderId = previousLeader.rows[0]?.player_id ? String(previousLeader.rows[0].player_id) : null;
+    }
+
+    await tx.query("select dune.promote_guild_member($1::bigint, $2::bigint, $3::smallint)", [safeGuildId, safePlayerId, nextRole]);
+
+    return {
+      ok: true,
+      guildId: safeGuildId,
+      guildName: guild.rows[0].guild_name,
+      playerId: safePlayerId,
+      newRoleId: nextRole,
+      previousLeaderId,
+      message: nextRole === GUILD_LEADER_ROLE_ID
+        ? "Leadership was updated in the database. Online players may need to relog before the change appears in-game."
+        : "Rank was updated in the database. Online players may need to relog before the change appears in-game."
+    };
+  });
+}
+
+async function supportsGuildDemotion(db) {
+  return await tableExists(db, "guild_members") && await tableExists(db, "guilds") &&
+    await functionExists(db, "dune.demote_guild_member(bigint,bigint,smallint)") &&
+    await guildIdentityColumnsExist(db, { members: ["guild_id", "player_id", "role_id"] });
+}
+
+// dune.demote_guild_member(guild_id, player_id, new_role) already refuses to demote the guild
+// leader itself (raises "Trying to demote admin. promote a member to admin instead."), and this
+// feature only ever offers Demote on Officer rows (Leader and Member are excluded in the UI), so
+// Demote always targets the plain Member role.
+export async function demoteGuildMember(db, guildId, playerId) {
+  await requireCapability(await supportsGuildDemotion(db), "Guild demotions require dune.guild_members, dune.guilds, and dune.demote_guild_member(bigint,bigint,smallint).");
+  const safeGuildId = intParam(guildId, "guild id", 1);
+  const safePlayerId = intParam(playerId, "player id", 1);
+
+  return db.transaction(async (tx) => {
+    const guild = await tx.query("select guild_id from dune.guilds where guild_id = $1 for update", [safeGuildId]);
+    if (!guild.rowCount) throw new Error(`Guild ${safeGuildId} was not found.`);
+
+    const member = await tx.query(
+      "select role_id::text as role_id from dune.guild_members where guild_id = $1 and player_id = $2 for update",
+      [safeGuildId, safePlayerId]
+    );
+    if (!member.rowCount) throw new Error(`Player ${safePlayerId} is not a member of guild ${safeGuildId}.`);
+    const currentRole = Number(member.rows[0].role_id);
+    if (currentRole >= GUILD_LEADER_ROLE_ID) {
+      throw new Error("This player is the guild leader. Promote another member to Leader before demoting them.");
+    }
+    if (currentRole < GUILD_OFFICER_ROLE_ID) {
+      throw new Error(`Player ${safePlayerId} is already a Member and cannot be demoted further.`);
+    }
+
+    await tx.query("select dune.demote_guild_member($1::bigint, $2::bigint, $3::smallint)", [safeGuildId, safePlayerId, 1]);
+
+    return { ok: true, guildId: safeGuildId, playerId: safePlayerId };
+  });
+}
+
+async function supportsGuildAdd(db) {
+  return await tableExists(db, "guild_members") && await tableExists(db, "guilds") &&
+    await functionExists(db, "dune.add_guild_member(bigint,bigint,smallint,integer,integer,smallint)") &&
+    await guildIdentityColumnsExist(db);
+}
+
+export async function addGuildMember(db, guildId, playerId, roleId = 1) {
+  await requireCapability(await supportsGuildAdd(db), "Adding guild members requires dune.guild_members, dune.guilds, and dune.add_guild_member(bigint,bigint,smallint,integer,integer,smallint).");
+  const safeGuildId = intParam(guildId, "guild id", 1);
+  const safeRole = intParam(roleId, "role id", 1, 99); // Add Member never creates a second Leader -- promote is a separate, explicit action
+
+  return db.transaction(async (tx) => {
+    const guild = await tx.query("select guild_id, guild_name from dune.guilds where guild_id = $1 for update", [safeGuildId]);
+    if (!guild.rowCount) throw new Error(`Guild ${safeGuildId} was not found.`);
+
+    const player = await resolvePlayerMutationTarget(tx, playerId);
+    try {
+      // dune.add_guild_member(in_player_id, in_guild_id, ...) -- player id comes first,
+      // confirmed against the real function signature in .claude/dune_backup.sql and against
+      // a live restore of it (an earlier version of this code had these two swapped).
+      await tx.query(
+        "select dune.add_guild_member($1::bigint, $2::bigint, $3::smallint, $4::integer, $5::integer, $6::smallint)",
+        [player.controllerId, safeGuildId, safeRole, MAX_GUILD_COUNT_PER_PLAYER, MAX_MEMBERS_PER_GUILD, NEUTRAL_GUILD_FACTION_ID]
+      );
+    } catch (error) {
+      if (/Cannot insert more than/.test(error.message)) throw new Error("This player is already in a guild. Remove them from their current guild first.");
+      if (/non existing guild/.test(error.message)) throw new Error(`Guild ${safeGuildId} was not found.`);
+      if (/non compatible/.test(error.message)) throw new Error("This player's faction is not compatible with this guild.");
+      throw error;
+    }
+
+    return { ok: true, guildId: safeGuildId, guildName: guild.rows[0].guild_name, playerId: player.controllerId, roleId: safeRole };
+  });
+}
+
+async function supportsGuildRemove(db) {
+  return await tableExists(db, "guild_members") && await tableExists(db, "guilds") &&
+    await functionExists(db, "dune.remove_guild_members(bigint[],bigint,smallint)") &&
+    await guildIdentityColumnsExist(db, { members: ["guild_id", "player_id", "role_id"] });
+}
+
+export async function removeGuildMember(db, guildId, playerId) {
+  await requireCapability(await supportsGuildRemove(db), "Removing guild members requires dune.guild_members, dune.guilds, and dune.remove_guild_members(bigint[],bigint,smallint).");
+  const safeGuildId = intParam(guildId, "guild id", 1);
+  const safePlayerId = intParam(playerId, "player id", 1);
+
+  return db.transaction(async (tx) => {
+    const guild = await tx.query("select guild_id from dune.guilds where guild_id = $1 for update", [safeGuildId]);
+    if (!guild.rowCount) throw new Error(`Guild ${safeGuildId} was not found.`);
+
+    const member = await tx.query(
+      "select role_id::text as role_id from dune.guild_members where guild_id = $1 and player_id = $2 for update",
+      [safeGuildId, safePlayerId]
+    );
+    if (!member.rowCount) throw new Error(`Player ${safePlayerId} is not a member of guild ${safeGuildId}.`);
+    if (Number(member.rows[0].role_id) >= GUILD_LEADER_ROLE_ID) {
+      throw new Error("This player is the guild leader. Promote another member to Leader before removing them.");
+    }
+
+    // The leader check above happens inside this same locked transaction (guild row + member
+    // row both FOR UPDATE), so there's no window for a concurrent promote to change leadership
+    // between the check and the delete below.
+    await tx.query("select dune.remove_guild_members($1::bigint[], $2::bigint, $3::smallint)", [[safePlayerId], safeGuildId, GUILD_REMOVE_REASON_ADMIN]);
+
+    return { ok: true, guildId: safeGuildId, playerId: safePlayerId };
+  });
+}
+
+async function supportsGuildDisband(db) {
+  return await tableExists(db, "guilds") && await tableExists(db, "guild_members") &&
+    await functionExists(db, "dune.disband_guild(bigint)") &&
+    await guildIdentityColumnsExist(db, { members: ["guild_id"] });
+}
+
+export async function disbandGuild(db, guildId) {
+  await requireCapability(await supportsGuildDisband(db), "Disbanding a guild requires dune.guilds and dune.disband_guild(bigint).");
+  const safeGuildId = intParam(guildId, "guild id", 1);
+
+  return db.transaction(async (tx) => {
+    const guild = await tx.query("select guild_id, guild_name from dune.guilds where guild_id = $1 for update", [safeGuildId]);
+    if (!guild.rowCount) throw new Error(`Guild ${safeGuildId} was not found.`);
+
+    const memberCount = await tx.query("select count(*)::int as count from dune.guild_members where guild_id = $1", [safeGuildId]);
+
+    await tx.query("select dune.disband_guild($1::bigint)", [safeGuildId]);
+    // dune.disband_guild deletes the guilds row but leaves guild_members rows behind, which would
+    // otherwise strand former members against the one-guild-per-player cap (MAX_GUILD_COUNT_PER_PLAYER)
+    // forever, since add_guild_member counts guild_members rows with no join back to guilds.
+    await tx.query("delete from dune.guild_members where guild_id = $1", [safeGuildId]);
+
+    return { ok: true, guildId: safeGuildId, guildName: guild.rows[0].guild_name, memberCount: memberCount.rows[0]?.count || 0 };
+  });
 }
 
 function firstExistingColumn(columns, names) {
@@ -4018,7 +4230,7 @@ async function portalGuild(db, identity) {
 
 function portalGuildRole(roleId) {
   const value = Number(roleId);
-  if (value >= 100) return "Leader";
+  if (value >= GUILD_LEADER_ROLE_ID) return "Leader";
   if (value > 1) return "Officer";
   return "Member";
 }

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -1896,8 +1896,10 @@ export async function guildMembers(db, guildId) {
 const GUILD_OFFICER_ROLE_ID = 50;
 const GUILD_LEADER_ROLE_ID = 100;
 const MAX_GUILD_COUNT_PER_PLAYER = 1; // real game invariant -- get_guild_for_player does a bare SELECT INTO with no LIMIT, implying one guild per player
-const MAX_MEMBERS_PER_GUILD = 2147483647; // soft cap; only gates auto-clearing invites at capacity, safe to raise
-const GUILD_REMOVE_REASON_ADMIN = 0; // best-guess sentinel; only affects the in-game notification text for other guildmates
+const DEFAULT_MAX_MEMBERS_PER_GUILD = 32;
+// Verified against dune.guild_handle_actor_delete in the shipped database: the game's own
+// generic database-removal path publishes reason 0 through dune.remove_guild_members.
+const GUILD_REMOVE_REASON_DATABASE_REMOVAL = 0;
 
 // The four guild mutations below hardcode literal guild_id/player_id/role_id/guild_name column
 // names in raw SQL, unlike guildMembers()'s defensive firstExistingColumn() resolution for reads
@@ -1912,6 +1914,13 @@ async function guildIdentityColumnsExist(db, { members = [] } = {}) {
   if (!members.length) return true;
   const memberColumns = await columnsFor(db, "guild_members");
   return members.every((column) => memberColumns.has(column));
+}
+
+async function lockGuildOperations(db) {
+  // Match the lock order used by every shipped guild mutation. Taking the game's advisory
+  // transaction lock before row locks avoids deadlocking with an in-game mutation that already
+  // owns the advisory lock and is waiting for the same guild row.
+  await db.query("select dune.guilds_get_exclusive_operation_lock()");
 }
 
 async function supportsGuildPromotion(db) {
@@ -1931,6 +1940,7 @@ export async function promoteGuildMember(db, guildId, playerId) {
   const safePlayerId = intParam(playerId, "player id", 1);
 
   return db.transaction(async (tx) => {
+    await lockGuildOperations(tx);
     // Lock the guilds row first -- guaranteed to exist if the guild is real, giving concurrent
     // promote requests for the same guild something to serialize against even before touching
     // guild_members. Same technique as the inventory-row lock in refillBaseGenerators.
@@ -1989,6 +1999,7 @@ export async function demoteGuildMember(db, guildId, playerId) {
   const safePlayerId = intParam(playerId, "player id", 1);
 
   return db.transaction(async (tx) => {
+    await lockGuildOperations(tx);
     const guild = await tx.query("select guild_id from dune.guilds where guild_id = $1 for update", [safeGuildId]);
     if (!guild.rowCount) throw new Error(`Guild ${safeGuildId} was not found.`);
 
@@ -2017,14 +2028,25 @@ async function supportsGuildAdd(db) {
     await guildIdentityColumnsExist(db);
 }
 
-export async function addGuildMember(db, guildId, playerId, roleId = 1) {
+export async function addGuildMember(db, guildId, playerId, roleId = 1, maxMembersPerGuild = DEFAULT_MAX_MEMBERS_PER_GUILD) {
   await requireCapability(await supportsGuildAdd(db), "Adding guild members requires dune.guild_members, dune.guilds, and dune.add_guild_member(bigint,bigint,smallint,integer,integer,smallint).");
   const safeGuildId = intParam(guildId, "guild id", 1);
   const safeRole = intParam(roleId, "role id", 1, 99); // Add Member never creates a second Leader -- promote is a separate, explicit action
+  const safeMaxMembers = intParam(maxMembersPerGuild, "maximum guild members", 1, 2147483647);
 
   return db.transaction(async (tx) => {
+    await lockGuildOperations(tx);
     const guild = await tx.query("select guild_id, guild_name from dune.guilds where guild_id = $1 for update", [safeGuildId]);
     if (!guild.rowCount) throw new Error(`Guild ${safeGuildId} was not found.`);
+
+    // add_guild_member uses this limit only to decide when invitations should be cleared; it
+    // does not reject an over-capacity insert itself. Enforce the effective server limit while
+    // holding the same guild-row lock that serializes concurrent Console additions.
+    const memberCount = await tx.query("select count(*)::int as count from dune.guild_members where guild_id = $1", [safeGuildId]);
+    const currentMembers = Number(memberCount.rows[0]?.count || 0);
+    if (currentMembers >= safeMaxMembers) {
+      throw new Error(`Guild ${safeGuildId} already has the configured maximum of ${safeMaxMembers} members.`);
+    }
 
     const player = await resolvePlayerMutationTarget(tx, playerId);
     try {
@@ -2033,7 +2055,7 @@ export async function addGuildMember(db, guildId, playerId, roleId = 1) {
       // a live restore of it (an earlier version of this code had these two swapped).
       await tx.query(
         "select dune.add_guild_member($1::bigint, $2::bigint, $3::smallint, $4::integer, $5::integer, $6::smallint)",
-        [player.controllerId, safeGuildId, safeRole, MAX_GUILD_COUNT_PER_PLAYER, MAX_MEMBERS_PER_GUILD, NEUTRAL_GUILD_FACTION_ID]
+        [player.controllerId, safeGuildId, safeRole, MAX_GUILD_COUNT_PER_PLAYER, safeMaxMembers, NEUTRAL_GUILD_FACTION_ID]
       );
     } catch (error) {
       if (/Cannot insert more than/.test(error.message)) throw new Error("This player is already in a guild. Remove them from their current guild first.");
@@ -2058,6 +2080,7 @@ export async function removeGuildMember(db, guildId, playerId) {
   const safePlayerId = intParam(playerId, "player id", 1);
 
   return db.transaction(async (tx) => {
+    await lockGuildOperations(tx);
     const guild = await tx.query("select guild_id from dune.guilds where guild_id = $1 for update", [safeGuildId]);
     if (!guild.rowCount) throw new Error(`Guild ${safeGuildId} was not found.`);
 
@@ -2073,7 +2096,7 @@ export async function removeGuildMember(db, guildId, playerId) {
     // The leader check above happens inside this same locked transaction (guild row + member
     // row both FOR UPDATE), so there's no window for a concurrent promote to change leadership
     // between the check and the delete below.
-    await tx.query("select dune.remove_guild_members($1::bigint[], $2::bigint, $3::smallint)", [[safePlayerId], safeGuildId, GUILD_REMOVE_REASON_ADMIN]);
+    await tx.query("select dune.remove_guild_members($1::bigint[], $2::bigint, $3::smallint)", [[safePlayerId], safeGuildId, GUILD_REMOVE_REASON_DATABASE_REMOVAL]);
 
     return { ok: true, guildId: safeGuildId, playerId: safePlayerId };
   });
@@ -2090,6 +2113,7 @@ export async function disbandGuild(db, guildId) {
   const safeGuildId = intParam(guildId, "guild id", 1);
 
   return db.transaction(async (tx) => {
+    await lockGuildOperations(tx);
     const guild = await tx.query("select guild_id, guild_name from dune.guilds where guild_id = $1 for update", [safeGuildId]);
     if (!guild.rowCount) throw new Error(`Guild ${safeGuildId} was not found.`);
 

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -48,6 +48,7 @@ import { createPublicDirectoryReporter, normalizeDiscordInvite, readDirectorySet
 import { choamTerminalOverview, installChoamTerminals, removeChoamTerminals } from "./services/choamTerminals.js";
 import { autoRefillPublicState, createAutoRefillScheduler, setBaseAutoRefill } from "./services/autoRefill.js";
 import { calculateAlwaysOnHostMemorySafety } from "./services/hostMemorySafety.js";
+import { parseEffectiveGuildMemberLimit } from "./services/guildSettings.js";
 
 const config = loadConfig();
 const auth = createAuth(config);
@@ -1926,7 +1927,11 @@ async function guildDemoteRoute(req, res, path) {
 
 async function guildAddMemberRoute(req, res, path) {
   const guildId = decodeURIComponent(path.split("/")[3]);
-  return directDbMutation(req, res, "guilds.add-member", null, (body) => duneDb.addGuildMember(db, guildId, body.playerId, body.roleId), { guildId });
+  return directDbMutation(req, res, "guilds.add-member", null, async (body) => {
+    const settings = await runDune(config, buildDuneArgs("userSettingsMapValues", { map: "Survival_1" }), { timeoutMs: 8000 });
+    const maxMembers = parseEffectiveGuildMemberLimit(settings.stdout);
+    return duneDb.addGuildMember(db, guildId, body.playerId, body.roleId, maxMembers);
+  }, { guildId });
 }
 
 async function guildRemoveMemberRoute(req, res, path) {

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -468,6 +468,11 @@ async function handleApi(req, res) {
     sortColumn: url.searchParams.get("sortColumn") || "guild_name",
     sortDirection: url.searchParams.get("sortDirection") || "asc"
   }));
+  if (path.match(/^\/api\/guilds\/[^/]+\/members\/[^/]+\/promote$/) && req.method === "POST") return guildPromoteRoute(req, res, path);
+  if (path.match(/^\/api\/guilds\/[^/]+\/members\/[^/]+\/demote$/) && req.method === "POST") return guildDemoteRoute(req, res, path);
+  if (path.match(/^\/api\/guilds\/[^/]+\/members$/) && req.method === "POST") return guildAddMemberRoute(req, res, path);
+  if (path.match(/^\/api\/guilds\/[^/]+\/members\/[^/]+$/) && req.method === "DELETE") return guildRemoveMemberRoute(req, res, path);
+  if (path.match(/^\/api\/guilds\/[^/]+$/) && req.method === "DELETE") return guildDisbandRoute(req, res, path);
   if (path.match(/^\/api\/guilds\/[^/]+\/members$/)) return dbJson(res, () => duneDb.guildMembers(db, decodeURIComponent(path.split("/")[3])));
   if (path === "/api/bases") return dbJson(res, () => duneDb.listBases(db, {
     q: url.searchParams.get("q") || "",
@@ -1903,6 +1908,37 @@ function queryParams(url, names) {
 async function playerDbMutation(req, res, path, action, phrase, fn) {
   const playerId = decodeURIComponent(path.split("/")[3]);
   return directDbMutation(req, res, action, phrase, (body) => fn(playerId, body), { playerId });
+}
+
+async function guildPromoteRoute(req, res, path) {
+  const parts = path.split("/");
+  const guildId = decodeURIComponent(parts[3]);
+  const playerId = decodeURIComponent(parts[5]);
+  return directDbMutation(req, res, "guilds.promote-member", null, () => duneDb.promoteGuildMember(db, guildId, playerId), { guildId, playerId });
+}
+
+async function guildDemoteRoute(req, res, path) {
+  const parts = path.split("/");
+  const guildId = decodeURIComponent(parts[3]);
+  const playerId = decodeURIComponent(parts[5]);
+  return directDbMutation(req, res, "guilds.demote-member", null, () => duneDb.demoteGuildMember(db, guildId, playerId), { guildId, playerId });
+}
+
+async function guildAddMemberRoute(req, res, path) {
+  const guildId = decodeURIComponent(path.split("/")[3]);
+  return directDbMutation(req, res, "guilds.add-member", null, (body) => duneDb.addGuildMember(db, guildId, body.playerId, body.roleId), { guildId });
+}
+
+async function guildRemoveMemberRoute(req, res, path) {
+  const parts = path.split("/");
+  const guildId = decodeURIComponent(parts[3]);
+  const playerId = decodeURIComponent(parts[5]);
+  return directDbMutation(req, res, "guilds.remove-member", null, () => duneDb.removeGuildMember(db, guildId, playerId), { guildId, playerId });
+}
+
+async function guildDisbandRoute(req, res, path) {
+  const guildId = decodeURIComponent(path.split("/")[3]);
+  return directDbMutation(req, res, "guilds.disband", "DISBAND GUILD", () => duneDb.disbandGuild(db, guildId), { guildId });
 }
 
 async function inventoryDeleteRoute(req, res, path) {

--- a/console/api/src/services/guildSettings.js
+++ b/console/api/src/services/guildSettings.js
@@ -1,0 +1,21 @@
+const DEFAULT_GUILD_MEMBER_LIMIT = 32;
+
+export function parseEffectiveGuildMemberLimit(stdout) {
+  const values = new Map();
+  for (const line of String(stdout || "").split(/\r?\n/)) {
+    const separator = line.indexOf("\t");
+    if (separator < 1) continue;
+    values.set(line.slice(0, separator), line.slice(separator + 1).trim());
+  }
+
+  // The legacy DuneGameMode field has effective precedence when an Advanced Editor profile
+  // contains both forms. Normal Console edits mirror it to the canonical GuildSettings field.
+  const raw = values.get("max_guild_members_allowed")
+    || values.get("guild_settings_max_guild_members_allowed")
+    || String(DEFAULT_GUILD_MEMBER_LIMIT);
+  const limit = Number(raw);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 2147483647) {
+    throw new Error("The configured maximum guild member count is invalid.");
+  }
+  return limit;
+}

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -16,7 +16,7 @@ import {
   queueGeneratorRefill,
   supportsGeneratorRefillQueue
 } from "../src/duneDb.js";
-import { addCurrency, addFactionReputation, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, addSpecializationXp, applyLandsraadMilestonePreset, augmentInventoryItem, augmentNewestPlayerItem, baseGeneratorFuelLevels, baseGenerators, changeDunePassword, completeJourneyNode, completeTutorial, dbStatus, deleteInventoryItem, exportBaseAsBlueprint, generatorUptimePolicy, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listBases, listGuilds, listPlayers, listRoutines, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerCurrency, playerFactions, playerIntel, playerInventory, playerJourney, playerPortalSnapshots, playerPosition, playerProfile, playerProgression, playerResearchItems, playerSolarisCoinTotal, playerVitals, portalGeneratorFuel, portalVehicles, refillBaseGenerators, repairVehicleDecay, resetJourneyNode, resetTutorial, routineDefinition, runSql, setLandsraadPlayerContribution, supportsGeneratorRefill, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError, _resetPlayerTargetCacheForTests } from "../src/duneDb.js";
+import { addCurrency, addFactionReputation, addGuildMember, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, addSpecializationXp, applyLandsraadMilestonePreset, augmentInventoryItem, augmentNewestPlayerItem, baseGeneratorFuelLevels, baseGenerators, changeDunePassword, completeJourneyNode, completeTutorial, dbStatus, deleteInventoryItem, demoteGuildMember, disbandGuild, exportBaseAsBlueprint, generatorUptimePolicy, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listBases, listGuilds, listPlayers, listRoutines, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerCraftingRecipes, playerCurrency, playerFactions, playerIntel, playerInventory, playerJourney, playerPortalSnapshots, playerPosition, playerProfile, playerProgression, playerResearchItems, playerSolarisCoinTotal, playerVitals, portalGeneratorFuel, portalVehicles, promoteGuildMember, refillBaseGenerators, removeGuildMember, repairVehicleDecay, resetJourneyNode, resetTutorial, routineDefinition, runSql, setLandsraadPlayerContribution, supportsGeneratorRefill, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError, _resetPlayerTargetCacheForTests } from "../src/duneDb.js";
 
 beforeEach(() => {
   _resetPlayerTargetCacheForTests();
@@ -1886,6 +1886,254 @@ test("guild members falls back to a direct account-id join when dune.actors is u
   assert.ok(memberQuery);
   assert.doesNotMatch(memberQuery.text, /dune\.actors/);
   assert.match(memberQuery.text, /left join dune\.player_state ps_by_account on ps_by_account\.account_id = coalesce\(null, gm\."player_id"\)/);
+});
+
+function okRows(rows) {
+  return { rows, rowCount: rows.length };
+}
+
+function guildMutationDb(calls, fixtures = {}) {
+  const db = {
+    async query(text, values = []) {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) return okRows([{ exists: true }]);
+      if (text.includes("to_regprocedure")) return okRows([{ exists: true }]);
+      if (text.includes("information_schema.columns")) {
+        const table = values[1];
+        if (table === "guilds") return okRows((fixtures.guildColumns || ["guild_id", "guild_name"]).map((column_name) => ({ column_name })));
+        if (table === "guild_members") return okRows((fixtures.memberColumns || ["guild_id", "player_id", "role_id"]).map((column_name) => ({ column_name })));
+        return okRows([]);
+      }
+      if (text.includes("from dune.guilds where guild_id = $1 for update")) {
+        return fixtures.guildRows === null ? okRows([]) : okRows(fixtures.guildRows || [{ guild_id: 1, guild_name: "Spicy Girls" }]);
+      }
+      if (text.includes("from dune.guild_members where guild_id = $1 and player_id = $2 for update")) {
+        return fixtures.memberRows === null ? okRows([]) : okRows(fixtures.memberRows || [{ role_id: "1" }]);
+      }
+      if (text.includes("select player_id from dune.guild_members where guild_id = $1 and role_id = $2")) {
+        return okRows(fixtures.previousLeaderRows || [{ player_id: "10" }]);
+      }
+      if (text.includes("dune.promote_guild_member(")) {
+        if (fixtures.promoteError) throw new Error(fixtures.promoteError);
+        return okRows([]);
+      }
+      if (text.includes("dune.demote_guild_member(")) {
+        if (fixtures.demoteError) throw new Error(fixtures.demoteError);
+        return okRows([]);
+      }
+      if (text.includes("from dune.actors a")) {
+        return okRows(fixtures.playerRows || [{ actor_id: 40, account_id: 44, controller_id: 41, player_state_id: 5, online_status: "Offline" }]);
+      }
+      if (text.includes("dune.add_guild_member(")) {
+        if (fixtures.addError) throw new Error(fixtures.addError);
+        return okRows([]);
+      }
+      if (text.includes("dune.remove_guild_members(")) {
+        if (fixtures.removeError) throw new Error(fixtures.removeError);
+        return okRows([]);
+      }
+      if (text.includes("select count(*)::int as count from dune.guild_members where guild_id = $1")) {
+        return okRows([{ count: fixtures.memberCount ?? 3 }]);
+      }
+      if (text.includes("dune.disband_guild(")) {
+        if (fixtures.disbandError) throw new Error(fixtures.disbandError);
+        return okRows([]);
+      }
+      return okRows([]);
+    },
+    async transaction(fn) {
+      return fn(db);
+    }
+  };
+  return db;
+}
+
+test("guild promotion bumps a member to officer without touching the leader", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls, { memberRows: [{ role_id: "1" }] });
+  const result = await promoteGuildMember(db, 1, 20);
+  assert.equal(result.ok, true);
+  assert.equal(result.newRoleId, 50);
+  assert.equal(result.previousLeaderId, null);
+  const promote = calls.find((call) => call.text.includes("dune.promote_guild_member("));
+  assert.ok(promote);
+  assert.deepEqual(promote.values, [1, 20, 50]);
+  // A plain member-to-officer bump never needs to know who the current leader is.
+  assert.ok(!calls.some((call) => call.text.includes("select player_id from dune.guild_members where guild_id = $1 and role_id = $2")));
+});
+
+test("guild promotion bumps an officer to leader and demotes the previous leader", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls, { memberRows: [{ role_id: "50" }], previousLeaderRows: [{ player_id: "10" }] });
+  const result = await promoteGuildMember(db, 1, 20);
+  assert.equal(result.ok, true);
+  assert.equal(result.newRoleId, 100);
+  assert.equal(result.previousLeaderId, "10");
+  const promote = calls.find((call) => call.text.includes("dune.promote_guild_member("));
+  assert.ok(promote);
+  assert.deepEqual(promote.values, [1, 20, 100]);
+});
+
+test("guild promotion is a no-op when the target is already the leader", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls, { memberRows: [{ role_id: "100" }] });
+  const result = await promoteGuildMember(db, 1, 20);
+  assert.equal(result.alreadyLeader, true);
+  assert.ok(!calls.some((call) => call.text.includes("dune.promote_guild_member(")));
+});
+
+test("guild promotion rejects when the guild does not exist", async () => {
+  const db = guildMutationDb([], { guildRows: [] });
+  await assert.rejects(() => promoteGuildMember(db, 1, 20), /was not found/);
+});
+
+test("guild promotion rejects when the player is not a guild member", async () => {
+  const db = guildMutationDb([], { memberRows: [] });
+  await assert.rejects(() => promoteGuildMember(db, 1, 20), /is not a member/);
+});
+
+test("guild promotion reports unsupported capability when schema functions are absent", async () => {
+  const db = { query: async (text) => text.includes("to_regclass") ? okRows([{ exists: false }]) : okRows([]) };
+  await assert.rejects(() => promoteGuildMember(db, 1, 20), UnsupportedCapabilityError);
+});
+
+test("guild promotion reports unsupported capability when guild_members lacks the expected columns", async () => {
+  const db = guildMutationDb([], { memberColumns: ["guild_id", "role_id"] }); // missing player_id
+  await assert.rejects(() => promoteGuildMember(db, 1, 20), UnsupportedCapabilityError);
+});
+
+test("guild demotion downgrades an officer to member", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls, { memberRows: [{ role_id: "50" }] });
+  const result = await demoteGuildMember(db, 1, 20);
+  assert.equal(result.ok, true);
+  const demote = calls.find((call) => call.text.includes("dune.demote_guild_member("));
+  assert.ok(demote);
+  assert.deepEqual(demote.values, [1, 20, 1]);
+});
+
+test("guild demotion rejects the guild leader without calling the database function", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls, { memberRows: [{ role_id: "100" }] });
+  await assert.rejects(() => demoteGuildMember(db, 1, 20), /is the guild leader/);
+  assert.ok(!calls.some((call) => call.text.includes("dune.demote_guild_member(")));
+});
+
+test("guild demotion rejects a plain member who cannot be demoted further", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls, { memberRows: [{ role_id: "1" }] });
+  await assert.rejects(() => demoteGuildMember(db, 1, 20), /already a Member/);
+  assert.ok(!calls.some((call) => call.text.includes("dune.demote_guild_member(")));
+});
+
+test("guild demotion rejects when the guild does not exist", async () => {
+  const db = guildMutationDb([], { guildRows: [] });
+  await assert.rejects(() => demoteGuildMember(db, 1, 20), /was not found/);
+});
+
+test("guild demotion rejects when the player is not a member", async () => {
+  const db = guildMutationDb([], { memberRows: [] });
+  await assert.rejects(() => demoteGuildMember(db, 1, 20), /is not a member/);
+});
+
+test("guild demotion reports unsupported capability when schema functions are absent", async () => {
+  const db = { query: async (text) => text.includes("to_regclass") ? okRows([{ exists: false }]) : okRows([]) };
+  await assert.rejects(() => demoteGuildMember(db, 1, 20), UnsupportedCapabilityError);
+});
+
+test("guild add member resolves the player and passes a one-guild-per-player cap", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls);
+  const result = await addGuildMember(db, 1, 40, 50);
+  assert.equal(result.ok, true);
+  const add = calls.find((call) => call.text.includes("dune.add_guild_member("));
+  assert.ok(add);
+  // dune.add_guild_member(in_player_id, in_guild_id, ...) -- player id first, then guild id.
+  assert.deepEqual(add.values, [41, 1, 50, 1, 2147483647, 3]);
+});
+
+test("guild add member surfaces a friendly error when the player is already in a guild", async () => {
+  const db = guildMutationDb([], { addError: "Cannot insert more than 1 guild entries for each user." });
+  await assert.rejects(() => addGuildMember(db, 1, 40, 1), /already in a guild/);
+});
+
+test("guild add member surfaces a friendly error when the guild does not exist", async () => {
+  const db = guildMutationDb([], { addError: "Trying to add user to non existing guild 1." });
+  await assert.rejects(() => addGuildMember(db, 1, 40, 1), /was not found/);
+});
+
+test("guild add member surfaces a friendly error when factions are incompatible", async () => {
+  const db = guildMutationDb([], { addError: "Trying to add user to with non compatible. player faction: 1, guild faction: 2" });
+  await assert.rejects(() => addGuildMember(db, 1, 40, 1), /faction is not compatible/);
+});
+
+test("guild add member reports unsupported capability when schema functions are absent", async () => {
+  const db = { query: async (text) => text.includes("to_regclass") ? okRows([{ exists: false }]) : okRows([]) };
+  await assert.rejects(() => addGuildMember(db, 1, 40, 1), UnsupportedCapabilityError);
+});
+
+test("guild remove member deletes a non-leader", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls, { memberRows: [{ role_id: "50" }] });
+  const result = await removeGuildMember(db, 1, 20);
+  assert.equal(result.ok, true);
+  const remove = calls.find((call) => call.text.includes("dune.remove_guild_members("));
+  assert.ok(remove);
+  assert.deepEqual(remove.values, [[20], 1, 0]);
+});
+
+test("guild remove member rejects removing the leader without calling the database function", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls, { memberRows: [{ role_id: "100" }] });
+  await assert.rejects(() => removeGuildMember(db, 1, 20), /is the guild leader/);
+  assert.ok(!calls.some((call) => call.text.includes("dune.remove_guild_members(")));
+});
+
+test("guild remove member rejects when the guild does not exist", async () => {
+  const db = guildMutationDb([], { guildRows: [] });
+  await assert.rejects(() => removeGuildMember(db, 1, 20), /was not found/);
+});
+
+test("guild remove member rejects when the player is not a member", async () => {
+  const db = guildMutationDb([], { memberRows: [] });
+  await assert.rejects(() => removeGuildMember(db, 1, 20), /is not a member/);
+});
+
+test("guild remove member reports unsupported capability when schema functions are absent", async () => {
+  const db = { query: async (text) => text.includes("to_regclass") ? okRows([{ exists: false }]) : okRows([]) };
+  await assert.rejects(() => removeGuildMember(db, 1, 20), UnsupportedCapabilityError);
+});
+
+test("guild disband deletes the guild then cleans up orphaned guild_members rows", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls, { memberCount: 5 });
+  const result = await disbandGuild(db, 1);
+  assert.equal(result.ok, true);
+  assert.equal(result.guildName, "Spicy Girls");
+  assert.equal(result.memberCount, 5);
+  const disband = calls.find((call) => call.text.includes("dune.disband_guild("));
+  assert.ok(disband);
+  assert.deepEqual(disband.values, [1]);
+  const cleanup = calls.find((call) => call.text.includes("delete from dune.guild_members where guild_id = $1"));
+  assert.ok(cleanup, "expected a defensive cleanup delete of orphaned guild_members rows");
+  assert.deepEqual(cleanup.values, [1]);
+  // The cleanup delete must run after the game's own disband function, not before.
+  assert.ok(calls.indexOf(disband) < calls.indexOf(cleanup));
+});
+
+test("guild disband rejects when the guild does not exist", async () => {
+  const db = guildMutationDb([], { guildRows: [] });
+  await assert.rejects(() => disbandGuild(db, 1), /was not found/);
+});
+
+test("guild disband reports unsupported capability when schema functions are absent", async () => {
+  const db = { query: async (text) => text.includes("to_regclass") ? okRows([{ exists: false }]) : okRows([]) };
+  await assert.rejects(() => disbandGuild(db, 1), UnsupportedCapabilityError);
+});
+
+test("guild disband reports unsupported capability when dune.guilds lacks the expected columns", async () => {
+  const db = guildMutationDb([], { guildColumns: ["guild_id"] }); // missing guild_name
+  await assert.rejects(() => disbandGuild(db, 1), UnsupportedCapabilityError);
 });
 
 const BASE_REQUIRED_TABLES = ["dune.buildings", "dune.building_instances", "dune.actor_fgl_entities", "dune.actors"];

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -2048,8 +2048,26 @@ test("guild add member resolves the player and passes a one-guild-per-player cap
   assert.equal(result.ok, true);
   const add = calls.find((call) => call.text.includes("dune.add_guild_member("));
   assert.ok(add);
+  const advisoryLockIndex = calls.findIndex((call) => call.text.includes("guilds_get_exclusive_operation_lock"));
+  const guildRowLockIndex = calls.findIndex((call) => call.text.includes("from dune.guilds where guild_id = $1 for update"));
+  assert.ok(advisoryLockIndex >= 0 && advisoryLockIndex < guildRowLockIndex);
   // dune.add_guild_member(in_player_id, in_guild_id, ...) -- player id first, then guild id.
-  assert.deepEqual(add.values, [41, 1, 50, 1, 2147483647, 3]);
+  assert.deepEqual(add.values, [41, 1, 50, 1, 32, 3]);
+});
+
+test("guild add member enforces the configured capacity before invoking the game function", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls, { memberCount: 48 });
+  await assert.rejects(() => addGuildMember(db, 1, 40, 1, 48), /configured maximum of 48 members/);
+  assert.ok(!calls.some((call) => call.text.includes("dune.add_guild_member(")));
+});
+
+test("guild add member passes a custom configured capacity to the game function", async () => {
+  const calls = [];
+  const db = guildMutationDb(calls, { memberCount: 47 });
+  await addGuildMember(db, 1, 40, 1, 48);
+  const add = calls.find((call) => call.text.includes("dune.add_guild_member("));
+  assert.deepEqual(add.values, [41, 1, 1, 1, 48, 3]);
 });
 
 test("guild add member surfaces a friendly error when the player is already in a guild", async () => {

--- a/console/api/test/guild-settings.test.js
+++ b/console/api/test/guild-settings.test.js
@@ -1,0 +1,20 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseEffectiveGuildMemberLimit } from "../src/services/guildSettings.js";
+
+test("guild member limit uses the effective legacy-precedence value", () => {
+  assert.equal(parseEffectiveGuildMemberLimit([
+    "max_guild_members_allowed\t48",
+    "guild_settings_max_guild_members_allowed\t32"
+  ].join("\n")), 48);
+});
+
+test("guild member limit uses the canonical value when the legacy field is absent", () => {
+  assert.equal(parseEffectiveGuildMemberLimit("guild_settings_max_guild_members_allowed\t64\n"), 64);
+});
+
+test("guild member limit defaults safely and rejects malformed values", () => {
+  assert.equal(parseEffectiveGuildMemberLimit(""), 32);
+  assert.throws(() => parseEffectiveGuildMemberLimit("max_guild_members_allowed\t0\n"), /invalid/);
+  assert.throws(() => parseEffectiveGuildMemberLimit("max_guild_members_allowed\tnot-a-number\n"), /invalid/);
+});

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -638,7 +638,7 @@ export function App() {
         }} />}
         {!redeploySetupOpen && tab === "Services" && <LazyTabBoundary label="Loading Services"><ServicesPanel services={services} setServices={setServices} setTask={setTask} openLogs={(service) => { setRedeploySetupOpen(false); setSelectedLogService(service); setTab("Logs"); }} onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Players" && <LazyTabBoundary label="Loading Players"><PlayersPanel onError={setError} renderCharacterAdmin={(props) => <LazyTabBoundary label="Loading Player Details"><CharacterAdminUI {...props} onError={setError} confirmAction={confirmDialog} waitForTask={waitForTaskSilently} formatMutationResult={formatMutationResult} /></LazyTabBoundary>} /></LazyTabBoundary>}
-        {!redeploySetupOpen && tab === "Guilds" && <LazyTabBoundary label="Loading Guilds"><GuildsPanel onError={setError} /></LazyTabBoundary>}
+        {!redeploySetupOpen && tab === "Guilds" && <LazyTabBoundary label="Loading Guilds"><GuildsPanel onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Bases" && <LazyTabBoundary label="Loading Bases"><BasesPanel onError={setError} confirmAction={confirmDialog} formatMutationResult={formatMutationResult} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Landsraad" && <LazyTabBoundary label="Loading Landsraad"><LandsraadPanel onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Admin Tools" && <LazyTabBoundary label="Loading Admin Tools"><AdminToolsPanel onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}

--- a/console/web/src/api/guilds.ts
+++ b/console/web/src/api/guilds.ts
@@ -1,4 +1,6 @@
-import { api } from "./client";
+import { api, post } from "./client";
+
+type GuildMutationResult = { supported: boolean; result?: Record<string, unknown>; reason?: string };
 
 export const guildsApi = {
   list: (params: { q?: string; page?: number; pageSize?: number; sortColumn?: string; sortDirection?: "asc" | "desc" } = {}) => {
@@ -11,5 +13,15 @@ export const guildsApi = {
     const qs = search.toString();
     return api<{ rows: Record<string, unknown>[]; totalCount: number; totalGuilds: number; capabilities: Record<string, unknown>; reason?: string }>(`/api/guilds${qs ? `?${qs}` : ""}`);
   },
-  members: (guildId: string) => api<{ rows: Record<string, unknown>[]; capabilities: Record<string, unknown>; reason?: string }>(`/api/guilds/${encodeURIComponent(guildId)}/members`)
+  members: (guildId: string) => api<{ rows: Record<string, unknown>[]; capabilities: Record<string, unknown>; reason?: string }>(`/api/guilds/${encodeURIComponent(guildId)}/members`),
+  promote: (guildId: string, playerId: string) =>
+    post<GuildMutationResult>(`/api/guilds/${encodeURIComponent(guildId)}/members/${encodeURIComponent(playerId)}/promote`),
+  demote: (guildId: string, playerId: string) =>
+    post<GuildMutationResult>(`/api/guilds/${encodeURIComponent(guildId)}/members/${encodeURIComponent(playerId)}/demote`),
+  addMember: (guildId: string, playerId: string, roleId: number) =>
+    post<GuildMutationResult>(`/api/guilds/${encodeURIComponent(guildId)}/members`, { playerId, roleId }),
+  removeMember: (guildId: string, playerId: string) =>
+    api<GuildMutationResult>(`/api/guilds/${encodeURIComponent(guildId)}/members/${encodeURIComponent(playerId)}`, { method: "DELETE" }),
+  disband: (guildId: string, confirmation: string) =>
+    api<GuildMutationResult>(`/api/guilds/${encodeURIComponent(guildId)}`, { method: "DELETE", body: JSON.stringify({ confirmation }) })
 };

--- a/console/web/src/features/guilds/GuildsPanel.test.tsx
+++ b/console/web/src/features/guilds/GuildsPanel.test.tsx
@@ -1,0 +1,261 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { guildsApi } from "../../api/guilds";
+import { playersApi } from "../../api/players";
+import { GuildsPanel } from "./GuildsPanel";
+
+vi.mock("../../api/guilds", () => ({
+  guildsApi: {
+    list: vi.fn(),
+    members: vi.fn(),
+    promote: vi.fn(),
+    demote: vi.fn(),
+    addMember: vi.fn(),
+    removeMember: vi.fn(),
+    disband: vi.fn()
+  }
+}));
+
+vi.mock("../../api/players", () => ({
+  playersApi: {
+    list: vi.fn()
+  }
+}));
+
+function renderPanel(overrides: Partial<Parameters<typeof GuildsPanel>[0]> = {}) {
+  const props = {
+    onError: vi.fn(),
+    confirmAction: vi.fn().mockResolvedValue(true),
+    ...overrides
+  };
+  render(<GuildsPanel {...props} />);
+  return props;
+}
+
+const guildRow = { guild_id: "1", guild_name: "Spicy Girls", guild_faction: "", member_count: 3, guild_description: "" };
+
+// Kynes = Leader, Vash = Officer, Chani = Member -- one row per rank tier.
+const memberRows = [
+  { player_id: "10", character_name: "Kynes", role_id: "100" },
+  { player_id: "20", character_name: "Vash", role_id: "50" },
+  { player_id: "30", character_name: "Chani", role_id: "1" }
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(guildsApi.list).mockResolvedValue({ rows: [guildRow], totalCount: 1, totalGuilds: 1, capabilities: { guilds: true } });
+  vi.mocked(guildsApi.members).mockResolvedValue({ rows: memberRows, capabilities: { guildMembers: true } });
+});
+
+async function openGuildMembers() {
+  await screen.findByText("Spicy Girls");
+  fireEvent.click(screen.getByText("Spicy Girls"));
+  await screen.findByText("Kynes");
+}
+
+describe("GuildsPanel member actions", () => {
+  it("shows all three actions on every row, greying out whichever don't apply", async () => {
+    renderPanel();
+    await openGuildMembers();
+
+    // Kynes (Leader): all three actions render but are disabled -- nothing to promote to, and
+    // both Demote and Remove require someone else to be promoted first.
+    expect(screen.getByRole("button", { name: "Cannot promote the leader further" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cannot demote the leader" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Cannot remove the leader" })).toBeDisabled();
+
+    // Vash (Officer): can promote to Leader, demote to Member, or be removed.
+    expect(screen.getByRole("button", { name: "Promote Vash to Leader" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Demote Vash to Member" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Remove Vash from guild" })).toBeEnabled();
+
+    // Chani (Member): can promote to Officer or be removed, but Demote is disabled -- nothing lower.
+    expect(screen.getByRole("button", { name: "Promote Chani to Officer" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Cannot demote Chani further" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Remove Chani from guild" })).toBeEnabled();
+  });
+
+  it("confirms, promotes an officer to leader, and refreshes the member list", async () => {
+    vi.mocked(guildsApi.promote).mockResolvedValue({ supported: true, result: { ok: true } });
+    const props = renderPanel();
+    await openGuildMembers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Promote Vash to Leader" }));
+
+    await waitFor(() => expect(props.confirmAction).toHaveBeenCalledWith(
+      "Promote Vash to Leader of Spicy Girls? Kynes will be demoted to Officer.",
+      { title: "Promote to Leader", confirmLabel: "Promote" }
+    ));
+    await waitFor(() => expect(guildsApi.promote).toHaveBeenCalledWith("1", "20"));
+    expect(vi.mocked(guildsApi.members).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("confirms, promotes a member to officer, and refreshes the member list", async () => {
+    vi.mocked(guildsApi.promote).mockResolvedValue({ supported: true, result: { ok: true } });
+    const props = renderPanel();
+    await openGuildMembers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Promote Chani to Officer" }));
+
+    await waitFor(() => expect(props.confirmAction).toHaveBeenCalledWith(
+      "Promote Chani to Officer of Spicy Girls?",
+      { title: "Promote to Officer", confirmLabel: "Promote" }
+    ));
+    await waitFor(() => expect(guildsApi.promote).toHaveBeenCalledWith("1", "30"));
+    expect(vi.mocked(guildsApi.members).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("does not promote when the confirm dialog is declined", async () => {
+    renderPanel({ confirmAction: vi.fn().mockResolvedValue(false) });
+    await openGuildMembers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Promote Vash to Leader" }));
+
+    await waitFor(() => expect(guildsApi.promote).not.toHaveBeenCalled());
+  });
+
+  it("reports a no-op instead of a silent success when the target was already the leader", async () => {
+    vi.mocked(guildsApi.promote).mockResolvedValue({ supported: true, result: { ok: true, alreadyLeader: true } });
+    const props = renderPanel();
+    await openGuildMembers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Promote Vash to Leader" }));
+
+    await waitFor(() => expect(guildsApi.promote).toHaveBeenCalledWith("1", "20"));
+    await waitFor(() => expect(props.onError).toHaveBeenCalledWith("Vash was already the guild leader -- no changes were made."));
+  });
+
+  it("shows a loading state on the member table while a post-promote refresh is in flight", async () => {
+    vi.mocked(guildsApi.promote).mockResolvedValue({ supported: true, result: { ok: true } });
+    renderPanel();
+    await openGuildMembers();
+
+    // Only the refetch triggered by the promote itself (not the initial open) needs to hang,
+    // so it can be observed mid-flight.
+    let resolveMembers: (value: { rows: typeof memberRows; capabilities: Record<string, unknown> }) => void = () => {};
+    vi.mocked(guildsApi.members).mockReturnValue(new Promise((resolve) => { resolveMembers = resolve; }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Promote Vash to Leader" }));
+
+    expect(await screen.findByText("(refreshing...)")).toBeInTheDocument();
+
+    resolveMembers({ rows: memberRows, capabilities: { guildMembers: true } });
+    await waitFor(() => expect(screen.queryByText("(refreshing...)")).not.toBeInTheDocument());
+  });
+
+  it("confirms, demotes an officer to member, and refreshes the member list", async () => {
+    vi.mocked(guildsApi.demote).mockResolvedValue({ supported: true, result: { ok: true } });
+    const props = renderPanel();
+    await openGuildMembers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Demote Vash to Member" }));
+
+    await waitFor(() => expect(props.confirmAction).toHaveBeenCalledWith(
+      "Demote Vash to Member of Spicy Girls?",
+      { title: "Demote to Member", confirmLabel: "Demote" }
+    ));
+    await waitFor(() => expect(guildsApi.demote).toHaveBeenCalledWith("1", "20"));
+    expect(vi.mocked(guildsApi.members).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("does not demote when the confirm dialog is declined", async () => {
+    renderPanel({ confirmAction: vi.fn().mockResolvedValue(false) });
+    await openGuildMembers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Demote Vash to Member" }));
+
+    await waitFor(() => expect(guildsApi.demote).not.toHaveBeenCalled());
+  });
+
+  it("confirms, removes a non-leader member, and refreshes the member list", async () => {
+    vi.mocked(guildsApi.removeMember).mockResolvedValue({ supported: true, result: { ok: true } });
+    const props = renderPanel();
+    await openGuildMembers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove Vash from guild" }));
+
+    await waitFor(() => expect(props.confirmAction).toHaveBeenCalledWith(
+      "Remove Vash from Spicy Girls?",
+      { title: "Remove Member", confirmLabel: "Remove" }
+    ));
+    await waitFor(() => expect(guildsApi.removeMember).toHaveBeenCalledWith("1", "20"));
+    expect(vi.mocked(guildsApi.members).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("only searches players after Search is clicked, not on keystroke", async () => {
+    vi.mocked(playersApi.list).mockResolvedValue({ rows: [{ actor_id: "40", character_name: "Duncan Idaho" }], totalCount: 1, totalPlayers: 1, capabilities: {} });
+    renderPanel();
+    await openGuildMembers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Member" }));
+    const modal = within(await screen.findByRole("dialog"));
+    fireEvent.change(modal.getByPlaceholderText("Search character name"), { target: { value: "Dun" } });
+    expect(playersApi.list).not.toHaveBeenCalled();
+
+    fireEvent.click(modal.getByRole("button", { name: "Search" }));
+    await waitFor(() => expect(playersApi.list).toHaveBeenCalledWith({ q: "Dun", pageSize: 8, status: "all" }));
+    expect(await modal.findByRole("button", { name: "Duncan Idaho" })).toBeInTheDocument();
+  });
+
+  it("adds the selected player to the guild and refreshes the member list", async () => {
+    vi.mocked(playersApi.list).mockResolvedValue({ rows: [{ actor_id: "40", character_name: "Duncan Idaho" }], totalCount: 1, totalPlayers: 1, capabilities: {} });
+    vi.mocked(guildsApi.addMember).mockResolvedValue({ supported: true, result: { ok: true } });
+    renderPanel();
+    await openGuildMembers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Member" }));
+    const modal = within(await screen.findByRole("dialog"));
+    fireEvent.change(modal.getByPlaceholderText("Search character name"), { target: { value: "Dun" } });
+    fireEvent.click(modal.getByRole("button", { name: "Search" }));
+    fireEvent.click(await modal.findByRole("button", { name: "Duncan Idaho" }));
+
+    fireEvent.click(modal.getByRole("button", { name: "Add to Guild" }));
+
+    await waitFor(() => expect(guildsApi.addMember).toHaveBeenCalledWith("1", "40", 1));
+    expect(vi.mocked(guildsApi.members).mock.calls.length).toBeGreaterThan(1);
+  });
+});
+
+describe("GuildsPanel disband guild", () => {
+  it("renders a Disband icon per top-level guild row", async () => {
+    renderPanel();
+    await screen.findByText("Spicy Girls");
+
+    expect(screen.getByRole("button", { name: "Disband Spicy Girls" })).toBeInTheDocument();
+  });
+
+  it("confirms with the member count, disbands, and refreshes the guild list", async () => {
+    vi.mocked(guildsApi.disband).mockResolvedValue({ supported: true, result: { ok: true } });
+    const props = renderPanel();
+    await screen.findByText("Spicy Girls");
+
+    fireEvent.click(screen.getByRole("button", { name: "Disband Spicy Girls" }));
+
+    await waitFor(() => expect(props.confirmAction).toHaveBeenCalledWith(
+      "Disband Spicy Girls? This permanently deletes the guild and removes all its members.",
+      { title: "Disband Guild", confirmLabel: "Disband", danger: true, details: [{ label: "Members", value: "3", tone: "danger" }] }
+    ));
+    await waitFor(() => expect(guildsApi.disband).toHaveBeenCalledWith("1", "DISBAND GUILD"));
+    expect(vi.mocked(guildsApi.list).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("closes the member panel when the disbanded guild was open", async () => {
+    vi.mocked(guildsApi.disband).mockResolvedValue({ supported: true, result: { ok: true } });
+    renderPanel();
+    await openGuildMembers();
+
+    fireEvent.click(screen.getByRole("button", { name: "Disband Spicy Girls" }));
+
+    await waitFor(() => expect(guildsApi.disband).toHaveBeenCalledWith("1", "DISBAND GUILD"));
+    expect(screen.queryByText("Members of Spicy Girls")).not.toBeInTheDocument();
+  });
+
+  it("does not disband when the confirm dialog is declined", async () => {
+    renderPanel({ confirmAction: vi.fn().mockResolvedValue(false) });
+    await screen.findByText("Spicy Girls");
+
+    fireEvent.click(screen.getByRole("button", { name: "Disband Spicy Girls" }));
+
+    await waitFor(() => expect(guildsApi.disband).not.toHaveBeenCalled());
+  });
+});

--- a/console/web/src/features/guilds/GuildsPanel.tsx
+++ b/console/web/src/features/guilds/GuildsPanel.tsx
@@ -1,23 +1,38 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { ChevronsDown, ChevronsUp, Trash2 } from "lucide-react";
 import { guildsApi } from "../../api/guilds";
+import { playersApi } from "../../api/players";
 import { DataTable, type SortDirection } from "../../components/common/DataTable";
 import { formatCell } from "../../lib/display";
 
 type GuildsPanelProps = {
   onError: (text: string) => void;
+  confirmAction: (message: string, options?: { title?: string; confirmLabel?: string; warning?: string; danger?: boolean; details?: { label: string; value: string; tone?: "accent" | "success" | "danger" }[] }) => Promise<boolean>;
 };
 
 const GUILDS_AUTO_REFRESH_MS = 10_000;
 const GUILDS_PAGE_SIZES = [25, 50, 100, 200] as const;
 const GUILDS_DEFAULT_PAGE_SIZE = 50;
+// Must match GUILD_OFFICER_ROLE_ID/GUILD_LEADER_ROLE_ID in console/api/src/duneDb.js -- there is
+// no shared constants module across the frontend/backend boundary, so this has to be kept in
+// sync by hand.
+const GUILD_OFFICER_ROLE_ID = 50;
+const GUILD_LEADER_ROLE_ID = 100;
 
 function errorText(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
 
+function guildRoleLabel(roleId: unknown): string {
+  const value = Number(roleId);
+  if (value >= GUILD_LEADER_ROLE_ID) return "Leader";
+  if (value >= GUILD_OFFICER_ROLE_ID) return "Officer";
+  return "Member";
+}
+
 type GuildsLoadParams = { q: string; page: number; pageSize: number; sortColumn: string; sortDirection: SortDirection };
 
-export function GuildsPanel({ onError }: GuildsPanelProps) {
+export function GuildsPanel({ onError, confirmAction }: GuildsPanelProps) {
   const [q, setQ] = useState("");
   const [submittedQ, setSubmittedQ] = useState("");
   const [page, setPage] = useState(0);
@@ -30,6 +45,18 @@ export function GuildsPanel({ onError }: GuildsPanelProps) {
   const [selectedGuild, setSelectedGuild] = useState<Record<string, unknown> | null>(null);
   const [memberRows, setMemberRows] = useState<Record<string, unknown>[]>([]);
   const [membersLoading, setMembersLoading] = useState(false);
+  const [promotingId, setPromotingId] = useState("");
+  const [demotingId, setDemotingId] = useState("");
+  const [removingId, setRemovingId] = useState("");
+  const [disbandingId, setDisbandingId] = useState("");
+  const [addOpen, setAddOpen] = useState(false);
+  const [addQuery, setAddQuery] = useState("");
+  const [addResults, setAddResults] = useState<Record<string, unknown>[]>([]);
+  const [addSearching, setAddSearching] = useState(false);
+  const [addSelected, setAddSelected] = useState<Record<string, unknown> | null>(null);
+  const [addRoleId, setAddRoleId] = useState(1);
+  const [addBusy, setAddBusy] = useState(false);
+  const [addError, setAddError] = useState("");
   const requestIdRef = useRef(0);
   const skipNextSearchReset = useRef(true);
 
@@ -106,6 +133,16 @@ export function GuildsPanel({ onError }: GuildsPanelProps) {
     };
   }, [submittedQ, page, pageSize, sortColumn, sortDirection, load]);
 
+  async function refreshMembers(guildId: string) {
+    setMembersLoading(true);
+    try {
+      const result = await guildsApi.members(guildId);
+      setMemberRows(result.rows || []);
+    } finally {
+      setMembersLoading(false);
+    }
+  }
+
   async function openGuild(row: Record<string, unknown>) {
     const guildId = String(row.guild_id || "");
     if (selectedGuild && String(selectedGuild.guild_id || "") === guildId) {
@@ -114,14 +151,159 @@ export function GuildsPanel({ onError }: GuildsPanelProps) {
       return;
     }
     setSelectedGuild(row);
-    setMembersLoading(true);
     try {
-      const result = await guildsApi.members(guildId);
-      setMemberRows(result.rows || []);
+      await refreshMembers(guildId);
+    } catch (error) {
+      onError(errorText(error));
+    }
+  }
+
+  async function handlePromote(row: Record<string, unknown>) {
+    const guildId = String(selectedGuild?.guild_id || "");
+    const playerId = String(row.player_id || "");
+    const name = String(row.character_name || "this member");
+    const guildName = String(selectedGuild?.guild_name || "this guild");
+    const isOfficer = Number(row.role_id) >= GUILD_OFFICER_ROLE_ID;
+    const currentLeader = memberRows.find((member) => Number(member.role_id) >= GUILD_LEADER_ROLE_ID);
+    const leaderName = currentLeader ? String(currentLeader.character_name || "the current leader") : "";
+    const confirmed = await confirmAction(
+      isOfficer
+        ? (leaderName
+            ? `Promote ${name} to Leader of ${guildName}? ${leaderName} will be demoted to Officer.`
+            : `Promote ${name} to Leader of ${guildName}?`)
+        : `Promote ${name} to Officer of ${guildName}?`,
+      { title: isOfficer ? "Promote to Leader" : "Promote to Officer", confirmLabel: "Promote" }
+    );
+    if (!confirmed) return;
+    onError("");
+    setPromotingId(playerId);
+    try {
+      const response = await guildsApi.promote(guildId, playerId);
+      await refreshMembers(guildId);
+      if (response.result?.alreadyLeader) {
+        onError(`${name} was already the guild leader -- no changes were made.`);
+      }
     } catch (error) {
       onError(errorText(error));
     } finally {
-      setMembersLoading(false);
+      setPromotingId("");
+    }
+  }
+
+  async function handleDemote(row: Record<string, unknown>) {
+    const guildId = String(selectedGuild?.guild_id || "");
+    const playerId = String(row.player_id || "");
+    const name = String(row.character_name || "this member");
+    const guildName = String(selectedGuild?.guild_name || "this guild");
+    const confirmed = await confirmAction(`Demote ${name} to Member of ${guildName}?`, { title: "Demote to Member", confirmLabel: "Demote" });
+    if (!confirmed) return;
+    onError("");
+    setDemotingId(playerId);
+    try {
+      await guildsApi.demote(guildId, playerId);
+      await refreshMembers(guildId);
+    } catch (error) {
+      onError(errorText(error));
+    } finally {
+      setDemotingId("");
+    }
+  }
+
+  async function handleRemove(row: Record<string, unknown>) {
+    const guildId = String(selectedGuild?.guild_id || "");
+    const playerId = String(row.player_id || "");
+    const name = String(row.character_name || "this member");
+    const guildName = String(selectedGuild?.guild_name || "this guild");
+    const confirmed = await confirmAction(`Remove ${name} from ${guildName}?`, { title: "Remove Member", confirmLabel: "Remove" });
+    if (!confirmed) return;
+    onError("");
+    setRemovingId(playerId);
+    try {
+      await guildsApi.removeMember(guildId, playerId);
+      await refreshMembers(guildId);
+    } catch (error) {
+      onError(errorText(error));
+    } finally {
+      setRemovingId("");
+    }
+  }
+
+  async function handleDisband(row: Record<string, unknown>) {
+    const guildId = String(row.guild_id || "");
+    const name = String(row.guild_name || "this guild");
+    // The row's own member_count can be several seconds stale (only refreshed by the 10s
+    // auto-refresh poll or a manual action) -- fetch the live count for this irreversible
+    // action's confirmation, falling back to the stale value if the fetch itself fails.
+    let memberCount = Number(row.member_count || 0);
+    try {
+      const fresh = await guildsApi.members(guildId);
+      memberCount = (fresh.rows || []).length;
+    } catch {
+      // Fall back to the guild list's own count above.
+    }
+    const confirmed = await confirmAction(
+      `Disband ${name}? This permanently deletes the guild and removes all its members.`,
+      { title: "Disband Guild", confirmLabel: "Disband", danger: true, details: [{ label: "Members", value: String(memberCount), tone: "danger" }] }
+    );
+    if (!confirmed) return;
+    onError("");
+    setDisbandingId(guildId);
+    try {
+      await guildsApi.disband(guildId, "DISBAND GUILD");
+      if (String(selectedGuild?.guild_id || "") === guildId) {
+        setSelectedGuild(null);
+        setMemberRows([]);
+      }
+      await load({ q: submittedQ, page, pageSize, sortColumn, sortDirection });
+    } catch (error) {
+      onError(errorText(error));
+    } finally {
+      setDisbandingId("");
+    }
+  }
+
+  function openAddModal() {
+    setAddQuery("");
+    setAddResults([]);
+    setAddSelected(null);
+    setAddRoleId(1);
+    setAddError("");
+    setAddOpen(true);
+  }
+
+  function closeAddModal() {
+    setAddOpen(false);
+  }
+
+  async function submitAddSearch() {
+    const query = addQuery.trim();
+    if (!query) return;
+    setAddSearching(true);
+    setAddError("");
+    try {
+      const result = await playersApi.list({ q: query, pageSize: 8, status: "all" });
+      setAddResults(result.rows || []);
+    } catch (error) {
+      setAddError(errorText(error));
+    } finally {
+      setAddSearching(false);
+    }
+  }
+
+  async function handleAddMember() {
+    if (!addSelected || !selectedGuild) return;
+    const guildId = String(selectedGuild.guild_id || "");
+    const playerId = String(addSelected.actor_id || addSelected.player_id || "");
+    setAddBusy(true);
+    setAddError("");
+    try {
+      await guildsApi.addMember(guildId, playerId, addRoleId);
+      await refreshMembers(guildId);
+      closeAddModal();
+    } catch (error) {
+      setAddError(errorText(error));
+    } finally {
+      setAddBusy(false);
     }
   }
 
@@ -169,6 +351,7 @@ export function GuildsPanel({ onError }: GuildsPanelProps) {
         rows={rows}
         columns={["guild_name", "guild_faction", "member_count", "guild_description"]}
         tableClassName="guilds-table"
+        actionClassName="actions-column"
         onRowClick={openGuild}
         sortColumn={sortColumn}
         sortDirection={sortDirection}
@@ -176,6 +359,18 @@ export function GuildsPanel({ onError }: GuildsPanelProps) {
         nonSortableColumns={["guild_description"]}
         rowKey={(row) => String(row.guild_id)}
         emptyMessage="No guilds have been found yet."
+        action={(row) => {
+          const guildId = String(row.guild_id || "");
+          return (
+            <button
+              className="icon-toggle-button danger"
+              disabled={disbandingId === guildId}
+              title="Disband guild"
+              aria-label={`Disband ${String(row.guild_name || "guild")}`}
+              onClick={(event) => { event.stopPropagation(); void handleDisband(row); }}
+            ><Trash2 size={16} /></button>
+          );
+        }}
       />
       <div className="panel-title guilds-pagination-footer">
         <p className="action-help-note">Showing {rangeStart}-{rangeEnd} of {totalCount} rows.</p>
@@ -196,19 +391,113 @@ export function GuildsPanel({ onError }: GuildsPanelProps) {
       {selectedGuild && (
         <div className="guild-members-panel">
           <div className="panel-title">
-            <h3>Members of {String(selectedGuild.guild_name || "Guild")}</h3>
-            <button onClick={() => { setSelectedGuild(null); setMemberRows([]); }}>Close</button>
+            <h3>
+              Members of {String(selectedGuild.guild_name || "Guild")}
+              {membersLoading && <span className="muted"> (refreshing...)</span>}
+            </h3>
+            <div className="action-row">
+              <button onClick={openAddModal}>Add Member</button>
+              <button onClick={() => { setSelectedGuild(null); setMemberRows([]); }}>Close</button>
+            </div>
           </div>
           <DataTable
             rows={memberRows}
             columns={["character_name", "role_id"]}
             tableClassName="guild-members-table"
+            actionClassName="actions-column"
             emptyMessage={membersLoading ? "Loading members..." : "This guild has no members."}
             renderCell={(row, col) => {
-              if (col === "role_id") return String(row.role_id) === "100" ? "Leader" : "Member";
+              if (col === "role_id") return guildRoleLabel(row.role_id);
               return formatCell(row[col]);
             }}
+            action={(row) => {
+              const role = Number(row.role_id);
+              const isLeader = role >= GUILD_LEADER_ROLE_ID;
+              const isOfficer = role >= GUILD_OFFICER_ROLE_ID && role < GUILD_LEADER_ROLE_ID;
+              const isMember = role < GUILD_OFFICER_ROLE_ID;
+              const playerId = String(row.player_id || "");
+              const name = String(row.character_name || "member");
+              return (
+                <span className="icon-toggle-group guild-member-actions">
+                  <button
+                    className="icon-toggle-button success"
+                    disabled={isLeader || promotingId === playerId}
+                    title={isLeader ? "Already the guild leader" : (isOfficer ? "Promote to Leader" : "Promote to Officer")}
+                    aria-label={isLeader ? "Cannot promote the leader further" : `Promote ${name} to ${isOfficer ? "Leader" : "Officer"}`}
+                    onClick={(event) => { event.stopPropagation(); void handlePromote(row); }}
+                  ><ChevronsUp size={16} /></button>
+                  <button
+                    className="icon-toggle-button warning"
+                    disabled={isLeader || isMember || demotingId === playerId}
+                    title={isLeader ? "Promote another member before demoting the leader" : (isMember ? "Already the lowest rank" : "Demote to Member")}
+                    aria-label={isLeader ? "Cannot demote the leader" : (isMember ? `Cannot demote ${name} further` : `Demote ${name} to Member`)}
+                    onClick={(event) => { event.stopPropagation(); void handleDemote(row); }}
+                  ><ChevronsDown size={16} /></button>
+                  <button
+                    className="icon-toggle-button danger"
+                    disabled={isLeader || removingId === playerId}
+                    title={isLeader ? "Promote another member before removing the leader" : "Remove from guild"}
+                    aria-label={isLeader ? "Cannot remove the leader" : `Remove ${name} from guild`}
+                    onClick={(event) => { event.stopPropagation(); void handleRemove(row); }}
+                  ><Trash2 size={16} /></button>
+                </span>
+              );
+            }}
           />
+        </div>
+      )}
+      {addOpen && selectedGuild && (
+        <div className="modal-overlay" role="presentation" onMouseDown={closeAddModal}>
+          <section className="confirm-modal guild-add-member-modal" role="dialog" aria-modal="true" aria-labelledby="guild-add-member-title" onMouseDown={(event) => event.stopPropagation()}>
+            <div className="confirm-modal-title">
+              <h3 id="guild-add-member-title">Add Member to {String(selectedGuild.guild_name || "Guild")}</h3>
+            </div>
+            {!addSelected ? (
+              <>
+                <p>Search for a character to add.</p>
+                <div className="action-row guild-add-member-search-row">
+                  <input
+                    value={addQuery}
+                    onChange={(event) => setAddQuery(event.target.value)}
+                    onKeyDown={(event) => { if (event.key === "Enter") void submitAddSearch(); }}
+                    placeholder="Search character name"
+                  />
+                  <button onClick={() => void submitAddSearch()} disabled={addSearching || !addQuery.trim()}>{addSearching ? "Searching..." : "Search"}</button>
+                </div>
+                <div className="guild-add-member-results">
+                  {addResults.length === 0 && <p className="action-help-note">No results yet. Enter a name and press Search.</p>}
+                  {addResults.map((candidate) => (
+                    <button
+                      key={String(candidate.actor_id || candidate.player_id)}
+                      className="guild-add-member-result"
+                      onClick={() => setAddSelected(candidate)}
+                    >
+                      {String(candidate.character_name || "Unknown")}
+                    </button>
+                  ))}
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="guild-add-member-selected">
+                  <span>{String(addSelected.character_name || "Selected player")}</span>
+                  <button onClick={() => setAddSelected(null)}>Change</button>
+                </div>
+                <label className="compact-select">
+                  Rank
+                  <select value={String(addRoleId)} onChange={(event) => setAddRoleId(Number(event.target.value))}>
+                    <option value="1">Member</option>
+                    <option value="50">Officer</option>
+                  </select>
+                </label>
+              </>
+            )}
+            {addError && <p className="danger-note">{addError}</p>}
+            <div className="confirm-modal-actions">
+              <button onClick={closeAddModal}>Cancel</button>
+              <button className="success" disabled={!addSelected || addBusy} onClick={() => void handleAddMember()}>{addBusy ? "Adding..." : "Add to Guild"}</button>
+            </div>
+          </section>
         </div>
       )}
     </section>

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -45,6 +45,8 @@ button.active { background: #9b5f2a; border-color: var(--accent-strong); }
 button.danger { border-color: var(--danger-strong); color: #ffc9c9; }
 button.success { border-color: var(--success); color: #d8f0c8; }
 button.success:hover { border-color: #63b57f; }
+button.warning { border-color: var(--warning); color: #ffd9a8; }
+button.warning:hover { border-color: #c68b4a; }
 button.restore-action, .icon-action.danger, .download-action { border-color: #f7e7c7; color: #f7e7c7; }
 button.restore-action:hover, .icon-action.danger:hover, .download-action:hover { border-color: #fff3d7; }
 .icon-action { width: 38px; height: 38px; padding: 7px; flex: 0 0 38px; }
@@ -1612,6 +1614,11 @@ body.debug .technical-details { display: block; }
 .blueprints-table th:last-child, .blueprints-table td:last-child { width: 154px; text-align: center; overflow: visible; }
 .blueprint-name { display: block; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--text-strong); font-weight: 700; }
 .blueprint-actions-column .icon-toggle-group { justify-content: center; }
+.guild-add-member-search-row { align-items: center; }
+.guild-add-member-search-row input { flex: 1 1 auto; min-width: 0; }
+.guild-add-member-results { display: grid; gap: 6px; max-height: 220px; overflow-y: auto; }
+.guild-add-member-result { text-align: left; width: 100%; }
+.guild-add-member-selected { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--panel-soft); font-weight: 700; }
 .bases-table { width: 100%; min-width: 0; table-layout: fixed; }
 .bases-table th { max-width: none; white-space: normal; overflow: visible; text-overflow: clip; line-height: 1.2; }
 .bases-table th, .bases-table td { padding: 8px 6px; font-size: 14px; }


### PR DESCRIPTION
## Summary
- Reuse the game's own stored procedures (`dune.promote_guild_member`, `dune.demote_guild_member`, `dune.add_guild_member`, `dune.remove_guild_members`, `dune.disband_guild`) instead of reinventing `guild_members` mutations, so writes ride the same `pg_notify` path the live game already listens on.
- Promote graduates Member -> Officer -> Leader (demoting the previous leader to Officer only on the final step); Demote reverses Officer -> Member. All three row actions (Promote/Demote/Remove) always render, greyed out with a tooltip when not applicable (e.g. the leader can't be promoted, demoted, or removed until someone else is promoted first).
- Add enforces the real one-guild-per-player invariant rather than a bypass sentinel; Disband additionally cleans up `guild_members` rows the game's function leaves orphaned, which would otherwise strand former members against that same invariant forever.
- Verified end-to-end against a real restore of the production schema; caught and fixed a live-only bug where `add_guild_member`'s `player_id` and `guild_id` arguments were swapped.

## Test plan
- [x] `node --test` in `console/api` (252 tests passing, incl. 27 new guild tests)
- [x] `vitest` in `console/web` (146 tests passing, incl. 15 new guild tests)
- [x] `tsc --noEmit` clean
- [x] Live-tested against a throwaway Postgres restore of the production schema: promote/demote/add/remove/disband all verified in the browser
