### PR TITLE
fix(guilds): drop no-op disband delete, stable row keys, name overflow

### DIFF
--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2115,11 +2115,10 @@ export async function disbandGuild(db, guildId) {
 
     const memberCount = await tx.query("select count(*)::int as count from dune.guild_members where guild_id = $1", [safeGuildId]);
 
+    // dune.disband_guild deletes the guilds row; guild_members rows for this guild go with it via
+    // guild_members_guild_id_fkey (FOREIGN KEY ... REFERENCES dune.guilds ON DELETE CASCADE), so
+    // there is nothing left for us to clean up here.
     await tx.query("select dune.disband_guild($1::bigint)", [safeGuildId]);
-    // dune.disband_guild deletes the guilds row but leaves guild_members rows behind, which would
-    // otherwise strand former members against the one-guild-per-player cap (MAX_GUILD_COUNT_PER_PLAYER)
-    // forever, since add_guild_member counts guild_members rows with no join back to guilds.
-    await tx.query("delete from dune.guild_members where guild_id = $1", [safeGuildId]);
 
     return { ok: true, guildId: safeGuildId, guildName: guild.rows[0].guild_name, memberCount: memberCount.rows[0]?.count || 0 };
   });

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -2122,7 +2122,7 @@ test("guild remove member reports unsupported capability when schema functions a
   await assert.rejects(() => removeGuildMember(db, 1, 20), UnsupportedCapabilityError);
 });
 
-test("guild disband deletes the guild then cleans up orphaned guild_members rows", async () => {
+test("guild disband delegates to the game function and reports the member count it removed", async () => {
   const calls = [];
   const db = guildMutationDb(calls, { memberCount: 5 });
   const result = await disbandGuild(db, 1);
@@ -2132,11 +2132,16 @@ test("guild disband deletes the guild then cleans up orphaned guild_members rows
   const disband = calls.find((call) => call.text.includes("dune.disband_guild("));
   assert.ok(disband);
   assert.deepEqual(disband.values, [1]);
-  const cleanup = calls.find((call) => call.text.includes("delete from dune.guild_members where guild_id = $1"));
-  assert.ok(cleanup, "expected a defensive cleanup delete of orphaned guild_members rows");
-  assert.deepEqual(cleanup.values, [1]);
-  // The cleanup delete must run after the game's own disband function, not before.
-  assert.ok(calls.indexOf(disband) < calls.indexOf(cleanup));
+  // guild_members rows cascade away with the guilds row via guild_members_guild_id_fkey
+  // (ON DELETE CASCADE), so we must not issue a redundant delete of our own.
+  assert.ok(
+    !calls.some((call) => call.text.includes("delete from dune.guild_members")),
+    "expected no manual guild_members delete -- the FK cascade already removes those rows"
+  );
+  // The member count is read before the disband, so the reported total isn't always zero.
+  const count = calls.find((call) => call.text.includes("count(*)::int as count from dune.guild_members"));
+  assert.ok(count);
+  assert.ok(calls.indexOf(count) < calls.indexOf(disband));
 });
 
 test("guild disband rejects when the guild does not exist", async () => {

--- a/console/web/src/features/guilds/GuildsPanel.tsx
+++ b/console/web/src/features/guilds/GuildsPanel.tsx
@@ -405,6 +405,7 @@ export function GuildsPanel({ onError, confirmAction }: GuildsPanelProps) {
             columns={["character_name", "role_id"]}
             tableClassName="guild-members-table"
             actionClassName="actions-column"
+            rowKey={(row) => String(row.player_id)}
             emptyMessage={membersLoading ? "Loading members..." : "This guild has no members."}
             renderCell={(row, col) => {
               if (col === "role_id") return guildRoleLabel(row.role_id);

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1627,8 +1627,10 @@ body.debug .technical-details { display: block; }
 .guild-add-member-search-row { align-items: center; }
 .guild-add-member-search-row input { flex: 1 1 auto; min-width: 0; }
 .guild-add-member-results { display: grid; gap: 6px; max-height: 220px; overflow-y: auto; }
-.guild-add-member-result { text-align: left; width: 100%; }
+.guild-add-member-result { text-align: left; width: 100%; overflow-wrap: anywhere; }
 .guild-add-member-selected { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 8px 10px; border: 1px solid var(--border); border-radius: 6px; background: var(--panel-soft); font-weight: 700; }
+.guild-add-member-selected span { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.guild-add-member-selected button { flex-shrink: 0; }
 .bases-table { width: 100%; min-width: 0; table-layout: fixed; }
 .bases-table th { max-width: none; white-space: normal; overflow: visible; text-overflow: clip; line-height: 1.2; }
 .bases-table th, .bases-table td { padding: 8px 6px; font-size: 14px; }


### PR DESCRIPTION
Follow-up fixes to the Guilds actions merged in #120.

- `disbandGuild` manually deleted `guild_members` after calling
  `dune.disband_guild`, on the belief that the game function orphans those
  rows. It doesn't — `guild_members_guild_id_fkey` is `ON DELETE CASCADE`, so
  the delete always affected 0 rows. Confirmed against a live database
  (`convalidated=t`, `confdeltype=c`, RI triggers enabled), not just the schema
  dump. The test asserting the delete was guarding a non-bug; it now asserts
  the delete is absent.
- Members table had no `rowKey`, so React fell back to array indices on a table
  whose rows are reordered by promote/demote/remove.
- Long character names overflowed the Add Member modal — pushing the "Change"
  button past the edge, and scrolling the results list sideways.

Backend 250/250, frontend 171/171, `tsc` clean. The two CSS fixes were verified
by measuring in-browser rather than by eye.