### PR TITLE
Fix Specialization tab XP fields, keystone column, and action feedback

### DIFF
--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2403,6 +2403,23 @@ export async function playerVitals(db, id) {
   };
 }
 
+// dune.specialization_keystones_map has no track column; the track is the name prefix
+// (e.g. "Combat_CombatKeystone_SkillPoint4" belongs to the Combat track).
+async function specializationKeystoneCounts(db, controllerId) {
+  const result = await db.query(`
+    select split_part(m.name, '_', 1) as track_type,
+           count(*)::int as total,
+           count(p.player_id)::int as owned
+    from dune.specialization_keystones_map m
+    left join dune.purchased_specialization_keystones p
+      on p.keystone_id = m.id and p.player_id = $1
+    group by 1`, [controllerId]).catch(() => ({ rows: [] }));
+  return new Map((result.rows || []).map((row) => [String(row.track_type || ""), {
+    owned: Number(row.owned) || 0,
+    total: Number(row.total) || 0
+  }]));
+}
+
 export async function playerSpecs(db, id) {
   if (!(await tableExists(db, "specialization_tracks"))) return unsupported("specs", ["dune.specialization_tracks"]);
   const player = await resolvePlayerMutationTarget(db, id);
@@ -2417,22 +2434,29 @@ export async function playerSpecs(db, id) {
     select coalesce((fe.components->'FLevelComponent'->1->>'UnspentSkillPoints')::int,0) unspent_points
     from dune.actor_fgl_entities afe join dune.fgl_entities fe on fe.entity_id=afe.entity_id
     where afe.slot_name='DuneCharacter' and afe.actor_id=$1 limit 1`, [player.actorId]).catch(() => ({ rows: [] }));
+  const keystonesSupported = await tableExists(db, "purchased_specialization_keystones")
+    && await tableExists(db, "specialization_keystones_map");
+  const keystonesByTrack = keystonesSupported ? await specializationKeystoneCounts(db, player.controllerId) : new Map();
   return {
     capabilities: {
       specs: true,
       specializationMutation: await supportsSpecializationLiveRefresh(db),
-      keystones: await tableExists(db, "purchased_specialization_keystones")
+      keystones: keystonesSupported
     },
     player,
     unspentPoints: Number(points.rows[0]?.unspent_points) || 0,
     skillModules: await playerSkillModules(db, player),
     rows: tracks.map((track) => {
       const row = byTrack.get(track);
+      const keystones = keystonesByTrack.get(track) || { owned: 0, total: 0 };
       return {
         player_id: player.controllerId,
         track_type: track,
         xp_amount: row?.xp_amount ?? 0,
-        level: row?.level ?? 0
+        level: row?.level ?? 0,
+        keystone_count: keystones.owned,
+        keystone_total: keystones.total,
+        has_keystone: keystones.total > 0 && keystones.owned >= keystones.total
       };
     })
   };

--- a/console/web/src/features/players/SpecializationTab.test.tsx
+++ b/console/web/src/features/players/SpecializationTab.test.tsx
@@ -391,6 +391,71 @@ describe("SpecializationTab", () => {
       });
     });
 
+    it("ignores a completed action and reload from the previously selected player", async () => {
+      const nextPlayerResponse = {
+        rows: [{ track_type: "Swordmaster", xp_amount: 9000, level: 5 }],
+        skillModules: [],
+        capabilities: {}
+      };
+      vi.mocked(playersApi.specs).mockImplementation(async (playerId) => (
+        playerId === "player-999" ? nextPlayerResponse : mockSpecsResponse
+      ));
+      let resolveAdd: (value: { supported: boolean }) => void = () => {};
+      vi.mocked(playersApi.addSpecializationXp).mockImplementation(
+        () => new Promise<{ supported: boolean }>((resolve) => { resolveAdd = resolve; })
+      );
+
+      const { rerender } = render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Add XP to Trooper" }));
+      await waitFor(() => {
+        expect(playersApi.addSpecializationXp).toHaveBeenCalledTimes(1);
+      });
+
+      rerender(<SpecializationTab {...defaultProps} dbPlayerId="player-999" playerName="NextPlayer" />);
+      await waitFor(() => {
+        expect(screen.getByText("Swordmaster")).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        resolveAdd({ supported: true });
+      });
+
+      expect(screen.getByText("Swordmaster")).toBeInTheDocument();
+      expect(screen.queryByText("Trooper")).not.toBeInTheDocument();
+      expect(screen.queryByText("XP updated. Relog required.")).not.toBeInTheDocument();
+      expect(playersApi.specs).toHaveBeenCalledTimes(2);
+      expect(playersApi.specs).toHaveBeenLastCalledWith("player-999");
+    });
+
+    it("does not dispatch a confirmed action after the selected player changes", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      let resolveConfirmation: (value: boolean) => void = () => {};
+      mockConfirmAction.mockImplementation(
+        () => new Promise<boolean>((resolve) => { resolveConfirmation = resolve; })
+      );
+
+      const { rerender } = render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Grant Max for Trooper" }));
+      await waitFor(() => {
+        expect(mockConfirmAction).toHaveBeenCalledTimes(1);
+      });
+
+      rerender(<SpecializationTab {...defaultProps} dbPlayerId="player-999" playerName="NextPlayer" />);
+      await act(async () => {
+        resolveConfirmation(true);
+      });
+
+      expect(playersApi.grantMaxSpecialization).not.toHaveBeenCalled();
+    });
+
     it("does not submit Add XP while the player is online", async () => {
       vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
       render(<SpecializationTab {...defaultProps} isOnline={true} />);

--- a/console/web/src/features/players/SpecializationTab.test.tsx
+++ b/console/web/src/features/players/SpecializationTab.test.tsx
@@ -43,7 +43,9 @@ const mockSpecsResponse = {
 };
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  // resetAllMocks, not clearAllMocks: the busy-state tests install deferred
+  // implementations that would otherwise leak into every later test in the file.
+  vi.resetAllMocks();
   mockConfirmAction.mockResolvedValue(true);
 });
 
@@ -108,6 +110,110 @@ describe("SpecializationTab", () => {
         expect(mockOnSkillBaselineChange).toHaveBeenCalledWith({
           "Skills.Key.Trooper1": 2
         });
+      });
+    });
+  });
+
+  describe("keystone column", () => {
+    it("shows Granted when every keystone for the track is owned", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue({
+        rows: [{ track_type: "Combat", xp_amount: 0, level: 0, keystone_count: 41, keystone_total: 41, has_keystone: true }],
+        skillModules: [],
+        capabilities: {}
+      });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Granted")).toBeInTheDocument();
+      });
+    });
+
+    it("shows a partial count when only some keystones are owned", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue({
+        rows: [{ track_type: "Combat", xp_amount: 0, level: 0, keystone_count: 12, keystone_total: 41, has_keystone: false }],
+        skillModules: [],
+        capabilities: {}
+      });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("12/41")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Granted")).not.toBeInTheDocument();
+    });
+
+    it("shows the empty marker when no keystones are owned", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue({
+        rows: [{ track_type: "Combat", xp_amount: 0, level: 0, keystone_count: 0, keystone_total: 41, has_keystone: false }],
+        skillModules: [],
+        capabilities: {}
+      });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Combat")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Granted")).not.toBeInTheDocument();
+      expect(screen.getByText("—")).toBeInTheDocument();
+    });
+  });
+
+  describe("keystone action feedback", () => {
+    it("reports how many keystones were reset", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.resetAllSpecializationKeystones).mockResolvedValue({ supported: true, result: { deletedRows: 205 } });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Reset All Keystones" }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/205 keystones reset/i)).toBeInTheDocument();
+      });
+    });
+
+    it("says nothing was reset when the player had no keystones", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.resetAllSpecializationKeystones).mockResolvedValue({ supported: true, result: { deletedRows: 0 } });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Reset All Keystones" }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/no keystones to reset/i)).toBeInTheDocument();
+      });
+      expect(mockOnActionLog).toHaveBeenCalledWith("Reset All Keystones", "TestPlayer", "0", "Succeeded");
+    });
+
+    it("reports how many keystones were granted", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.grantAllSpecializationKeystones).mockResolvedValue({ supported: true, result: { insertedRows: 205 } });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Grant All Keystones" }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/205 keystones granted/i)).toBeInTheDocument();
+      });
+    });
+
+    it("says nothing changed when every keystone was already granted", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.grantAllSpecializationKeystones).mockResolvedValue({ supported: true, result: { insertedRows: 0 } });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: "Grant All Keystones" }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/already granted/i)).toBeInTheDocument();
       });
     });
   });
@@ -217,6 +323,74 @@ describe("SpecializationTab", () => {
       });
     });
 
+    it("keeps the XP amount independent for each track", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const xpInputs = screen.getAllByRole("spinbutton");
+      await fireEvent.change(xpInputs[0], { target: { value: "5000" } });
+
+      expect(xpInputs[0]).toHaveValue(5000);
+      expect(xpInputs[1]).toHaveValue(1000);
+      expect(xpInputs[2]).toHaveValue(1000);
+    });
+
+    it("submits each track with its own XP amount", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      vi.mocked(playersApi.addSpecializationXp).mockResolvedValue({ supported: true });
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      await fireEvent.change(screen.getAllByRole("spinbutton")[0], { target: { value: "5000" } });
+
+      const addButtons = screen.getAllByRole("button", { name: /Add XP to/i });
+      await act(async () => {
+        fireEvent.click(addButtons[1]);
+      });
+
+      await waitFor(() => {
+        expect(playersApi.addSpecializationXp).toHaveBeenCalledWith("player-123", {
+          trackType: "Mentat",
+          amount: 1000,
+          confirmation: "ADD SPECIALIZATION XP"
+        });
+      });
+
+      await act(async () => {
+        fireEvent.click(addButtons[0]);
+      });
+
+      await waitFor(() => {
+        expect(playersApi.addSpecializationXp).toHaveBeenCalledWith("player-123", {
+          trackType: "Trooper",
+          amount: 5000,
+          confirmation: "ADD SPECIALIZATION XP"
+        });
+      });
+    });
+
+    it("resets XP amounts when the selected player changes", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      const { rerender } = render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      await fireEvent.change(screen.getAllByRole("spinbutton")[0], { target: { value: "5000" } });
+      expect(screen.getAllByRole("spinbutton")[0]).toHaveValue(5000);
+
+      rerender(<SpecializationTab {...defaultProps} dbPlayerId="player-999" />);
+
+      await waitFor(() => {
+        expect(screen.getAllByRole("spinbutton")[0]).toHaveValue(1000);
+      });
+    });
+
     it("does not submit Add XP while the player is online", async () => {
       vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
       render(<SpecializationTab {...defaultProps} isOnline={true} />);
@@ -228,6 +402,63 @@ describe("SpecializationTab", () => {
       fireEvent.click(addButtons[0]);
       expect(addButtons[0]).toBeDisabled();
       expect(playersApi.addSpecializationXp).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("busy state", () => {
+    type SpecActionResult = { supported: boolean; result?: Record<string, unknown>; reason?: string };
+
+    it("locks only the row whose action is in flight", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      let resolveAdd: (value: SpecActionResult) => void = () => {};
+      vi.mocked(playersApi.addSpecializationXp).mockImplementation(
+        () => new Promise<SpecActionResult>((resolve) => { resolveAdd = resolve; })
+      );
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      const addButtons = screen.getAllByRole("button", { name: /Add XP to/i });
+      await act(async () => {
+        fireEvent.click(addButtons[0]);
+      });
+
+      expect(addButtons[0]).toBeDisabled();
+      expect(screen.getByRole("button", { name: "Grant Max for Trooper" })).toBeDisabled();
+      expect(addButtons[1]).not.toBeDisabled();
+      expect(screen.getAllByRole("spinbutton")[1]).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: "Grant Max for Mentat" })).not.toBeDisabled();
+
+      await act(async () => {
+        resolveAdd({ supported: true });
+      });
+    });
+
+    it("locks every row while a keystone action is in flight", async () => {
+      vi.mocked(playersApi.specs).mockResolvedValue(mockSpecsResponse);
+      let resolveGrant: (value: SpecActionResult) => void = () => {};
+      vi.mocked(playersApi.grantAllSpecializationKeystones).mockImplementation(
+        () => new Promise<SpecActionResult>((resolve) => { resolveGrant = resolve; })
+      );
+      render(<SpecializationTab {...defaultProps} />);
+      await waitFor(() => {
+        expect(screen.getByText("Trooper")).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Grant All Keystones" }));
+      });
+
+      await waitFor(() => {
+        screen.getAllByRole("button", { name: /Add XP to/i }).forEach((btn) => {
+          expect(btn).toBeDisabled();
+        });
+      });
+
+      await act(async () => {
+        resolveGrant({ supported: true });
+      });
     });
   });
 

--- a/console/web/src/features/players/SpecializationTab.tsx
+++ b/console/web/src/features/players/SpecializationTab.tsx
@@ -3,11 +3,35 @@ import { KeyRound, RotateCcw, Trophy, Zap } from "lucide-react";
 import { playersApi } from "../../api/players";
 import { InlineActionResult } from "../../components/common/InlineActionResult";
 
-type SpecializationTrackRow = { trackType: string; xp: number; level: number; keystone?: boolean };
+type SpecializationTrackRow = {
+  trackType: string;
+  xp: number;
+  level: number;
+  keystone: boolean;
+  keystoneOwned: number;
+  keystoneTotal: number;
+};
 
 type ConfirmAction = (message: string, options?: { title?: string; confirmLabel?: string; cancelLabel?: string; danger?: boolean; details?: { label: string; value: string; tone?: "accent" | "success" | "danger" }[] }) => Promise<boolean>;
 
 type ActionResult = { key: string; tone: "success" | "danger" | "neutral"; text: string; pending?: boolean };
+
+const DEFAULT_XP_AMOUNT = "1000";
+const KEYSTONE_RESULT_KEY = "specKeystones";
+
+function trackResultKey(trackType: string) {
+  return `spec_${trackType}`;
+}
+
+function pluralKeystones(count: number) {
+  return count === 1 ? "keystone" : "keystones";
+}
+
+// Keystone mutations report how many rows they touched; a zero count means the action
+// succeeded but changed nothing, which needs different wording from a real change.
+function countFromResult(response: { result?: Record<string, unknown> } | undefined, field: string) {
+  return Math.max(0, Math.floor(Number(response?.result?.[field] ?? 0) || 0));
+}
 
 type SpecializationTabProps = {
   dbPlayerId: string;
@@ -18,6 +42,18 @@ type SpecializationTabProps = {
   onSkillBaselineChange?: (baseline: Record<string, number>) => void;
   onActionLog?: (actionType: string, target: string, amount: string, notes: string) => void;
 };
+
+function KeystoneCell({ row }: { row: SpecializationTrackRow }) {
+  if (row.keystone) return <span className="spec-keystone-yes"><KeyRound size={14} /> Granted</span>;
+  if (row.keystoneOwned > 0) {
+    return (
+      <span className="spec-keystone-partial" title={`${row.keystoneOwned} of ${row.keystoneTotal} keystones purchased`}>
+        <KeyRound size={14} /> {row.keystoneOwned}/{row.keystoneTotal}
+      </span>
+    );
+  }
+  return <span className="spec-keystone-no">—</span>;
+}
 
 function friendlyInlineError(error: unknown) {
   return error instanceof Error ? error.message : String(error);
@@ -35,22 +71,43 @@ export function SpecializationTab({
   const [rows, setRows] = useState<SpecializationTrackRow[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
-  const [xpAmount, setXpAmount] = useState("1000");
-  const [actionResult, setActionResult] = useState<ActionResult | null>(null);
-  const resultTimer = useRef<number | null>(null);
+  const [xpAmounts, setXpAmounts] = useState<Record<string, string>>({});
+  const [actionResults, setActionResults] = useState<Record<string, ActionResult>>({});
+  const resultTimers = useRef<Record<string, number>>({});
   const loadRequest = useRef(0);
 
   useEffect(() => {
+    clearResults();
+    setXpAmounts({});
     void load();
   }, [dbPlayerId]);
 
-  useEffect(() => () => { if (resultTimer.current) window.clearTimeout(resultTimer.current); }, []);
+  useEffect(() => () => clearResultTimers(), []);
+
+  function clearResultTimers() {
+    Object.values(resultTimers.current).forEach((timer) => window.clearTimeout(timer));
+    resultTimers.current = {};
+  }
+
+  function clearResults() {
+    clearResultTimers();
+    setActionResults({});
+  }
 
   function showResult(key: string, text: string, tone: "success" | "danger" | "neutral" = "success", pending = false) {
-    setActionResult({ key, text, tone, pending });
-    if (resultTimer.current) window.clearTimeout(resultTimer.current);
-    resultTimer.current = null;
-    if (!pending) resultTimer.current = window.setTimeout(() => setActionResult(null), 8000);
+    setActionResults((current) => ({ ...current, [key]: { key, text, tone, pending } }));
+    if (resultTimers.current[key]) window.clearTimeout(resultTimers.current[key]);
+    delete resultTimers.current[key];
+    if (pending) return;
+    resultTimers.current[key] = window.setTimeout(() => {
+      delete resultTimers.current[key];
+      setActionResults((current) => {
+        if (!current[key]) return current;
+        const next = { ...current };
+        delete next[key];
+        return next;
+      });
+    }, 8000);
   }
 
   async function load() {
@@ -71,7 +128,9 @@ export function SpecializationTab({
         trackType: String(row.track_type || row.trackType || ""),
         xp: Number(row.xp_amount ?? row.xp ?? 0),
         level: Math.max(0, Math.floor(Number(row.level ?? 0) || 0)),
-        keystone: Boolean(row.keystone || row.has_keystone)
+        keystone: Boolean(row.keystone || row.has_keystone),
+        keystoneOwned: Math.max(0, Math.floor(Number(row.keystone_count ?? 0) || 0)),
+        keystoneTotal: Math.max(0, Math.floor(Number(row.keystone_total ?? 0) || 0))
       })).filter((row) => row.trackType));
       const learnedRows = Array.isArray(response.skillModules) ? response.skillModules as Record<string, unknown>[] : [];
       const baseline = Object.fromEntries(learnedRows.map((row) => {
@@ -91,32 +150,32 @@ export function SpecializationTab({
   }
 
   async function addXp(trackType: string) {
-    const amount = Number(xpAmount) || 0;
+    const amount = Number(xpAmounts[trackType] ?? DEFAULT_XP_AMOUNT) || 0;
     if (!amount) {
-      showResult(`spec_${trackType}`, "Enter an XP amount first.", "danger");
+      showResult(trackResultKey(trackType), "Enter an XP amount first.", "danger");
       return;
     }
     if (isOnline) {
-      showResult(`spec_${trackType}`, "The player must be offline for specialization changes.", "danger");
+      showResult(trackResultKey(trackType), "The player must be offline for specialization changes.", "danger");
       return;
     }
     onError("");
-    showResult(`spec_${trackType}`, "Updating XP", "neutral", true);
+    showResult(trackResultKey(trackType), "Updating XP", "neutral", true);
     try {
       await playersApi.addSpecializationXp(dbPlayerId, { trackType, amount, confirmation: "ADD SPECIALIZATION XP" });
-      showResult(`spec_${trackType}`, "XP updated. Relog required.", "success");
+      showResult(trackResultKey(trackType), "XP updated. Relog required.", "success");
       onActionLog?.("Add Specialization XP", trackType, String(amount), "Succeeded");
       await load();
     } catch (err) {
       const message = friendlyInlineError(err);
-      showResult(`spec_${trackType}`, message, "danger");
+      showResult(trackResultKey(trackType), message, "danger");
       onActionLog?.("Add Specialization XP", trackType, String(amount), `Failed: ${message}`);
     }
   }
 
   async function grantMax(trackType: string) {
     if (isOnline) {
-      showResult(`spec_${trackType}`, "The player must be offline for specialization changes.", "danger");
+      showResult(trackResultKey(trackType), "The player must be offline for specialization changes.", "danger");
       return;
     }
     if (!(await confirmAction(`Grant max level for ${trackType} to ${playerName}? This is a high-impact action.`, {
@@ -126,22 +185,22 @@ export function SpecializationTab({
       details: [{ label: "Track", value: trackType, tone: "accent" }, { label: "Player", value: playerName }]
     }))) return;
     onError("");
-    showResult(`spec_${trackType}`, "Granting max level", "neutral", true);
+    showResult(trackResultKey(trackType), "Granting max level", "neutral", true);
     try {
       await playersApi.grantMaxSpecialization(dbPlayerId, { trackType, confirmation: "GRANT MAX SPECIALIZATION" });
-      showResult(`spec_${trackType}`, "Max level granted. Relog required.", "success");
+      showResult(trackResultKey(trackType), "Max level granted. Relog required.", "success");
       onActionLog?.("Grant Max Specialization", trackType, "1", "Succeeded");
       await load();
     } catch (err) {
       const message = friendlyInlineError(err);
-      showResult(`spec_${trackType}`, message, "danger");
+      showResult(trackResultKey(trackType), message, "danger");
       onActionLog?.("Grant Max Specialization", trackType, "1", `Failed: ${message}`);
     }
   }
 
   async function resetTrack(trackType: string) {
     if (isOnline) {
-      showResult(`spec_${trackType}`, "The player must be offline for specialization changes.", "danger");
+      showResult(trackResultKey(trackType), "The player must be offline for specialization changes.", "danger");
       return;
     }
     if (!(await confirmAction(`Reset ${trackType} specialization for ${playerName}?`, {
@@ -150,22 +209,22 @@ export function SpecializationTab({
       details: [{ label: "Track", value: trackType, tone: "danger" }]
     }))) return;
     onError("");
-    showResult(`spec_${trackType}`, "Resetting track", "neutral", true);
+    showResult(trackResultKey(trackType), "Resetting track", "neutral", true);
     try {
       await playersApi.resetSpecialization(dbPlayerId, { trackType, confirmation: "RESET SPECIALIZATION" });
-      showResult(`spec_${trackType}`, "Track reset. Relog required.", "success");
+      showResult(trackResultKey(trackType), "Track reset. Relog required.", "success");
       onActionLog?.("Reset Specialization", trackType, "1", "Succeeded");
       await load();
     } catch (err) {
       const message = friendlyInlineError(err);
-      showResult(`spec_${trackType}`, message, "danger");
+      showResult(trackResultKey(trackType), message, "danger");
       onActionLog?.("Reset Specialization", trackType, "1", `Failed: ${message}`);
     }
   }
 
   async function grantAllKeystones() {
     if (isOnline) {
-      showResult("specKeystones", "The player must be offline for specialization changes.", "danger");
+      showResult(KEYSTONE_RESULT_KEY, "The player must be offline for specialization changes.", "danger");
       return;
     }
     if (!(await confirmAction(`Grant all specialization keystones to ${playerName}? This is a high-impact action that affects all tracks.`, {
@@ -175,22 +234,27 @@ export function SpecializationTab({
       details: [{ label: "Player", value: playerName, tone: "accent" }]
     }))) return;
     onError("");
-    showResult("specKeystones", "Granting keystones", "neutral", true);
+    showResult(KEYSTONE_RESULT_KEY, "Granting keystones", "neutral", true);
     try {
-      await playersApi.grantAllSpecializationKeystones(dbPlayerId, "GRANT ALL KEYSTONES");
-      showResult("specKeystones", "Keystones granted. Relog required.", "success");
-      onActionLog?.("Grant All Keystones", playerName, "1", "Succeeded");
+      const response = await playersApi.grantAllSpecializationKeystones(dbPlayerId, "GRANT ALL KEYSTONES");
+      const granted = countFromResult(response, "insertedRows");
+      showResult(
+        KEYSTONE_RESULT_KEY,
+        granted ? `${granted} ${pluralKeystones(granted)} granted. Relog required.` : "All keystones were already granted.",
+        granted ? "success" : "neutral"
+      );
+      onActionLog?.("Grant All Keystones", playerName, String(granted), "Succeeded");
       await load();
     } catch (err) {
       const message = friendlyInlineError(err);
-      showResult("specKeystones", message, "danger");
+      showResult(KEYSTONE_RESULT_KEY, message, "danger");
       onActionLog?.("Grant All Keystones", playerName, "1", `Failed: ${message}`);
     }
   }
 
   async function resetAllKeystones() {
     if (isOnline) {
-      showResult("specKeystones", "The player must be offline for specialization changes.", "danger");
+      showResult(KEYSTONE_RESULT_KEY, "The player must be offline for specialization changes.", "danger");
       return;
     }
     if (!(await confirmAction(`Reset all specialization keystones for ${playerName}?`, {
@@ -199,20 +263,28 @@ export function SpecializationTab({
       details: [{ label: "Player", value: playerName, tone: "danger" }]
     }))) return;
     onError("");
-    showResult("specKeystones", "Resetting keystones", "neutral", true);
+    showResult(KEYSTONE_RESULT_KEY, "Resetting keystones", "neutral", true);
     try {
-      await playersApi.resetAllSpecializationKeystones(dbPlayerId, "RESET ALL KEYSTONES");
-      showResult("specKeystones", "Keystones reset. Relog required.", "success");
-      onActionLog?.("Reset All Keystones", playerName, "1", "Succeeded");
+      const response = await playersApi.resetAllSpecializationKeystones(dbPlayerId, "RESET ALL KEYSTONES");
+      const removed = countFromResult(response, "deletedRows");
+      showResult(
+        KEYSTONE_RESULT_KEY,
+        removed ? `${removed} ${pluralKeystones(removed)} reset. Relog required.` : "This player had no keystones to reset.",
+        removed ? "success" : "neutral"
+      );
+      onActionLog?.("Reset All Keystones", playerName, String(removed), "Succeeded");
       await load();
     } catch (err) {
       const message = friendlyInlineError(err);
-      showResult("specKeystones", message, "danger");
+      showResult(KEYSTONE_RESULT_KEY, message, "danger");
       onActionLog?.("Reset All Keystones", playerName, "1", `Failed: ${message}`);
     }
   }
 
-  const isBusy = Boolean(actionResult?.pending);
+  // Keystone actions touch every track, so they block (and are blocked by) all rows.
+  // A per-track action only locks its own row.
+  const keystoneBusy = Boolean(actionResults[KEYSTONE_RESULT_KEY]?.pending);
+  const anyBusy = Object.values(actionResults).some((result) => result.pending);
   const canAct = Boolean(dbPlayerId) && !isOnline;
 
   return (
@@ -228,7 +300,7 @@ export function SpecializationTab({
             {loading ? "Loading..." : "Reload"}
           </button>
           <button
-            disabled={!canAct || isBusy}
+            disabled={!canAct || anyBusy}
             onClick={() => void grantAllKeystones()}
             aria-label="Grant All Keystones"
           >
@@ -236,13 +308,13 @@ export function SpecializationTab({
           </button>
           <button
             className="danger"
-            disabled={!canAct || isBusy}
+            disabled={!canAct || anyBusy}
             onClick={() => void resetAllKeystones()}
             aria-label="Reset All Keystones"
           >
             <RotateCcw size={14} /> Reset All Keystones
           </button>
-          <InlineActionResult result={actionResult} resultKey="specKeystones" />
+          <InlineActionResult result={actionResults[KEYSTONE_RESULT_KEY] ?? null} resultKey={KEYSTONE_RESULT_KEY} />
         </div>
         <p className="specialization-offline-notice">
           The player must be offline for all specialization changes. A relog is required to see changes in-game.
@@ -272,14 +344,17 @@ export function SpecializationTab({
             </tr>
           </thead>
           <tbody>
-            {rows.map((row) => (
+            {rows.map((row) => {
+              const resultKey = trackResultKey(row.trackType);
+              const rowBusy = keystoneBusy || Boolean(actionResults[resultKey]?.pending);
+              return (
               <tr key={row.trackType}>
                 <td>
                   <div className="spec-track-name">
                     <Trophy size={14} className="spec-track-icon" />
                     {row.trackType}
                   </div>
-                  <InlineActionResult result={actionResult} resultKey={`spec_${row.trackType}`} />
+                  <InlineActionResult result={actionResults[resultKey] ?? null} resultKey={resultKey} />
                 </td>
                 <td>{row.xp.toLocaleString()}</td>
                 <td>
@@ -289,9 +364,7 @@ export function SpecializationTab({
                   </span>
                 </td>
                 <td>
-                  {row.keystone
-                    ? <span className="spec-keystone-yes"><KeyRound size={14} /> Granted</span>
-                    : <span className="spec-keystone-no">—</span>}
+                  <KeystoneCell row={row} />
                 </td>
                 <td>
                   <div className="specialization-xp-control">
@@ -299,13 +372,13 @@ export function SpecializationTab({
                       className="playerAdmin_specXpInput"
                       type="number"
                       min="0"
-                      value={xpAmount}
-                      onChange={(event) => setXpAmount(event.target.value)}
-                      disabled={!canAct || isBusy}
+                      value={xpAmounts[row.trackType] ?? DEFAULT_XP_AMOUNT}
+                      onChange={(event) => setXpAmounts((current) => ({ ...current, [row.trackType]: event.target.value }))}
+                      disabled={!canAct || rowBusy}
                       aria-label={`XP amount for ${row.trackType}`}
                     />
                     <button
-                      disabled={!canAct || isBusy}
+                      disabled={!canAct || rowBusy}
                       onClick={() => void addXp(row.trackType)}
                       aria-label={`Add XP to ${row.trackType}`}
                     >
@@ -315,7 +388,7 @@ export function SpecializationTab({
                 </td>
                 <td className="playerAdmin_actionCell">
                   <button
-                    disabled={!canAct || isBusy}
+                    disabled={!canAct || rowBusy}
                     onClick={() => void grantMax(row.trackType)}
                     aria-label={`Grant Max for ${row.trackType}`}
                   >
@@ -323,7 +396,7 @@ export function SpecializationTab({
                   </button>
                   <button
                     className="danger"
-                    disabled={!canAct || isBusy}
+                    disabled={!canAct || rowBusy}
                     onClick={() => void resetTrack(row.trackType)}
                     aria-label={`Reset ${row.trackType}`}
                   >
@@ -331,7 +404,8 @@ export function SpecializationTab({
                   </button>
                 </td>
               </tr>
-            ))}
+              );
+            })}
             {!rows.length && (
               <tr>
                 <td colSpan={6}>

--- a/console/web/src/features/players/SpecializationTab.tsx
+++ b/console/web/src/features/players/SpecializationTab.tsx
@@ -75,6 +75,8 @@ export function SpecializationTab({
   const [actionResults, setActionResults] = useState<Record<string, ActionResult>>({});
   const resultTimers = useRef<Record<string, number>>({});
   const loadRequest = useRef(0);
+  const activePlayerId = useRef(dbPlayerId);
+  activePlayerId.current = dbPlayerId;
 
   useEffect(() => {
     clearResults();
@@ -110,9 +112,13 @@ export function SpecializationTab({
     }, 8000);
   }
 
-  async function load() {
+  function isActivePlayer(playerId: string) {
+    return activePlayerId.current === playerId;
+  }
+
+  async function load(playerId = dbPlayerId) {
     const request = ++loadRequest.current;
-    if (!dbPlayerId) {
+    if (!playerId) {
       setRows([]);
       setError("");
       setLoading(false);
@@ -122,8 +128,8 @@ export function SpecializationTab({
     setLoading(true);
     setError("");
     try {
-      const response = await playersApi.specs(dbPlayerId);
-      if (request !== loadRequest.current) return;
+      const response = await playersApi.specs(playerId);
+      if (request !== loadRequest.current || !isActivePlayer(playerId)) return;
       setRows((response.rows || []).map((row) => ({
         trackType: String(row.track_type || row.trackType || ""),
         xp: Number(row.xp_amount ?? row.xp ?? 0),
@@ -140,7 +146,7 @@ export function SpecializationTab({
       }).filter(([moduleId, level]) => moduleId && Number(level) > 0));
       onSkillBaselineChange?.(baseline);
     } catch (err) {
-      if (request !== loadRequest.current) return;
+      if (request !== loadRequest.current || !isActivePlayer(playerId)) return;
       setRows([]);
       setError(friendlyInlineError(err));
       onSkillBaselineChange?.({});
@@ -150,6 +156,7 @@ export function SpecializationTab({
   }
 
   async function addXp(trackType: string) {
+    const playerId = dbPlayerId;
     const amount = Number(xpAmounts[trackType] ?? DEFAULT_XP_AMOUNT) || 0;
     if (!amount) {
       showResult(trackResultKey(trackType), "Enter an XP amount first.", "danger");
@@ -162,18 +169,20 @@ export function SpecializationTab({
     onError("");
     showResult(trackResultKey(trackType), "Updating XP", "neutral", true);
     try {
-      await playersApi.addSpecializationXp(dbPlayerId, { trackType, amount, confirmation: "ADD SPECIALIZATION XP" });
-      showResult(trackResultKey(trackType), "XP updated. Relog required.", "success");
+      await playersApi.addSpecializationXp(playerId, { trackType, amount, confirmation: "ADD SPECIALIZATION XP" });
       onActionLog?.("Add Specialization XP", trackType, String(amount), "Succeeded");
-      await load();
+      if (!isActivePlayer(playerId)) return;
+      showResult(trackResultKey(trackType), "XP updated. Relog required.", "success");
+      await load(playerId);
     } catch (err) {
       const message = friendlyInlineError(err);
-      showResult(trackResultKey(trackType), message, "danger");
       onActionLog?.("Add Specialization XP", trackType, String(amount), `Failed: ${message}`);
+      if (isActivePlayer(playerId)) showResult(trackResultKey(trackType), message, "danger");
     }
   }
 
   async function grantMax(trackType: string) {
+    const playerId = dbPlayerId;
     if (isOnline) {
       showResult(trackResultKey(trackType), "The player must be offline for specialization changes.", "danger");
       return;
@@ -184,21 +193,24 @@ export function SpecializationTab({
       danger: true,
       details: [{ label: "Track", value: trackType, tone: "accent" }, { label: "Player", value: playerName }]
     }))) return;
+    if (!isActivePlayer(playerId)) return;
     onError("");
     showResult(trackResultKey(trackType), "Granting max level", "neutral", true);
     try {
-      await playersApi.grantMaxSpecialization(dbPlayerId, { trackType, confirmation: "GRANT MAX SPECIALIZATION" });
-      showResult(trackResultKey(trackType), "Max level granted. Relog required.", "success");
+      await playersApi.grantMaxSpecialization(playerId, { trackType, confirmation: "GRANT MAX SPECIALIZATION" });
       onActionLog?.("Grant Max Specialization", trackType, "1", "Succeeded");
-      await load();
+      if (!isActivePlayer(playerId)) return;
+      showResult(trackResultKey(trackType), "Max level granted. Relog required.", "success");
+      await load(playerId);
     } catch (err) {
       const message = friendlyInlineError(err);
-      showResult(trackResultKey(trackType), message, "danger");
       onActionLog?.("Grant Max Specialization", trackType, "1", `Failed: ${message}`);
+      if (isActivePlayer(playerId)) showResult(trackResultKey(trackType), message, "danger");
     }
   }
 
   async function resetTrack(trackType: string) {
+    const playerId = dbPlayerId;
     if (isOnline) {
       showResult(trackResultKey(trackType), "The player must be offline for specialization changes.", "danger");
       return;
@@ -208,21 +220,24 @@ export function SpecializationTab({
       danger: true,
       details: [{ label: "Track", value: trackType, tone: "danger" }]
     }))) return;
+    if (!isActivePlayer(playerId)) return;
     onError("");
     showResult(trackResultKey(trackType), "Resetting track", "neutral", true);
     try {
-      await playersApi.resetSpecialization(dbPlayerId, { trackType, confirmation: "RESET SPECIALIZATION" });
-      showResult(trackResultKey(trackType), "Track reset. Relog required.", "success");
+      await playersApi.resetSpecialization(playerId, { trackType, confirmation: "RESET SPECIALIZATION" });
       onActionLog?.("Reset Specialization", trackType, "1", "Succeeded");
-      await load();
+      if (!isActivePlayer(playerId)) return;
+      showResult(trackResultKey(trackType), "Track reset. Relog required.", "success");
+      await load(playerId);
     } catch (err) {
       const message = friendlyInlineError(err);
-      showResult(trackResultKey(trackType), message, "danger");
       onActionLog?.("Reset Specialization", trackType, "1", `Failed: ${message}`);
+      if (isActivePlayer(playerId)) showResult(trackResultKey(trackType), message, "danger");
     }
   }
 
   async function grantAllKeystones() {
+    const playerId = dbPlayerId;
     if (isOnline) {
       showResult(KEYSTONE_RESULT_KEY, "The player must be offline for specialization changes.", "danger");
       return;
@@ -233,26 +248,29 @@ export function SpecializationTab({
       danger: true,
       details: [{ label: "Player", value: playerName, tone: "accent" }]
     }))) return;
+    if (!isActivePlayer(playerId)) return;
     onError("");
     showResult(KEYSTONE_RESULT_KEY, "Granting keystones", "neutral", true);
     try {
-      const response = await playersApi.grantAllSpecializationKeystones(dbPlayerId, "GRANT ALL KEYSTONES");
+      const response = await playersApi.grantAllSpecializationKeystones(playerId, "GRANT ALL KEYSTONES");
       const granted = countFromResult(response, "insertedRows");
+      onActionLog?.("Grant All Keystones", playerName, String(granted), "Succeeded");
+      if (!isActivePlayer(playerId)) return;
       showResult(
         KEYSTONE_RESULT_KEY,
         granted ? `${granted} ${pluralKeystones(granted)} granted. Relog required.` : "All keystones were already granted.",
         granted ? "success" : "neutral"
       );
-      onActionLog?.("Grant All Keystones", playerName, String(granted), "Succeeded");
-      await load();
+      await load(playerId);
     } catch (err) {
       const message = friendlyInlineError(err);
-      showResult(KEYSTONE_RESULT_KEY, message, "danger");
       onActionLog?.("Grant All Keystones", playerName, "1", `Failed: ${message}`);
+      if (isActivePlayer(playerId)) showResult(KEYSTONE_RESULT_KEY, message, "danger");
     }
   }
 
   async function resetAllKeystones() {
+    const playerId = dbPlayerId;
     if (isOnline) {
       showResult(KEYSTONE_RESULT_KEY, "The player must be offline for specialization changes.", "danger");
       return;
@@ -262,22 +280,24 @@ export function SpecializationTab({
       danger: true,
       details: [{ label: "Player", value: playerName, tone: "danger" }]
     }))) return;
+    if (!isActivePlayer(playerId)) return;
     onError("");
     showResult(KEYSTONE_RESULT_KEY, "Resetting keystones", "neutral", true);
     try {
-      const response = await playersApi.resetAllSpecializationKeystones(dbPlayerId, "RESET ALL KEYSTONES");
+      const response = await playersApi.resetAllSpecializationKeystones(playerId, "RESET ALL KEYSTONES");
       const removed = countFromResult(response, "deletedRows");
+      onActionLog?.("Reset All Keystones", playerName, String(removed), "Succeeded");
+      if (!isActivePlayer(playerId)) return;
       showResult(
         KEYSTONE_RESULT_KEY,
         removed ? `${removed} ${pluralKeystones(removed)} reset. Relog required.` : "This player had no keystones to reset.",
         removed ? "success" : "neutral"
       );
-      onActionLog?.("Reset All Keystones", playerName, String(removed), "Succeeded");
-      await load();
+      await load(playerId);
     } catch (err) {
       const message = friendlyInlineError(err);
-      showResult(KEYSTONE_RESULT_KEY, message, "danger");
       onActionLog?.("Reset All Keystones", playerName, "1", `Failed: ${message}`);
+      if (isActivePlayer(playerId)) showResult(KEYSTONE_RESULT_KEY, message, "danger");
     }
   }
 

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1563,10 +1563,11 @@ body.debug .technical-details { display: block; }
 .spec-track-icon { flex: 0 0 auto; color: #c68b4a; }
 .playerAdmin_specializationTable td:first-child .inline-action-result-wrap { display: flex; justify-content: flex-start; width: 100%; min-height: 0; margin-top: 5px; white-space: normal; }
 .playerAdmin_specializationTable td:first-child .inline-action-result { font-size: 12px; line-height: 1.3; text-align: left; }
-.spec-level-badge, .spec-keystone-yes { display: inline-flex; align-items: center; justify-content: center; gap: 5px; color: #ceb894; }
+.spec-level-badge, .spec-keystone-yes, .spec-keystone-partial { display: inline-flex; align-items: center; justify-content: center; gap: 5px; color: #ceb894; }
 .spec-level-badge { width: 60px; min-width: 60px; max-width: 60px; min-height: 28px; box-sizing: border-box; padding: 4px 8px; border: 1px solid rgba(214, 185, 140, .2); border-radius: 6px; background: rgba(255, 255, 255, .03); font-weight: 700; }
 .spec-level-max, .spec-keystone-yes { color: #8ed0a8; }
 .spec-keystone-no { color: #746c61; }
+.spec-keystone-partial { color: #d6b98c; font-variant-numeric: tabular-nums; }
 .specialization-xp-control { display: flex; align-items: center; justify-content: center; gap: 7px; width: 100%; }
 .specialization-xp-control button { flex: 0 0 104px; width: 104px; min-width: 104px; justify-content: center; padding-inline: 8px; }
 .playerAdmin_specializationTable .playerAdmin_actionCell { display: flex; align-items: center; justify-content: center; flex-wrap: nowrap; gap: 8px; width: 100%; min-width: 0; }


### PR DESCRIPTION
Typing an XP amount into one specialization track populated every track's field — all
rows were bound to a single shared state value. Drafts are now keyed by track, and
busy/result state is per-row so one track's action no longer locks the whole table.

Two related problems surfaced while verifying the fix:

- The Keystone column was permanently "—". `playerSpecs` never returned keystone state,
  so the flag the UI read was always false. It now derives per-track ownership from the
  keystone name prefix and renders granted / partial (n/41) / none.
- Grant and Reset All Keystones reported success identically whether they changed 205
  rows or zero, which made a working reset look like a no-op. They now report the count.

Verified against a restored production dump: 0 → 205 → 0 keystones, per-track XP writes
landing on the correct track only, and the offline gate rejecting at both the UI and
`requireOfflinePlayer`. Suites green — api 794/794, web 183/183 (35 tests on this tab, up
from 21).
