### PR TITLE
Add base permission editing and water refill to the Bases panel

### DIFF
--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3390,9 +3390,16 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
     // permission procedures the panel hides the editor rather than offering a
     // control that fails on save.
     const basePermissions = await supportsBasePermissionEditing(db).catch(() => false);
+    // Same probing pattern as generatorRefill/generatorRefillQueue above, but
+    // gated on supportsWaterRefill rather than supportsGeneratorRefill: water
+    // refill needs none of the item-insert columns the generator capability
+    // check requires, so reusing that check would wrongly hide Refill Water
+    // on a schema that has everything water actually needs.
+    const waterRefill = await supportsWaterRefill(db).catch(() => false);
+    const waterRefillQueue = waterRefill && await supportsWaterRefillQueue(db).catch(() => false);
 
     return {
-      capabilities: { bases: true, generatorRefill, generatorRefillQueue, basePermissions },
+      capabilities: { bases: true, generatorRefill, generatorRefillQueue, basePermissions, waterRefill, waterRefillQueue },
       totalCount: result.rows[0] ? Number(result.rows[0].total_count) : 0,
       totalBases: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_bases) : 0,
       totalPieces: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_pieces) : 0,
@@ -5693,6 +5700,409 @@ function reconcileQueuedGeneratorRefills(repoRoot, outcomes) {
   }
   writeQueuedGeneratorRefills(repoRoot, next);
   return next;
+}
+
+// ---------------------------------------------------------------------------
+// Water
+//
+// Water storage lives somewhere fundamentally different from generator fuel:
+// the fill level is a JSONB scalar on the placeable's own component
+// (FWaterStorageComponent.m_WaterStored), not a stack of discrete inventory
+// items. Blood (Blood Purifier / Improved Blood Purifier only) is different
+// again -- it isn't a component at all, but a Blueprint-class-keyed property
+// on dune.actors.properties (BP_BloodWaterExtractor[_Advanced]_C.m_CurrentAmount).
+// Both mechanisms, every building_type, and every capacity below were
+// confirmed against a live database, not guessed -- see
+// C:\Users\jvign\.claude\plans\bases\water-storage-tab.md for the full trail.
+// ---------------------------------------------------------------------------
+
+const WATER_TYPES = {
+  waterCistern: {
+    name: "Water Cistern",
+    buildingTypes: ["watercistern_placeable"],
+    capacity: 5000
+  },
+  mediumWaterCistern: {
+    name: "Medium Water Cistern",
+    buildingTypes: ["mediumwatercistern_placeable"],
+    capacity: 25000
+  },
+  largeWaterCistern: {
+    name: "Large Water Cistern",
+    buildingTypes: ["largewatercistern_placeable"],
+    capacity: 100000
+  },
+  windtrap: {
+    name: "Windtrap",
+    buildingTypes: ["windtrap_placeable"],
+    capacity: 500
+  },
+  // Displays in-game as "Blood Purifier" / "Improved Blood Purifier" (see
+  // runtime/data/admin-items.json's BloodWaterExtraction[Advanced]_Patent
+  // entries) -- building_type keeps the game's own internal name.
+  bloodWaterExtractor: {
+    name: "Blood Purifier",
+    buildingTypes: ["bloodwaterextractor_placeable"],
+    capacity: 1000,
+    bloodPropertyKey: "BP_BloodWaterExtractor_C",
+    bloodCapacity: 6000
+  },
+  bloodWaterExtractorAdvanced: {
+    name: "Improved Blood Purifier",
+    buildingTypes: ["bloodwaterextractionadvanced_placeable"],
+    capacity: 1000,
+    bloodPropertyKey: "BP_BloodWaterExtractor_Advanced_C",
+    bloodCapacity: 24000
+  }
+};
+
+const WATER_TYPE_ORDER = [
+  "waterCistern", "mediumWaterCistern", "largeWaterCistern",
+  "windtrap", "bloodWaterExtractor", "bloodWaterExtractorAdvanced"
+];
+
+const WATER_BUILDING_TYPE_PAIRS = WATER_TYPE_ORDER.flatMap(
+  (type) => WATER_TYPES[type].buildingTypes.map((buildingType) => [type, buildingType])
+);
+
+function waterTypeParams() {
+  return [
+    WATER_BUILDING_TYPE_PAIRS.map(([type]) => type),
+    WATER_BUILDING_TYPE_PAIRS.map(([, buildingType]) => buildingType)
+  ];
+}
+
+// Every water container at a base, grouped by type -- the Water tab's shape.
+// Mirrors portalGeneratorFuel, but for one base rather than many, and reads
+// levels straight off each placeable's own row rather than an inventory:
+// there is no fuel-cell-style consumable involved.
+export async function baseWater(db, baseId) {
+  const target = intParam(baseId, "base id", 1);
+  const [types, buildingTypes] = waterTypeParams();
+  const bloodKeys = WATER_BUILDING_TYPE_PAIRS.map(([type]) => WATER_TYPES[type].bloodPropertyKey || null);
+  const result = await db.query(`
+    with requested_claims as (
+      select distinct b.id, afe.actor_id
+      from dune.buildings b
+      join dune.building_instances bi on bi.building_id = b.id
+      join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+      where b.id = $1
+    ), base_entities as (
+      select distinct rc.id, claim_afe.entity_id as owner_entity_id
+      from requested_claims rc
+      join dune.actor_fgl_entities claim_afe on claim_afe.actor_id = rc.actor_id
+    ), water_types as (
+      select * from unnest($2::text[], $3::text[], $4::text[]) as t(water_type, building_type, blood_property_key)
+    ), containers as (
+      select p.id as placeable_id, wt.water_type,
+        coalesce(state.stored, 0) as water_stored,
+        case when wt.blood_property_key is not null
+          then (a.properties -> wt.blood_property_key ->> 'm_CurrentAmount')::numeric
+          else null
+        end as blood_stored
+      from base_entities be
+      join dune.placeables p on p.owner_entity_id = be.owner_entity_id
+      join dune.actors a on a.id = p.id
+      join water_types wt on wt.building_type = lower(p.building_type)
+      left join lateral (
+        -- Guarded + limit 1: some water placeables carry a second
+        -- actor_fgl_entities row (slot_name='ContainerInventory') alongside
+        -- the one that actually holds FWaterStorageComponent. An unguarded
+        -- join fans out and double-counts the container -- confirmed live
+        -- against dune2 (a base's Windtrap count read 7 instead of 4).
+        select (fe.components->'FWaterStorageComponent'->1->>'m_WaterStored')::int as stored
+        from dune.actor_fgl_entities afe
+        join dune.fgl_entities fe on fe.entity_id = afe.entity_id
+        where afe.actor_id = p.id and fe.components ? 'FWaterStorageComponent'
+        limit 1
+      ) state on true
+    )
+    select water_type, count(*)::int as container_count,
+      sum(water_stored)::int as water_stored,
+      sum(blood_stored)::numeric as blood_stored
+    from containers group by water_type`, [target, types, buildingTypes, bloodKeys]);
+
+  const containers = result.rows.map((row) => {
+    const type = row.water_type;
+    const spec = WATER_TYPES[type];
+    const count = Number(row.container_count) || 0;
+    const stored = Number(row.water_stored) || 0;
+    const capacity = count * spec.capacity;
+    const entry = {
+      type,
+      name: spec.name,
+      count,
+      stored,
+      capacity,
+      percent: capacity > 0 ? Math.round((stored / capacity) * 1000) / 10 : 0
+    };
+    if (spec.bloodCapacity) {
+      const bloodStored = Math.round(Number(row.blood_stored) || 0);
+      const bloodCapacity = count * spec.bloodCapacity;
+      entry.bloodStored = bloodStored;
+      entry.bloodCapacity = bloodCapacity;
+      entry.bloodPercent = bloodCapacity > 0 ? Math.round((bloodStored / bloodCapacity) * 1000) / 10 : 0;
+    }
+    return entry;
+  }).sort((left, right) => WATER_TYPE_ORDER.indexOf(left.type) - WATER_TYPE_ORDER.indexOf(right.type));
+
+  return { baseId: target, containers };
+}
+
+// Every water device at a base, individually. Refill and the auto-refill scan
+// (like baseGeneratorFuelLevels) need to see and write each one, not just a
+// per-type total -- entity_id is resolved here through the same guarded
+// lateral used by baseWater, so reading and writing can never disagree about
+// which fgl_entities row backs a given placeable.
+export async function baseWaterDevices(db, baseId) {
+  const target = intParam(baseId, "base id", 1);
+  const [types, buildingTypes] = waterTypeParams();
+  const result = await db.query(`
+    with requested_claims as (
+      select distinct b.id, afe.actor_id
+      from dune.buildings b
+      join dune.building_instances bi on bi.building_id = b.id
+      join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+      where b.id = $1
+    ), base_entities as (
+      select distinct rc.id, claim_afe.entity_id as owner_entity_id
+      from requested_claims rc
+      join dune.actor_fgl_entities claim_afe on claim_afe.actor_id = rc.actor_id
+    ), water_types as (
+      select * from unnest($2::text[], $3::text[]) as t(water_type, building_type)
+    )
+    select distinct p.id::text as placeable_id, wt.water_type, entity.entity_id::text as entity_id
+    from base_entities be
+    join dune.placeables p on p.owner_entity_id = be.owner_entity_id
+    join water_types wt on wt.building_type = lower(p.building_type)
+    left join lateral (
+      select afe.entity_id
+      from dune.actor_fgl_entities afe
+      join dune.fgl_entities fe on fe.entity_id = afe.entity_id
+      where afe.actor_id = p.id and fe.components ? 'FWaterStorageComponent'
+      limit 1
+    ) entity on true
+    order by placeable_id`, [target, types, buildingTypes]);
+  return result.rows;
+}
+
+export async function supportsWaterRefill(db) {
+  if (!(await tableExists(db, "placeables"))) return false;
+  if (!(await tableExists(db, "actor_fgl_entities")) || !(await tableExists(db, "fgl_entities"))) return false;
+  const placeableColumns = await columnsFor(db, "placeables");
+  return ["id", "owner_entity_id", "building_type"].every((column) => placeableColumns.has(column));
+}
+
+export async function supportsWaterRefillQueue(db) {
+  if (!(await supportsWaterRefill(db))) return false;
+  return tableExists(db, "world_partition");
+}
+
+// Tops every water device at a base up to its configured cap, straight into
+// FWaterStorageComponent -- one jsonb_set per device, no stack/slot
+// bookkeeping like generator fuel needs (water is a scalar, not a stack of
+// discrete items). Blood (dune.actors.properties) is never touched here: per
+// user decision it's meant to be gathered in-world, not admin-conjured.
+export async function refillBaseWater(db, repoRoot, baseId) {
+  await requireCapability(await supportsWaterRefill(db),
+    "Water refill requires dune.placeables, dune.actor_fgl_entities, and dune.fgl_entities.");
+  const target = intParam(baseId, "base id", 1);
+  const devices = await baseWaterDevices(db, target);
+  if (!devices.length) throw new Error("No water storage was found at this base");
+
+  return db.transaction(async (tx) => {
+    const refilled = [];
+    for (const device of devices) {
+      const spec = WATER_TYPES[device.water_type];
+      const summary = { placeableId: device.placeable_id, type: device.water_type, label: spec.name };
+      if (!device.entity_id) {
+        refilled.push({ ...summary, before: 0, after: 0, added: 0 });
+        continue;
+      }
+      // Lock the entity row before reading it, so a concurrent refill of the
+      // same device can't race the read-then-write -- same technique
+      // refillBaseGenerators uses for its inventory rows.
+      const current = await tx.query(
+        `select (components->'FWaterStorageComponent'->1->>'m_WaterStored')::int as stored
+         from dune.fgl_entities where entity_id = $1 for update`, [device.entity_id]);
+      const before = Number(current.rows[0]?.stored) || 0;
+      const cap = spec.capacity;
+      if (before >= cap) {
+        refilled.push({ ...summary, before, after: before, added: 0 });
+        continue;
+      }
+      await tx.query(
+        `update dune.fgl_entities
+         set components = jsonb_set(components, '{FWaterStorageComponent,1,m_WaterStored}', to_jsonb($1::int))
+         where entity_id = $2`, [cap, device.entity_id]);
+      refilled.push({ ...summary, before, after: cap, added: cap - before });
+    }
+    return {
+      ok: true,
+      baseId: target,
+      devices: refilled,
+      totalAdded: refilled.reduce((sum, entry) => sum + (entry.added || 0), 0)
+    };
+  });
+}
+
+// Per-device fill percent for one base, as a fraction of the same cap
+// refillBaseWater fills to -- the auto-refill scan's view. Deliberately
+// per-device rather than reusing baseWater's per-type aggregate, for the same
+// reason baseGeneratorFuelLevels doesn't reuse portalGeneratorFuel: a single
+// starved device standing among full siblings of the same type is exactly
+// what an automated refill decision turns on.
+//
+// lowestPercent is null for a base with no recognised devices, not 0 --
+// "nothing to measure" must not read as "empty" to a caller deciding whether
+// to refill.
+export async function baseWaterFuelLevels(db, baseId) {
+  const target = intParam(baseId, "base id", 1);
+  const devices = await baseWaterDevices(db, target);
+  const entityIds = devices.map((device) => device.entity_id).filter(Boolean);
+
+  const stored = new Map();
+  if (entityIds.length) {
+    const result = await db.query(
+      `select entity_id::text as entity_id,
+        (components->'FWaterStorageComponent'->1->>'m_WaterStored')::int as stored
+       from dune.fgl_entities where entity_id = any($1::bigint[])`, [entityIds]);
+    for (const row of result.rows || []) {
+      stored.set(row.entity_id, Number(row.stored) || 0);
+    }
+  }
+
+  const entries = [];
+  for (const device of devices) {
+    const spec = WATER_TYPES[device.water_type];
+    const units = device.entity_id ? (stored.get(device.entity_id) || 0) : 0;
+    entries.push({
+      placeableId: device.placeable_id,
+      waterType: device.water_type,
+      units,
+      cap: spec.capacity,
+      percent: spec.capacity > 0 ? Math.round((units / spec.capacity) * 1000) / 10 : 0
+    });
+  }
+
+  return {
+    baseId: target,
+    deviceCount: entries.length,
+    devices: entries,
+    lowestPercent: entries.length ? Math.min(...entries.map((entry) => entry.percent)) : null
+  };
+}
+
+// Pending water-refill queue. Same reasoning and shape as the generator
+// queue above (a live map can overwrite an immediate write, so a refill
+// aimed at one is recorded here and applied once that map is confirmed
+// down) -- own file, so the two queues can never collide or cross-count.
+const PENDING_WATER_REFILL_PATH = "runtime/generated/pending-water-refills.json";
+
+function pendingWaterRefillFile(repoRoot) {
+  return resolve(repoRoot || "", PENDING_WATER_REFILL_PATH);
+}
+
+export function listQueuedWaterRefills(repoRoot) {
+  const file = pendingWaterRefillFile(repoRoot);
+  if (!existsSync(file)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    if (!Array.isArray(parsed)) return [];
+    const seen = new Set();
+    return parsed.map(normalizePendingRefill).filter((entry) => {
+      if (!entry || seen.has(entry.baseId)) return false;
+      seen.add(entry.baseId);
+      return true;
+    });
+  } catch (error) {
+    console.warn(`Ignoring unreadable pending water refill queue: ${redact(error?.message || error)}`);
+    return [];
+  }
+}
+
+function writeQueuedWaterRefills(repoRoot, entries) {
+  writeJsonAtomic(pendingWaterRefillFile(repoRoot), entries);
+  return entries;
+}
+
+export function queueWaterRefill(repoRoot, { baseId, map = "", partitionId = 0, now = () => new Date() } = {}) {
+  const entry = normalizePendingRefill({ baseId, map, partitionId, queuedAt: now().toISOString() });
+  if (!entry) throw new Error("Invalid base id");
+  const others = listQueuedWaterRefills(repoRoot).filter((row) => row.baseId !== entry.baseId);
+  if (others.length >= MAX_PENDING_REFILLS) {
+    throw new Error(`The pending water refill queue already holds ${MAX_PENDING_REFILLS} bases. Restart the affected maps to apply them first.`);
+  }
+  writeQueuedWaterRefills(repoRoot, [...others, entry]);
+  return entry;
+}
+
+export function cancelQueuedWaterRefill(repoRoot, baseId) {
+  const target = intParam(baseId, "base id", 1);
+  const entries = listQueuedWaterRefills(repoRoot);
+  const remaining = entries.filter((entry) => entry.baseId !== target);
+  if (remaining.length === entries.length) throw new Error("That base has no queued water refill.");
+  writeQueuedWaterRefills(repoRoot, remaining);
+  return { ok: true, baseId: target, pending: remaining.length };
+}
+
+function reconcileQueuedWaterRefills(repoRoot, outcomes) {
+  const next = [];
+  for (const entry of listQueuedWaterRefills(repoRoot)) {
+    const outcome = outcomes.get(entry.baseId);
+    if (!outcome || outcome.queuedAt !== entry.queuedAt) {
+      next.push(entry);
+      continue;
+    }
+    if (outcome.keep) next.push({ ...entry, attempts: outcome.attempts, nextRetryAt: outcome.nextRetryAt, lastError: outcome.lastError });
+  }
+  writeQueuedWaterRefills(repoRoot, next);
+  return next;
+}
+
+// Applies every queued water refill whose map is currently down and leaves
+// the rest queued. Same driver and reasoning as flushGeneratorRefills.
+export async function flushWaterRefills(db, repoRoot, { now = Date.now } = {}) {
+  const pending = listQueuedWaterRefills(repoRoot);
+  if (!pending.length) return { flushed: [], pending: 0 };
+  const observed = await observeRefillPartitions(db, { now });
+  if (!observed) return { flushed: [], pending: pending.length, unsupported: true };
+
+  const flushed = [];
+  const outcomes = new Map();
+  const timestamp = now();
+  for (const entry of pending) {
+    const queuedMs = Date.parse(entry.queuedAt);
+    if (Number.isFinite(queuedMs) && timestamp - queuedMs >= pendingRefillMaxAgeMs()) {
+      const message = `Queued for longer than the ${Math.round(pendingRefillMaxAgeMs() / 3600000)}h limit without being applied.`;
+      outcomes.set(entry.baseId, { queuedAt: entry.queuedAt, keep: false });
+      flushed.push({ baseId: entry.baseId, map: entry.map, partitionId: entry.partitionId, ok: false, expired: true, dropped: true, error: message });
+      continue;
+    }
+    if (!partitionWriteSafe(observed, entry.partitionId)) continue;
+    if (entry.nextRetryAt && timestamp < entry.nextRetryAt) continue;
+    try {
+      const result = await refillBaseWater(db, repoRoot, entry.baseId);
+      outcomes.set(entry.baseId, { queuedAt: entry.queuedAt, keep: false });
+      flushed.push({
+        baseId: entry.baseId,
+        map: entry.map,
+        partitionId: entry.partitionId,
+        ok: true,
+        totalAdded: result.totalAdded,
+        devices: result.devices
+      });
+    } catch (error) {
+      const message = String(error?.message || error).slice(0, 300);
+      const attempts = isTransientFlushError(message) ? entry.attempts : entry.attempts + 1;
+      const dropped = attempts >= MAX_REFILL_FLUSH_ATTEMPTS;
+      const nextRetryAt = timestamp + pendingRefillRetryDelayMs();
+      outcomes.set(entry.baseId, { queuedAt: entry.queuedAt, keep: !dropped, attempts, nextRetryAt, lastError: message });
+      flushed.push({ baseId: entry.baseId, map: entry.map, partitionId: entry.partitionId, ok: false, attempts, dropped, error: message });
+    }
+  }
+  const remaining = outcomes.size ? reconcileQueuedWaterRefills(repoRoot, outcomes) : pending;
+  return { flushed, pending: remaining.length };
 }
 
 export async function giveItemToPlayer(db, playerId, { itemName = "", itemId = "", templateId = "", quantity = 1, quality = 1, augments = [], augmentQuality = 1, allowOnlinePreAugmented = false }) {

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2994,6 +2994,12 @@ export async function basePermissionActor(db, baseId) {
     left join dune.actors a on a.id = afe.actor_id
     left join dune.map_names mn on mn.map_name = a.map
     where b.id = $1
+    -- A base commonly has several building_instances rows ("pieces"), and only
+    -- this one column varies per piece. Without an explicit order, an orphaned
+    -- piece (owner_entity_id null) could beat a sibling piece that resolves
+    -- fine, since the left join no longer filters candidacy down to valid rows
+    -- the way the old inner join did. Prefer a resolved row deterministically.
+    order by (a.id is null) asc, bi.instance_id asc
     limit 1`, [target]);
   const row = result.rows[0];
   if (!row) throw new Error("That base was not found.");
@@ -3498,7 +3504,18 @@ export async function exportBaseAsBlueprint(db, id) {
       limit 1
     ) owner on true
     group by pa.actor_name, owner.character_name, a.id, a.class, a.map, a.transform`, [baseId]);
-  if (!baseRow.rows.length) throw new UnsupportedCapabilityError(`Base ${baseId} was not found.`);
+  if (!baseRow.rows.length) {
+    // The query above inner-joins all the way to a resolved actor -- it can't
+    // usefully left-join instead, since a blueprint needs real, resolved piece
+    // data to export. So distinguishing "doesn't exist" from "exists but its
+    // owner-entity link is broken" (building_instances.owner_entity_id is
+    // nullable) takes a cheap follow-up existence check instead, the same
+    // distinction basePermissionActor and baseMapLocation make for their
+    // simpler single-row queries.
+    const exists = await db.query("select 1 from dune.buildings where id = $1", [baseId]);
+    if (exists.rows.length) throw new UnsupportedCapabilityError(`Base ${baseId} has no resolvable owner entity, so it cannot be exported.`);
+    throw new UnsupportedCapabilityError(`Base ${baseId} was not found.`);
+  }
   const base = baseRow.rows[0];
   const anchor = { x: Number(base.x), y: Number(base.y), z: Number(base.z) };
 
@@ -5600,19 +5617,31 @@ export async function partitionRestartTargets(db) {
 
 // The map and partition a base sits in. Resolved server-side on every request:
 // whether a write is safe must never depend on a client-supplied map name.
+//
+// Left-joined rather than inner-joined so a base whose owner-entity link is
+// broken (building_instances.owner_entity_id is nullable, ON DELETE SET NULL
+// against fgl_entities) is distinguished from a base that never existed --
+// autoRefill.js pattern-matches the "was not found" text specifically to
+// decide whether to un-enroll a base, so the two cases must throw different
+// messages rather than collapse a broken link into "no longer exists".
+// order by prefers a resolved sibling piece the same way basePermissionActor
+// does, so a multi-piece base with one orphaned piece still resolves cleanly.
 export async function baseMapLocation(db, baseId) {
   const target = intParam(baseId, "base id", 1);
   const result = await db.query(`
-    select coalesce(a.map, '') as map,
+    select a.id::text as actor_id,
+           coalesce(a.map, '') as map,
            coalesce(a.partition_id, 0)::int as partition_id
     from dune.buildings b
-    join dune.building_instances bi on bi.building_id = b.id
-    join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
-    join dune.actors a on a.id = afe.actor_id
+    left join dune.building_instances bi on bi.building_id = b.id
+    left join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+    left join dune.actors a on a.id = afe.actor_id
     where b.id = $1
+    order by (a.id is null) asc, bi.instance_id asc
     limit 1`, [target]);
   const row = result.rows[0];
   if (!row) throw new Error("That base was not found.");
+  if (!row.actor_id) throw new Error("This base has no resolvable owner entity, so its map location is unavailable.");
   return { map: String(row.map || ""), partitionId: Number(row.partition_id || 0) };
 }
 

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3076,6 +3076,10 @@ export async function basePermissionCandidates(db, { q = "", limit = 25 } = {}) 
   await requireCapability(await supportsBasePermissionEditing(db),
     "Base permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
   const safeLimit = intParam(limit, "limit", 1, 100);
+  const playerStateColumns = await columnsFor(db, "player_state");
+  const internalGmPawnFilter = playerStateColumns.has("player_pawn_id")
+    ? `and coalesce(ps.player_pawn_id, 0) <> ${INTERNAL_GM_PLAYER_PAWN_ID}::bigint`
+    : "";
   const values = [];
   let filter = "";
   if (q) {
@@ -3091,6 +3095,8 @@ export async function basePermissionCandidates(db, { q = "", limit = 25 } = {}) 
            coalesce(ps.character_name, '') as character_name
     from dune.player_state ps
     where coalesce(ps.player_controller_id, 0) > 0
+      and ps.player_controller_id <> ${INTERNAL_GM_PLAYER_PAWN_ID}::bigint
+      ${internalGmPawnFilter}
       and nullif(btrim(coalesce(ps.character_name, '')), '') is not null
       and ps.character_name not in ('Server', 'Message of the Day')
       ${filter}
@@ -5764,8 +5770,7 @@ function reconcileQueuedGeneratorRefills(repoRoot, outcomes) {
 // again -- it isn't a component at all, but a Blueprint-class-keyed property
 // on dune.actors.properties (BP_BloodWaterExtractor[_Advanced]_C.m_CurrentAmount).
 // Both mechanisms, every building_type, and every capacity below were
-// confirmed against a live database, not guessed -- see
-// C:\Users\jvign\.claude\plans\bases\water-storage-tab.md for the full trail.
+// confirmed against a live database rather than inferred from display names.
 // ---------------------------------------------------------------------------
 
 const WATER_TYPES = {

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2989,14 +2989,20 @@ export async function basePermissionActor(db, baseId) {
            coalesce(mn.map_name_id, 0)::int as map_name_id,
            coalesce(a.partition_id, 0)::int as partition_id
     from dune.buildings b
-    join dune.building_instances bi on bi.building_id = b.id
-    join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
-    join dune.actors a on a.id = afe.actor_id
+    left join dune.building_instances bi on bi.building_id = b.id
+    left join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+    left join dune.actors a on a.id = afe.actor_id
     left join dune.map_names mn on mn.map_name = a.map
     where b.id = $1
     limit 1`, [target]);
   const row = result.rows[0];
   if (!row) throw new Error("That base was not found.");
+  // building_instances.owner_entity_id is nullable (ON DELETE SET NULL against
+  // fgl_entities), so the entity link can be broken even though the base row
+  // itself still exists. Left-joining down to actors instead of inner-joining
+  // lets that case surface as its own message rather than the same "not found"
+  // an operator would see for a genuinely deleted base id.
+  if (!row.actor_id) throw new Error("This base has no resolvable owner entity, so permission editing is unavailable for it.");
   return {
     baseId: target,
     actorId: String(row.actor_id),

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -2944,6 +2944,261 @@ function permissionRankLabel(rank) {
   return PERMISSION_RANK_LABELS[rank] || `Rank ${rank}`;
 }
 
+const PERMISSION_OWNER_RANK = 1;
+const PERMISSION_EDITABLE_RANKS = new Set([1, 2, 3]);
+// Fallback only. The real cap comes from live server config via
+// parseEffectivePermissionLimit -- matching the shipped DefaultGame.ini's
+// m_MaxPermissionsPerActor=32 under [/Script/DuneSandbox.PermissionSettings].
+const DEFAULT_MAX_PERMISSIONS_PER_ACTOR = 32;
+
+// Base permission editing goes through the game's own stored procedures, never
+// through direct DML on permission_actor_rank. They do three things a hand-
+// written insert would skip: refresh the base marker, delete the player's marker
+// on removal, and pg_notify('permission_notify_channel', ...) -- which the
+// running map server LISTENs on and applies immediately. Verified in-game on a
+// live server: a rank change written this way moved a player between sections in
+// the owner's open Permissions panel with no relog and no restart. Writing the
+// table directly would land the row and leave the running server unaware of it,
+// which is the silently-reverted behaviour this avoids.
+async function supportsBasePermissionEditing(db) {
+  for (const table of ["permission_actor_rank", "permission_actor", "actors", "player_state", "map_names"]) {
+    if (!(await tableExists(db, table))) return false;
+  }
+  return await functionExists(db, "dune.permission_set_player_rank(bigint,bigint,smallint,text)")
+    && await functionExists(db, "dune.permission_remove_player_rank(bigint,bigint)");
+}
+
+export async function basePermissionsSupported(db) {
+  return supportsBasePermissionEditing(db).catch(() => false);
+}
+
+// The base id the Bases table shows is min(buildings.id) for the claim, which is
+// NOT the permission actor id -- on a live server the two differ for every base,
+// by a varying offset. Resolving the actor here (rather than trusting anything
+// client-supplied) is what keeps an edit from landing on a neighbouring base.
+//
+// map_name_id is resolved for the same call: permission_set_player_rank
+// interpolates its map argument into the notify payload unquoted, so it must be
+// the numeric dune.map_names id. Passing the text map name would emit malformed
+// JSON to the game server.
+export async function basePermissionActor(db, baseId) {
+  const target = intParam(baseId, "base id", 1);
+  const result = await db.query(`
+    select a.id::text as actor_id,
+           coalesce(a.map, '') as map,
+           coalesce(mn.map_name_id, 0)::int as map_name_id,
+           coalesce(a.partition_id, 0)::int as partition_id
+    from dune.buildings b
+    join dune.building_instances bi on bi.building_id = b.id
+    join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+    join dune.actors a on a.id = afe.actor_id
+    left join dune.map_names mn on mn.map_name = a.map
+    where b.id = $1
+    limit 1`, [target]);
+  const row = result.rows[0];
+  if (!row) throw new Error("That base was not found.");
+  return {
+    baseId: target,
+    actorId: String(row.actor_id),
+    map: String(row.map || ""),
+    mapNameId: Number(row.map_name_id || 0),
+    partitionId: Number(row.partition_id || 0)
+  };
+}
+
+// permission_actor_rank.player_id is a player's player_controller_id, not just
+// any actors row belonging to their account -- one account holds several. The
+// shipped permission_actor_create_or_update_base_marker joins
+// `player_state on player_controller_id = player_id`, and a live A/B confirmed
+// it: a rank row written for a non-canonical actor id was accepted by the
+// procedure and never appeared in game, while the same write against the
+// player_controller_id appeared immediately.
+//
+// The fallback lookup exists so such a phantom row is still shown to the
+// operator rather than silently vanishing from the roster: resolving the name
+// through owner_account_id is how listBases does it, and every actors row of an
+// account maps to the same character name.
+export async function listBasePermissions(db, baseId) {
+  await requireCapability(await supportsBasePermissionEditing(db),
+    "Base permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
+  const { actorId, map, mapNameId } = await basePermissionActor(db, baseId);
+  const result = await db.query(`
+    select par.player_id::text as player_id,
+           coalesce(ps.character_name, fallback.character_name, '') as character_name,
+           par.rank::int as rank,
+           (ps.player_controller_id is not null) as canonical
+    from dune.permission_actor_rank par
+    left join dune.player_state ps on ps.player_controller_id = par.player_id
+    left join lateral (
+      select fps.character_name
+      from dune.actors fa
+      join dune.player_state fps on fps.account_id = fa.owner_account_id
+      where fa.id = par.player_id
+      limit 1
+    ) fallback on true
+    where par.permission_actor_id = $1::bigint
+    order by par.rank asc, coalesce(ps.character_name, fallback.character_name, '') asc`, [actorId]);
+  return {
+    baseId: intParam(baseId, "base id", 1),
+    actorId,
+    map,
+    mapNameId,
+    entries: result.rows.map((row) => ({
+      playerId: String(row.player_id),
+      name: String(row.character_name || ""),
+      rank: Number(row.rank),
+      label: permissionRankLabel(Number(row.rank)),
+      // False means this row names an actor that is not the account's
+      // player_controller_id, so the game ignores it. Surfaced rather than
+      // hidden: it is the one roster state the console can see and the game
+      // client cannot.
+      canonical: row.canonical === true
+    }))
+  };
+}
+
+// Candidates for the roster picker. Deliberately keyed on player_controller_id
+// rather than reusing listPlayers' actor_id: listPlayers is row-per-pawn, and
+// handing a pawn id to permission_set_player_rank writes a row the game ignores.
+export async function basePermissionCandidates(db, { q = "", limit = 25 } = {}) {
+  await requireCapability(await supportsBasePermissionEditing(db),
+    "Base permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
+  const safeLimit = intParam(limit, "limit", 1, 100);
+  const values = [];
+  let filter = "";
+  if (q) {
+    values.push(`%${q}%`);
+    filter = `and (ps.character_name ilike $${values.length} or ps.player_controller_id::text = $${values.length})`;
+  }
+  values.push(safeLimit);
+  const result = await db.query(`
+    select distinct ps.player_controller_id::text as player_id,
+           coalesce(ps.character_name, '') as character_name
+    from dune.player_state ps
+    where coalesce(ps.player_controller_id, 0) > 0
+      and nullif(btrim(coalesce(ps.character_name, '')), '') is not null
+      and ps.character_name not in ('Server', 'Message of the Day')
+      ${filter}
+    order by character_name asc
+    limit $${values.length}`, values);
+  return result.rows.map((row) => ({ playerId: String(row.player_id), name: String(row.character_name || "") }));
+}
+
+function normalizeDesiredPermissions(entries) {
+  if (!Array.isArray(entries)) throw new Error("Permissions must be a list of players and ranks.");
+  const seen = new Set();
+  const desired = entries.map((entry) => {
+    const playerId = String(intParam(entry?.playerId, "player id", 1));
+    const rank = Number(entry?.rank);
+    if (!PERMISSION_EDITABLE_RANKS.has(rank)) {
+      throw new Error(`Rank ${entry?.rank} is not a valid base permission rank.`);
+    }
+    if (seen.has(playerId)) throw new Error("The same player was listed twice.");
+    seen.add(playerId);
+    return { playerId, rank };
+  });
+  const owners = desired.filter((entry) => entry.rank === PERMISSION_OWNER_RANK);
+  if (owners.length !== 1) {
+    throw new Error(owners.length === 0
+      ? "A base must have exactly one Owner. Promote a player to Owner before saving."
+      : `A base can only have one Owner; ${owners.length} were selected.`);
+  }
+  return desired;
+}
+
+// Applies a whole roster in one transaction, built entirely from the shipped
+// procedures. Two invariants the procedures do NOT enforce are enforced here:
+//
+//   - One Owner. permission_set_player_rank is a plain upsert, so setting rank 1
+//     for a second player would simply leave the base with two owners.
+//   - The cap. The procedure never counts rows; the limit comes from live server
+//     config (see parseEffectivePermissionLimit), not a constant.
+//
+// Write order matters even though NOTIFY is only delivered at commit: the marker
+// refresh inside permission_set_player_rank looks up the rank-1 holder with a
+// LIMIT 1, so a moment with two rank-1 rows could stamp the wrong owner onto the
+// base marker. Removals run first, then non-owner ranks, then the Owner last --
+// so at most one rank-1 row exists when the owner write lands.
+export async function setBasePermissions(db, baseId, entries, maxPermissionsPerActor = DEFAULT_MAX_PERMISSIONS_PER_ACTOR) {
+  await requireCapability(await supportsBasePermissionEditing(db),
+    "Base permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
+  const target = intParam(baseId, "base id", 1);
+  const safeMax = intParam(maxPermissionsPerActor, "maximum permissions per base", 1, 2147483647);
+  const desired = normalizeDesiredPermissions(entries);
+  if (desired.length > safeMax) {
+    throw new Error(`This base would hold ${desired.length} permissions, above the configured maximum of ${safeMax}.`);
+  }
+
+  return db.transaction(async (tx) => {
+    // The shipped procedures reference their tables unqualified and carry no
+    // `SET search_path` of their own; they resolve only because the console
+    // connects as the `dune` role, whose default "$user" path puts the dune
+    // schema first. Every query this file writes is schema-qualified, so setting
+    // it here costs nothing and keeps the feature working if ADMIN_DATABASE_URL
+    // is ever pointed at a differently-named role.
+    await tx.query("set local search_path to dune, public");
+
+    const actor = await basePermissionActor(tx, target);
+    if (!actor.mapNameId) {
+      throw new Error(`This base's map (${actor.map || "unknown"}) has no dune.map_names entry, so the game cannot be notified of the change.`);
+    }
+    // Lock the claim actor row, not the rank rows: a base whose roster is being
+    // fully replaced may have no rank rows to lock, and `for update` over zero
+    // rows serializes nothing. The actors row is guaranteed to exist.
+    const locked = await tx.query("select id from dune.actors where id = $1::bigint for update", [actor.actorId]);
+    if (!locked.rowCount) throw new Error("That base was not found.");
+
+    const existing = await tx.query(
+      "select player_id::text as player_id, rank::int as rank from dune.permission_actor_rank where permission_actor_id = $1::bigint",
+      [actor.actorId]);
+    const currentByPlayer = new Map(existing.rows.map((row) => [String(row.player_id), Number(row.rank)]));
+
+    // Every target player must be a real permission holder, i.e. an account's
+    // player_controller_id. Anything else writes a row the game ignores.
+    const canonical = await tx.query(
+      "select player_controller_id::text as player_id from dune.player_state where player_controller_id = any($1::bigint[])",
+      [desired.map((entry) => entry.playerId)]);
+    const canonicalIds = new Set(canonical.rows.map((row) => String(row.player_id)));
+    for (const entry of desired) {
+      if (!canonicalIds.has(entry.playerId)) {
+        throw new Error(`Player ${entry.playerId} is not a known player character, so the game would ignore this permission.`);
+      }
+    }
+
+    const desiredByPlayer = new Map(desired.map((entry) => [entry.playerId, entry.rank]));
+    const removed = [...currentByPlayer.keys()].filter((playerId) => !desiredByPlayer.has(playerId));
+    // Unchanged rows are skipped: every write fires a notify, and re-notifying
+    // the game about a rank it already has is pointless traffic.
+    const changed = desired.filter((entry) => currentByPlayer.get(entry.playerId) !== entry.rank);
+
+    for (const playerId of removed) {
+      await tx.query("select dune.permission_remove_player_rank($1::bigint, $2::bigint)", [actor.actorId, playerId]);
+    }
+    for (const entry of changed.filter((row) => row.rank !== PERMISSION_OWNER_RANK)) {
+      await tx.query("select dune.permission_set_player_rank($1::bigint, $2::bigint, $3::smallint, $4::text)",
+        [actor.actorId, entry.playerId, entry.rank, String(actor.mapNameId)]);
+    }
+    for (const entry of changed.filter((row) => row.rank === PERMISSION_OWNER_RANK)) {
+      await tx.query("select dune.permission_set_player_rank($1::bigint, $2::bigint, $3::smallint, $4::text)",
+        [actor.actorId, entry.playerId, entry.rank, String(actor.mapNameId)]);
+    }
+
+    return {
+      ok: true,
+      baseId: target,
+      actorId: actor.actorId,
+      map: actor.map,
+      added: changed.filter((entry) => !currentByPlayer.has(entry.playerId)).length,
+      reranked: changed.filter((entry) => currentByPlayer.has(entry.playerId)).length,
+      removed: removed.length,
+      total: desired.length,
+      // Changes reach a running map server immediately: the procedures notify
+      // permission_notify_channel, which the server LISTENs on. No restart.
+      message: "Permissions were updated. The change applies to the running map immediately."
+    };
+  });
+}
+
 const BASE_SORT_COLUMNS = {
   base_id: { order: ["id"] },
   name: { order: ["lower(coalesce(name, ''))"] },
@@ -3131,9 +3386,13 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
     // Without world_partition the console cannot tell a running map from a
     // stopped one, so the panel hides the queue entirely and refills stay immediate.
     const generatorRefillQueue = generatorRefill && await supportsGeneratorRefillQueue(db).catch(() => false);
+    // Probed the same way and for the same reason: without the shipped
+    // permission procedures the panel hides the editor rather than offering a
+    // control that fails on save.
+    const basePermissions = await supportsBasePermissionEditing(db).catch(() => false);
 
     return {
-      capabilities: { bases: true, generatorRefill, generatorRefillQueue },
+      capabilities: { bases: true, generatorRefill, generatorRefillQueue, basePermissions },
       totalCount: result.rows[0] ? Number(result.rows[0].total_count) : 0,
       totalBases: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_bases) : 0,
       totalPieces: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_pieces) : 0,

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3068,7 +3068,10 @@ export async function basePermissionCandidates(db, { q = "", limit = 25 } = {}) 
   let filter = "";
   if (q) {
     values.push(`%${q}%`);
-    filter = `and (ps.character_name ilike $${values.length} or ps.player_controller_id::text = $${values.length})`;
+    const likeParam = values.length;
+    values.push(q);
+    const idParam = values.length;
+    filter = `and (ps.character_name ilike $${likeParam} or ps.player_controller_id::text = $${idParam})`;
   }
   values.push(safeLimit);
   const result = await db.query(`
@@ -3381,22 +3384,32 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
     }
 
     // Probed here rather than per row so the panel can disable Refill outright
-    // instead of failing on click.
-    const generatorRefill = await supportsGeneratorRefill(db).catch(() => false);
+    // instead of failing on click. These three don't depend on each other, so
+    // they run concurrently rather than as three sequential round-trip chains
+    // on this hot list/search/sort/page endpoint.
+    //
+    // basePermissions: probed the same way and for the same reason as
+    // generatorRefill -- without the shipped permission procedures the panel
+    // hides the editor rather than offering a control that fails on save.
+    //
+    // waterRefill: gated on supportsWaterRefill rather than
+    // supportsGeneratorRefill: water refill needs none of the item-insert
+    // columns the generator capability check requires, so reusing that check
+    // would wrongly hide Refill Water on a schema that has everything water
+    // actually needs.
+    const [generatorRefill, basePermissions, waterRefill] = await Promise.all([
+      supportsGeneratorRefill(db).catch(() => false),
+      supportsBasePermissionEditing(db).catch(() => false),
+      supportsWaterRefill(db).catch(() => false)
+    ]);
     // Without world_partition the console cannot tell a running map from a
-    // stopped one, so the panel hides the queue entirely and refills stay immediate.
-    const generatorRefillQueue = generatorRefill && await supportsGeneratorRefillQueue(db).catch(() => false);
-    // Probed the same way and for the same reason: without the shipped
-    // permission procedures the panel hides the editor rather than offering a
-    // control that fails on save.
-    const basePermissions = await supportsBasePermissionEditing(db).catch(() => false);
-    // Same probing pattern as generatorRefill/generatorRefillQueue above, but
-    // gated on supportsWaterRefill rather than supportsGeneratorRefill: water
-    // refill needs none of the item-insert columns the generator capability
-    // check requires, so reusing that check would wrongly hide Refill Water
-    // on a schema that has everything water actually needs.
-    const waterRefill = await supportsWaterRefill(db).catch(() => false);
-    const waterRefillQueue = waterRefill && await supportsWaterRefillQueue(db).catch(() => false);
+    // stopped one, so the panel hides the queue entirely and refills stay
+    // immediate. Each check reuses the flag just computed above instead of
+    // re-deriving it, and both run concurrently for the same reason as above.
+    const [generatorRefillQueue, waterRefillQueue] = await Promise.all([
+      generatorRefill ? supportsGeneratorRefillQueue(db, { generatorRefill }).catch(() => false) : Promise.resolve(false),
+      waterRefill ? supportsWaterRefillQueue(db, { waterRefill }).catch(() => false) : Promise.resolve(false)
+    ]);
 
     return {
       capabilities: { bases: true, generatorRefill, generatorRefillQueue, basePermissions, waterRefill, waterRefillQueue },
@@ -5552,8 +5565,12 @@ function partitionWriteSafe(observed, partitionId) {
   return observed.safe.has(partitionId);
 }
 
-export async function supportsGeneratorRefillQueue(db) {
-  if (!(await supportsGeneratorRefill(db))) return false;
+// generatorRefill accepts an already-known flag so a caller that just
+// computed supportsGeneratorRefill (e.g. listBases) doesn't pay for a second,
+// redundant re-derivation of the same boolean on every call.
+export async function supportsGeneratorRefillQueue(db, { generatorRefill } = {}) {
+  const supported = generatorRefill !== undefined ? generatorRefill : await supportsGeneratorRefill(db);
+  if (!supported) return false;
   return tableExists(db, "world_partition");
 }
 
@@ -5893,8 +5910,11 @@ export async function supportsWaterRefill(db) {
   return ["id", "owner_entity_id", "building_type"].every((column) => placeableColumns.has(column));
 }
 
-export async function supportsWaterRefillQueue(db) {
-  if (!(await supportsWaterRefill(db))) return false;
+// Mirrors supportsGeneratorRefillQueue's waterRefill-reuse parameter, for the
+// same reason.
+export async function supportsWaterRefillQueue(db, { waterRefill } = {}) {
+  const supported = waterRefill !== undefined ? waterRefill : await supportsWaterRefill(db);
+  if (!supported) return false;
   return tableExists(db, "world_partition");
 }
 
@@ -5903,7 +5923,7 @@ export async function supportsWaterRefillQueue(db) {
 // bookkeeping like generator fuel needs (water is a scalar, not a stack of
 // discrete items). Blood (dune.actors.properties) is never touched here: per
 // user decision it's meant to be gathered in-world, not admin-conjured.
-export async function refillBaseWater(db, repoRoot, baseId) {
+export async function refillBaseWater(db, baseId) {
   await requireCapability(await supportsWaterRefill(db),
     "Water refill requires dune.placeables, dune.actor_fgl_entities, and dune.fgl_entities.");
   const target = intParam(baseId, "base id", 1);
@@ -6082,7 +6102,7 @@ export async function flushWaterRefills(db, repoRoot, { now = Date.now } = {}) {
     if (!partitionWriteSafe(observed, entry.partitionId)) continue;
     if (entry.nextRetryAt && timestamp < entry.nextRetryAt) continue;
     try {
-      const result = await refillBaseWater(db, repoRoot, entry.baseId);
+      const result = await refillBaseWater(db, entry.baseId);
       outcomes.set(entry.baseId, { queuedAt: entry.queuedAt, keep: false });
       flushed.push({
         baseId: entry.baseId,

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -180,10 +180,13 @@ if (deathPoller.enabled) deathPoller.init(db, config.repoRoot).catch(() => {});
 // (scheduler, IP change, CLI). Idle cost is one small file read per tick.
 const generatorRefillFlushIntervalMs = Number(process.env.ADMIN_REFILL_FLUSH_INTERVAL_MS);
 setInterval(() => {
-  if (!duneDb.listQueuedGeneratorRefills(config.repoRoot).length) return;
-  runBackgroundTick("Generator refill flush", () => flushQueuedGeneratorRefills());
-  // Independent check in the same tick rather than a second setInterval: an
-  // idle water queue costs one more cheap file read, not a new timer.
+  // Two independent checks in the same tick rather than two setIntervals: an
+  // idle queue costs one more cheap file read, not a new timer. Each queue's
+  // check must stand alone -- an early return keyed on one queue's length
+  // would silently skip the other whenever only it had pending entries.
+  if (duneDb.listQueuedGeneratorRefills(config.repoRoot).length) {
+    runBackgroundTick("Generator refill flush", () => flushQueuedGeneratorRefills());
+  }
   if (duneDb.listQueuedWaterRefills(config.repoRoot).length) {
     runBackgroundTick("Water refill flush", () => flushQueuedWaterRefills());
   }

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -49,6 +49,7 @@ import { choamTerminalOverview, installChoamTerminals, removeChoamTerminals } fr
 import { autoRefillPublicState, createAutoRefillScheduler, setBaseAutoRefill } from "./services/autoRefill.js";
 import { calculateAlwaysOnHostMemorySafety } from "./services/hostMemorySafety.js";
 import { parseEffectiveGuildMemberLimit } from "./services/guildSettings.js";
+import { parseEffectivePermissionLimit } from "./services/permissionSettings.js";
 
 const config = loadConfig();
 const auth = createAuth(config);
@@ -488,6 +489,9 @@ async function handleApi(req, res) {
   if (path.match(/^\/api\/bases\/[^/]+\/refill-generators$/) && req.method === "POST") return baseRefillGeneratorsRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/queued-refill$/) && req.method === "DELETE") return baseCancelQueuedRefillRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/auto-refill$/) && req.method === "POST") return baseAutoRefillToggleRoute(req, res, path);
+  if (path === "/api/bases/permission-candidates") return basePermissionCandidatesRoute(res, url);
+  if (path.match(/^\/api\/bases\/[^/]+\/permissions$/) && req.method === "GET") return basePermissionsRoute(res, path);
+  if (path.match(/^\/api\/bases\/[^/]+\/permissions$/) && req.method === "PUT") return baseSetPermissionsRoute(req, res, path);
   if (path === "/api/admin/items/catalog") return json(res, 200, { rows: listCatalogItems(config.repoRoot, { q: url.searchParams.get("q") || "", limit: url.searchParams.get("limit") || 500 }) });
   if (path === "/api/admin/items/search") return commandJson(res, "adminItemSearch", { q: url.searchParams.get("q") || "" });
   if (path === "/api/admin/items") return commandJson(res, url.searchParams.get("category") ? "adminItemListCategory" : "adminItemList", { category: url.searchParams.get("category") || "" });
@@ -2027,6 +2031,47 @@ async function baseRefillGeneratorsRoute(req, res, path) {
       return { ok: true, queued: true, ...entry };
     }
     return duneDb.refillBaseGenerators(db, config.repoRoot, baseId);
+  }, { baseId });
+}
+
+async function basePermissionsRoute(res, path) {
+  const baseId = Number(decodeURIComponent(path.split("/")[3]));
+  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  try {
+    return json(res, 200, { supported: true, ...(await duneDb.listBasePermissions(db, baseId)) });
+  } catch (error) {
+    const status = error.unsupported ? 501 : 400;
+    return json(res, status, { supported: false, error: redact(error.message || error), reason: redact(error.message || error) });
+  }
+}
+
+async function basePermissionCandidatesRoute(res, url) {
+  try {
+    const rows = await duneDb.basePermissionCandidates(db, {
+      q: url.searchParams.get("q") || "",
+      limit: url.searchParams.get("limit") || 25
+    });
+    return json(res, 200, { supported: true, rows });
+  } catch (error) {
+    const status = error.unsupported ? 501 : 400;
+    return json(res, status, { supported: false, rows: [], error: redact(error.message || error), reason: redact(error.message || error) });
+  }
+}
+
+// No confirmation phrase, matching the guild mutations and the refill route:
+// permissions are reversible from this same editor. Still rate limited and
+// audited -- this writes to player property.
+//
+// The cap is read from live server config on every save rather than baked in,
+// exactly as guildAddMemberRoute resolves the guild member limit. Raising it is
+// then a settings edit, not a release.
+async function baseSetPermissionsRoute(req, res, path) {
+  const baseId = Number(decodeURIComponent(path.split("/")[3]));
+  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  return directDbMutation(req, res, "bases.set-permissions", null, async (body) => {
+    const settings = await runDune(config, buildDuneArgs("userSettingsMapValues", { map: "Survival_1" }), { timeoutMs: 8000 });
+    const maxPermissions = parseEffectivePermissionLimit(settings.stdout);
+    return duneDb.setBasePermissions(db, baseId, body.entries, maxPermissions);
   }, { baseId });
 }
 

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -51,6 +51,7 @@ import { autoRefillWaterPublicState, createAutoRefillWaterScheduler, setBaseAuto
 import { calculateAlwaysOnHostMemorySafety } from "./services/hostMemorySafety.js";
 import { parseEffectiveGuildMemberLimit } from "./services/guildSettings.js";
 import { parseEffectivePermissionLimit } from "./services/permissionSettings.js";
+import { flushBaseRefillQueues } from "./services/baseRefillFlush.js";
 
 const config = loadConfig();
 const auth = createAuth(config);
@@ -61,7 +62,10 @@ const bridgeRateLimiter = createBridgeRateLimiter();
 // Both flush paths go through flushQueuedGeneratorRefills/flushQueuedWaterRefills
 // so a write lands in the audit log no matter which one applied it.
 const tasks = new TaskManager(config, {
-  onMapDown: () => { void flushQueuedGeneratorRefills(); void flushQueuedWaterRefills(); }
+  onMapDown: () => flushBaseRefillQueues({
+    flushGenerators: flushQueuedGeneratorRefills,
+    flushWater: flushQueuedWaterRefills
+  })
 });
 let db = createDb(config);
 const publicDirectory = createPublicDirectoryReporter(config, { getDb: () => db });

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -47,6 +47,7 @@ import { EDA_EXCHANGE_BOT_ADDON_ID, ADDON_SCHEDULER_PERMISSION, createAddonJobSc
 import { createPublicDirectoryReporter, normalizeDiscordInvite, readDirectorySettings } from "./services/publicDirectory.js";
 import { choamTerminalOverview, installChoamTerminals, removeChoamTerminals } from "./services/choamTerminals.js";
 import { autoRefillPublicState, createAutoRefillScheduler, setBaseAutoRefill } from "./services/autoRefill.js";
+import { autoRefillWaterPublicState, createAutoRefillWaterScheduler, setBaseAutoRefillWater } from "./services/autoRefillWater.js";
 import { calculateAlwaysOnHostMemorySafety } from "./services/hostMemorySafety.js";
 import { parseEffectiveGuildMemberLimit } from "./services/guildSettings.js";
 import { parseEffectivePermissionLimit } from "./services/permissionSettings.js";
@@ -57,9 +58,11 @@ const loginRateLimiter = createLoginRateLimiter();
 const mutationRateLimiter = createMutationRateLimiter();
 const bridgeRateLimiter = createBridgeRateLimiter();
 // Deferred db read: db is assigned below and is reassignable on reconnect.
-// Both flush paths go through flushQueuedGeneratorRefills so a write lands in the
-// audit log no matter which one applied it.
-const tasks = new TaskManager(config, { onMapDown: () => flushQueuedGeneratorRefills() });
+// Both flush paths go through flushQueuedGeneratorRefills/flushQueuedWaterRefills
+// so a write lands in the audit log no matter which one applied it.
+const tasks = new TaskManager(config, {
+  onMapDown: () => { void flushQueuedGeneratorRefills(); void flushQueuedWaterRefills(); }
+});
 let db = createDb(config);
 const publicDirectory = createPublicDirectoryReporter(config, { getDb: () => db });
 let carePackageAutoRunning = false;
@@ -70,6 +73,8 @@ let carePackageAutoNextAllowedRun = 0;
 // existing fuel rows, so an empty generator has nothing to serialize two
 // concurrent inserts against without this guard.
 let generatorRefillFlushRunning = false;
+// Same reasoning as generatorRefillFlushRunning, for the water queue.
+let waterRefillFlushRunning = false;
 let messageOfTheDayAutoRunning = false;
 let messageOfTheDayAutoLastRun = 0;
 let messageOfTheDayAutoNextAllowedRun = 0;
@@ -90,6 +95,12 @@ const addonJobScheduler = createAddonJobScheduler(config, {
 });
 const landsraadMilestoneReconciler = createLandsraadMilestoneReconciler(config, { getDb: () => db });
 const autoRefillScheduler = createAutoRefillScheduler({
+  config,
+  getDb: () => db,
+  duneDb,
+  failureBackoffMs: BACKGROUND_SCAN_FAILURE_BACKOFF_MS
+});
+const autoRefillWaterScheduler = createAutoRefillWaterScheduler({
   config,
   getDb: () => db,
   duneDb,
@@ -146,6 +157,7 @@ setInterval(() => {
   // Daily, but gated inside the tick like every other long-period job here.
   // Costs one small file read when no base is enrolled, and no database query.
   runBackgroundTick("Bases auto-refill", () => autoRefillScheduler.tick());
+  runBackgroundTick("Bases water auto-refill", () => autoRefillWaterScheduler.tick());
 }, 10000).unref?.();
 
 setInterval(() => {
@@ -170,6 +182,11 @@ const generatorRefillFlushIntervalMs = Number(process.env.ADMIN_REFILL_FLUSH_INT
 setInterval(() => {
   if (!duneDb.listQueuedGeneratorRefills(config.repoRoot).length) return;
   runBackgroundTick("Generator refill flush", () => flushQueuedGeneratorRefills());
+  // Independent check in the same tick rather than a second setInterval: an
+  // idle water queue costs one more cheap file read, not a new timer.
+  if (duneDb.listQueuedWaterRefills(config.repoRoot).length) {
+    runBackgroundTick("Water refill flush", () => flushQueuedWaterRefills());
+  }
 }, Number.isFinite(generatorRefillFlushIntervalMs) && generatorRefillFlushIntervalMs > 0 ? generatorRefillFlushIntervalMs : 5000).unref?.();
 
 // Every queued-refill write goes through here so it is audited whichever path
@@ -184,6 +201,19 @@ async function flushQueuedGeneratorRefills() {
     return result;
   } finally {
     generatorRefillFlushRunning = false;
+  }
+}
+
+// Same reasoning as flushQueuedGeneratorRefills, for the water queue.
+async function flushQueuedWaterRefills() {
+  if (waterRefillFlushRunning) return { flushed: [] };
+  waterRefillFlushRunning = true;
+  try {
+    const result = await duneDb.flushWaterRefills(db, config.repoRoot);
+    for (const entry of result.flushed || []) audit(config, null, "bases.flush-queued-water-refill", entry);
+    return result;
+  } finally {
+    waterRefillFlushRunning = false;
   }
 }
 
@@ -485,10 +515,16 @@ async function handleApi(req, res) {
   }));
   if (path === "/api/bases/pending-refills") return pendingGeneratorRefillsRoute(res);
   if (path === "/api/bases/auto-refill") return basesAutoRefillStateRoute(res);
+  if (path === "/api/bases/pending-water-refills") return pendingWaterRefillsRoute(res);
+  if (path === "/api/bases/auto-refill-water") return basesAutoRefillWaterStateRoute(res);
   if (path.match(/^\/api\/bases\/[^/]+\/export$/) && req.method === "GET") return baseBlueprintDownloadRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/refill-generators$/) && req.method === "POST") return baseRefillGeneratorsRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/queued-refill$/) && req.method === "DELETE") return baseCancelQueuedRefillRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/auto-refill$/) && req.method === "POST") return baseAutoRefillToggleRoute(req, res, path);
+  if (path.match(/^\/api\/bases\/[^/]+\/water$/) && req.method === "GET") return baseWaterRoute(res, path);
+  if (path.match(/^\/api\/bases\/[^/]+\/refill-water$/) && req.method === "POST") return baseRefillWaterRoute(req, res, path);
+  if (path.match(/^\/api\/bases\/[^/]+\/queued-water-refill$/) && req.method === "DELETE") return baseCancelQueuedWaterRefillRoute(req, res, path);
+  if (path.match(/^\/api\/bases\/[^/]+\/auto-refill-water$/) && req.method === "POST") return baseAutoRefillWaterToggleRoute(req, res, path);
   if (path === "/api/bases/permission-candidates") return basePermissionCandidatesRoute(res, url);
   if (path.match(/^\/api\/bases\/[^/]+\/permissions$/) && req.method === "GET") return basePermissionsRoute(res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/permissions$/) && req.method === "PUT") return baseSetPermissionsRoute(req, res, path);
@@ -2151,6 +2187,103 @@ async function baseAutoRefillToggleRoute(req, res, path) {
   try {
     const result = setBaseAutoRefill(config.repoRoot, baseId, body.enabled);
     audit(config, req, "bases.auto-refill", { baseId, enabled: result.enabled, total: result.total });
+    return json(res, 200, result);
+  } catch (error) {
+    return json(res, 400, { ok: false, error: redact(error?.message || error) });
+  }
+}
+
+async function baseWaterRoute(res, path) {
+  const baseId = Number(decodeURIComponent(path.split("/")[3]));
+  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  try {
+    return json(res, 200, { supported: true, ...(await duneDb.baseWater(db, baseId)) });
+  } catch (error) {
+    const status = error.unsupported ? 501 : 400;
+    return json(res, status, { supported: false, error: redact(error.message || error), reason: redact(error.message || error) });
+  }
+}
+
+// Mirrors baseRefillGeneratorsRoute: no confirmation phrase (additive and
+// reversible), queued instead of written immediately when the base's map is
+// currently live.
+async function baseRefillWaterRoute(req, res, path) {
+  const baseId = Number(decodeURIComponent(path.split("/")[3]));
+  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  return directDbMutation(req, res, "bases.refill-water", null, async () => {
+    const target = await duneDb.baseRefillTarget(db, baseId);
+    if (target.queueSupported && !target.writeSafeNow) {
+      const entry = duneDb.queueWaterRefill(config.repoRoot, {
+        baseId,
+        map: target.map,
+        partitionId: target.partitionId
+      });
+      return { ok: true, queued: true, ...entry };
+    }
+    return duneDb.refillBaseWater(db, config.repoRoot, baseId);
+  }, { baseId });
+}
+
+async function baseCancelQueuedWaterRefillRoute(req, res, path) {
+  const baseId = Number(decodeURIComponent(path.split("/")[3]));
+  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  return directDbMutation(req, res, "bases.cancel-queued-water-refill", null,
+    () => duneDb.cancelQueuedWaterRefill(config.repoRoot, baseId), { baseId });
+}
+
+// Mirrors pendingGeneratorRefillsRoute.
+async function pendingWaterRefillsRoute(res) {
+  const pending = duneDb.listQueuedWaterRefills(config.repoRoot);
+  const targets = pending.length
+    ? await duneDb.partitionRestartTargets(db).catch(() => new Map())
+    : new Map();
+  const byTarget = new Map();
+  for (const entry of pending) {
+    const map = entry.map || "Unknown";
+    const key = `${map}|${entry.partitionId}`;
+    const target = targets.get(entry.partitionId);
+    const group = byTarget.get(key) || {
+      map,
+      partitionId: entry.partitionId,
+      partitionMap: target?.map || "",
+      dimensionIndex: target?.dimensionIndex ?? 0,
+      count: 0
+    };
+    group.count += 1;
+    byTarget.set(key, group);
+  }
+  return json(res, 200, {
+    supported: true,
+    total: pending.length,
+    pending,
+    byTarget: [...byTarget.values()].sort((a, b) => a.map.localeCompare(b.map) || a.partitionId - b.partitionId)
+  });
+}
+
+// Mirrors basesAutoRefillStateRoute, gated on supportsWaterRefillQueue rather
+// than supportsGeneratorRefillQueue -- water refill needs none of the
+// item-insert columns the generator capability check requires.
+async function basesAutoRefillWaterStateRoute(res) {
+  const supported = await duneDb.supportsWaterRefillQueue(db).catch(() => false);
+  return json(res, 200, { supported, ...autoRefillWaterPublicState(config.repoRoot) });
+}
+
+// Mirrors baseAutoRefillToggleRoute.
+async function baseAutoRefillWaterToggleRoute(req, res, path) {
+  const baseId = Number(decodeURIComponent(path.split("/")[3]));
+  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  const body = await readJson(req);
+  if (typeof body.enabled !== "boolean") {
+    return json(res, 400, { error: "Auto-refill enabled must be true or false." });
+  }
+  if (body.enabled && !(await duneDb.supportsWaterRefillQueue(db).catch(() => false))) {
+    return json(res, 501, {
+      error: "Auto-refill needs the pending water-refill queue, which requires dune.world_partition on this database."
+    });
+  }
+  try {
+    const result = setBaseAutoRefillWater(config.repoRoot, baseId, body.enabled);
+    audit(config, req, "bases.auto-refill-water", { baseId, enabled: result.enabled, total: result.total });
     return json(res, 200, result);
   } catch (error) {
     return json(res, 400, { ok: false, error: redact(error?.message || error) });

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -2223,7 +2223,7 @@ async function baseRefillWaterRoute(req, res, path) {
       });
       return { ok: true, queued: true, ...entry };
     }
-    return duneDb.refillBaseWater(db, config.repoRoot, baseId);
+    return duneDb.refillBaseWater(db, baseId);
   }, { baseId });
 }
 

--- a/console/api/src/services/autoRefillWater.js
+++ b/console/api/src/services/autoRefillWater.js
@@ -1,0 +1,459 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { audit } from "../audit.js";
+import { redact } from "../redact.js";
+import { clampInt, writeJsonAtomic } from "../jsonStore.js";
+
+// Opt-in per-base automatic water refills. Mirrors autoRefill.js (generator
+// auto-refill) exactly, with its own enrollment file and env-configurable
+// threshold/interval so the two subsystems never share state or interfere
+// with each other. This owns only the enrollment list and the daily
+// decision; the refill itself goes through the pending water-refill queue in
+// duneDb.js, so the write still lands in a window where the base's map is
+// confirmed down and is still audited by the flush.
+const AUTO_REFILL_WATER_PATH = "runtime/generated/auto-refill-water-bases.json";
+
+// Bounded well under the queue's own MAX_PENDING_REFILLS (500) so a scan that
+// enqueues every enrolled base can never overflow it.
+const MAX_AUTO_REFILL_WATER_BASES = 200;
+const MAX_RUN_DETAIL_LENGTH = 500;
+
+// How many completed queue cycles a base gets before auto-refill stops trying.
+// Mirrors MAX_REFILL_FLUSH_ATTEMPTS: some bases cannot be fixed by a refill at
+// all, and queueing a write against player property daily forever is not an
+// acceptable answer to that. Reset the moment a scan finds the base healthy.
+const MAX_CONSECUTIVE_QUEUES = 3;
+
+// How far out an overdue scan is armed at boot. See the note in tick().
+const OVERDUE_ARM_DELAY_MS = 5 * 60 * 1000;
+
+// Fixed in code, env-overridable only -- matching how every other refill
+// tunable (ADMIN_REFILL_*) is exposed rather than adding a settings surface.
+// Distinct env vars from the generator version so the two can be tuned
+// independently.
+export function autoRefillWaterThresholdPercent(env = process.env) {
+  return clampInt(env.ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT, 50, 1, 99);
+}
+
+export function autoRefillWaterIntervalHours(env = process.env) {
+  return clampInt(env.ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS, 24, 1, 168);
+}
+
+function autoRefillWaterFile(repoRoot) {
+  return resolve(repoRoot || "", AUTO_REFILL_WATER_PATH);
+}
+
+// Keeps only a parseable timestamp: a hand-edited nextRunAt that does not parse
+// must read as "unset" rather than as a date in the distant past or future.
+function isoField(value) {
+  if (typeof value !== "string") return "";
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return "";
+  return new Date(parsed).toISOString();
+}
+
+function normalizeEntry(entry) {
+  const source = entry && typeof entry === "object" ? entry : {};
+  // Checked before Number(), which turns null and "" into 0 -- that would make a
+  // base with no water storage at all persist as 0% and read as starved.
+  const raw = source.lastLowestPercent;
+  const percent = raw === null || raw === undefined || raw === "" ? Number.NaN : Number(raw);
+  return {
+    enabledAt: isoField(source.enabledAt),
+    lastCheckedAt: isoField(source.lastCheckedAt),
+    lastQueuedAt: isoField(source.lastQueuedAt),
+    // A device can hold more than its cap if it was filled by hand, so the
+    // ceiling is generous; the point is only that it stays a bounded number.
+    lastLowestPercent: Number.isFinite(percent) ? Math.min(Math.max(percent, 0), 10000) : null,
+    consecutiveQueues: clampInt(source.consecutiveQueues, 0, 0, MAX_CONSECUTIVE_QUEUES),
+    stalledAt: isoField(source.stalledAt)
+  };
+}
+
+function normalizeState(raw) {
+  const source = raw && typeof raw === "object" && !Array.isArray(raw) ? raw : {};
+  const rawBases = source.bases && typeof source.bases === "object" && !Array.isArray(source.bases)
+    ? source.bases
+    : {};
+  const bases = {};
+  let overCap = 0;
+  for (const [key, value] of Object.entries(rawBases)) {
+    const baseId = Math.floor(Number(key));
+    if (!Number.isInteger(baseId) || baseId < 1) continue;
+    // `continue` rather than `break` so the count below is the real overage.
+    if (Object.keys(bases).length >= MAX_AUTO_REFILL_WATER_BASES) {
+      overCap += 1;
+      continue;
+    }
+    bases[String(baseId)] = normalizeEntry(value);
+  }
+  // Every write path re-normalizes, so a silent truncation here would erase the
+  // dropped bases permanently on the next save. Say so, as the pending refill
+  // queue does when it discards state it cannot use.
+  if (overCap) {
+    console.warn(`Auto-refill water enrollment lists more than ${MAX_AUTO_REFILL_WATER_BASES} bases; ignoring ${overCap} beyond the cap.`);
+  }
+  return {
+    schemaVersion: 1,
+    nextRunAt: isoField(source.nextRunAt),
+    lastRunAt: isoField(source.lastRunAt),
+    lastRunStatus: String(source.lastRunStatus ?? "").slice(0, 40),
+    lastRunDetail: String(source.lastRunDetail ?? "").slice(0, MAX_RUN_DETAIL_LENGTH),
+    bases
+  };
+}
+
+// A corrupt or hand-edited file never blocks the console: it degrades to an
+// empty enrollment, which is also the safe direction (nothing gets refilled).
+export function readAutoRefillWaterState(repoRoot) {
+  const file = autoRefillWaterFile(repoRoot);
+  if (!existsSync(file)) return normalizeState({});
+  try {
+    return normalizeState(JSON.parse(readFileSync(file, "utf8")));
+  } catch (error) {
+    console.warn(`Ignoring unreadable auto-refill water enrollment file: ${redact(error?.message || error)}`);
+    return normalizeState({});
+  }
+}
+
+// Deliberately synchronous read-modify-write, matching
+// writeQueuedWaterRefills in duneDb.js: with no await between read and
+// write, two requests in one console process cannot drop each other's change.
+// The temp-file rename covers crash safety.
+export function writeAutoRefillWaterState(repoRoot, state) {
+  const file = autoRefillWaterFile(repoRoot);
+  const next = normalizeState(state);
+  writeJsonAtomic(file, next);
+  return next;
+}
+
+export function isAutoRefillWaterEnabled(repoRoot, baseId) {
+  const target = Math.floor(Number(baseId));
+  if (!Number.isInteger(target) || target < 1) return false;
+  return Boolean(readAutoRefillWaterState(repoRoot).bases[String(target)]);
+}
+
+// Idempotent in both directions: a double-clicked toggle is not an error.
+export function setBaseAutoRefillWater(repoRoot, baseId, enabled, { now = () => Date.now(), env = process.env } = {}) {
+  const target = Number(baseId);
+  if (!Number.isInteger(target) || target < 1) throw new Error("Invalid base id");
+  const state = readAutoRefillWaterState(repoRoot);
+  const key = String(target);
+  const bases = { ...state.bases };
+  const wasEmpty = Object.keys(bases).length === 0;
+
+  if (enabled) {
+    if (!bases[key]) {
+      if (Object.keys(bases).length >= MAX_AUTO_REFILL_WATER_BASES) {
+        throw new Error(`Auto-refill water already covers ${MAX_AUTO_REFILL_WATER_BASES} bases. Turn it off somewhere before adding another.`);
+      }
+      bases[key] = normalizeEntry({ enabledAt: new Date(now()).toISOString() });
+    }
+  } else {
+    delete bases[key];
+  }
+
+  const remaining = Object.keys(bases).length;
+  let nextRunAt = state.nextRunAt;
+  if (!remaining) {
+    nextRunAt = "";
+  } else if (wasEmpty || !nextRunAt) {
+    // Arm a full interval out, so turning auto-refill on never fires an
+    // immediate surprise write into a base the operator was still looking at.
+    nextRunAt = new Date(now() + autoRefillWaterIntervalHours(env) * 3600000).toISOString();
+  }
+
+  const next = writeAutoRefillWaterState(repoRoot, { ...state, bases, nextRunAt });
+  return { ok: true, baseId: target, enabled: Boolean(next.bases[key]), total: remaining };
+}
+
+// Shape returned by GET /api/bases/auto-refill-water.
+export function autoRefillWaterPublicState(repoRoot, { env = process.env } = {}) {
+  const state = readAutoRefillWaterState(repoRoot);
+  return {
+    thresholdPercent: autoRefillWaterThresholdPercent(env),
+    intervalHours: autoRefillWaterIntervalHours(env),
+    nextRunAt: state.nextRunAt,
+    lastRunAt: state.lastRunAt,
+    lastRunStatus: state.lastRunStatus,
+    lastRunDetail: state.lastRunDetail,
+    total: Object.keys(state.bases).length,
+    bases: Object.entries(state.bases)
+      .map(([key, entry]) => ({ baseId: Number(key), ...entry }))
+      .sort((a, b) => a.baseId - b.baseId)
+  };
+}
+
+export function createAutoRefillWaterScheduler(options = {}) {
+  const {
+    config,
+    // A getter, not the pool: server.js reassigns `db` when the connection is
+    // reconfigured, and a captured reference would keep using the dead pool.
+    getDb,
+    duneDb,
+    now = () => Date.now(),
+    auditImpl = audit,
+    log = console,
+    failureBackoffMs = 60000,
+    overdueArmDelayMs = OVERDUE_ARM_DELAY_MS,
+    env = process.env
+  } = options;
+
+  // Instance-scoped guards, the same role carePackageAutoRunning plays in
+  // server.js and `running` plays in createAddonJobScheduler.
+  let running = false;
+  let nextAllowedAttemptAt = 0;
+  let armedForThisProcess = false;
+
+  function intervalMs() {
+    return autoRefillWaterIntervalHours(env) * 3600000;
+  }
+
+  function auditSafely(action, detail) {
+    try {
+      auditImpl(config, null, action, detail);
+    } catch (error) {
+      log.error(`Auto-refill water audit failed: ${redact(error?.message || error)}`);
+    }
+  }
+
+  function persistRunCompletion(completedAtMs, outcomes, removed, status, detail) {
+    // Re-read before writing so a toggle that landed while the scan was in
+    // flight is not clobbered, and so a base un-enrolled mid-scan is not
+    // resurrected by its own outcome.
+    const current = readAutoRefillWaterState(config.repoRoot);
+    const bases = { ...current.bases };
+    for (const key of removed) delete bases[key];
+    for (const [key, outcome] of outcomes) {
+      if (!bases[key]) continue;
+      bases[key] = { ...bases[key], ...outcome };
+    }
+    const remaining = Object.keys(bases).length;
+    writeAutoRefillWaterState(config.repoRoot, {
+      ...current,
+      bases,
+      lastRunAt: new Date(completedAtMs).toISOString(),
+      lastRunStatus: status,
+      lastRunDetail: detail,
+      // Re-arm from completion, not from run start, so a slow scan cannot
+      // trigger back-to-back runs. A run where every base failed (status
+      // "fail") never throws out of run(), so it would otherwise wait a full
+      // interval before retrying a transient outage -- use the same short
+      // backoff a failure that escapes run() gets instead.
+      nextRunAt: remaining ? new Date(completedAtMs + (status === "fail" ? failureBackoffMs : intervalMs())).toISOString() : ""
+    });
+  }
+
+  async function scanBase(baseId, threshold, context) {
+    const { enrollment, pendingBaseIds, outcomes, removed, failures, counters } = context;
+    const key = String(baseId);
+    const db = getDb();
+    const previous = enrollment[key] || {};
+    const priorQueues = previous.consecutiveQueues || 0;
+    try {
+      const levels = await duneDb.baseWaterFuelLevels(db, baseId);
+      counters.checked += 1;
+      const lowest = levels.lowestPercent;
+      const outcome = {
+        lastCheckedAt: new Date(now()).toISOString(),
+        lastLowestPercent: lowest,
+        consecutiveQueues: priorQueues,
+        stalledAt: previous.stalledAt || ""
+      };
+
+      // null means no recognised water storage -- which baseWaterDevices
+      // reports both for a base with none built and for a base that no
+      // longer exists, since it returns zero rows either way. Only
+      // baseMapLocation separates them, so it is asked here rather than
+      // relying on a later call that a null percent means we never reach.
+      if (lowest === null) {
+        await duneDb.baseMapLocation(db, baseId);
+        outcome.consecutiveQueues = 0;
+        outcome.stalledAt = "";
+        outcomes.set(key, outcome);
+        return;
+      }
+
+      // Healthy again: whatever kept it low before has been resolved.
+      if (lowest >= threshold) {
+        outcome.consecutiveQueues = 0;
+        outcome.stalledAt = "";
+        outcomes.set(key, outcome);
+        return;
+      }
+
+      // An entry from an earlier scan is still waiting for its map to go down.
+      // Re-queueing would replace it and reset its attempts to 0, defeating the
+      // flush's three-strike backstop -- and a map that simply has not restarted
+      // yet is not evidence that refills are failing, so the stall counter must
+      // not advance either.
+      if (pendingBaseIds.has(baseId)) {
+        counters.alreadyQueued += 1;
+        outcomes.set(key, outcome);
+        return;
+      }
+
+      // Queued this many times without the water ever coming back up.
+      // Something about this base cannot be fixed by a refill (a base
+      // released or misconfigured, a flush that keeps failing until it drops
+      // the entry), so stop rather than queue a write against player
+      // property every day forever. This only fires once the prior queue
+      // entry has left pendingBaseIds -- applied or dropped by the flush --
+      // so a map that simply has not restarted yet never gets marked stalled
+      // before its queued refill had a chance to land.
+      if (priorQueues >= MAX_CONSECUTIVE_QUEUES) {
+        counters.stalled += 1;
+        const stalledNow = !previous.stalledAt;
+        outcome.stalledAt = previous.stalledAt || new Date(now()).toISOString();
+        if (stalledNow) {
+          auditSafely("bases.auto-refill-water-stalled", {
+            baseId,
+            lowestPercent: lowest,
+            thresholdPercent: threshold,
+            consecutiveQueues: priorQueues
+          });
+        }
+        outcomes.set(key, outcome);
+        return;
+      }
+
+      const target = await duneDb.baseRefillTarget(db, baseId, { observed: context.observed });
+      if (!target.queueSupported) {
+        // Enrollment is gated on the queue capability, so reaching here means
+        // the database changed under a running console. Refusing keeps an
+        // automated write out of a possibly-live base.
+        failures.push(`${baseId}: water refill queueing is unsupported on this database`);
+        outcomes.set(key, outcome);
+        return;
+      }
+      duneDb.queueWaterRefill(config.repoRoot, {
+        baseId,
+        map: target.map,
+        partitionId: target.partitionId
+      });
+      outcome.lastQueuedAt = new Date(now()).toISOString();
+      outcome.consecutiveQueues = priorQueues + 1;
+      counters.queued += 1;
+      auditSafely("bases.auto-refill-water-queued", {
+        baseId,
+        lowestPercent: lowest,
+        thresholdPercent: threshold,
+        deviceCount: levels.deviceCount,
+        attempt: outcome.consecutiveQueues,
+        map: target.map,
+        partitionId: target.partitionId
+      });
+      // Do not mark stalled here: this refill was only just queued, not yet
+      // applied. Stalling is decided on a later scan (above) once this queue
+      // entry has left pendingBaseIds and water is still low.
+      outcomes.set(key, outcome);
+    } catch (error) {
+      const message = String(error?.message || error);
+      // A base that no longer exists would otherwise be retried every day
+      // forever. Every other error leaves the enrollment alone.
+      if (/was not found/i.test(message)) {
+        removed.push(key);
+        counters.dropped += 1;
+        auditSafely("bases.auto-refill-water-unenrolled", { baseId, reason: "base no longer exists" });
+        return;
+      }
+      failures.push(`${baseId}: ${message}`);
+    }
+  }
+
+  async function run(baseIds, enrollment) {
+    const threshold = autoRefillWaterThresholdPercent(env);
+    const context = {
+      enrollment,
+      // Read once per scan: which bases already have an unflushed queue entry.
+      pendingBaseIds: new Set(duneDb.listQueuedWaterRefills(config.repoRoot).map((entry) => entry.baseId)),
+      // Observed once per scan and reused by every base's baseRefillTarget call
+      // below, rather than every base re-running the same world_partition scan.
+      observed: await duneDb.observeRefillPartitions(getDb()),
+      outcomes: new Map(),
+      removed: [],
+      failures: [],
+      counters: { checked: 0, queued: 0, dropped: 0, stalled: 0, alreadyQueued: 0 }
+    };
+    const { outcomes, removed, failures, counters } = context;
+
+    for (const key of baseIds) {
+      await scanBase(Number(key), threshold, context);
+    }
+
+    const status = failures.length ? (counters.checked ? "partial" : "fail") : "ok";
+    const detail = failures.length
+      ? redact(failures.join("; ")).slice(0, MAX_RUN_DETAIL_LENGTH)
+      : `Checked ${counters.checked}, queued ${counters.queued}`;
+    persistRunCompletion(now(), outcomes, removed, status, detail);
+
+    auditSafely("bases.auto-refill-water-scan", {
+      enrolled: baseIds.length,
+      thresholdPercent: threshold,
+      ...counters,
+      failures: failures.length,
+      status
+    });
+    return { status, ...counters, failures: failures.length };
+  }
+
+  async function tick() {
+    if (running) return;
+    const startedAt = now();
+    if (startedAt < nextAllowedAttemptAt) return;
+
+    const state = readAutoRefillWaterState(config.repoRoot);
+    const baseIds = Object.keys(state.bases);
+    // Idle cost is one small file read and no database query at all, so this
+    // can share the 10s background tick without adding load.
+    if (!baseIds.length) {
+      armedForThisProcess = false;
+      return;
+    }
+
+    const dueAtMs = Date.parse(state.nextRunAt || "") || 0;
+    if (!armedForThisProcess) {
+      armedForThisProcess = true;
+      if (!dueAtMs || dueAtMs <= startedAt) {
+        // Overdue at boot. Arm a few minutes out rather than a full interval:
+        // createAddonJobScheduler re-arms a whole interval, which is harmless at
+        // 30 minutes but at 24 hours would let a host that restarts more often
+        // than daily never scan at all. A few minutes also keeps the scan off
+        // the boot path, where the stack is still coming up.
+        writeAutoRefillWaterState(config.repoRoot, {
+          ...state,
+          nextRunAt: new Date(startedAt + overdueArmDelayMs).toISOString()
+        });
+        return;
+      }
+    }
+    if (!dueAtMs) {
+      writeAutoRefillWaterState(config.repoRoot, {
+        ...state,
+        nextRunAt: new Date(startedAt + intervalMs()).toISOString()
+      });
+      return;
+    }
+    if (startedAt < dueAtMs) return;
+
+    running = true;
+    try {
+      return await run(baseIds, state.bases);
+    } catch (error) {
+      // A failure that escapes run() must still move nextRunAt, or every tick
+      // retries it at the full tick rate.
+      nextAllowedAttemptAt = now() + failureBackoffMs;
+      persistRunCompletion(now(), new Map(), [], "fail", redact(String(error?.message || error)).slice(0, MAX_RUN_DETAIL_LENGTH));
+      throw error;
+    } finally {
+      running = false;
+    }
+  }
+
+  return {
+    tick,
+    publicState: () => autoRefillWaterPublicState(config.repoRoot, { env }),
+    thresholdPercent: () => autoRefillWaterThresholdPercent(env),
+    intervalHours: () => autoRefillWaterIntervalHours(env)
+  };
+}

--- a/console/api/src/services/baseRefillFlush.js
+++ b/console/api/src/services/baseRefillFlush.js
@@ -1,0 +1,27 @@
+import { redact } from "../redact.js";
+
+// A map restart must not begin its start/spawn half until both refill queues
+// have finished using the brief write-safe window. Promise.allSettled is
+// deliberate: if one queue fails, we still wait for the other rather than
+// returning early while it is writing to PostgreSQL.
+export async function flushBaseRefillQueues({ flushGenerators, flushWater }) {
+  const [generatorResult, waterResult] = await Promise.allSettled([
+    Promise.resolve().then(flushGenerators),
+    Promise.resolve().then(flushWater)
+  ]);
+
+  const flushed = [];
+  const failures = [];
+  if (generatorResult.status === "fulfilled") {
+    flushed.push(...(generatorResult.value?.flushed || []).map((entry) => ({ ...entry, refillType: "generator" })));
+  } else {
+    failures.push({ refillType: "generator", error: redact(String(generatorResult.reason?.message || generatorResult.reason)) });
+  }
+  if (waterResult.status === "fulfilled") {
+    flushed.push(...(waterResult.value?.flushed || []).map((entry) => ({ ...entry, refillType: "water" })));
+  } else {
+    failures.push({ refillType: "water", error: redact(String(waterResult.reason?.message || waterResult.reason)) });
+  }
+
+  return { flushed, failures };
+}

--- a/console/api/src/services/permissionSettings.js
+++ b/console/api/src/services/permissionSettings.js
@@ -1,0 +1,33 @@
+// The game caps how many permission entries one actor (a base's claim totem)
+// can hold. Read it from live server config rather than hardcoding: raising the
+// cap must be a settings edit, not a code change.
+//
+// Precedence is deliberately the OPPOSITE of parseEffectiveGuildMemberLimit.
+// The guild limit's legacy DuneGameMode field wins because an Advanced Editor
+// profile can carry both forms. Here the shipped DefaultGame.ini defines
+// m_MaxPermissionsPerActor=32 under [/Script/DuneSandbox.PermissionSettings] and
+// carries no such key in the DuneGameMode section at all, so the canonical
+// PermissionSettings field is the one the server actually enforces. Reading the
+// legacy field first would inherit its 20 as the default and silently cap
+// rosters below what the server permits.
+const DEFAULT_MAX_PERMISSIONS_PER_ACTOR = 32;
+
+export function parseEffectivePermissionLimit(stdout) {
+  const values = new Map();
+  for (const line of String(stdout || "").split(/\r?\n/)) {
+    const separator = line.indexOf("\t");
+    if (separator < 1) continue;
+    values.set(line.slice(0, separator), line.slice(separator + 1).trim());
+  }
+
+  const raw = values.get("permission_max_permissions_per_actor")
+    || values.get("max_permissions_per_actor")
+    || String(DEFAULT_MAX_PERMISSIONS_PER_ACTOR);
+  const limit = Number(raw);
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 2147483647) {
+    throw new Error("The configured maximum permissions per base is invalid.");
+  }
+  return limit;
+}
+
+export { DEFAULT_MAX_PERMISSIONS_PER_ACTOR };

--- a/console/api/src/tasks.js
+++ b/console/api/src/tasks.js
@@ -177,8 +177,15 @@ export class TaskManager {
     if (!this.onMapDown) return;
     try {
       const result = await this.onMapDown(operation);
-      const applied = (result?.flushed || []).filter((entry) => entry.ok).length;
-      if (applied) this.append(task, `Applied ${applied} queued generator refill${applied === 1 ? "" : "s"}.`, "stdout");
+      const applied = (result?.flushed || []).filter((entry) => entry.ok);
+      const generators = applied.filter((entry) => entry.refillType !== "water").length;
+      const water = applied.filter((entry) => entry.refillType === "water").length;
+      if (generators) this.append(task, `Applied ${generators} queued generator refill${generators === 1 ? "" : "s"}.`, "stdout");
+      if (water) this.append(task, `Applied ${water} queued water refill${water === 1 ? "" : "s"}.`, "stdout");
+      for (const failure of result?.failures || []) {
+        const label = failure.refillType === "water" ? "water refills" : "generator refills";
+        this.append(task, `Queued ${label} were not applied: ${failure.error || "unknown error"}`, "stderr");
+      }
     } catch (error) {
       this.append(task, `Queued generator refills were not applied: ${error?.message || error}`, "stderr");
     }

--- a/console/api/test-support/pgIntegrationDb.js
+++ b/console/api/test-support/pgIntegrationDb.js
@@ -1,0 +1,105 @@
+import { randomBytes } from "node:crypto";
+import pg from "pg";
+
+const { Pool, Client } = pg;
+
+// CREATE DATABASE / DROP DATABASE contend for the same cluster-wide catalog
+// state. Confirmed via a live CI run: once a third Postgres-backed
+// integration suite started running concurrently against the same server,
+// Postgres's own log showed two unrelated, live backends killed with
+// "FATAL: terminating connection due to administrator command" -- a real
+// server-side race, not a client-side artifact, and not caused by any bug in
+// the suites' own database-name scoping (each already uses a distinct,
+// randomly-suffixed name). A single fixed advisory lock, held only around
+// each test's own CREATE/DROP DATABASE calls -- never around the test body
+// itself -- forces those two operations to interleave one at a time across
+// every integration test file, while test bodies still run fully in
+// parallel against their own isolated databases.
+const DDL_LOCK_KEY = 847362910;
+
+export function pgConnectionConfig(database = "dune") {
+  if (process.env.ADMIN_DATABASE_URL) {
+    const url = new URL(process.env.ADMIN_DATABASE_URL);
+    url.pathname = `/${database}`;
+    return { connectionString: url.toString() };
+  }
+  return {
+    host: process.env.DUNE_DB_HOST || process.env.PGHOST || "127.0.0.1",
+    port: Number(process.env.DUNE_DB_PORT || process.env.PGPORT || process.env.POSTGRES_PORT || 15432),
+    database,
+    user: process.env.DUNE_DB_USER || process.env.PGUSER || "dune",
+    password: process.env.DUNE_DB_PASSWORD || process.env.PGPASSWORD || "dune",
+    connectionTimeoutMillis: 3000
+  };
+}
+
+export function pgTransactionalDb(pool) {
+  return {
+    query: (text, values = []) => pool.query(text, values),
+    async transaction(fn) {
+      const client = await pool.connect();
+      try {
+        await client.query("begin");
+        const result = await fn({ query: (text, values = []) => client.query(text, values) });
+        await client.query("commit");
+        return result;
+      } catch (error) {
+        await client.query("rollback").catch(() => {});
+        throw error;
+      } finally {
+        client.release();
+      }
+    }
+  };
+}
+
+async function withDdlLock(admin, fn) {
+  await admin.query("select pg_advisory_lock($1)", [DDL_LOCK_KEY]);
+  try {
+    return await fn();
+  } finally {
+    await admin.query("select pg_advisory_unlock($1)", [DDL_LOCK_KEY]).catch(() => {});
+  }
+}
+
+// Runs `run(pool, database)` against a throwaway, isolated Postgres database.
+// `admin` is a single dedicated Client (not a Pool) so the advisory lock it
+// takes and releases is unambiguously scoped to one session throughout.
+//
+// namePrefix must be unique per call site -- it's the first line of defence
+// against two suites ever colliding on a database name, independent of the
+// lock this helper adds.
+export async function withIsolatedDatabase(t, { namePrefix, unavailableLabel, createFailLabel }, run) {
+  const label = unavailableLabel || "this integration test";
+  const admin = new Client(pgConnectionConfig());
+  const database = `${namePrefix}_${process.pid}_${randomBytes(4).toString("hex")}`;
+  let pool;
+  try {
+    await admin.connect();
+  } catch (error) {
+    if (process.env.CI) throw new Error(`PostgreSQL is required for ${label}: ${error.message}`);
+    t.skip(`PostgreSQL unavailable: ${error.message}`);
+    return null;
+  }
+  try {
+    await withDdlLock(admin, () => admin.query(`create database "${database}"`));
+  } catch (error) {
+    await admin.end().catch(() => {});
+    if (process.env.CI) throw new Error(`PostgreSQL must allow an isolated database for ${createFailLabel || label}: ${error.message}`);
+    t.skip(`PostgreSQL cannot create an isolated test database: ${error.message}`);
+    return null;
+  }
+  try {
+    pool = new Pool({ ...pgConnectionConfig(database), max: 4 });
+    return await run(pool, database);
+  } finally {
+    await pool?.end().catch(() => {});
+    // Best-effort: catches any connection the pool's own end() missed.
+    await admin.query(
+      "select pg_terminate_backend(pid) from pg_stat_activity where datname = $1 and pid <> pg_backend_pid()",
+      [database]
+    ).catch(() => {});
+    await withDdlLock(admin, () => admin.query(`drop database if exists "${database}"`).catch(() => {}));
+    await admin.end().catch(() => {});
+  }
+}

--- a/console/api/test/autoRefill.test.js
+++ b/console/api/test/autoRefill.test.js
@@ -57,10 +57,17 @@ const TEST_ENV = {};
 function fakeDuneDb({
   levels = {},
   missingBases = [],
+  // Distinct from missingBases: the real baseMapLocation throws a different
+  // message for a base whose owner-entity link is broken (still exists) vs
+  // one that's genuinely gone. Only the latter should un-enroll -- collapsing
+  // the two would silently drop a base that still exists and may still need
+  // fuel, which is exactly the bug this option exists to guard against.
+  orphanedBases = [],
   target = { map: "Survival_1", partitionId: 3, queueSupported: true, writeSafeNow: false },
   calls = []
 } = {}) {
   const missing = new Set(missingBases.map(Number));
+  const orphaned = new Set(orphanedBases.map(Number));
   return {
     calls,
     baseGeneratorFuelLevels: async (_db, _repoRoot, baseId) => {
@@ -73,6 +80,7 @@ function fakeDuneDb({
     baseMapLocation: async (_db, baseId) => {
       calls.push({ fn: "baseMapLocation", baseId });
       if (missing.has(Number(baseId))) throw new Error("That base was not found.");
+      if (orphaned.has(Number(baseId))) throw new Error("This base has no resolvable owner entity, so its map location is unavailable.");
       return { map: "Survival_1", partitionId: 3 };
     },
     baseRefillTarget: async (_db, baseId) => {
@@ -381,6 +389,32 @@ test("a base that no longer exists is un-enrolled, but other failures keep their
     // un-enrolling it, so only 517 actually errored.
     assert.equal(state.lastRunStatus, "partial");
     assert.match(state.lastRunDetail, /517/);
+  });
+});
+
+test("a base with a broken owner-entity link is not un-enrolled, unlike a genuinely deleted base", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefill(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    writeAutoRefillState(repoRoot, { ...readAutoRefillState(repoRoot), nextRunAt: new Date(START).toISOString() });
+    const duneDb = fakeDuneDb({
+      // Reads as zero devices, same as a deleted base -- only baseMapLocation
+      // tells them apart, and it must not collapse "link broken" into "gone".
+      orphanedBases: [482],
+      levels: {}
+    });
+    const { scheduler, audits } = makeScheduler(repoRoot, duneDb, clock);
+
+    await scheduler.tick();
+    clock.advance(2000);
+    const result = await scheduler.tick();
+
+    const state = readAutoRefillState(repoRoot);
+    // The base still exists -- dropping it here could leave its generators
+    // unattended, so enrollment must survive.
+    assert.deepEqual(Object.keys(state.bases), ["482"]);
+    assert.equal(audits.some((entry) => entry.action === "bases.auto-refill-unenrolled"), false);
+    assert.equal(result.failures, 1);
   });
 });
 

--- a/console/api/test/autoRefillWater.test.js
+++ b/console/api/test/autoRefillWater.test.js
@@ -1,0 +1,427 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  autoRefillWaterPublicState,
+  createAutoRefillWaterScheduler,
+  isAutoRefillWaterEnabled,
+  readAutoRefillWaterState,
+  setBaseAutoRefillWater,
+  writeAutoRefillWaterState
+} from "../src/services/autoRefillWater.js";
+import { listQueuedWaterRefills, queueWaterRefill } from "../src/duneDb.js";
+
+// Mirrors autoRefill.test.js exactly, retargeted at the water auto-refill
+// subsystem -- same enrollment/scheduler mechanics, own files, own env vars.
+
+async function withTempRepoRoot(fn) {
+  const repoRoot = mkdtempSync(join(tmpdir(), "dune-auto-refill-water-"));
+  try {
+    return await fn(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+function statePath(repoRoot) {
+  return join(repoRoot, "runtime/generated/auto-refill-water-bases.json");
+}
+
+function writeRawState(repoRoot, text) {
+  mkdirSync(join(repoRoot, "runtime/generated"), { recursive: true });
+  writeFileSync(statePath(repoRoot), text);
+}
+
+const HOUR_MS = 3600000;
+const START = Date.UTC(2026, 6, 30, 12, 0, 0);
+
+function makeClock(start = START) {
+  let current = start;
+  return { now: () => current, advance: (ms) => { current += ms; }, at: () => current };
+}
+
+const TEST_ENV = {};
+
+function fakeDuneDb({
+  levels = {},
+  missingBases = [],
+  target = { map: "Survival_1", partitionId: 3, queueSupported: true, writeSafeNow: false },
+  calls = []
+} = {}) {
+  const missing = new Set(missingBases.map(Number));
+  return {
+    calls,
+    baseWaterFuelLevels: async (_db, baseId) => {
+      calls.push({ fn: "baseWaterFuelLevels", baseId });
+      const entry = levels[baseId];
+      if (entry instanceof Error) throw entry;
+      if (!entry) return { baseId, deviceCount: 0, devices: [], lowestPercent: null };
+      return { baseId, deviceCount: entry.deviceCount ?? 1, devices: [], lowestPercent: entry.lowestPercent };
+    },
+    baseMapLocation: async (_db, baseId) => {
+      calls.push({ fn: "baseMapLocation", baseId });
+      if (missing.has(Number(baseId))) throw new Error("That base was not found.");
+      return { map: "Survival_1", partitionId: 3 };
+    },
+    baseRefillTarget: async (_db, baseId) => {
+      calls.push({ fn: "baseRefillTarget", baseId });
+      return typeof target === "function" ? target(baseId) : target;
+    },
+    observeRefillPartitions: async () => {
+      calls.push({ fn: "observeRefillPartitions" });
+      return null;
+    },
+    queueWaterRefill,
+    listQueuedWaterRefills
+  };
+}
+
+function forceDue(repoRoot, clock) {
+  writeAutoRefillWaterState(repoRoot, { ...readAutoRefillWaterState(repoRoot), nextRunAt: new Date(clock.now()).toISOString() });
+}
+
+function drainQueue(repoRoot) {
+  writeFileSync(join(repoRoot, "runtime/generated/pending-water-refills.json"), "[]\n");
+}
+
+async function primeScheduler(scheduler, repoRoot, clock) {
+  forceDue(repoRoot, clock);
+  await scheduler.tick();
+  clock.advance(2000);
+}
+
+function makeScheduler(repoRoot, duneDb, clock, options = {}) {
+  const audits = [];
+  const scheduler = createAutoRefillWaterScheduler({
+    config: { repoRoot },
+    getDb: () => ({ query: async () => { throw new Error("the scheduler must not query the database directly"); } }),
+    duneDb,
+    now: clock.now,
+    auditImpl: (_config, _req, action, detail) => audits.push({ action, detail }),
+    env: TEST_ENV,
+    overdueArmDelayMs: 1000,
+    ...options
+  });
+  return { scheduler, audits };
+}
+
+// --- Enrollment store -------------------------------------------------------
+
+test("water auto-refill enrollment round-trips and is idempotent in both directions", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const clock = makeClock();
+    assert.deepEqual(readAutoRefillWaterState(repoRoot).bases, {});
+    assert.equal(isAutoRefillWaterEnabled(repoRoot, 482), false);
+
+    const first = setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    assert.deepEqual({ ok: first.ok, enabled: first.enabled, total: first.total }, { ok: true, enabled: true, total: 1 });
+    const enabledAt = readAutoRefillWaterState(repoRoot).bases["482"].enabledAt;
+
+    clock.advance(HOUR_MS);
+    const again = setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    assert.equal(again.total, 1);
+    assert.equal(readAutoRefillWaterState(repoRoot).bases["482"].enabledAt, enabledAt);
+    assert.equal(isAutoRefillWaterEnabled(repoRoot, 482), true);
+
+    setBaseAutoRefillWater(repoRoot, 517, true, { now: clock.now, env: TEST_ENV });
+    const off = setBaseAutoRefillWater(repoRoot, 482, false, { now: clock.now, env: TEST_ENV });
+    assert.deepEqual({ enabled: off.enabled, total: off.total }, { enabled: false, total: 1 });
+    assert.equal(setBaseAutoRefillWater(repoRoot, 482, false, { now: clock.now, env: TEST_ENV }).total, 1);
+  });
+});
+
+test("enabling water auto-refill arms the first scan a full interval out, and emptying the list disarms it", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    assert.equal(readAutoRefillWaterState(repoRoot).nextRunAt, new Date(START + 24 * HOUR_MS).toISOString());
+
+    setBaseAutoRefillWater(repoRoot, 517, true, { now: clock.now, env: TEST_ENV });
+    assert.equal(readAutoRefillWaterState(repoRoot).nextRunAt, new Date(START + 24 * HOUR_MS).toISOString());
+
+    setBaseAutoRefillWater(repoRoot, 482, false, { now: clock.now, env: TEST_ENV });
+    setBaseAutoRefillWater(repoRoot, 517, false, { now: clock.now, env: TEST_ENV });
+    assert.equal(readAutoRefillWaterState(repoRoot).nextRunAt, "");
+  });
+});
+
+test("a missing or corrupt water auto-refill enrollment file reads as empty instead of throwing", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    assert.deepEqual(readAutoRefillWaterState(repoRoot).bases, {});
+
+    writeRawState(repoRoot, "{not json");
+    assert.deepEqual(readAutoRefillWaterState(repoRoot).bases, {});
+
+    writeRawState(repoRoot, "[1,2,3]");
+    assert.deepEqual(readAutoRefillWaterState(repoRoot).bases, {});
+    writeRawState(repoRoot, JSON.stringify({ bases: [482] }));
+    assert.deepEqual(readAutoRefillWaterState(repoRoot).bases, {});
+
+    assert.equal(isAutoRefillWaterEnabled(repoRoot, 482), false);
+  });
+});
+
+test("water auto-refill enrollment is capped so a full scan can never overflow the refill queue", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const bases = {};
+    for (let baseId = 1; baseId <= 200; baseId += 1) bases[baseId] = { enabledAt: new Date(START).toISOString() };
+    writeAutoRefillWaterState(repoRoot, { bases, nextRunAt: new Date(START).toISOString() });
+    assert.equal(Object.keys(readAutoRefillWaterState(repoRoot).bases).length, 200);
+
+    assert.throws(() => setBaseAutoRefillWater(repoRoot, 5000, true, { env: TEST_ENV }), /already covers 200 bases/);
+    assert.equal(setBaseAutoRefillWater(repoRoot, 7, true, { env: TEST_ENV }).total, 200);
+  });
+});
+
+test("autoRefillWaterPublicState reports the tunables and a sorted base list", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefillWater(repoRoot, 517, true, { now: clock.now, env: TEST_ENV });
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+
+    const state = autoRefillWaterPublicState(repoRoot, { env: TEST_ENV });
+    assert.equal(state.thresholdPercent, 50);
+    assert.equal(state.intervalHours, 24);
+    assert.equal(state.total, 2);
+    assert.deepEqual(state.bases.map((entry) => entry.baseId), [482, 517]);
+  });
+});
+
+test("water threshold and interval clamp out-of-range overrides, independently of the generator env vars", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    assert.equal(autoRefillWaterPublicState(repoRoot, { env: { ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT: "0" } }).thresholdPercent, 1);
+    assert.equal(autoRefillWaterPublicState(repoRoot, { env: { ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT: "500" } }).thresholdPercent, 99);
+    assert.equal(autoRefillWaterPublicState(repoRoot, { env: { ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT: "nope" } }).thresholdPercent, 50);
+    assert.equal(autoRefillWaterPublicState(repoRoot, { env: { ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS: "0" } }).intervalHours, 1);
+    assert.equal(autoRefillWaterPublicState(repoRoot, { env: { ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS: "9999" } }).intervalHours, 168);
+    // Setting the *generator* env vars must not leak into the water tunables.
+    assert.equal(autoRefillWaterPublicState(repoRoot, { env: { ADMIN_AUTO_REFILL_THRESHOLD_PERCENT: "10" } }).thresholdPercent, 50);
+  });
+});
+
+// --- Scheduler --------------------------------------------------------------
+
+test("an empty water enrollment never touches the database", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    const clock = makeClock();
+    const duneDb = fakeDuneDb();
+    const { scheduler, audits } = makeScheduler(repoRoot, duneDb, clock);
+
+    await scheduler.tick();
+
+    assert.deepEqual(duneDb.calls, []);
+    assert.deepEqual(audits, []);
+  });
+});
+
+test("a water scan that is not yet due is a no-op", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    const duneDb = fakeDuneDb({ levels: { 482: { lowestPercent: 5 } } });
+    const { scheduler } = makeScheduler(repoRoot, duneDb, clock);
+
+    clock.advance(HOUR_MS);
+    await scheduler.tick();
+
+    assert.deepEqual(duneDb.calls, []);
+    assert.deepEqual(listQueuedWaterRefills(repoRoot), []);
+  });
+});
+
+test("a due water scan queues only the bases under the threshold", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    const clock = makeClock();
+    for (const baseId of [482, 517, 601]) setBaseAutoRefillWater(repoRoot, baseId, true, { now: clock.now, env: TEST_ENV });
+    writeAutoRefillWaterState(repoRoot, { ...readAutoRefillWaterState(repoRoot), nextRunAt: new Date(START).toISOString() });
+    const duneDb = fakeDuneDb({
+      levels: {
+        482: { lowestPercent: 20 },
+        517: { lowestPercent: 50 },
+        601: { lowestPercent: 49.9 }
+      }
+    });
+    const { scheduler, audits } = makeScheduler(repoRoot, duneDb, clock);
+
+    await scheduler.tick();
+    clock.advance(2000);
+    const result = await scheduler.tick();
+
+    assert.equal(result.queued, 2);
+    assert.equal(result.checked, 3);
+    assert.deepEqual(listQueuedWaterRefills(repoRoot).map((entry) => entry.baseId).sort((a, b) => a - b), [482, 601]);
+    assert.deepEqual(audits.filter((entry) => entry.action === "bases.auto-refill-water-queued").map((entry) => entry.detail.baseId), [482, 601]);
+    const scan = audits.find((entry) => entry.action === "bases.auto-refill-water-scan");
+    assert.deepEqual({ enrolled: scan.detail.enrolled, queued: scan.detail.queued, status: scan.detail.status }, { enrolled: 3, queued: 2, status: "ok" });
+
+    const state = readAutoRefillWaterState(repoRoot);
+    assert.equal(state.bases["517"].lastLowestPercent, 50);
+    assert.equal(state.bases["517"].lastQueuedAt, "");
+    assert.equal(state.bases["482"].lastQueuedAt, new Date(clock.at()).toISOString());
+    assert.equal(state.nextRunAt, new Date(clock.at() + 24 * HOUR_MS).toISOString());
+    assert.equal(state.lastRunStatus, "ok");
+  });
+});
+
+test("a base with no water storage is checked but never queued", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    writeAutoRefillWaterState(repoRoot, { ...readAutoRefillWaterState(repoRoot), nextRunAt: new Date(START).toISOString() });
+    const duneDb = fakeDuneDb({ levels: { 482: { lowestPercent: null, deviceCount: 0 } } });
+    const { scheduler } = makeScheduler(repoRoot, duneDb, clock);
+
+    await scheduler.tick();
+    clock.advance(2000);
+    const result = await scheduler.tick();
+
+    assert.equal(result.queued, 0);
+    assert.deepEqual(listQueuedWaterRefills(repoRoot), []);
+    assert.equal(readAutoRefillWaterState(repoRoot).bases["482"].lastLowestPercent, null);
+  });
+});
+
+test("a base that no longer exists is un-enrolled from water auto-refill, but other failures keep their enrollment", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    const clock = makeClock();
+    for (const baseId of [482, 517]) setBaseAutoRefillWater(repoRoot, baseId, true, { now: clock.now, env: TEST_ENV });
+    writeAutoRefillWaterState(repoRoot, { ...readAutoRefillWaterState(repoRoot), nextRunAt: new Date(START).toISOString() });
+    const duneDb = fakeDuneDb({
+      missingBases: [482],
+      levels: {
+        517: new Error("connection terminated unexpectedly")
+      }
+    });
+    const { scheduler, audits } = makeScheduler(repoRoot, duneDb, clock);
+
+    await scheduler.tick();
+    clock.advance(2000);
+    const result = await scheduler.tick();
+
+    const state = readAutoRefillWaterState(repoRoot);
+    assert.deepEqual(Object.keys(state.bases), ["517"]);
+    assert.equal(audits.some((entry) => entry.action === "bases.auto-refill-water-unenrolled" && entry.detail.baseId === 482), true);
+    assert.equal(result.failures, 1);
+    assert.equal(state.lastRunStatus, "partial");
+    assert.match(state.lastRunDetail, /517/);
+  });
+});
+
+test("a base whose database lost queue support is not water-refilled directly", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    writeAutoRefillWaterState(repoRoot, { ...readAutoRefillWaterState(repoRoot), nextRunAt: new Date(START).toISOString() });
+    const duneDb = fakeDuneDb({
+      levels: { 482: { lowestPercent: 5 } },
+      target: { map: "Survival_1", partitionId: 3, queueSupported: false, writeSafeNow: true }
+    });
+    const { scheduler } = makeScheduler(repoRoot, duneDb, clock);
+
+    await scheduler.tick();
+    clock.advance(2000);
+    const result = await scheduler.tick();
+
+    assert.equal(result.queued, 0);
+    assert.equal(result.failures, 1);
+    assert.deepEqual(listQueuedWaterRefills(repoRoot), []);
+  });
+});
+
+test("a water scan leaves an already-queued base alone instead of resetting its attempts", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    writeAutoRefillWaterState(repoRoot, { ...readAutoRefillWaterState(repoRoot), nextRunAt: new Date(START).toISOString() });
+    queueWaterRefill(repoRoot, { baseId: 482, map: "Survival_1", partitionId: 3 });
+    const queued = listQueuedWaterRefills(repoRoot);
+    writeFileSync(
+      join(repoRoot, "runtime/generated/pending-water-refills.json"),
+      `${JSON.stringify([{ ...queued[0], attempts: 2, lastError: "relation does not exist" }], null, 2)}\n`
+    );
+    const duneDb = fakeDuneDb({ levels: { 482: { lowestPercent: 10 } } });
+    const { scheduler } = makeScheduler(repoRoot, duneDb, clock);
+
+    await scheduler.tick();
+    clock.advance(2000);
+    const result = await scheduler.tick();
+
+    const after = listQueuedWaterRefills(repoRoot);
+    assert.equal(after.length, 1);
+    assert.equal(after[0].attempts, 2);
+    assert.equal(result.queued, 0);
+    assert.equal(result.alreadyQueued, 1);
+    assert.equal(readAutoRefillWaterState(repoRoot).bases["482"].consecutiveQueues, 0);
+    assert.equal(readAutoRefillWaterState(repoRoot).bases["482"].stalledAt, "");
+  });
+});
+
+test("a base whose water refills never take effect stops being queued after three cycles", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    const duneDb = fakeDuneDb({ levels: { 482: { lowestPercent: 10 } } });
+    const { scheduler, audits } = makeScheduler(repoRoot, duneDb, clock);
+    await primeScheduler(scheduler, repoRoot, clock);
+
+    const queuedPerCycle = [];
+    for (let cycle = 0; cycle < 5; cycle += 1) {
+      forceDue(repoRoot, clock);
+      const result = await scheduler.tick();
+      queuedPerCycle.push(result?.queued ?? 0);
+      drainQueue(repoRoot);
+      clock.advance(24 * HOUR_MS);
+    }
+
+    assert.deepEqual(queuedPerCycle, [1, 1, 1, 0, 0]);
+    const entry = readAutoRefillWaterState(repoRoot).bases["482"];
+    assert.equal(entry.consecutiveQueues, 3);
+    assert.notEqual(entry.stalledAt, "");
+    assert.equal(audits.filter((a) => a.action === "bases.auto-refill-water-stalled").length, 1);
+    assert.equal(audits.filter((a) => a.action === "bases.auto-refill-water-queued").length, 3);
+  });
+});
+
+test("a base that comes back above the water threshold clears its stall", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    const levels = { 482: { lowestPercent: 10 } };
+    const duneDb = fakeDuneDb({ levels });
+    const { scheduler } = makeScheduler(repoRoot, duneDb, clock);
+    await primeScheduler(scheduler, repoRoot, clock);
+
+    for (let cycle = 0; cycle < 4; cycle += 1) {
+      forceDue(repoRoot, clock);
+      await scheduler.tick();
+      drainQueue(repoRoot);
+      clock.advance(24 * HOUR_MS);
+    }
+    assert.equal(readAutoRefillWaterState(repoRoot).bases["482"].consecutiveQueues, 3);
+
+    levels[482] = { lowestPercent: 100 };
+    forceDue(repoRoot, clock);
+    await scheduler.tick();
+
+    const recovered = readAutoRefillWaterState(repoRoot).bases["482"];
+    assert.equal(recovered.consecutiveQueues, 0);
+    assert.equal(recovered.stalledAt, "");
+
+    levels[482] = { lowestPercent: 10 };
+    clock.advance(24 * HOUR_MS);
+    forceDue(repoRoot, clock);
+    const result = await scheduler.tick();
+    assert.equal(result.queued, 1);
+  });
+});
+
+test("the water auto-refill enrollment file is written atomically with owner-only permissions", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    setBaseAutoRefillWater(repoRoot, 482, true, { env: TEST_ENV });
+    const raw = readFileSync(statePath(repoRoot), "utf8");
+    assert.equal(raw.endsWith("}\n"), true);
+    assert.equal(JSON.parse(raw).schemaVersion, 1);
+  });
+});

--- a/console/api/test/basePermissions.integration.test.js
+++ b/console/api/test/basePermissions.integration.test.js
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { randomBytes } from "node:crypto";
 import pg from "pg";
-import { setBasePermissions, listBasePermissions, basePermissionCandidates } from "../src/duneDb.js";
+import { setBasePermissions, listBasePermissions, basePermissionCandidates, baseMapLocation } from "../src/duneDb.js";
 
 const { Pool, Client } = pg;
 
@@ -78,8 +78,9 @@ const SCHEMA = `
 
   create table dune.buildings (id bigint primary key);
   -- owner_entity_id is nullable in production: it carries an
-  -- ON DELETE SET NULL foreign key against fgl_entities.
-  create table dune.building_instances (building_id bigint not null, owner_entity_id bigint);
+  -- ON DELETE SET NULL foreign key against fgl_entities. instance_id is the
+  -- per-piece tiebreak basePermissionActor/baseMapLocation order by.
+  create table dune.building_instances (building_id bigint not null, instance_id integer not null, owner_entity_id bigint);
   create table dune.actor_fgl_entities (entity_id bigint not null, actor_id bigint not null);
   create table dune.actors (id bigint primary key, map text, partition_id bigint, owner_account_id bigint);
   create table dune.map_names (map_name_id smallint primary key, map_name text not null);
@@ -119,7 +120,7 @@ const SCHEMA = `
 
 const SEED = `
   insert into dune.buildings (id) values (${BASE_ID});
-  insert into dune.building_instances (building_id, owner_entity_id) values (${BASE_ID}, ${ENTITY_ID});
+  insert into dune.building_instances (building_id, instance_id, owner_entity_id) values (${BASE_ID}, 0, ${ENTITY_ID});
   insert into dune.actor_fgl_entities (entity_id, actor_id) values (${ENTITY_ID}, ${ACTOR_ID});
   insert into dune.actors (id, map, partition_id, owner_account_id) values (${ACTOR_ID}, '${MAP_NAME}', 8, null);
   insert into dune.map_names (map_name_id, map_name) values (${MAP_NAME_ID}, '${MAP_NAME}');
@@ -327,7 +328,7 @@ test("real PostgreSQL: a base with a broken owner-entity link gets a clear error
   await withDatabase(t, async (pool) => {
     const orphanBaseId = 2000;
     await pool.query("insert into dune.buildings (id) values ($1)", [orphanBaseId]);
-    await pool.query("insert into dune.building_instances (building_id, owner_entity_id) values ($1, null)", [orphanBaseId]);
+    await pool.query("insert into dune.building_instances (building_id, instance_id, owner_entity_id) values ($1, 0, null)", [orphanBaseId]);
 
     const db = transactionalDb(pool);
     await assert.rejects(
@@ -338,6 +339,46 @@ test("real PostgreSQL: a base with a broken owner-entity link gets a clear error
     await assert.rejects(
       () => listBasePermissions(db, 999999),
       /That base was not found/);
+  });
+});
+
+// A base can legitimately have several building_instances rows ("pieces") --
+// listBases' piece_count and exportBaseAsBlueprint's multi-piece fetch both
+// depend on that. Before the left-join fix's order by, an orphaned piece
+// could nondeterministically beat a sibling piece that resolves fine. This
+// seeds one orphaned piece alongside the SEED's already-valid piece on the
+// same base and proves resolution is stable regardless of insertion order.
+test("real PostgreSQL: a base with one orphaned piece and one valid piece still resolves the valid one", async (t) => {
+  await withDatabase(t, async (pool) => {
+    // instance_id 1, inserted after the SEED's valid instance_id 0 -- if the
+    // missing order by regressed, an unordered LIMIT 1 could return this one.
+    await pool.query("insert into dune.building_instances (building_id, instance_id, owner_entity_id) values ($1, 1, null)", [BASE_ID]);
+
+    const db = transactionalDb(pool);
+    const roster = await listBasePermissions(db, BASE_ID);
+    assert.equal(roster.actorId, String(ACTOR_ID));
+
+    const location = await baseMapLocation(db, BASE_ID);
+    assert.equal(location.map, MAP_NAME);
+  });
+});
+
+test("real PostgreSQL: baseMapLocation distinguishes a broken owner-entity link from a missing base id", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const orphanBaseId = 2001;
+    await pool.query("insert into dune.buildings (id) values ($1)", [orphanBaseId]);
+    await pool.query("insert into dune.building_instances (building_id, instance_id, owner_entity_id) values ($1, 0, null)", [orphanBaseId]);
+
+    const db = transactionalDb(pool);
+    await assert.rejects(
+      () => baseMapLocation(db, orphanBaseId),
+      /no resolvable owner entity/);
+    await assert.rejects(
+      () => baseMapLocation(db, 999999),
+      /That base was not found/);
+    // The unbroken case is unaffected.
+    const location = await baseMapLocation(db, BASE_ID);
+    assert.equal(location.map, MAP_NAME);
   });
 });
 

--- a/console/api/test/basePermissions.integration.test.js
+++ b/console/api/test/basePermissions.integration.test.js
@@ -1,10 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { randomBytes } from "node:crypto";
 import pg from "pg";
 import { setBasePermissions, listBasePermissions, basePermissionCandidates, baseMapLocation } from "../src/duneDb.js";
+import { pgConnectionConfig, pgTransactionalDb, withIsolatedDatabase } from "../test-support/pgIntegrationDb.js";
 
-const { Pool, Client } = pg;
+const { Client } = pg;
 
 // The mocked suite in basePermissions.test.js string-matches SQL and can prove
 // what we *intend* to send. It cannot catch the failures that only a real
@@ -36,42 +36,6 @@ const ACTOR_ID = 1004;
 const ENTITY_ID = 5001;
 const MAP_NAME = "DeepDesert";
 const MAP_NAME_ID = 7;
-
-function connectionConfig(database = "dune") {
-  if (process.env.ADMIN_DATABASE_URL) {
-    const url = new URL(process.env.ADMIN_DATABASE_URL);
-    url.pathname = `/${database}`;
-    return { connectionString: url.toString() };
-  }
-  return {
-    host: process.env.DUNE_DB_HOST || process.env.PGHOST || "127.0.0.1",
-    port: Number(process.env.DUNE_DB_PORT || process.env.PGPORT || process.env.POSTGRES_PORT || 15432),
-    database,
-    user: process.env.DUNE_DB_USER || process.env.PGUSER || "dune",
-    password: process.env.DUNE_DB_PASSWORD || process.env.PGPASSWORD || "dune",
-    connectionTimeoutMillis: 3000
-  };
-}
-
-function transactionalDb(pool) {
-  return {
-    query: (text, values = []) => pool.query(text, values),
-    async transaction(fn) {
-      const client = await pool.connect();
-      try {
-        await client.query("begin");
-        const result = await fn({ query: (text, values = []) => client.query(text, values) });
-        await client.query("commit");
-        return result;
-      } catch (error) {
-        await client.query("rollback").catch(() => {});
-        throw error;
-      } finally {
-        client.release();
-      }
-    }
-  };
-}
 
 const SCHEMA = `
   create schema dune;
@@ -136,35 +100,14 @@ const SEED = `
 `;
 
 async function withDatabase(t, run) {
-  const admin = new Pool(connectionConfig());
-  const database = `dune_perms_${process.pid}_${randomBytes(4).toString("hex")}`;
-  let pool;
-  try {
-    await admin.query("select 1");
-  } catch (error) {
-    await admin.end().catch(() => {});
-    if (process.env.CI) throw new Error(`PostgreSQL is required for the base permission integration test: ${error.message}`);
-    t.skip(`PostgreSQL unavailable: ${error.message}`);
-    return null;
-  }
-  try {
-    await admin.query(`create database "${database}"`);
-  } catch (error) {
-    await admin.end().catch(() => {});
-    if (process.env.CI) throw new Error(`PostgreSQL must allow an isolated test database: ${error.message}`);
-    t.skip(`PostgreSQL cannot create an isolated test database: ${error.message}`);
-    return null;
-  }
-  try {
-    pool = new Pool({ ...connectionConfig(database), max: 4 });
+  return withIsolatedDatabase(t, {
+    namePrefix: "dune_perms",
+    unavailableLabel: "the base permission integration test"
+  }, async (pool, database) => {
     await pool.query(SCHEMA);
     await pool.query(SEED);
-    return await run(pool, database);
-  } finally {
-    await pool?.end().catch(() => {});
-    await admin.query(`drop database if exists "${database}" with (force)`).catch(() => {});
-    await admin.end().catch(() => {});
-  }
+    return run(pool, database);
+  });
 }
 
 async function ranks(pool) {
@@ -176,7 +119,7 @@ async function ranks(pool) {
 
 test("real PostgreSQL: a roster save writes through the shipped procedures with the right argument order", async (t) => {
   await withDatabase(t, async (pool) => {
-    const db = transactionalDb(pool);
+    const db = pgTransactionalDb(pool);
     const result = await setBasePermissions(db, BASE_ID, [
       { playerId: "4", rank: OWNER_RANK },
       { playerId: "23", rank: ASSOCIATE_RANK }
@@ -195,7 +138,7 @@ test("real PostgreSQL: a roster save writes through the shipped procedures with 
 
 test("real PostgreSQL: promoting swaps the owner without ever leaving two", async (t) => {
   await withDatabase(t, async (pool) => {
-    const db = transactionalDb(pool);
+    const db = pgTransactionalDb(pool);
     await setBasePermissions(db, BASE_ID, [
       { playerId: "4", rank: OWNER_RANK },
       { playerId: "23", rank: CO_OWNER_RANK }
@@ -216,7 +159,7 @@ test("real PostgreSQL: promoting swaps the owner without ever leaving two", asyn
 
 test("real PostgreSQL: removing a player deletes only that rank row", async (t) => {
   await withDatabase(t, async (pool) => {
-    const db = transactionalDb(pool);
+    const db = pgTransactionalDb(pool);
     await setBasePermissions(db, BASE_ID, [
       { playerId: "4", rank: OWNER_RANK },
       { playerId: "23", rank: ASSOCIATE_RANK },
@@ -240,13 +183,13 @@ test("real PostgreSQL: removing a player deletes only that rank row", async (t) 
 // notification the game receives is only valid if we pass the numeric id.
 test("real PostgreSQL: the emitted notification payload is well-formed JSON carrying the numeric map id", async (t) => {
   await withDatabase(t, async (pool, database) => {
-    const listener = new Client(connectionConfig(database));
+    const listener = new Client(pgConnectionConfig(database));
     const received = [];
     await listener.connect();
     listener.on("notification", (message) => received.push(message.payload));
     await listener.query("listen permission_notify_channel");
 
-    const db = transactionalDb(pool);
+    const db = pgTransactionalDb(pool);
     await setBasePermissions(db, BASE_ID, [
       { playerId: "4", rank: OWNER_RANK },
       { playerId: "23", rank: ASSOCIATE_RANK }
@@ -272,7 +215,7 @@ test("real PostgreSQL: the emitted notification payload is well-formed JSON carr
 // successful save. Confirmed against a live server before this guard existed.
 test("real PostgreSQL: a player id that is not a player_controller_id is refused", async (t) => {
   await withDatabase(t, async (pool) => {
-    const db = transactionalDb(pool);
+    const db = pgTransactionalDb(pool);
     await assert.rejects(
       () => setBasePermissions(db, BASE_ID, [
         { playerId: "4", rank: OWNER_RANK },
@@ -286,7 +229,7 @@ test("real PostgreSQL: a player id that is not a player_controller_id is refused
 
 test("real PostgreSQL: the roster reads back with resolved names and rank labels", async (t) => {
   await withDatabase(t, async (pool) => {
-    const db = transactionalDb(pool);
+    const db = pgTransactionalDb(pool);
     await setBasePermissions(db, BASE_ID, [
       { playerId: "4", rank: OWNER_RANK },
       { playerId: "29", rank: CO_OWNER_RANK }
@@ -308,7 +251,7 @@ test("real PostgreSQL: a rank row on a non-canonical actor is surfaced, not hidd
   await withDatabase(t, async (pool) => {
     await pool.query("insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values ($1, 5, $2)",
       [ACTOR_ID, ASSOCIATE_RANK]);
-    const roster = await listBasePermissions(transactionalDb(pool), BASE_ID);
+    const roster = await listBasePermissions(pgTransactionalDb(pool), BASE_ID);
     const orphan = roster.entries.find((entry) => entry.playerId === "5");
     assert.ok(orphan, "the ignored row must still be listed");
     assert.equal(orphan.canonical, false);
@@ -330,7 +273,7 @@ test("real PostgreSQL: a base with a broken owner-entity link gets a clear error
     await pool.query("insert into dune.buildings (id) values ($1)", [orphanBaseId]);
     await pool.query("insert into dune.building_instances (building_id, instance_id, owner_entity_id) values ($1, 0, null)", [orphanBaseId]);
 
-    const db = transactionalDb(pool);
+    const db = pgTransactionalDb(pool);
     await assert.rejects(
       () => listBasePermissions(db, orphanBaseId),
       /no resolvable owner entity/);
@@ -354,7 +297,7 @@ test("real PostgreSQL: a base with one orphaned piece and one valid piece still 
     // missing order by regressed, an unordered LIMIT 1 could return this one.
     await pool.query("insert into dune.building_instances (building_id, instance_id, owner_entity_id) values ($1, 1, null)", [BASE_ID]);
 
-    const db = transactionalDb(pool);
+    const db = pgTransactionalDb(pool);
     const roster = await listBasePermissions(db, BASE_ID);
     assert.equal(roster.actorId, String(ACTOR_ID));
 
@@ -369,7 +312,7 @@ test("real PostgreSQL: baseMapLocation distinguishes a broken owner-entity link 
     await pool.query("insert into dune.buildings (id) values ($1)", [orphanBaseId]);
     await pool.query("insert into dune.building_instances (building_id, instance_id, owner_entity_id) values ($1, 0, null)", [orphanBaseId]);
 
-    const db = transactionalDb(pool);
+    const db = pgTransactionalDb(pool);
     await assert.rejects(
       () => baseMapLocation(db, orphanBaseId),
       /no resolvable owner entity/);
@@ -384,7 +327,7 @@ test("real PostgreSQL: baseMapLocation distinguishes a broken owner-entity link 
 
 test("real PostgreSQL: the candidate picker returns player_controller_ids and excludes system accounts", async (t) => {
   await withDatabase(t, async (pool) => {
-    const candidates = await basePermissionCandidates(transactionalDb(pool), { limit: 50 });
+    const candidates = await basePermissionCandidates(pgTransactionalDb(pool), { limit: 50 });
     const ids = candidates.map((row) => row.playerId);
     assert.deepEqual(ids.sort(), ["23", "29", "4"].sort());
     assert.ok(!candidates.some((row) => row.name === "Server"), "system accounts must not be offered");

--- a/console/api/test/basePermissions.integration.test.js
+++ b/console/api/test/basePermissions.integration.test.js
@@ -77,7 +77,9 @@ const SCHEMA = `
   create schema dune;
 
   create table dune.buildings (id bigint primary key);
-  create table dune.building_instances (building_id bigint not null, owner_entity_id bigint not null);
+  -- owner_entity_id is nullable in production: it carries an
+  -- ON DELETE SET NULL foreign key against fgl_entities.
+  create table dune.building_instances (building_id bigint not null, owner_entity_id bigint);
   create table dune.actor_fgl_entities (entity_id bigint not null, actor_id bigint not null);
   create table dune.actors (id bigint primary key, map text, partition_id bigint, owner_account_id bigint);
   create table dune.map_names (map_name_id smallint primary key, map_name text not null);
@@ -312,6 +314,30 @@ test("real PostgreSQL: a rank row on a non-canonical actor is surfaced, not hidd
     // The name still resolves through the account, which is why the console can
     // show it meaningfully rather than as a bare id.
     assert.equal(orphan.name, "DarkShark");
+  });
+});
+
+// building_instances.owner_entity_id is nullable in production (ON DELETE SET
+// NULL against fgl_entities), so a base can exist in dune.buildings while its
+// owning entity link is broken. That must surface a distinct, clear error --
+// not the same "not found" message a genuinely deleted base id gets, which
+// would read as a client-side glitch to an operator looking at a base that is
+// plainly visible in the table.
+test("real PostgreSQL: a base with a broken owner-entity link gets a clear error, not 'not found'", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const orphanBaseId = 2000;
+    await pool.query("insert into dune.buildings (id) values ($1)", [orphanBaseId]);
+    await pool.query("insert into dune.building_instances (building_id, owner_entity_id) values ($1, null)", [orphanBaseId]);
+
+    const db = transactionalDb(pool);
+    await assert.rejects(
+      () => listBasePermissions(db, orphanBaseId),
+      /no resolvable owner entity/);
+    // A genuinely nonexistent base id must still get the original message --
+    // the left-join restructuring must not blur the two cases together.
+    await assert.rejects(
+      () => listBasePermissions(db, 999999),
+      /That base was not found/);
   });
 });
 

--- a/console/api/test/basePermissions.integration.test.js
+++ b/console/api/test/basePermissions.integration.test.js
@@ -50,7 +50,7 @@ const SCHEMA = `
   create table dune.map_names (map_name_id smallint primary key, map_name text not null);
   create table dune.permission_actor (actor_id bigint primary key, actor_name text);
   create table dune.permission_actor_rank (permission_actor_id bigint not null, player_id bigint not null, rank smallint not null);
-  create table dune.player_state (account_id bigint, player_controller_id bigint, character_name text);
+  create table dune.player_state (account_id bigint, player_controller_id bigint, player_pawn_id bigint, character_name text);
 
   create function dune.permission_actor_create_or_update_base_marker(in_actor_id bigint, in_player_id bigint, in_rank smallint)
   returns void language plpgsql as $$ begin return; end $$;
@@ -93,8 +93,14 @@ const SEED = `
   -- Account 2 owns three actor rows; only player_controller_id 4 is a real
   -- permission holder. Ids 5 and 6 exist to prove they are rejected.
   insert into dune.actors (id, owner_account_id) values (4, 2), (5, 2), (6, 2), (23, 6), (29, 8);
-  insert into dune.player_state (account_id, player_controller_id, character_name)
-    values (2, 4, 'DarkShark'), (6, 23, 'Furizu'), (8, 29, 'Yaida'), (99, 900000201, 'Server');
+  insert into dune.player_state (account_id, player_controller_id, player_pawn_id, character_name)
+    values
+      (2, 4, 4, 'DarkShark'),
+      (6, 23, 23, 'Furizu'),
+      (8, 29, 29, 'Yaida'),
+      (99, 900000201, 900000201, 'Server'),
+      (100, 900000202, 900000103, 'GM'),
+      (101, 900000103, 900000203, 'Reserved GM Controller');
 
   insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values (${ACTOR_ID}, 4, ${OWNER_RANK});
 `;
@@ -331,6 +337,8 @@ test("real PostgreSQL: the candidate picker returns player_controller_ids and ex
     const ids = candidates.map((row) => row.playerId);
     assert.deepEqual(ids.sort(), ["23", "29", "4"].sort());
     assert.ok(!candidates.some((row) => row.name === "Server"), "system accounts must not be offered");
+    assert.ok(!candidates.some((row) => row.name === "GM"), "the reserved GM pawn must not be offered");
+    assert.ok(!candidates.some((row) => row.name === "Reserved GM Controller"), "the reserved GM controller must not be offered");
     // 5 and 6 belong to the same account as 4 but are not controller ids.
     assert.ok(!ids.includes("5") && !ids.includes("6"));
   });

--- a/console/api/test/basePermissions.integration.test.js
+++ b/console/api/test/basePermissions.integration.test.js
@@ -1,0 +1,327 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import pg from "pg";
+import { setBasePermissions, listBasePermissions, basePermissionCandidates } from "../src/duneDb.js";
+
+const { Pool, Client } = pg;
+
+// The mocked suite in basePermissions.test.js string-matches SQL and can prove
+// what we *intend* to send. It cannot catch the failures that only a real
+// PostgreSQL round trip surfaces, and this feature has three of them:
+//
+//   1. Transposed arguments. permission_set_player_rank(actor_id, player_id, ..)
+//      takes two bigints; swapping them is invisible to a mock and writes a rank
+//      row keyed on the wrong column against a live database.
+//   2. search_path. The shipped procedures reference their tables unqualified
+//      and carry no `SET search_path`, so they resolve only because the console
+//      connects as a role whose default path reaches the dune schema.
+//   3. The notify payload. permission_set_player_rank interpolates its map
+//      argument into JSON *unquoted*, so passing a map name rather than the
+//      numeric dune.map_names id emits malformed JSON to the game server.
+//
+// The procedure bodies below are transcribed from the shipped schema so those
+// three can be exercised for real. permission_actor_create_or_update_base_marker
+// is stubbed: the real one rebuilds map markers, which is the game's concern,
+// not ours -- what matters here is that our call reaches the procedure with the
+// right arguments and that the notification it emits is well formed.
+const OWNER_RANK = 1;
+const CO_OWNER_RANK = 2;
+const ASSOCIATE_RANK = 3;
+
+// Deliberately different values, mirroring production where the displayed base
+// id and the permission actor id never match.
+const BASE_ID = 1006;
+const ACTOR_ID = 1004;
+const ENTITY_ID = 5001;
+const MAP_NAME = "DeepDesert";
+const MAP_NAME_ID = 7;
+
+function connectionConfig(database = "dune") {
+  if (process.env.ADMIN_DATABASE_URL) {
+    const url = new URL(process.env.ADMIN_DATABASE_URL);
+    url.pathname = `/${database}`;
+    return { connectionString: url.toString() };
+  }
+  return {
+    host: process.env.DUNE_DB_HOST || process.env.PGHOST || "127.0.0.1",
+    port: Number(process.env.DUNE_DB_PORT || process.env.PGPORT || process.env.POSTGRES_PORT || 15432),
+    database,
+    user: process.env.DUNE_DB_USER || process.env.PGUSER || "dune",
+    password: process.env.DUNE_DB_PASSWORD || process.env.PGPASSWORD || "dune",
+    connectionTimeoutMillis: 3000
+  };
+}
+
+function transactionalDb(pool) {
+  return {
+    query: (text, values = []) => pool.query(text, values),
+    async transaction(fn) {
+      const client = await pool.connect();
+      try {
+        await client.query("begin");
+        const result = await fn({ query: (text, values = []) => client.query(text, values) });
+        await client.query("commit");
+        return result;
+      } catch (error) {
+        await client.query("rollback").catch(() => {});
+        throw error;
+      } finally {
+        client.release();
+      }
+    }
+  };
+}
+
+const SCHEMA = `
+  create schema dune;
+
+  create table dune.buildings (id bigint primary key);
+  create table dune.building_instances (building_id bigint not null, owner_entity_id bigint not null);
+  create table dune.actor_fgl_entities (entity_id bigint not null, actor_id bigint not null);
+  create table dune.actors (id bigint primary key, map text, partition_id bigint, owner_account_id bigint);
+  create table dune.map_names (map_name_id smallint primary key, map_name text not null);
+  create table dune.permission_actor (actor_id bigint primary key, actor_name text);
+  create table dune.permission_actor_rank (permission_actor_id bigint not null, player_id bigint not null, rank smallint not null);
+  create table dune.player_state (account_id bigint, player_controller_id bigint, character_name text);
+
+  create function dune.permission_actor_create_or_update_base_marker(in_actor_id bigint, in_player_id bigint, in_rank smallint)
+  returns void language plpgsql as $$ begin return; end $$;
+
+  create function dune.permission_set_player_rank(in_actor_id bigint, in_player_id bigint, in_rank smallint, in_map_id text)
+  returns void language plpgsql as $$
+  declare found_actor_id bigint;
+  begin
+    select permission_actor_id from permission_actor_rank
+      where permission_actor_id = in_actor_id and player_id = in_player_id into found_actor_id;
+    if not found then
+      insert into permission_actor_rank(permission_actor_id, player_id, rank) values(in_actor_id, in_player_id, in_rank);
+    else
+      update permission_actor_rank set rank = in_rank
+        where permission_actor_rank.permission_actor_id = in_actor_id and player_id = in_player_id;
+    end if;
+    perform permission_actor_create_or_update_base_marker(in_actor_id, in_player_id, in_rank);
+    perform pg_notify('permission_notify_channel',
+      format('set_rank#{"ActorId" : %s , "PlayerId" : %s, "PlayerGuildId" : %s, "Rank" : %s, "Map" : %s}',
+             in_actor_id, in_player_id, 0, in_rank, in_map_id));
+  end $$;
+
+  create function dune.permission_remove_player_rank(in_actor_id bigint, in_player_id bigint)
+  returns void language plpgsql as $$
+  begin
+    delete from permission_actor_rank where permission_actor_id = in_actor_id and player_id = in_player_id;
+    perform pg_notify('permission_notify_channel',
+      format('remove_rank#{"ActorId" : %s , "PlayerId" : %s}', in_actor_id, in_player_id));
+  end $$;
+`;
+
+const SEED = `
+  insert into dune.buildings (id) values (${BASE_ID});
+  insert into dune.building_instances (building_id, owner_entity_id) values (${BASE_ID}, ${ENTITY_ID});
+  insert into dune.actor_fgl_entities (entity_id, actor_id) values (${ENTITY_ID}, ${ACTOR_ID});
+  insert into dune.actors (id, map, partition_id, owner_account_id) values (${ACTOR_ID}, '${MAP_NAME}', 8, null);
+  insert into dune.map_names (map_name_id, map_name) values (${MAP_NAME_ID}, '${MAP_NAME}');
+  insert into dune.permission_actor (actor_id, actor_name) values (${ACTOR_ID}, 'DD Test');
+
+  -- Account 2 owns three actor rows; only player_controller_id 4 is a real
+  -- permission holder. Ids 5 and 6 exist to prove they are rejected.
+  insert into dune.actors (id, owner_account_id) values (4, 2), (5, 2), (6, 2), (23, 6), (29, 8);
+  insert into dune.player_state (account_id, player_controller_id, character_name)
+    values (2, 4, 'DarkShark'), (6, 23, 'Furizu'), (8, 29, 'Yaida'), (99, 900000201, 'Server');
+
+  insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values (${ACTOR_ID}, 4, ${OWNER_RANK});
+`;
+
+async function withDatabase(t, run) {
+  const admin = new Pool(connectionConfig());
+  const database = `dune_perms_${process.pid}_${randomBytes(4).toString("hex")}`;
+  let pool;
+  try {
+    await admin.query("select 1");
+  } catch (error) {
+    await admin.end().catch(() => {});
+    if (process.env.CI) throw new Error(`PostgreSQL is required for the base permission integration test: ${error.message}`);
+    t.skip(`PostgreSQL unavailable: ${error.message}`);
+    return null;
+  }
+  try {
+    await admin.query(`create database "${database}"`);
+  } catch (error) {
+    await admin.end().catch(() => {});
+    if (process.env.CI) throw new Error(`PostgreSQL must allow an isolated test database: ${error.message}`);
+    t.skip(`PostgreSQL cannot create an isolated test database: ${error.message}`);
+    return null;
+  }
+  try {
+    pool = new Pool({ ...connectionConfig(database), max: 4 });
+    await pool.query(SCHEMA);
+    await pool.query(SEED);
+    return await run(pool, database);
+  } finally {
+    await pool?.end().catch(() => {});
+    await admin.query(`drop database if exists "${database}" with (force)`).catch(() => {});
+    await admin.end().catch(() => {});
+  }
+}
+
+async function ranks(pool) {
+  const result = await pool.query(
+    "select player_id::text as player_id, rank::int as rank from dune.permission_actor_rank where permission_actor_id = $1 order by rank, player_id",
+    [ACTOR_ID]);
+  return result.rows.map((row) => ({ playerId: row.player_id, rank: row.rank }));
+}
+
+test("real PostgreSQL: a roster save writes through the shipped procedures with the right argument order", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = transactionalDb(pool);
+    const result = await setBasePermissions(db, BASE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "23", rank: ASSOCIATE_RANK }
+    ], 32);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.actorId, String(ACTOR_ID));
+    // Transposed arguments would key the row on the player and store the actor
+    // id in player_id -- this is the assertion a mocked test cannot make.
+    assert.deepEqual(await ranks(pool), [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "23", rank: ASSOCIATE_RANK }
+    ]);
+  });
+});
+
+test("real PostgreSQL: promoting swaps the owner without ever leaving two", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = transactionalDb(pool);
+    await setBasePermissions(db, BASE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "23", rank: CO_OWNER_RANK }
+    ], 32);
+    await setBasePermissions(db, BASE_ID, [
+      { playerId: "23", rank: OWNER_RANK },
+      { playerId: "4", rank: CO_OWNER_RANK }
+    ], 32);
+
+    const rows = await ranks(pool);
+    assert.deepEqual(rows, [
+      { playerId: "23", rank: OWNER_RANK },
+      { playerId: "4", rank: CO_OWNER_RANK }
+    ]);
+    assert.equal(rows.filter((row) => row.rank === OWNER_RANK).length, 1);
+  });
+});
+
+test("real PostgreSQL: removing a player deletes only that rank row", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = transactionalDb(pool);
+    await setBasePermissions(db, BASE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "23", rank: ASSOCIATE_RANK },
+      { playerId: "29", rank: ASSOCIATE_RANK }
+    ], 32);
+    const result = await setBasePermissions(db, BASE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "29", rank: ASSOCIATE_RANK }
+    ], 32);
+
+    assert.equal(result.removed, 1);
+    assert.deepEqual(await ranks(pool), [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "29", rank: ASSOCIATE_RANK }
+    ]);
+  });
+});
+
+// The procedure interpolates its map argument into the payload unquoted. A text
+// map name produces `"Map" : DeepDesert}`, which is not parseable -- so the
+// notification the game receives is only valid if we pass the numeric id.
+test("real PostgreSQL: the emitted notification payload is well-formed JSON carrying the numeric map id", async (t) => {
+  await withDatabase(t, async (pool, database) => {
+    const listener = new Client(connectionConfig(database));
+    const received = [];
+    await listener.connect();
+    listener.on("notification", (message) => received.push(message.payload));
+    await listener.query("listen permission_notify_channel");
+
+    const db = transactionalDb(pool);
+    await setBasePermissions(db, BASE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "23", rank: ASSOCIATE_RANK }
+    ], 32);
+
+    // NOTIFY is delivered on commit; give the listener a moment to drain.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await listener.query("select 1");
+    await listener.end();
+
+    const setRank = received.find((payload) => payload.startsWith("set_rank#"));
+    assert.ok(setRank, `expected a set_rank notification, got ${JSON.stringify(received)}`);
+    const body = JSON.parse(setRank.slice("set_rank#".length));
+    assert.equal(body.ActorId, ACTOR_ID);
+    assert.equal(body.PlayerId, 23);
+    assert.equal(body.Rank, ASSOCIATE_RANK);
+    assert.equal(body.Map, MAP_NAME_ID);
+  });
+});
+
+// A rank row written against a non-canonical actor id is accepted by the
+// procedure and then ignored by the game -- a silent no-op that looks like a
+// successful save. Confirmed against a live server before this guard existed.
+test("real PostgreSQL: a player id that is not a player_controller_id is refused", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = transactionalDb(pool);
+    await assert.rejects(
+      () => setBasePermissions(db, BASE_ID, [
+        { playerId: "4", rank: OWNER_RANK },
+        { playerId: "5", rank: ASSOCIATE_RANK }
+      ], 32),
+      /not a known player character/);
+    // The rejection must leave the roster untouched, not half-applied.
+    assert.deepEqual(await ranks(pool), [{ playerId: "4", rank: OWNER_RANK }]);
+  });
+});
+
+test("real PostgreSQL: the roster reads back with resolved names and rank labels", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = transactionalDb(pool);
+    await setBasePermissions(db, BASE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "29", rank: CO_OWNER_RANK }
+    ], 32);
+
+    const roster = await listBasePermissions(db, BASE_ID);
+    assert.equal(roster.actorId, String(ACTOR_ID));
+    assert.equal(roster.mapNameId, MAP_NAME_ID);
+    assert.deepEqual(roster.entries.map((entry) => [entry.name, entry.label, entry.canonical]), [
+      ["DarkShark", "Owner", true],
+      ["Yaida", "Co-Owner", true]
+    ]);
+  });
+});
+
+// listBasePermissions must not silently drop a row the game ignores -- it is the
+// one roster state the console can see and the game client cannot.
+test("real PostgreSQL: a rank row on a non-canonical actor is surfaced, not hidden", async (t) => {
+  await withDatabase(t, async (pool) => {
+    await pool.query("insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values ($1, 5, $2)",
+      [ACTOR_ID, ASSOCIATE_RANK]);
+    const roster = await listBasePermissions(transactionalDb(pool), BASE_ID);
+    const orphan = roster.entries.find((entry) => entry.playerId === "5");
+    assert.ok(orphan, "the ignored row must still be listed");
+    assert.equal(orphan.canonical, false);
+    // The name still resolves through the account, which is why the console can
+    // show it meaningfully rather than as a bare id.
+    assert.equal(orphan.name, "DarkShark");
+  });
+});
+
+test("real PostgreSQL: the candidate picker returns player_controller_ids and excludes system accounts", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const candidates = await basePermissionCandidates(transactionalDb(pool), { limit: 50 });
+    const ids = candidates.map((row) => row.playerId);
+    assert.deepEqual(ids.sort(), ["23", "29", "4"].sort());
+    assert.ok(!candidates.some((row) => row.name === "Server"), "system accounts must not be offered");
+    // 5 and 6 belong to the same account as 4 but are not controller ids.
+    assert.ok(!ids.includes("5") && !ids.includes("6"));
+  });
+});

--- a/console/api/test/basePermissions.test.js
+++ b/console/api/test/basePermissions.test.js
@@ -31,7 +31,9 @@ function createDb({ existing = [], canonicalPlayers = ["4", "23", "29", "437"], 
         // nullable, ON DELETE SET NULL against fgl_entities) so the left-join
         // chain resolves the buildings row but not down to an actor.
         if (buildings === "missing") return { rows: [] };
-        if (buildings === "orphaned") return { rows: [{ actor_id: null, map: null, map_name_id: null, partition_id: null }] };
+        // Matches the real query's coalesce(...) wrapping: a genuine orphaned
+        // row never comes back with literal nulls for these three fields.
+        if (buildings === "orphaned") return { rows: [{ actor_id: null, map: "", map_name_id: 0, partition_id: 0 }] };
         return { rows: [{ actor_id: ACTOR_ID, map: "DeepDesert", map_name_id: mapNameId, partition_id: 59 }] };
       }
       if (text.includes("for update")) return { rows: [{ id: ACTOR_ID }], rowCount: 1 };

--- a/console/api/test/basePermissions.test.js
+++ b/console/api/test/basePermissions.test.js
@@ -13,7 +13,7 @@ const SUPPORTED_FUNCTIONS = [
 const BASE_ID = 1006;
 const ACTOR_ID = "1004";
 
-function createDb({ existing = [], canonicalPlayers = ["4", "23", "29", "437"], mapNameId = 7 } = {}) {
+function createDb({ existing = [], canonicalPlayers = ["4", "23", "29", "437"], mapNameId = 7, buildings = "found" } = {}) {
   const calls = [];
   const db = {
     calls,
@@ -26,6 +26,12 @@ function createDb({ existing = [], canonicalPlayers = ["4", "23", "29", "437"], 
         return { rows: [{ exists: SUPPORTED_FUNCTIONS.includes(String(values[0] || "")) }] };
       }
       if (text.includes("from dune.buildings b")) {
+        // "missing" mirrors a base id that does not exist at all; "orphaned"
+        // mirrors building_instances.owner_entity_id being null (it is
+        // nullable, ON DELETE SET NULL against fgl_entities) so the left-join
+        // chain resolves the buildings row but not down to an actor.
+        if (buildings === "missing") return { rows: [] };
+        if (buildings === "orphaned") return { rows: [{ actor_id: null, map: null, map_name_id: null, partition_id: null }] };
         return { rows: [{ actor_id: ACTOR_ID, map: "DeepDesert", map_name_id: mapNameId, partition_id: 59 }] };
       }
       if (text.includes("for update")) return { rows: [{ id: ACTOR_ID }], rowCount: 1 };
@@ -89,6 +95,24 @@ test("setBasePermissions refuses a base whose map has no map_names entry", async
   await assert.rejects(
     () => setBasePermissions(createDb({ mapNameId: 0 }), BASE_ID, [{ playerId: "4", rank: 1 }]),
     /no dune.map_names entry/);
+});
+
+test("listBasePermissions rejects a base id that does not exist", async () => {
+  await assert.rejects(
+    () => listBasePermissions(createDb({ buildings: "missing" }), 999999),
+    /That base was not found/);
+});
+
+test("listBasePermissions surfaces a clear error when the base's owner-entity link is broken", async () => {
+  await assert.rejects(
+    () => listBasePermissions(createDb({ buildings: "orphaned" }), BASE_ID),
+    /no resolvable owner entity/);
+});
+
+test("setBasePermissions surfaces a clear error when the base's owner-entity link is broken", async () => {
+  await assert.rejects(
+    () => setBasePermissions(createDb({ buildings: "orphaned" }), BASE_ID, [{ playerId: "4", rank: 1 }]),
+    /no resolvable owner entity/);
 });
 
 test("setBasePermissions writes through the shipped procedures, never raw DML", async () => {

--- a/console/api/test/basePermissions.test.js
+++ b/console/api/test/basePermissions.test.js
@@ -1,0 +1,179 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { setBasePermissions, listBasePermissions } from "../src/duneDb.js";
+
+const SUPPORTED_TABLES = ["dune.permission_actor_rank", "dune.permission_actor", "dune.actors", "dune.player_state", "dune.map_names"];
+const SUPPORTED_FUNCTIONS = [
+  "dune.permission_set_player_rank(bigint,bigint,smallint,text)",
+  "dune.permission_remove_player_rank(bigint,bigint)"
+];
+
+// The displayed base_id and the permission actor id are deliberately different
+// here, mirroring production where they differ for every base.
+const BASE_ID = 1006;
+const ACTOR_ID = "1004";
+
+function createDb({ existing = [], canonicalPlayers = ["4", "23", "29", "437"], mapNameId = 7 } = {}) {
+  const calls = [];
+  const db = {
+    calls,
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        return { rows: [{ exists: SUPPORTED_TABLES.includes(String(values[0] || "")) }] };
+      }
+      if (text.includes("to_regprocedure")) {
+        return { rows: [{ exists: SUPPORTED_FUNCTIONS.includes(String(values[0] || "")) }] };
+      }
+      if (text.includes("from dune.buildings b")) {
+        return { rows: [{ actor_id: ACTOR_ID, map: "DeepDesert", map_name_id: mapNameId, partition_id: 59 }] };
+      }
+      if (text.includes("for update")) return { rows: [{ id: ACTOR_ID }], rowCount: 1 };
+      if (text.includes("from dune.permission_actor_rank")) {
+        return { rows: existing.map((entry) => ({ player_id: entry.playerId, rank: entry.rank })) };
+      }
+      if (text.includes("player_controller_id = any")) {
+        const requested = values[0] || [];
+        return { rows: requested.filter((id) => canonicalPlayers.includes(String(id))).map((id) => ({ player_id: String(id) })) };
+      }
+      return { rows: [] };
+    },
+    transaction: async (fn) => fn(db)
+  };
+  return db;
+}
+
+function procCalls(db, name) {
+  return db.calls.filter((call) => call.text.includes(name)).map((call) => call.values);
+}
+
+test("setBasePermissions rejects a roster without exactly one owner", async () => {
+  await assert.rejects(
+    () => setBasePermissions(createDb(), BASE_ID, [{ playerId: "4", rank: 2 }]),
+    /exactly one Owner/);
+  await assert.rejects(
+    () => setBasePermissions(createDb(), BASE_ID, [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 1 }]),
+    /only have one Owner/);
+});
+
+test("setBasePermissions rejects invalid ranks and duplicate players", async () => {
+  await assert.rejects(
+    () => setBasePermissions(createDb(), BASE_ID, [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 4 }]),
+    /not a valid base permission rank/);
+  await assert.rejects(
+    () => setBasePermissions(createDb(), BASE_ID, [{ playerId: "4", rank: 1 }, { playerId: "4", rank: 3 }]),
+    /listed twice/);
+});
+
+// The cap comes from live server config, so it arrives as an argument rather
+// than a constant. Passing a small one proves it is actually enforced.
+test("setBasePermissions enforces the configured cap", async () => {
+  await assert.rejects(
+    () => setBasePermissions(createDb(), BASE_ID, [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 3 }], 1),
+    /above the configured maximum of 1/);
+});
+
+// A rank row written against a non-canonical actor id is accepted by the shipped
+// procedure and then ignored by the game -- confirmed live. Catching it here is
+// the difference between a no-op that looks successful and a clear error.
+test("setBasePermissions refuses a player id that is not a player_controller_id", async () => {
+  await assert.rejects(
+    () => setBasePermissions(createDb({ canonicalPlayers: ["4"] }), BASE_ID, [
+      { playerId: "4", rank: 1 },
+      { playerId: "5", rank: 3 }
+    ]),
+    /not a known player character/);
+});
+
+test("setBasePermissions refuses a base whose map has no map_names entry", async () => {
+  await assert.rejects(
+    () => setBasePermissions(createDb({ mapNameId: 0 }), BASE_ID, [{ playerId: "4", rank: 1 }]),
+    /no dune.map_names entry/);
+});
+
+test("setBasePermissions writes through the shipped procedures, never raw DML", async () => {
+  const db = createDb({ existing: [{ playerId: "4", rank: 1 }] });
+  await setBasePermissions(db, BASE_ID, [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 3 }]);
+  const written = db.calls.filter((call) => /insert into|update .*permission_actor_rank|delete from/i.test(call.text));
+  assert.deepEqual(written, [], "permission rows must only be written by the game's own procedures");
+  assert.equal(procCalls(db, "permission_set_player_rank").length, 1);
+});
+
+test("setBasePermissions passes the numeric map_name_id to the notify payload", async () => {
+  const db = createDb({ existing: [] });
+  await setBasePermissions(db, BASE_ID, [{ playerId: "4", rank: 1 }]);
+  const [values] = procCalls(db, "permission_set_player_rank");
+  // Not "DeepDesert": the procedure interpolates this unquoted into JSON.
+  assert.equal(values[3], "7");
+});
+
+test("setBasePermissions skips unchanged rows", async () => {
+  const db = createDb({ existing: [{ playerId: "4", rank: 1 }, { playerId: "29", rank: 2 }] });
+  const result = await setBasePermissions(db, BASE_ID, [{ playerId: "4", rank: 1 }, { playerId: "29", rank: 2 }]);
+  assert.equal(procCalls(db, "permission_set_player_rank").length, 0);
+  assert.equal(procCalls(db, "permission_remove_player_rank").length, 0);
+  assert.equal(result.added, 0);
+  assert.equal(result.reranked, 0);
+  assert.equal(result.removed, 0);
+});
+
+// The marker refresh inside permission_set_player_rank resolves the owner with a
+// LIMIT 1 over rank-1 rows, so a moment with two owners could stamp the wrong
+// name onto the base marker. The outgoing owner must be demoted first.
+test("setBasePermissions demotes the outgoing owner before promoting the new one", async () => {
+  const db = createDb({ existing: [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 3 }] });
+  await setBasePermissions(db, BASE_ID, [{ playerId: "23", rank: 1 }, { playerId: "4", rank: 2 }]);
+  const ranks = procCalls(db, "permission_set_player_rank").map((values) => ({ playerId: String(values[1]), rank: values[2] }));
+  assert.deepEqual(ranks, [{ playerId: "4", rank: 2 }, { playerId: "23", rank: 1 }]);
+});
+
+test("setBasePermissions removes dropped players before writing the owner", async () => {
+  const db = createDb({ existing: [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 3 }] });
+  const result = await setBasePermissions(db, BASE_ID, [{ playerId: "29", rank: 1 }]);
+  const order = db.calls
+    .filter((call) => /permission_remove_player_rank|permission_set_player_rank/.test(call.text))
+    .map((call) => call.text.includes("remove") ? "remove" : "set");
+  assert.deepEqual(order, ["remove", "remove", "set"]);
+  assert.equal(result.removed, 2);
+  assert.equal(result.added, 1);
+});
+
+// The procedures resolve their own unqualified table names through search_path,
+// which works only because the console connects as the `dune` role. Setting it
+// explicitly keeps the feature working if that ever changes.
+test("setBasePermissions pins search_path for the transaction", async () => {
+  const db = createDb({ existing: [] });
+  await setBasePermissions(db, BASE_ID, [{ playerId: "4", rank: 1 }]);
+  assert.ok(db.calls.some((call) => /set local search_path to dune/.test(call.text)));
+});
+
+// The lock has to be on a row guaranteed to exist. A base whose roster is being
+// fully replaced may have no rank rows, and `for update` over zero rows
+// serializes nothing at all.
+test("setBasePermissions locks the claim actor row, not the rank rows", async () => {
+  const db = createDb({ existing: [] });
+  await setBasePermissions(db, BASE_ID, [{ playerId: "4", rank: 1 }]);
+  const lock = db.calls.find((call) => call.text.includes("for update"));
+  assert.match(lock.text, /from dune\.actors/);
+  assert.deepEqual(lock.values, [ACTOR_ID]);
+});
+
+test("listBasePermissions labels ranks and flags rows the game ignores", async () => {
+  const db = createDb();
+  db.query = async (text, values = []) => {
+    if (text.includes("to_regclass")) return { rows: [{ exists: SUPPORTED_TABLES.includes(String(values[0] || "")) }] };
+    if (text.includes("to_regprocedure")) return { rows: [{ exists: SUPPORTED_FUNCTIONS.includes(String(values[0] || "")) }] };
+    if (text.includes("from dune.buildings b")) {
+      return { rows: [{ actor_id: ACTOR_ID, map: "DeepDesert", map_name_id: 7, partition_id: 59 }] };
+    }
+    return { rows: [
+      { player_id: "4", character_name: "DarkShark", rank: 1, canonical: true },
+      { player_id: "29", character_name: "Yaida", rank: 2, canonical: true },
+      { player_id: "5", character_name: "DarkShark", rank: 3, canonical: false }
+    ] };
+  };
+  const result = await listBasePermissions(db, BASE_ID);
+  assert.equal(result.actorId, ACTOR_ID);
+  assert.deepEqual(result.entries.map((entry) => entry.label), ["Owner", "Co-Owner", "Associate"]);
+  assert.deepEqual(result.entries.map((entry) => entry.canonical), [true, true, false]);
+});

--- a/console/api/test/baseRefillFlush.test.js
+++ b/console/api/test/baseRefillFlush.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { flushBaseRefillQueues } from "../src/services/baseRefillFlush.js";
+
+test("map-down refill flush waits for both queues and labels their results", async () => {
+  const completed = [];
+  let releaseWater;
+  const waterBlocked = new Promise((resolve) => { releaseWater = resolve; });
+
+  const pending = flushBaseRefillQueues({
+    flushGenerators: async () => {
+      completed.push("generator");
+      return { flushed: [{ baseId: 11, ok: true }] };
+    },
+    flushWater: async () => {
+      await waterBlocked;
+      completed.push("water");
+      return { flushed: [{ baseId: 22, ok: true }] };
+    }
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(completed, ["generator"]);
+  let settled = false;
+  void pending.then(() => { settled = true; });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, false, "the map-down hook must remain pending while either queue is flushing");
+
+  releaseWater();
+  const result = await pending;
+  assert.deepEqual(completed, ["generator", "water"]);
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.flushed, [
+    { baseId: 11, ok: true, refillType: "generator" },
+    { baseId: 22, ok: true, refillType: "water" }
+  ]);
+});
+
+test("a failed queue does not stop the hook waiting for the other queue", async () => {
+  let waterFinished = false;
+  const result = await flushBaseRefillQueues({
+    flushGenerators: async () => { throw new Error("generator database unavailable"); },
+    flushWater: async () => {
+      await new Promise((resolve) => setImmediate(resolve));
+      waterFinished = true;
+      return { flushed: [{ baseId: 33, ok: true }] };
+    }
+  });
+
+  assert.equal(waterFinished, true);
+  assert.deepEqual(result.flushed, [{ baseId: 33, ok: true, refillType: "water" }]);
+  assert.deepEqual(result.failures, [{ refillType: "generator", error: "generator database unavailable" }]);
+});

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -2565,6 +2565,33 @@ test("export base throws an unsupported error when required tables are missing",
   await assert.rejects(() => exportBaseAsBlueprint(db, 1006), UnsupportedCapabilityError);
 });
 
+test("export base reports a genuinely missing base id as not found", async () => {
+  const db = {
+    query: async (text) => {
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("from dune.buildings b")) return { rows: [] };
+      // The follow-up existence check: no buildings row at all.
+      if (text.includes("select 1 from dune.buildings where id")) return { rows: [] };
+      return { rows: [] };
+    }
+  };
+  await assert.rejects(() => exportBaseAsBlueprint(db, 999999), /was not found/);
+});
+
+test("export base distinguishes a broken owner-entity link from a missing base id", async () => {
+  const db = {
+    query: async (text) => {
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("from dune.buildings b")) return { rows: [] };
+      // The follow-up existence check: the buildings row exists, so the empty
+      // result above must be from a broken owner-entity link, not a missing id.
+      if (text.includes("select 1 from dune.buildings where id")) return { rows: [{ "?column?": 1 }] };
+      return { rows: [] };
+    }
+  };
+  await assert.rejects(() => exportBaseAsBlueprint(db, 1006), /no resolvable owner entity/);
+});
+
 test("export base resolves the owner via the base's actor id", async () => {
   const calls = [];
   const db = {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -4634,7 +4634,11 @@ function fakeQueueDb(calls, { devices = [], items = {}, partitions = [], basePar
       })) };
     }
     if (text.includes("coalesce(a.partition_id, 0)::int as partition_id")) {
-      return { rows: basePartition ? [basePartition] : [] };
+      // baseMapLocation now also selects actor_id to distinguish a genuinely
+      // missing base from one with a broken owner-entity link; default it to
+      // a resolved id here so existing callers testing write-safety don't
+      // have to know about that distinction unless they explicitly opt in.
+      return { rows: basePartition ? [{ actor_id: "1", ...basePartition }] : [] };
     }
     return inner(text, values);
   };

--- a/console/api/test/generatorRefill.integration.test.js
+++ b/console/api/test/generatorRefill.integration.test.js
@@ -1,71 +1,14 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { randomBytes } from "node:crypto";
-import pg from "pg";
 import { refillBaseGenerators } from "../src/duneDb.js";
-
-const { Pool } = pg;
-
-function connectionConfig(database = "dune") {
-  if (process.env.ADMIN_DATABASE_URL) {
-    const url = new URL(process.env.ADMIN_DATABASE_URL);
-    url.pathname = `/${database}`;
-    return { connectionString: url.toString() };
-  }
-  return {
-    host: process.env.DUNE_DB_HOST || process.env.PGHOST || "127.0.0.1",
-    port: Number(process.env.DUNE_DB_PORT || process.env.PGPORT || process.env.POSTGRES_PORT || 15432),
-    database,
-    user: process.env.DUNE_DB_USER || process.env.PGUSER || "dune",
-    password: process.env.DUNE_DB_PASSWORD || process.env.PGPASSWORD || "dune",
-    connectionTimeoutMillis: 3000
-  };
-}
-
-function transactionalDb(pool) {
-  return {
-    query: (text, values = []) => pool.query(text, values),
-    async transaction(fn) {
-      const client = await pool.connect();
-      try {
-        await client.query("begin");
-        const result = await fn({ query: (text, values = []) => client.query(text, values) });
-        await client.query("commit");
-        return result;
-      } catch (error) {
-        await client.query("rollback").catch(() => {});
-        throw error;
-      } finally {
-        client.release();
-      }
-    }
-  };
-}
+import { pgTransactionalDb, withIsolatedDatabase } from "../test-support/pgIntegrationDb.js";
 
 test("real PostgreSQL serializes concurrent refills of an empty generator inventory", async (t) => {
-  const admin = new Pool(connectionConfig());
-  const database = `dune_refill_${process.pid}_${randomBytes(4).toString("hex")}`;
-  let pool;
-  try {
-    await admin.query("select 1");
-  } catch (error) {
-    await admin.end().catch(() => {});
-    if (process.env.CI) throw new Error(`PostgreSQL is required for the refill concurrency test: ${error.message}`);
-    t.skip(`PostgreSQL unavailable: ${error.message}`);
-    return;
-  }
-
-  try {
-    await admin.query(`create database "${database}"`);
-  } catch (error) {
-    await admin.end().catch(() => {});
-    if (process.env.CI) throw new Error(`PostgreSQL must allow an isolated refill test database: ${error.message}`);
-    t.skip(`PostgreSQL cannot create an isolated test database: ${error.message}`);
-    return;
-  }
-
-  try {
-    pool = new Pool({ ...connectionConfig(database), max: 4 });
+  await withIsolatedDatabase(t, {
+    namePrefix: "dune_refill",
+    unavailableLabel: "the refill concurrency test",
+    createFailLabel: "the refill concurrency test"
+  }, async (pool) => {
     await pool.query(`
       create schema dune;
       create table dune.buildings (id bigint primary key);
@@ -94,7 +37,7 @@ test("real PostgreSQL serializes concurrent refills of an empty generator invent
       insert into dune.inventories (id, actor_id, max_item_count) values (701, 5001, 10);
     `);
 
-    const db = transactionalDb(pool);
+    const db = pgTransactionalDb(pool);
     const [first, second] = await Promise.all([
       refillBaseGenerators(db, "", 482),
       refillBaseGenerators(db, "", 482)
@@ -106,13 +49,5 @@ test("real PostgreSQL serializes concurrent refills of an empty generator invent
 
     assert.deepEqual(stored.rows[0], { rows: 1, units: 499 });
     assert.equal(first.totalAdded + second.totalAdded, 499);
-  } finally {
-    await pool?.end().catch(() => {});
-    await admin.query(
-      "select pg_terminate_backend(pid) from pg_stat_activity where datname = $1 and pid <> pg_backend_pid()",
-      [database]
-    ).catch(() => {});
-    await admin.query(`drop database if exists "${database}"`).catch(() => {});
-    await admin.end().catch(() => {});
-  }
+  });
 });

--- a/console/api/test/permission-settings.test.js
+++ b/console/api/test/permission-settings.test.js
@@ -1,0 +1,29 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseEffectivePermissionLimit } from "../src/services/permissionSettings.js";
+
+// Precedence here is deliberately the reverse of the guild limit's. The shipped
+// DefaultGame.ini defines m_MaxPermissionsPerActor=32 only under
+// [/Script/DuneSandbox.PermissionSettings] and carries no DuneGameMode form, so
+// the canonical field is the one the server enforces. Reading the legacy field
+// first would inherit its 20 and cap rosters below what the game allows.
+test("permission limit prefers the canonical PermissionSettings value over the legacy field", () => {
+  assert.equal(parseEffectivePermissionLimit([
+    "max_permissions_per_actor\t20",
+    "permission_max_permissions_per_actor\t36"
+  ].join("\n")), 36);
+});
+
+test("permission limit falls back to the legacy field when the canonical one is absent", () => {
+  assert.equal(parseEffectivePermissionLimit("max_permissions_per_actor\t20\n"), 20);
+});
+
+test("permission limit defaults to the shipped 32 when neither field is set", () => {
+  assert.equal(parseEffectivePermissionLimit(""), 32);
+});
+
+test("permission limit rejects malformed values", () => {
+  assert.throws(() => parseEffectivePermissionLimit("permission_max_permissions_per_actor\t0\n"), /invalid/);
+  assert.throws(() => parseEffectivePermissionLimit("permission_max_permissions_per_actor\tnot-a-number\n"), /invalid/);
+  assert.throws(() => parseEffectivePermissionLimit("permission_max_permissions_per_actor\t-4\n"), /invalid/);
+});

--- a/console/api/test/refillBaseWater.integration.test.js
+++ b/console/api/test/refillBaseWater.integration.test.js
@@ -1,10 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { randomBytes } from "node:crypto";
-import pg from "pg";
 import { baseWater, refillBaseWater } from "../src/duneDb.js";
-
-const { Pool } = pg;
+import { pgTransactionalDb, withIsolatedDatabase } from "../test-support/pgIntegrationDb.js";
 
 // Mirrors generatorRefill.integration.test.js -- a throwaway real-Postgres
 // database rather than a mock, because the behaviour under test (a guarded
@@ -12,66 +9,12 @@ const { Pool } = pg;
 // must touch water and never blood) is exactly the kind of thing a fake
 // query layer would let pass silently wrong.
 
-function connectionConfig(database = "dune") {
-  if (process.env.ADMIN_DATABASE_URL) {
-    const url = new URL(process.env.ADMIN_DATABASE_URL);
-    url.pathname = `/${database}`;
-    return { connectionString: url.toString() };
-  }
-  return {
-    host: process.env.DUNE_DB_HOST || process.env.PGHOST || "127.0.0.1",
-    port: Number(process.env.DUNE_DB_PORT || process.env.PGPORT || process.env.POSTGRES_PORT || 15432),
-    database,
-    user: process.env.DUNE_DB_USER || process.env.PGUSER || "dune",
-    password: process.env.DUNE_DB_PASSWORD || process.env.PGPASSWORD || "dune",
-    connectionTimeoutMillis: 3000
-  };
-}
-
-function transactionalDb(pool) {
-  return {
-    query: (text, values = []) => pool.query(text, values),
-    async transaction(fn) {
-      const client = await pool.connect();
-      try {
-        await client.query("begin");
-        const result = await fn({ query: (text, values = []) => client.query(text, values) });
-        await client.query("commit");
-        return result;
-      } catch (error) {
-        await client.query("rollback").catch(() => {});
-        throw error;
-      } finally {
-        client.release();
-      }
-    }
-  };
-}
-
 test("real PostgreSQL refillBaseWater tops water to capacity, leaves blood untouched, and avoids the ContainerInventory fan-out", async (t) => {
-  const admin = new Pool(connectionConfig());
-  const database = `dune_water_refill_${process.pid}_${randomBytes(4).toString("hex")}`;
-  let pool;
-  try {
-    await admin.query("select 1");
-  } catch (error) {
-    await admin.end().catch(() => {});
-    if (process.env.CI) throw new Error(`PostgreSQL is required for the water refill test: ${error.message}`);
-    t.skip(`PostgreSQL unavailable: ${error.message}`);
-    return;
-  }
-
-  try {
-    await admin.query(`create database "${database}"`);
-  } catch (error) {
-    await admin.end().catch(() => {});
-    if (process.env.CI) throw new Error(`PostgreSQL must allow an isolated water refill test database: ${error.message}`);
-    t.skip(`PostgreSQL cannot create an isolated test database: ${error.message}`);
-    return;
-  }
-
-  try {
-    pool = new Pool({ ...connectionConfig(database), max: 4 });
+  await withIsolatedDatabase(t, {
+    namePrefix: "dune_water_refill",
+    unavailableLabel: "the water refill test",
+    createFailLabel: "the water refill test"
+  }, async (pool) => {
     await pool.query(`
       create schema dune;
       create table dune.buildings (id bigint primary key);
@@ -107,7 +50,7 @@ test("real PostgreSQL refillBaseWater tops water to capacity, leaves blood untou
       insert into dune.actor_fgl_entities values (9003, 5002, 'Actor');
     `);
 
-    const db = transactionalDb(pool);
+    const db = pgTransactionalDb(pool);
 
     const before = await baseWater(db, 482);
     const cisternBefore = before.containers.find((c) => c.type === "waterCistern");
@@ -137,13 +80,5 @@ test("real PostgreSQL refillBaseWater tops water to capacity, leaves blood untou
     // A second refill on an already-full base adds nothing.
     const again = await refillBaseWater(db, 482);
     assert.equal(again.totalAdded, 0);
-  } finally {
-    await pool?.end().catch(() => {});
-    await admin.query(
-      "select pg_terminate_backend(pid) from pg_stat_activity where datname = $1 and pid <> pg_backend_pid()",
-      [database]
-    ).catch(() => {});
-    await admin.query(`drop database if exists "${database}"`).catch(() => {});
-    await admin.end().catch(() => {});
-  }
+  });
 });

--- a/console/api/test/refillBaseWater.integration.test.js
+++ b/console/api/test/refillBaseWater.integration.test.js
@@ -89,20 +89,22 @@ test("real PostgreSQL refillBaseWater tops water to capacity, leaves blood untou
       insert into dune.placeables values (5001, 100, 'WaterCistern_Placeable');
       insert into dune.actors values (5001, '{}'::jsonb);
       insert into dune.fgl_entities values (9001, '{"FWaterStorageComponent": [0, {"m_WaterStored": 1250}]}'::jsonb);
-      insert into dune.actor_fgl_entities values (5001, 9001, 'Actor');
+      -- actor_fgl_entities columns are (entity_id, actor_id, slot_name):
+      -- entity_id=9001 (the fgl_entities row above), actor_id=5001 (the placeable).
+      insert into dune.actor_fgl_entities values (9001, 5001, 'Actor');
       -- Same placeable also carries a ContainerInventory-slot entity with no
       -- water component -- the exact fan-out shape confirmed live on dune2.
       -- An unguarded join must not double the container or overwrite the
       -- wrong entity.
       insert into dune.fgl_entities values (9002, '{}'::jsonb);
-      insert into dune.actor_fgl_entities values (5001, 9002, 'ContainerInventory');
+      insert into dune.actor_fgl_entities values (9002, 5001, 'ContainerInventory');
 
       -- A Blood Purifier (water capacity 1000, blood capacity 6000), with
       -- both water and blood partially filled.
       insert into dune.placeables values (5002, 100, 'BloodWaterExtractor_Placeable');
       insert into dune.actors values (5002, '{"BP_BloodWaterExtractor_C": {"m_CurrentAmount": 3114.6}}'::jsonb);
       insert into dune.fgl_entities values (9003, '{"FWaterStorageComponent": [0, {"m_WaterStored": 200}]}'::jsonb);
-      insert into dune.actor_fgl_entities values (5002, 9003, 'Actor');
+      insert into dune.actor_fgl_entities values (9003, 5002, 'Actor');
     `);
 
     const db = transactionalDb(pool);

--- a/console/api/test/refillBaseWater.integration.test.js
+++ b/console/api/test/refillBaseWater.integration.test.js
@@ -117,7 +117,7 @@ test("real PostgreSQL refillBaseWater tops water to capacity, leaves blood untou
     assert.equal(bloodBefore.stored, 200);
     assert.equal(bloodBefore.bloodStored, 3115); // rounded
 
-    const result = await refillBaseWater(db, "", 482);
+    const result = await refillBaseWater(db, 482);
     assert.equal(result.ok, true);
     assert.equal(result.totalAdded, (5000 - 1250) + (1000 - 200));
 
@@ -135,7 +135,7 @@ test("real PostgreSQL refillBaseWater tops water to capacity, leaves blood untou
     assert.equal(Number(bloodProperty.rows[0].amount), 3114.6);
 
     // A second refill on an already-full base adds nothing.
-    const again = await refillBaseWater(db, "", 482);
+    const again = await refillBaseWater(db, 482);
     assert.equal(again.totalAdded, 0);
   } finally {
     await pool?.end().catch(() => {});

--- a/console/api/test/refillBaseWater.integration.test.js
+++ b/console/api/test/refillBaseWater.integration.test.js
@@ -1,0 +1,147 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { randomBytes } from "node:crypto";
+import pg from "pg";
+import { baseWater, refillBaseWater } from "../src/duneDb.js";
+
+const { Pool } = pg;
+
+// Mirrors generatorRefill.integration.test.js -- a throwaway real-Postgres
+// database rather than a mock, because the behaviour under test (a guarded
+// lateral join avoiding the ContainerInventory fan-out, and a jsonb_set that
+// must touch water and never blood) is exactly the kind of thing a fake
+// query layer would let pass silently wrong.
+
+function connectionConfig(database = "dune") {
+  if (process.env.ADMIN_DATABASE_URL) {
+    const url = new URL(process.env.ADMIN_DATABASE_URL);
+    url.pathname = `/${database}`;
+    return { connectionString: url.toString() };
+  }
+  return {
+    host: process.env.DUNE_DB_HOST || process.env.PGHOST || "127.0.0.1",
+    port: Number(process.env.DUNE_DB_PORT || process.env.PGPORT || process.env.POSTGRES_PORT || 15432),
+    database,
+    user: process.env.DUNE_DB_USER || process.env.PGUSER || "dune",
+    password: process.env.DUNE_DB_PASSWORD || process.env.PGPASSWORD || "dune",
+    connectionTimeoutMillis: 3000
+  };
+}
+
+function transactionalDb(pool) {
+  return {
+    query: (text, values = []) => pool.query(text, values),
+    async transaction(fn) {
+      const client = await pool.connect();
+      try {
+        await client.query("begin");
+        const result = await fn({ query: (text, values = []) => client.query(text, values) });
+        await client.query("commit");
+        return result;
+      } catch (error) {
+        await client.query("rollback").catch(() => {});
+        throw error;
+      } finally {
+        client.release();
+      }
+    }
+  };
+}
+
+test("real PostgreSQL refillBaseWater tops water to capacity, leaves blood untouched, and avoids the ContainerInventory fan-out", async (t) => {
+  const admin = new Pool(connectionConfig());
+  const database = `dune_water_refill_${process.pid}_${randomBytes(4).toString("hex")}`;
+  let pool;
+  try {
+    await admin.query("select 1");
+  } catch (error) {
+    await admin.end().catch(() => {});
+    if (process.env.CI) throw new Error(`PostgreSQL is required for the water refill test: ${error.message}`);
+    t.skip(`PostgreSQL unavailable: ${error.message}`);
+    return;
+  }
+
+  try {
+    await admin.query(`create database "${database}"`);
+  } catch (error) {
+    await admin.end().catch(() => {});
+    if (process.env.CI) throw new Error(`PostgreSQL must allow an isolated water refill test database: ${error.message}`);
+    t.skip(`PostgreSQL cannot create an isolated test database: ${error.message}`);
+    return;
+  }
+
+  try {
+    pool = new Pool({ ...connectionConfig(database), max: 4 });
+    await pool.query(`
+      create schema dune;
+      create table dune.buildings (id bigint primary key);
+      create table dune.building_instances (building_id bigint not null, owner_entity_id bigint not null);
+      create table dune.actor_fgl_entities (entity_id bigint not null, actor_id bigint not null, slot_name text);
+      create table dune.placeables (id bigint primary key, owner_entity_id bigint not null, building_type text not null);
+      create table dune.actors (id bigint primary key, properties jsonb not null default '{}'::jsonb);
+      create table dune.fgl_entities (entity_id bigint primary key, components jsonb not null default '{}'::jsonb);
+
+      insert into dune.buildings values (482);
+      insert into dune.building_instances values (482, 100);
+      insert into dune.actor_fgl_entities values (100, 200);
+
+      -- A Water Cistern (capacity 5000), partially filled.
+      insert into dune.placeables values (5001, 100, 'WaterCistern_Placeable');
+      insert into dune.actors values (5001, '{}'::jsonb);
+      insert into dune.fgl_entities values (9001, '{"FWaterStorageComponent": [0, {"m_WaterStored": 1250}]}'::jsonb);
+      insert into dune.actor_fgl_entities values (5001, 9001, 'Actor');
+      -- Same placeable also carries a ContainerInventory-slot entity with no
+      -- water component -- the exact fan-out shape confirmed live on dune2.
+      -- An unguarded join must not double the container or overwrite the
+      -- wrong entity.
+      insert into dune.fgl_entities values (9002, '{}'::jsonb);
+      insert into dune.actor_fgl_entities values (5001, 9002, 'ContainerInventory');
+
+      -- A Blood Purifier (water capacity 1000, blood capacity 6000), with
+      -- both water and blood partially filled.
+      insert into dune.placeables values (5002, 100, 'BloodWaterExtractor_Placeable');
+      insert into dune.actors values (5002, '{"BP_BloodWaterExtractor_C": {"m_CurrentAmount": 3114.6}}'::jsonb);
+      insert into dune.fgl_entities values (9003, '{"FWaterStorageComponent": [0, {"m_WaterStored": 200}]}'::jsonb);
+      insert into dune.actor_fgl_entities values (5002, 9003, 'Actor');
+    `);
+
+    const db = transactionalDb(pool);
+
+    const before = await baseWater(db, 482);
+    const cisternBefore = before.containers.find((c) => c.type === "waterCistern");
+    const bloodBefore = before.containers.find((c) => c.type === "bloodWaterExtractor");
+    assert.equal(cisternBefore.stored, 1250);
+    assert.equal(cisternBefore.count, 1);
+    assert.equal(bloodBefore.stored, 200);
+    assert.equal(bloodBefore.bloodStored, 3115); // rounded
+
+    const result = await refillBaseWater(db, "", 482);
+    assert.equal(result.ok, true);
+    assert.equal(result.totalAdded, (5000 - 1250) + (1000 - 200));
+
+    const after = await baseWater(db, 482);
+    const cisternAfter = after.containers.find((c) => c.type === "waterCistern");
+    const bloodAfter = after.containers.find((c) => c.type === "bloodWaterExtractor");
+    assert.equal(cisternAfter.stored, 5000);
+    // The fan-out guard means exactly one container, not two.
+    assert.equal(cisternAfter.count, 1);
+    assert.equal(bloodAfter.stored, 1000);
+    // Blood is never touched by a refill -- only the water component.
+    assert.equal(bloodAfter.bloodStored, 3115);
+
+    const bloodProperty = await pool.query("select properties->'BP_BloodWaterExtractor_C'->>'m_CurrentAmount' as amount from dune.actors where id = 5002");
+    assert.equal(Number(bloodProperty.rows[0].amount), 3114.6);
+
+    // A second refill on an already-full base adds nothing.
+    const again = await refillBaseWater(db, "", 482);
+    assert.equal(again.totalAdded, 0);
+  } finally {
+    await pool?.end().catch(() => {});
+    await admin.query(
+      "select pg_terminate_backend(pid) from pg_stat_activity where datname = $1 and pid <> pg_backend_pid()",
+      [database]
+    ).catch(() => {});
+    await admin.query(`drop database if exists "${database}"`).catch(() => {});
+    await admin.end().catch(() => {});
+  }
+});

--- a/console/api/test/tasks.test.js
+++ b/console/api/test/tasks.test.js
@@ -409,6 +409,32 @@ test("a Sietch restart flushes queued map writes between the stop and start step
   assert.deepEqual(callLog, ["sietches stop-partition 31", "flush:sietchesRestartStop", "sietches start-partition 31"]);
 });
 
+test("map-down refill results distinguish generator, water, and queue-specific failures", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "arrakis-task-flush-results-"));
+  const manager = new TaskManager(
+    { duneScript: join(dir, "dune"), repoRoot: dir, taskRetention: 20, commandTimeoutMs: 5000 },
+    {
+      onMapDown: async () => ({
+        flushed: [
+          { ok: true, refillType: "generator" },
+          { ok: true, refillType: "water" }
+        ],
+        failures: [{ refillType: "water", error: "database unavailable" }]
+      })
+    }
+  );
+  const task = { logLines: [], subscribers: new Set() };
+
+  await manager.flushPendingMapWrites(task, "restartServiceStop");
+
+  const lines = task.logLines.map((entry) => entry.line);
+  assert.deepEqual(lines, [
+    "Applied 1 queued generator refill.",
+    "Applied 1 queued water refill.",
+    "Queued water refills were not applied: database unavailable"
+  ]);
+});
+
 function waitForTask(manager, id) {
   return new Promise((resolve, reject) => {
     const deadline = Date.now() + 3000;

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -53,6 +53,60 @@ export type AutoRefillState = {
   bases: AutoRefillBase[];
 };
 
+// Water refill has no fuelName/capped/skipped concepts: it's a plain
+// jsonb_set straight to capacity, not a stack of discrete inventory items.
+export type RefillWaterDeviceResult = {
+  placeableId: string;
+  type: string;
+  label: string;
+  before: number;
+  after: number;
+  added: number;
+};
+
+export type WaterContainerEntry = {
+  type: string;
+  name: string;
+  count: number;
+  stored: number;
+  capacity: number;
+  percent: number;
+  // Only present for Blood Purifier / Improved Blood Purifier -- their raw
+  // blood input buffer, a completely different storage mechanism from water.
+  bloodStored?: number;
+  bloodCapacity?: number;
+  bloodPercent?: number;
+};
+
+export type BaseWater = {
+  supported: boolean;
+  baseId: number;
+  containers: WaterContainerEntry[];
+  reason?: string;
+};
+
+export type AutoRefillWaterBase = {
+  baseId: number;
+  enabledAt: string;
+  lastCheckedAt: string;
+  lastQueuedAt: string;
+  lastLowestPercent: number | null;
+  consecutiveQueues: number;
+  stalledAt: string;
+};
+
+export type AutoRefillWaterState = {
+  supported: boolean;
+  thresholdPercent: number;
+  intervalHours: number;
+  nextRunAt: string;
+  lastRunAt: string;
+  lastRunStatus: string;
+  lastRunDetail: string;
+  total: number;
+  bases: AutoRefillWaterBase[];
+};
+
 // rank 1/2/3 = Owner/Co-Owner/Associate, confirmed in both directions against a
 // live server: the game's own Permissions panel writes exactly these values.
 // The 5/4/3 badges the game UI shows beside those labels are decoration, not
@@ -144,5 +198,31 @@ export const basesApi = {
     search.set("limit", String(limit));
     return api<{ supported: boolean; rows: BasePermissionCandidate[]; reason?: string }>(
       `/api/bases/permission-candidates?${search.toString()}`);
-  }
+  },
+  water: (baseId: string) =>
+    api<BaseWater>(`/api/bases/${encodeURIComponent(baseId)}/water`),
+  // A refill for a map that is currently running comes back as
+  // `result.queued`: the write is deferred to the next time that map is down.
+  refillWater: (baseId: string) =>
+    post<{
+      supported: boolean;
+      result?: {
+        ok: boolean;
+        baseId: number;
+        queued?: boolean;
+        map?: string;
+        partitionId?: number;
+        totalAdded?: number;
+        devices?: RefillWaterDeviceResult[];
+      };
+      reason?: string;
+    }>(`/api/bases/${encodeURIComponent(baseId)}/refill-water`, {}),
+  cancelQueuedWaterRefill: (baseId: string) =>
+    api<{ supported: boolean; result?: { ok: boolean; baseId: number; pending: number }; reason?: string }>(
+      `/api/bases/${encodeURIComponent(baseId)}/queued-water-refill`, { method: "DELETE" }),
+  pendingWaterRefills: () => api<PendingRefills>("/api/bases/pending-water-refills"),
+  autoRefillWater: () => api<AutoRefillWaterState>("/api/bases/auto-refill-water"),
+  setAutoRefillWater: (baseId: string, enabled: boolean) =>
+    post<{ ok: boolean; baseId: number; enabled: boolean; total: number }>(
+      `/api/bases/${encodeURIComponent(baseId)}/auto-refill-water`, { enabled })
 };

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -53,6 +53,47 @@ export type AutoRefillState = {
   bases: AutoRefillBase[];
 };
 
+// rank 1/2/3 = Owner/Co-Owner/Associate, confirmed in both directions against a
+// live server: the game's own Permissions panel writes exactly these values.
+// The 5/4/3 badges the game UI shows beside those labels are decoration, not
+// ranks -- no row in permission_actor_rank ever holds a 4 or 5.
+export type BasePermissionRank = 1 | 2 | 3;
+
+export type BasePermissionEntry = {
+  playerId: string;
+  name: string;
+  rank: BasePermissionRank;
+  label: string;
+  // False when this row names an actor that is not the account's
+  // player_controller_id. The game ignores such rows, but they are shown rather
+  // than hidden -- it is a state the console can see and the game client cannot.
+  canonical: boolean;
+};
+
+export type BasePermissions = {
+  supported: boolean;
+  baseId: number;
+  actorId: string;
+  map: string;
+  mapNameId: number;
+  entries: BasePermissionEntry[];
+  reason?: string;
+};
+
+export type BasePermissionCandidate = { playerId: string; name: string };
+
+export type SetBasePermissionsResult = {
+  ok: boolean;
+  baseId: number;
+  actorId: string;
+  map: string;
+  added: number;
+  reranked: number;
+  removed: number;
+  total: number;
+  message: string;
+};
+
 export const basesApi = {
   list: (params: { q?: string; page?: number; pageSize?: number; sortColumn?: string; sortDirection?: "asc" | "desc" } = {}) => {
     const search = new URLSearchParams();
@@ -87,5 +128,21 @@ export const basesApi = {
   autoRefill: () => api<AutoRefillState>("/api/bases/auto-refill"),
   setAutoRefill: (baseId: string, enabled: boolean) =>
     post<{ ok: boolean; baseId: number; enabled: boolean; total: number }>(
-      `/api/bases/${encodeURIComponent(baseId)}/auto-refill`, { enabled })
+      `/api/bases/${encodeURIComponent(baseId)}/auto-refill`, { enabled }),
+  permissions: (baseId: string) =>
+    api<BasePermissions>(`/api/bases/${encodeURIComponent(baseId)}/permissions`),
+  // A whole roster, not a delta: the server diffs it against current state and
+  // applies the difference through the game's own stored procedures in one
+  // transaction. Changes reach a running map immediately -- no restart.
+  setPermissions: (baseId: string, entries: { playerId: string; rank: BasePermissionRank }[]) =>
+    api<{ supported: boolean; result?: SetBasePermissionsResult; reason?: string }>(
+      `/api/bases/${encodeURIComponent(baseId)}/permissions`,
+      { method: "PUT", body: JSON.stringify({ entries }) }),
+  permissionCandidates: (q: string, limit = 25) => {
+    const search = new URLSearchParams();
+    if (q) search.set("q", q);
+    search.set("limit", String(limit));
+    return api<{ supported: boolean; rows: BasePermissionCandidate[]; reason?: string }>(
+      `/api/bases/permission-candidates?${search.toString()}`);
+  }
 };

--- a/console/web/src/components/common/DataTable.tsx
+++ b/console/web/src/components/common/DataTable.tsx
@@ -84,6 +84,9 @@ type DataTableProps = {
   secondaryActionClassName?: string;
   secondaryActionPosition?: "start" | "end";
   tableClassName?: string;
+  // Extra class on the scroll container. Lets a panel opt out of the shared
+  // max-height cap without changing it for every table.
+  wrapClassName?: string;
   renderCell?: (row: Record<string, unknown>, column: string) => ReactNode;
   emptyMessage?: string;
   sortColumn?: string;
@@ -109,6 +112,7 @@ export function DataTable({
   secondaryActionClassName = "",
   secondaryActionPosition = "end",
   tableClassName = "",
+  wrapClassName = "",
   renderCell,
   emptyMessage = "No rows.",
   sortColumn,
@@ -129,5 +133,5 @@ export function DataTable({
   const totalColumns = cols.length + (action ? 1 : 0) + (secondaryAction ? 1 : 0);
   const leadingSecondaryHeader = secondaryAction && secondaryActionPosition === "start" ? <th className={secondaryActionClassName}>{secondaryActionLabel}</th> : null;
   const trailingSecondaryHeader = secondaryAction && secondaryActionPosition === "end" ? <th className={secondaryActionClassName}>{secondaryActionLabel}</th> : null;
-  return <div className="table-wrap" role="region" aria-label="Scrollable data table" tabIndex={0}><table className={tableClassName}><thead><tr>{leadingSecondaryHeader}{cols.map((col) => { const sortable = onSort && !nonSortableColumns.includes(col); const label = columnLabels[col] || friendlyColumnName(col); return <th key={col} className={sortable ? "sortable" : ""} style={colStyle(col)} title={headerTitles ? label : undefined} onClick={sortable ? () => onSort?.(col) : undefined}>{label}{sortable && sortColumn === col && <span className="sort-indicator">{sortDirection === "desc" ? " ↓" : " ↑"}</span>}{resizableColumns && resize.resizeHandle(col)}</th>; })}{action && <th className={actionClassName}>Actions</th>}{trailingSecondaryHeader}</tr></thead><tbody>{rows.map((row, index) => <Fragment key={rowKey ? rowKey(row) : index}><tr onClick={() => onRowClick?.(row)} className={onRowClick ? "clickable" : ""}>{secondaryAction && secondaryActionPosition === "start" && <td className={secondaryActionClassName}>{secondaryAction(row)}</td>}{cols.map((col) => <td key={col} style={colStyle(col)}>{renderCell ? renderCell(row, col) : formatCell(row[col])}</td>)}{action && <td className={actionClassName}>{action(row)}</td>}{secondaryAction && secondaryActionPosition === "end" && <td className={secondaryActionClassName}>{secondaryAction(row)}</td>}</tr>{isRowExpanded?.(row) && renderExpandedRow && <tr className="expanded-row"><td colSpan={totalColumns} className="expanded-row-cell">{renderExpandedRow(row)}</td></tr>}</Fragment>)}</tbody></table></div>;
+  return <div className={`table-wrap${wrapClassName ? ` ${wrapClassName}` : ""}`} role="region" aria-label="Scrollable data table" tabIndex={0}><table className={tableClassName}><thead><tr>{leadingSecondaryHeader}{cols.map((col) => { const sortable = onSort && !nonSortableColumns.includes(col); const label = columnLabels[col] || friendlyColumnName(col); return <th key={col} className={sortable ? "sortable" : ""} style={colStyle(col)} title={headerTitles ? label : undefined} onClick={sortable ? () => onSort?.(col) : undefined}>{label}{sortable && sortColumn === col && <span className="sort-indicator">{sortDirection === "desc" ? " ↓" : " ↑"}</span>}{resizableColumns && resize.resizeHandle(col)}</th>; })}{action && <th className={actionClassName}>Actions</th>}{trailingSecondaryHeader}</tr></thead><tbody>{rows.map((row, index) => <Fragment key={rowKey ? rowKey(row) : index}><tr onClick={() => onRowClick?.(row)} className={onRowClick ? "clickable" : ""}>{secondaryAction && secondaryActionPosition === "start" && <td className={secondaryActionClassName}>{secondaryAction(row)}</td>}{cols.map((col) => <td key={col} style={colStyle(col)}>{renderCell ? renderCell(row, col) : formatCell(row[col])}</td>)}{action && <td className={actionClassName}>{action(row)}</td>}{secondaryAction && secondaryActionPosition === "end" && <td className={secondaryActionClassName}>{secondaryAction(row)}</td>}</tr>{isRowExpanded?.(row) && renderExpandedRow && <tr className="expanded-row"><td colSpan={totalColumns} className="expanded-row-cell">{renderExpandedRow(row)}</td></tr>}</Fragment>)}</tbody></table></div>;
 }

--- a/console/web/src/features/bases/BasePermissionsTab.tsx
+++ b/console/web/src/features/bases/BasePermissionsTab.tsx
@@ -1,0 +1,266 @@
+import { useCallback, useEffect, useState } from "react";
+import { Plus, Trash2, TriangleAlert } from "lucide-react";
+import {
+  basesApi,
+  type BasePermissionCandidate,
+  type BasePermissionEntry,
+  type BasePermissionRank
+} from "../../api/bases";
+
+type BasePermissionsTabProps = {
+  baseId: string;
+  baseName: string;
+  onSaved: () => void;
+};
+
+const OWNER_RANK: BasePermissionRank = 1;
+const CO_OWNER_RANK: BasePermissionRank = 2;
+const ASSOCIATE_RANK: BasePermissionRank = 3;
+
+const RANK_LABELS: Record<BasePermissionRank, string> = {
+  1: "Owner",
+  2: "Co-Owner",
+  3: "Associate"
+};
+
+const RANK_OPTIONS: BasePermissionRank[] = [OWNER_RANK, CO_OWNER_RANK, ASSOCIATE_RANK];
+
+type DraftEntry = { playerId: string; name: string; rank: BasePermissionRank; canonical: boolean };
+
+function toDraft(entries: BasePermissionEntry[]): DraftEntry[] {
+  return entries.map((entry) => ({
+    playerId: entry.playerId,
+    name: entry.name,
+    rank: entry.rank,
+    canonical: entry.canonical
+  }));
+}
+
+function sortDraft(entries: DraftEntry[]) {
+  return [...entries].sort((left, right) => left.rank - right.rank || left.name.localeCompare(right.name));
+}
+
+function sameRoster(left: DraftEntry[], right: DraftEntry[]) {
+  if (left.length !== right.length) return false;
+  const rightByPlayer = new Map(right.map((entry) => [entry.playerId, entry.rank]));
+  return left.every((entry) => rightByPlayer.get(entry.playerId) === entry.rank);
+}
+
+function errorText(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function BasePermissionsTab({ baseId, baseName, onSaved }: BasePermissionsTabProps) {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [saved, setSaved] = useState<DraftEntry[]>([]);
+  const [draft, setDraft] = useState<DraftEntry[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState("");
+  const [statusKind, setStatusKind] = useState<"" | "ok" | "fail">("");
+  const [candidateQuery, setCandidateQuery] = useState("");
+  const [candidates, setCandidates] = useState<BasePermissionCandidate[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const [addRank, setAddRank] = useState<BasePermissionRank>(ASSOCIATE_RANK);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError("");
+    try {
+      const result = await basesApi.permissions(baseId);
+      const entries = toDraft(result.entries || []);
+      setSaved(entries);
+      setDraft(entries);
+    } catch (error) {
+      setLoadError(errorText(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [baseId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const dirty = !sameRoster(saved, draft);
+  const owner = draft.find((entry) => entry.rank === OWNER_RANK);
+
+  // Promoting to Owner demotes whoever currently holds it, in the same local
+  // edit. The server enforces the one-owner rule too, but doing it here means
+  // the invariant can never be broken on screen -- there is no intermediate
+  // state showing two Owners for the user to try to save.
+  function changeRank(playerId: string, nextRank: BasePermissionRank) {
+    setDraft((current) => current.map((entry) => {
+      if (entry.playerId === playerId) return { ...entry, rank: nextRank };
+      if (nextRank === OWNER_RANK && entry.rank === OWNER_RANK) return { ...entry, rank: CO_OWNER_RANK };
+      return entry;
+    }));
+  }
+
+  function removeEntry(playerId: string) {
+    setDraft((current) => current.filter((entry) => entry.playerId !== playerId));
+  }
+
+  function addCandidate(candidate: BasePermissionCandidate) {
+    setDraft((current) => {
+      if (current.some((entry) => entry.playerId === candidate.playerId)) return current;
+      const next = [...current, { playerId: candidate.playerId, name: candidate.name, rank: addRank, canonical: true }];
+      // Adding straight to Owner has to demote the incumbent for the same
+      // reason changeRank does.
+      if (addRank !== OWNER_RANK) return next;
+      return next.map((entry) => entry.playerId === candidate.playerId || entry.rank !== OWNER_RANK
+        ? entry
+        : { ...entry, rank: CO_OWNER_RANK });
+    });
+  }
+
+  // Explicit submit rather than search-as-you-type: this queries the server, and
+  // a debounced field would fire a request per keystroke.
+  async function submitCandidateSearch() {
+    setSearching(true);
+    try {
+      const result = await basesApi.permissionCandidates(candidateQuery);
+      setCandidates(result.rows || []);
+      setSearched(true);
+    } catch (error) {
+      setStatus(errorText(error));
+      setStatusKind("fail");
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  function clearCandidateSearch() {
+    setCandidateQuery("");
+    setCandidates([]);
+    setSearched(false);
+  }
+
+  async function save() {
+    if (!owner) return;
+    setSaving(true);
+    setStatus("");
+    setStatusKind("");
+    try {
+      const response = await basesApi.setPermissions(baseId, draft.map((entry) => ({ playerId: entry.playerId, rank: entry.rank })));
+      setSaved(draft);
+      setStatus(response.result?.message || "Permissions were updated.");
+      setStatusKind("ok");
+      onSaved();
+    } catch (error) {
+      setStatus(errorText(error));
+      setStatusKind("fail");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return <p className="muted" role="status">Loading permissions…</p>;
+  }
+  if (loadError) {
+    return <p className="bases-permissions-error" role="alert">
+      {loadError} <button onClick={() => void load()}>Retry</button>
+    </p>;
+  }
+
+  const alreadyOnRoster = new Set(draft.map((entry) => entry.playerId));
+
+  return (
+    <div className="bases-permissions" onClick={(event) => event.stopPropagation()}>
+      <p className="action-help-note">
+        Exactly one Owner. Promoting a player demotes the current Owner to Co-Owner. Changes apply to the running map immediately.
+      </p>
+
+      <div className="bases-permissions-roster">
+        {sortDraft(draft).map((entry) => {
+          const isOwner = entry.rank === OWNER_RANK;
+          return (
+            <div className={`bases-permissions-row${isOwner ? " bases-permissions-row-owner" : ""}`} key={entry.playerId}>
+              <span className="bases-permissions-name" title={entry.name || entry.playerId}>
+                {entry.name || `Player ${entry.playerId}`}
+                {!entry.canonical && <span className="bases-permissions-orphan" title="This entry does not match a known player character, so the game ignores it. Removing it is safe.">
+                  <TriangleAlert size={13} aria-label="Ignored by the game" />
+                </span>}
+              </span>
+              <select
+                value={String(entry.rank)}
+                disabled={saving}
+                aria-label={`Rank for ${entry.name || entry.playerId}`}
+                onChange={(event) => changeRank(entry.playerId, Number(event.target.value) as BasePermissionRank)}
+              >
+                {RANK_OPTIONS.map((rank) => <option key={rank} value={rank}>{RANK_LABELS[rank]}</option>)}
+              </select>
+              <button
+                className="icon-toggle-button bases-permissions-remove"
+                // Removing the Owner would leave the base ownerless, which the
+                // server rejects. Promote a replacement first -- that demotes
+                // this one automatically and frees the button.
+                disabled={isOwner || saving}
+                title={isOwner ? "Promote another player to Owner before removing this one" : `Remove ${entry.name || entry.playerId}`}
+                aria-label={`Remove ${entry.name || entry.playerId}`}
+                onClick={() => removeEntry(entry.playerId)}
+              ><Trash2 size={15} /></button>
+            </div>
+          );
+        })}
+        {!draft.length && <p className="muted">This base has no permission entries.</p>}
+      </div>
+
+      <div className="bases-permissions-add">
+        <div className="action-row bases-permissions-search-row">
+          <input
+            value={candidateQuery}
+            placeholder="Search a player to add"
+            disabled={saving}
+            onChange={(event) => setCandidateQuery(event.target.value)}
+            onKeyDown={(event) => { if (event.key === "Enter") void submitCandidateSearch(); }}
+          />
+          <button disabled={searching || saving} onClick={() => void submitCandidateSearch()}>Search</button>
+          <button disabled={!candidateQuery && !searched} onClick={clearCandidateSearch}>Clear</button>
+          <label className="compact-select">
+            Add as
+            <select value={String(addRank)} disabled={saving} onChange={(event) => setAddRank(Number(event.target.value) as BasePermissionRank)}>
+              {RANK_OPTIONS.map((rank) => <option key={rank} value={rank}>{RANK_LABELS[rank]}</option>)}
+            </select>
+          </label>
+        </div>
+        {searched && !candidates.length && <p className="muted">No players matched that search.</p>}
+        {candidates.length > 0 && <ul className="bases-permissions-candidates">
+          {candidates.map((candidate) => (
+            <li key={candidate.playerId}>
+              <span>{candidate.name}</span>
+              <button
+                className="icon-toggle-button"
+                disabled={alreadyOnRoster.has(candidate.playerId) || saving}
+                title={alreadyOnRoster.has(candidate.playerId) ? "Already on this base" : `Add ${candidate.name} as ${RANK_LABELS[addRank]}`}
+                aria-label={`Add ${candidate.name}`}
+                onClick={() => addCandidate(candidate)}
+              ><Plus size={15} /></button>
+            </li>
+          ))}
+        </ul>}
+      </div>
+
+      {dirty && <p className="confirm-modal-warning bases-permissions-warning" role="status">
+        Saving writes to the live database and notifies the running map server. An online player may need to reopen the base's panel to see the change.
+      </p>}
+      {!owner && <p className="bases-permissions-error" role="alert">
+        This base has no Owner. Set one before saving.
+      </p>}
+      {status && <p className={`inline-task-result${statusKind ? ` result-${statusKind}` : ""}`} role={statusKind === "fail" ? "alert" : "status"}>
+        <strong>{status}</strong>
+      </p>}
+
+      <div className="bases-permissions-actions">
+        <span className="muted">{dirty ? "Unsaved changes" : ""}</span>
+        <button disabled={!dirty || saving} onClick={() => setDraft(saved)}>Revert</button>
+        <button
+          className="update-action"
+          disabled={!dirty || !owner || saving}
+          title={`Save permissions for ${baseName}`}
+          onClick={() => void save()}
+        >{saving ? "Saving…" : "Save changes"}</button>
+      </div>
+    </div>
+  );
+}

--- a/console/web/src/features/bases/BaseWaterTab.tsx
+++ b/console/web/src/features/bases/BaseWaterTab.tsx
@@ -84,35 +84,37 @@ export function BaseWaterTab({ baseId, autoRefill }: BaseWaterTabProps) {
       {!containers.length && <p className="muted">No water storage at this base.</p>}
 
       <div className="bases-generator-breakdown">
-        {containers.map((container) => (
-          <div className="bases-generator-group" key={container.type}>
-            <div className="bases-generator-group-title">{container.name}</div>
-            <dl className="bases-generator-stats">
-              <dt>Containers</dt>
-              <dd>{container.count.toLocaleString()}</dd>
-              <dt>Water Volume</dt>
-              <dd>{container.stored.toLocaleString()} / {container.capacity.toLocaleString()}</dd>
-              <dt>Water Fill</dt>
-              <dd>
-                <div className="progress-row">
-                  <div className="progress-track"><div className="progress-fill" style={{ width: `${container.percent}%` }} /></div>
-                  <span>{container.percent}%</span>
-                </div>
-              </dd>
-              {container.bloodCapacity !== undefined && <>
-                <dt>Blood Volume</dt>
-                <dd>{(container.bloodStored ?? 0).toLocaleString()} / {container.bloodCapacity.toLocaleString()}</dd>
-                <dt>Blood Fill</dt>
+        <div className="bases-generator-cards bases-water-cards">
+          {containers.map((container) => (
+            <div className="bases-generator-group" key={container.type}>
+              <div className="bases-generator-group-title">{container.name}</div>
+              <dl className="bases-generator-stats">
+                <dt>Containers</dt>
+                <dd>{container.count.toLocaleString()}</dd>
+                <dt>Water Volume</dt>
+                <dd>{container.stored.toLocaleString()} / {container.capacity.toLocaleString()}</dd>
+                <dt>Water Fill</dt>
                 <dd>
                   <div className="progress-row">
-                    <div className="progress-track"><div className="progress-fill" style={{ width: `${container.bloodPercent ?? 0}%` }} /></div>
-                    <span>{container.bloodPercent ?? 0}%</span>
+                    <div className="progress-track"><div className="progress-fill progress-fill-water" style={{ width: `${container.percent}%` }} /></div>
+                    <span>{container.percent}%</span>
                   </div>
                 </dd>
-              </>}
-            </dl>
-          </div>
-        ))}
+                {container.bloodCapacity !== undefined && <>
+                  <dt>Blood Volume</dt>
+                  <dd>{(container.bloodStored ?? 0).toLocaleString()} / {container.bloodCapacity.toLocaleString()}</dd>
+                  <dt>Blood Fill</dt>
+                  <dd>
+                    <div className="progress-row">
+                      <div className="progress-track"><div className="progress-fill progress-fill-blood" style={{ width: `${container.bloodPercent ?? 0}%` }} /></div>
+                      <span>{container.bloodPercent ?? 0}%</span>
+                    </div>
+                  </dd>
+                </>}
+              </dl>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/console/web/src/features/bases/BaseWaterTab.tsx
+++ b/console/web/src/features/bases/BaseWaterTab.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useState } from "react";
+import { basesApi, type WaterContainerEntry } from "../../api/bases";
+import { InfoTooltip } from "../../components/common/DisplayPrimitives";
+
+// Auto-refill state/handlers live in BasesPanel (mirrors generator
+// Auto-Refill), which passes down whatever this tab needs to render its own
+// toggle without owning any of that state itself.
+export type BaseWaterAutoRefillProps = {
+  supported: boolean;
+  unavailable: boolean;
+  enabled: boolean;
+  saving: boolean;
+  stalledAt: string;
+  consecutiveQueues: number;
+  canToggle: boolean;
+  tooltip: string;
+  onToggle: (enabled: boolean) => void;
+  onRetry: () => void;
+};
+
+type BaseWaterTabProps = {
+  baseId: string;
+  autoRefill: BaseWaterAutoRefillProps;
+};
+
+function errorText(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function BaseWaterTab({ baseId, autoRefill }: BaseWaterTabProps) {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [containers, setContainers] = useState<WaterContainerEntry[]>([]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError("");
+    try {
+      const result = await basesApi.water(baseId);
+      setContainers(result.containers || []);
+    } catch (error) {
+      setLoadError(errorText(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [baseId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  if (loading) {
+    return <p className="muted" role="status">Loading water storage…</p>;
+  }
+  if (loadError) {
+    return <p className="bases-permissions-error" role="alert">
+      {loadError} <button onClick={() => void load()}>Retry</button>
+    </p>;
+  }
+
+  return (
+    <div className="bases-water" onClick={(event) => event.stopPropagation()}>
+      {autoRefill.supported && <div className="bases-auto-refill">
+        {autoRefill.unavailable
+          ? <p className="bases-auto-refill-unknown" role="status">
+              Auto-refill state could not be read. <button onClick={autoRefill.onRetry}>Retry</button>
+            </p>
+          : <div className="memory-feature-toggle">
+              <InfoTooltip id={`auto-refill-water-help-${baseId}`} label="About Auto-Refill">{autoRefill.tooltip}</InfoTooltip>
+              <label className={`switch-checkbox bases-auto-refill-toggle ${autoRefill.enabled ? "enabled" : "disabled"}`}>
+                <input
+                  type="checkbox"
+                  checked={autoRefill.enabled}
+                  disabled={autoRefill.saving || !autoRefill.canToggle}
+                  onChange={(event) => autoRefill.onToggle(event.target.checked)}
+                />
+                <span className="switch-label">Auto-Refill</span>
+                <strong className="switch-state">{autoRefill.saving ? "Saving" : autoRefill.enabled ? "ON" : "OFF"}</strong>
+              </label>
+            </div>}
+        {autoRefill.stalledAt && <p className="bases-auto-refill-stalled" role="alert">
+          Paused after {autoRefill.consecutiveQueues} refills that did not raise the water. Refill manually to check why, or turn auto-refill off and on to resume.
+        </p>}
+      </div>}
+
+      {!containers.length && <p className="muted">No water storage at this base.</p>}
+
+      <div className="bases-generator-breakdown">
+        {containers.map((container) => (
+          <div className="bases-generator-group" key={container.type}>
+            <div className="bases-generator-group-title">{container.name}</div>
+            <dl className="bases-generator-stats">
+              <dt>Containers</dt>
+              <dd>{container.count.toLocaleString()}</dd>
+              <dt>Water Volume</dt>
+              <dd>{container.stored.toLocaleString()} / {container.capacity.toLocaleString()}</dd>
+              <dt>Water Fill</dt>
+              <dd>
+                <div className="progress-row">
+                  <div className="progress-track"><div className="progress-fill" style={{ width: `${container.percent}%` }} /></div>
+                  <span>{container.percent}%</span>
+                </div>
+              </dd>
+              {container.bloodCapacity !== undefined && <>
+                <dt>Blood Volume</dt>
+                <dd>{(container.bloodStored ?? 0).toLocaleString()} / {container.bloodCapacity.toLocaleString()}</dd>
+                <dt>Blood Fill</dt>
+                <dd>
+                  <div className="progress-row">
+                    <div className="progress-track"><div className="progress-fill" style={{ width: `${container.bloodPercent ?? 0}%` }} /></div>
+                    <span>{container.bloodPercent ?? 0}%</span>
+                  </div>
+                </dd>
+              </>}
+            </dl>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/console/web/src/features/bases/BaseWaterTab.tsx
+++ b/console/web/src/features/bases/BaseWaterTab.tsx
@@ -21,13 +21,17 @@ export type BaseWaterAutoRefillProps = {
 type BaseWaterTabProps = {
   baseId: string;
   autoRefill: BaseWaterAutoRefillProps;
+  // Bumped by BasesPanel after an immediate (non-queued) refill -- water isn't
+  // part of the row/list data this tab could otherwise pick up on its own, so
+  // this is the only signal telling an already-open tab to refetch.
+  refreshToken?: number;
 };
 
 function errorText(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
 
-export function BaseWaterTab({ baseId, autoRefill }: BaseWaterTabProps) {
+export function BaseWaterTab({ baseId, autoRefill, refreshToken }: BaseWaterTabProps) {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState("");
   const [containers, setContainers] = useState<WaterContainerEntry[]>([]);
@@ -45,7 +49,7 @@ export function BaseWaterTab({ baseId, autoRefill }: BaseWaterTabProps) {
     }
   }, [baseId]);
 
-  useEffect(() => { void load(); }, [load]);
+  useEffect(() => { void load(); }, [load, refreshToken]);
 
   if (loading) {
     return <p className="muted" role="status">Loading water storage…</p>;
@@ -58,32 +62,32 @@ export function BaseWaterTab({ baseId, autoRefill }: BaseWaterTabProps) {
 
   return (
     <div className="bases-water" onClick={(event) => event.stopPropagation()}>
-      {autoRefill.supported && <div className="bases-auto-refill">
-        {autoRefill.unavailable
-          ? <p className="bases-auto-refill-unknown" role="status">
-              Auto-refill state could not be read. <button onClick={autoRefill.onRetry}>Retry</button>
-            </p>
-          : <div className="memory-feature-toggle">
-              <InfoTooltip id={`auto-refill-water-help-${baseId}`} label="About Auto-Refill">{autoRefill.tooltip}</InfoTooltip>
-              <label className={`switch-checkbox bases-auto-refill-toggle ${autoRefill.enabled ? "enabled" : "disabled"}`}>
-                <input
-                  type="checkbox"
-                  checked={autoRefill.enabled}
-                  disabled={autoRefill.saving || !autoRefill.canToggle}
-                  onChange={(event) => autoRefill.onToggle(event.target.checked)}
-                />
-                <span className="switch-label">Auto-Refill</span>
-                <strong className="switch-state">{autoRefill.saving ? "Saving" : autoRefill.enabled ? "ON" : "OFF"}</strong>
-              </label>
-            </div>}
-        {autoRefill.stalledAt && <p className="bases-auto-refill-stalled" role="alert">
-          Paused after {autoRefill.consecutiveQueues} refills that did not raise the water. Refill manually to check why, or turn auto-refill off and on to resume.
-        </p>}
-      </div>}
-
-      {!containers.length && <p className="muted">No water storage at this base.</p>}
-
       <div className="bases-generator-breakdown">
+        {autoRefill.supported && <div className="bases-auto-refill">
+          {autoRefill.unavailable
+            ? <p className="bases-auto-refill-unknown" role="status">
+                Auto-refill state could not be read. <button onClick={autoRefill.onRetry}>Retry</button>
+              </p>
+            : <div className="memory-feature-toggle">
+                <InfoTooltip id={`auto-refill-water-help-${baseId}`} label="About Auto-Refill">{autoRefill.tooltip}</InfoTooltip>
+                <label className={`switch-checkbox bases-auto-refill-toggle ${autoRefill.enabled ? "enabled" : "disabled"}`}>
+                  <input
+                    type="checkbox"
+                    checked={autoRefill.enabled}
+                    disabled={autoRefill.saving || !autoRefill.canToggle}
+                    onChange={(event) => autoRefill.onToggle(event.target.checked)}
+                  />
+                  <span className="switch-label">Auto-Refill</span>
+                  <strong className="switch-state">{autoRefill.saving ? "Saving" : autoRefill.enabled ? "ON" : "OFF"}</strong>
+                </label>
+              </div>}
+          {autoRefill.stalledAt && <p className="bases-auto-refill-stalled" role="alert">
+            Paused after {autoRefill.consecutiveQueues} refills that did not raise the water. Refill manually to check why, or turn auto-refill off and on to resume.
+          </p>}
+        </div>}
+
+        {!containers.length && <p className="muted">No water storage at this base.</p>}
+
         <div className="bases-generator-cards bases-water-cards">
           {containers.map((container) => (
             <div className="bases-generator-group" key={container.type}>

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -10,7 +10,10 @@ vi.mock("../../api/bases", () => ({
     cancelQueuedRefill: vi.fn(),
     pendingRefills: vi.fn(),
     autoRefill: vi.fn(),
-    setAutoRefill: vi.fn()
+    setAutoRefill: vi.fn(),
+    permissions: vi.fn(),
+    setPermissions: vi.fn(),
+    permissionCandidates: vi.fn()
   }
 }));
 
@@ -638,5 +641,168 @@ describe("BasesPanel auto-refill", () => {
     const refill = await screen.findByRole("button", { name: "Refill Generators (auto-refill on)" });
     expect(refill).toHaveClass("bases-auto-refill-on");
     expect(refill).not.toHaveClass("bases-auto-refill-stalled-icon");
+  });
+});
+
+describe("BasesPanel permissions editing", () => {
+  const permissionRow = {
+    ...commonRow,
+    base_id: "1006",
+    name: "Sietch One",
+    owner_name: "DarkShark",
+    shared_with: [{ name: "Yaida", rank: 2, label: "Co-Owner" }],
+    generatorDataAvailable: true,
+    generatorCount: 0,
+    generatorUptimeMultiplier: 1,
+    generatorUptimeEventLabel: "",
+    generatorUptimeEventEndsAt: "",
+    generatorUnstockedCount: 0,
+    generatorAllUnstocked: false
+  };
+
+  function mockList(basePermissions: boolean) {
+    vi.mocked(basesApi.list).mockResolvedValue({
+      capabilities: { bases: true, basePermissions },
+      totalCount: 1,
+      totalBases: 1,
+      totalPieces: 10,
+      totalPlaceables: 4,
+      rows: [permissionRow]
+    } as never);
+  }
+
+  // The only route into the editor now that the pencil is gone: expand the row,
+  // then switch to Permissions.
+  async function openPermissionsTab() {
+    fireEvent.click(await screen.findByRole("button", { name: "Show permissions for Sietch One" }));
+    fireEvent.click(await screen.findByRole("tab", { name: "Permissions" }));
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Permissions" })).toHaveAttribute("aria-selected", "true"));
+  }
+
+  function mockRoster() {
+    vi.mocked(basesApi.permissions).mockResolvedValue({
+      supported: true,
+      baseId: 1006,
+      actorId: "1004",
+      map: "DeepDesert",
+      mapNameId: 7,
+      entries: [
+        { playerId: "4", name: "DarkShark", rank: 1, label: "Owner", canonical: true },
+        { playerId: "29", name: "Yaida", rank: 2, label: "Co-Owner", canonical: true }
+      ]
+    } as never);
+  }
+
+  it("hides the editor entirely when the schema does not support it", async () => {
+    mockList(false);
+    renderPanel();
+    expect(await screen.findByText("Sietch One")).toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Permissions" })).not.toBeInTheDocument();
+    // With no generators and no permission capability there is nothing to
+    // expand into, so the row keeps its original chevron-less shape.
+    expect(screen.queryByRole("button", { name: /Sietch One/ })).not.toBeInTheDocument();
+  });
+
+  // A base with no generators had no expand chevron before this feature. It
+  // needs one now, or the Permissions tab would be unreachable for those rows.
+  it("gives a generator-less base an expand chevron once permissions are editable", async () => {
+    mockList(true);
+    mockRoster();
+    renderPanel();
+    expect(await screen.findByRole("button", { name: "Show permissions for Sietch One" })).toBeInTheDocument();
+  });
+
+  it("reaches the roster by expanding the row and switching tabs", async () => {
+    mockList(true);
+    mockRoster();
+    renderPanel();
+    await openPermissionsTab();
+    // The roster's own control, not the name text -- "DarkShark" also appears in
+    // the Owner cell of the row above.
+    expect(await screen.findByRole("combobox", { name: "Rank for DarkShark" })).toBeInTheDocument();
+  });
+
+  it("defaults to the Power tab when the row is expanded normally", async () => {
+    mockList(true);
+    mockRoster();
+    renderPanel();
+    fireEvent.click(await screen.findByText("Sietch One"));
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Power" })).toHaveAttribute("aria-selected", "true"));
+  });
+
+  // Promoting has to demote the incumbent in the same edit, so the one-owner
+  // rule can never be violated on screen.
+  it("demotes the current owner when another player is promoted", async () => {
+    mockList(true);
+    mockRoster();
+    renderPanel();
+    await openPermissionsTab();
+    const yaidaRank = await screen.findByRole("combobox", { name: "Rank for Yaida" });
+    fireEvent.change(yaidaRank, { target: { value: "1" } });
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: "Rank for Yaida" })).toHaveValue("1");
+      expect(screen.getByRole("combobox", { name: "Rank for DarkShark" })).toHaveValue("2");
+    });
+  });
+
+  it("blocks removing the owner and enables Save only once the roster is dirty", async () => {
+    mockList(true);
+    mockRoster();
+    renderPanel();
+    await openPermissionsTab();
+    expect(await screen.findByRole("button", { name: "Remove DarkShark" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Remove Yaida" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove Yaida" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled());
+    expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+  });
+
+  it("reverts local edits without calling the server", async () => {
+    mockList(true);
+    mockRoster();
+    renderPanel();
+    await openPermissionsTab();
+    fireEvent.click(await screen.findByRole("button", { name: "Remove Yaida" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Revert" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+    await waitFor(() => expect(screen.getByRole("combobox", { name: "Rank for Yaida" })).toBeInTheDocument());
+    expect(basesApi.setPermissions).not.toHaveBeenCalled();
+  });
+
+  it("saves the whole roster as one request", async () => {
+    mockList(true);
+    mockRoster();
+    vi.mocked(basesApi.setPermissions).mockResolvedValue({
+      supported: true,
+      result: { ok: true, baseId: 1006, actorId: "1004", map: "DeepDesert", added: 0, reranked: 0, removed: 1, total: 1, message: "Permissions were updated." }
+    } as never);
+    renderPanel();
+    await openPermissionsTab();
+    fireEvent.click(await screen.findByRole("button", { name: "Remove Yaida" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+    await waitFor(() => expect(basesApi.setPermissions).toHaveBeenCalledWith("1006", [{ playerId: "4", rank: 1 }]));
+  });
+
+  // A roster row naming a non-canonical actor is one the game ignores. The
+  // console can see it and the game client cannot, so it must be visible here.
+  it("flags a roster entry the game ignores", async () => {
+    mockList(true);
+    vi.mocked(basesApi.permissions).mockResolvedValue({
+      supported: true,
+      baseId: 1006,
+      actorId: "1004",
+      map: "DeepDesert",
+      mapNameId: 7,
+      entries: [
+        { playerId: "4", name: "DarkShark", rank: 1, label: "Owner", canonical: true },
+        { playerId: "5", name: "DarkShark", rank: 3, label: "Associate", canonical: false }
+      ]
+    } as never);
+    renderPanel();
+    await openPermissionsTab();
+    expect(await screen.findByLabelText("Ignored by the game")).toBeInTheDocument();
   });
 });

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -13,7 +13,13 @@ vi.mock("../../api/bases", () => ({
     setAutoRefill: vi.fn(),
     permissions: vi.fn(),
     setPermissions: vi.fn(),
-    permissionCandidates: vi.fn()
+    permissionCandidates: vi.fn(),
+    water: vi.fn(),
+    refillWater: vi.fn(),
+    cancelQueuedWaterRefill: vi.fn(),
+    pendingWaterRefills: vi.fn(),
+    autoRefillWater: vi.fn(),
+    setAutoRefillWater: vi.fn()
   }
 }));
 
@@ -100,12 +106,14 @@ describe("BasesPanel generator details", () => {
       "2 · Lowest Queued Reserve 2h 0m. Queued Reserve counts fuel still in inventory. It excludes fuel currently burning, so the in-game Total Uptime may be higher."
     );
     expect(screen.getByText("Unavailable")).toHaveAttribute("title", "Generator data is unavailable");
-    expect(screen.queryByRole("button", { name: "Show generator details for Sietch Two" })).not.toBeInTheDocument();
+    // The chevron always renders now -- every base can be expanded into at
+    // least the Water tab, even one with no generator data at all.
+    expect(screen.getByRole("button", { name: "Show details for Sietch Two" })).toBeInTheDocument();
     // Column headers get the same tooltip treatment for when their label is
     // wider than the (user-resizable) column default.
     expect(screen.getByRole("columnheader", { name: /Building Pieces/ })).toHaveAttribute("title", "Building Pieces");
 
-    fireEvent.click(screen.getByRole("button", { name: "Show generator details for Sietch One" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show details for Sietch One" }));
 
     expect(screen.getByText("Fuel-Powered Generator")).toBeInTheDocument();
     expect(screen.getByText("Spice-Powered Generator")).toBeInTheDocument();
@@ -162,7 +170,7 @@ describe("BasesPanel generator details", () => {
       "4 · 1 with no queued fuel · Lowest Queued Reserve 3h 0m. Queued Reserve counts fuel still in inventory. It excludes fuel currently burning, so the in-game Total Uptime may be higher."
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Show generator details for Sietch Three" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show details for Sietch Three" }));
 
     expect(screen.getByText("Fuel-Powered Generator")).toBeInTheDocument();
     expect(screen.getByText("Spice-Powered Generator")).toBeInTheDocument();
@@ -388,7 +396,7 @@ describe("BasesPanel auto-refill", () => {
 
   async function expandRow(name: string) {
     await screen.findByText(name);
-    fireEvent.click(await screen.findByRole("button", { name: `Show generator details for ${name}` }));
+    fireEvent.click(await screen.findByRole("button", { name: `Show details for ${name}` }));
   }
 
   it("offers the toggle only when the database supports the refill queue", async () => {
@@ -674,7 +682,7 @@ describe("BasesPanel permissions editing", () => {
   // The only route into the editor now that the pencil is gone: expand the row,
   // then switch to Permissions.
   async function openPermissionsTab() {
-    fireEvent.click(await screen.findByRole("button", { name: "Show permissions for Sietch One" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Show details for Sietch One" }));
     fireEvent.click(await screen.findByRole("tab", { name: "Permissions" }));
     await waitFor(() => expect(screen.getByRole("tab", { name: "Permissions" })).toHaveAttribute("aria-selected", "true"));
   }
@@ -693,14 +701,17 @@ describe("BasesPanel permissions editing", () => {
     } as never);
   }
 
-  it("hides the editor entirely when the schema does not support it", async () => {
+  it("hides the Permissions tab when the schema does not support it, but still allows expanding into Power/Water", async () => {
     mockList(false);
     renderPanel();
     expect(await screen.findByText("Sietch One")).toBeInTheDocument();
+    // The chevron always renders now -- every base can always be expanded
+    // into at least the Water tab -- so this base's lack of permission
+    // support has to be checked by expanding it, not by the chevron's absence.
+    fireEvent.click(await screen.findByRole("button", { name: "Show details for Sietch One" }));
+    expect(screen.getByRole("tab", { name: "Power" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Water" })).toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "Permissions" })).not.toBeInTheDocument();
-    // With no generators and no permission capability there is nothing to
-    // expand into, so the row keeps its original chevron-less shape.
-    expect(screen.queryByRole("button", { name: /Sietch One/ })).not.toBeInTheDocument();
   });
 
   // A base with no generators had no expand chevron before this feature. It
@@ -709,7 +720,7 @@ describe("BasesPanel permissions editing", () => {
     mockList(true);
     mockRoster();
     renderPanel();
-    expect(await screen.findByRole("button", { name: "Show permissions for Sietch One" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Show details for Sietch One" })).toBeInTheDocument();
   });
 
   it("reaches the roster by expanding the row and switching tabs", async () => {
@@ -804,5 +815,200 @@ describe("BasesPanel permissions editing", () => {
     renderPanel();
     await openPermissionsTab();
     expect(await screen.findByLabelText("Ignored by the game")).toBeInTheDocument();
+  });
+});
+
+describe("BasesPanel water refill", () => {
+  const waterCapableBase = {
+    ...commonRow,
+    generatorDataAvailable: true,
+    generatorCount: 0,
+    generators: []
+  };
+
+  function waterCapableList(row: Record<string, unknown>) {
+    return {
+      capabilities: { bases: true, waterRefill: true, waterRefillQueue: true },
+      totalCount: 1,
+      totalBases: 1,
+      totalPieces: 10,
+      totalPlaceables: 4,
+      rows: [{ ...waterCapableBase, ...row }]
+    };
+  }
+
+  beforeEach(() => {
+    vi.mocked(basesApi.pendingRefills).mockResolvedValue({ supported: true, total: 0, pending: [], byTarget: [] });
+    vi.mocked(basesApi.pendingWaterRefills).mockResolvedValue({ supported: true, total: 0, pending: [], byTarget: [] });
+  });
+
+  // Water isn't part of the row/list data the way generator fuel is --
+  // BaseWaterTab fetches its own container levels -- so an immediate
+  // (non-queued) refill needs its own signal to make an already-open Water
+  // tab refetch, rather than relying on the bases list reloading.
+  it("refetches the open Water tab's container levels after an immediate refill", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue(waterCapableList({ base_id: "4002", name: "Sietch Immediate" }));
+    vi.mocked(basesApi.water)
+      .mockResolvedValueOnce({
+        supported: true,
+        baseId: 4002,
+        containers: [{ type: "waterCistern", name: "Water Cistern", count: 1, stored: 1250, capacity: 5000, percent: 25 }]
+      })
+      .mockResolvedValueOnce({
+        supported: true,
+        baseId: 4002,
+        containers: [{ type: "waterCistern", name: "Water Cistern", count: 1, stored: 5000, capacity: 5000, percent: 100 }]
+      });
+    vi.mocked(basesApi.refillWater).mockResolvedValue({
+      supported: true,
+      result: {
+        ok: true,
+        baseId: 4002,
+        totalAdded: 3750,
+        devices: [{ placeableId: "9101", type: "waterCistern", label: "Water Cistern", before: 1250, after: 5000, added: 3750 }]
+      }
+    });
+
+    renderPanel();
+    await screen.findByText("Sietch Immediate");
+    fireEvent.click(await screen.findByRole("button", { name: "Show details for Sietch Immediate" }));
+    fireEvent.click(await screen.findByRole("tab", { name: "Water" }));
+
+    expect(await screen.findByText("1,250 / 5,000")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Refill Water" }));
+    await waitFor(() => expect(basesApi.refillWater).toHaveBeenCalledWith("4002"));
+
+    expect(await screen.findByText("5,000 / 5,000")).toBeInTheDocument();
+    expect(vi.mocked(basesApi.water).mock.calls.length).toBe(2);
+  });
+
+  it("does not refetch the Water tab when the refill is queued instead of applied immediately", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue(waterCapableList({ base_id: "4003", name: "Sietch Queued Water" }));
+    vi.mocked(basesApi.water).mockResolvedValue({
+      supported: true,
+      baseId: 4003,
+      containers: [{ type: "waterCistern", name: "Water Cistern", count: 1, stored: 1250, capacity: 5000, percent: 25 }]
+    });
+    vi.mocked(basesApi.refillWater).mockResolvedValue({
+      supported: true,
+      result: { ok: true, baseId: 4003, queued: true, map: "DeepDesert_1", partitionId: 8 }
+    });
+
+    renderPanel();
+    await screen.findByText("Sietch Queued Water");
+    fireEvent.click(await screen.findByRole("button", { name: "Show details for Sietch Queued Water" }));
+    fireEvent.click(await screen.findByRole("tab", { name: "Water" }));
+
+    await screen.findByText("1,250 / 5,000");
+    fireEvent.click(screen.getByRole("button", { name: "Refill Water" }));
+    await waitFor(() => expect(basesApi.refillWater).toHaveBeenCalledWith("4003"));
+
+    // Queued refills are applied later by a map restart, not written yet -- so
+    // there is nothing fresh to refetch, and the queue banner is what should
+    // update instead (covered by basesApi.pendingWaterRefills below).
+    await waitFor(() => expect(basesApi.pendingWaterRefills).toHaveBeenCalled());
+    expect(vi.mocked(basesApi.water).mock.calls.length).toBe(1);
+  });
+});
+
+describe("BasesPanel combined fuel/water queue and stalled banners", () => {
+  beforeEach(() => {
+    vi.mocked(basesApi.pendingRefills).mockResolvedValue({ supported: true, total: 0, pending: [], byTarget: [] });
+    vi.mocked(basesApi.autoRefill).mockResolvedValue({
+      supported: true, thresholdPercent: 50, intervalHours: 24, nextRunAt: "", lastRunAt: "", lastRunStatus: "", lastRunDetail: "", total: 0, bases: []
+    });
+  });
+
+  it("shows only the water badge, not a fuel badge, when only water refills are queued", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue({
+      capabilities: { bases: true, waterRefill: true, waterRefillQueue: true },
+      totalCount: 1,
+      totalBases: 1,
+      totalPieces: 10,
+      totalPlaceables: 4,
+      rows: [{ ...commonRow, base_id: "4101", name: "Sietch Water Only", generatorDataAvailable: true, generatorCount: 0, generators: [] }]
+    });
+    vi.mocked(basesApi.pendingWaterRefills).mockResolvedValue({
+      supported: true,
+      total: 1,
+      pending: [{ baseId: 4101, map: "DeepDesert", partitionId: 8, queuedAt: new Date().toISOString(), attempts: 0, lastError: "" }],
+      byTarget: [{ map: "DeepDesert", partitionId: 8, partitionMap: "DeepDesert_1", dimensionIndex: 0, count: 1 }]
+    });
+    vi.mocked(basesApi.autoRefillWater).mockResolvedValue({
+      supported: true, thresholdPercent: 50, intervalHours: 24, nextRunAt: "", lastRunAt: "", lastRunStatus: "", lastRunDetail: "", total: 0, bases: []
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText("1 refill queued")).toBeInTheDocument();
+    // The banner's title icons and each row's badges are gated on
+    // fuelCount/waterCount independently -- with zero fuel queued, no "fuel"
+    // badge should render alongside the water one.
+    expect(screen.queryByText(/\d+ fuel\b/)).not.toBeInTheDocument();
+  });
+
+  it("scopes the stalled-banner explanation to only the resource that actually stalled", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue({
+      capabilities: { bases: true, waterRefill: true, waterRefillQueue: true },
+      totalCount: 1,
+      totalBases: 1,
+      totalPieces: 10,
+      totalPlaceables: 4,
+      rows: [{ ...commonRow, base_id: "4102", name: "Sietch Stalled Water", generatorDataAvailable: true, generatorCount: 0, generators: [] }]
+    });
+    vi.mocked(basesApi.pendingWaterRefills).mockResolvedValue({ supported: true, total: 0, pending: [], byTarget: [] });
+    vi.mocked(basesApi.autoRefillWater).mockResolvedValue({
+      supported: true, thresholdPercent: 50, intervalHours: 24, nextRunAt: "", lastRunAt: "", lastRunStatus: "", lastRunDetail: "",
+      total: 1,
+      bases: [{
+        baseId: 4102,
+        enabledAt: "2026-07-29T12:00:00.000Z",
+        lastCheckedAt: "",
+        lastQueuedAt: "",
+        lastLowestPercent: 8,
+        consecutiveQueues: 3,
+        stalledAt: new Date().toISOString()
+      }]
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText("1 base has stalled auto-refill")).toBeInTheDocument();
+    expect(screen.getByText(/without raising the water on this base/)).toBeInTheDocument();
+    expect(screen.queryByText(/fuel or water/)).not.toBeInTheDocument();
+  });
+
+  it("merges both resources into one queued-refills banner with per-type badges", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue({
+      capabilities: { bases: true, generatorRefill: true, generatorRefillQueue: true, waterRefill: true, waterRefillQueue: true },
+      totalCount: 1,
+      totalBases: 1,
+      totalPieces: 10,
+      totalPlaceables: 4,
+      rows: [{ ...commonRow, base_id: "4103", name: "Sietch Both Queued", generatorDataAvailable: true, generatorCount: 1, generators: [] }]
+    });
+    vi.mocked(basesApi.pendingRefills).mockResolvedValue({
+      supported: true,
+      total: 1,
+      pending: [{ baseId: 4103, map: "DeepDesert", partitionId: 8, queuedAt: new Date().toISOString(), attempts: 0, lastError: "" }],
+      byTarget: [{ map: "DeepDesert", partitionId: 8, partitionMap: "DeepDesert_1", dimensionIndex: 0, count: 1 }]
+    });
+    vi.mocked(basesApi.pendingWaterRefills).mockResolvedValue({
+      supported: true,
+      total: 1,
+      pending: [{ baseId: 4103, map: "DeepDesert", partitionId: 8, queuedAt: new Date().toISOString(), attempts: 0, lastError: "" }],
+      byTarget: [{ map: "DeepDesert", partitionId: 8, partitionMap: "DeepDesert_1", dimensionIndex: 0, count: 1 }]
+    });
+    vi.mocked(basesApi.autoRefillWater).mockResolvedValue({
+      supported: true, thresholdPercent: 50, intervalHours: 24, nextRunAt: "", lastRunAt: "", lastRunStatus: "", lastRunDetail: "", total: 0, bases: []
+    });
+
+    renderPanel();
+
+    // One target, one queued fuel refill and one queued water refill: a single
+    // combined banner, not two separate ones.
+    expect(await screen.findByText("2 refills queued")).toBeInTheDocument();
+    expect(document.querySelectorAll(".bases-pending-refills")).toHaveLength(1);
   });
 });

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronUp, Download, Fuel, X } from "lucide-react";
+import { ChevronDown, ChevronUp, Download, Fuel, Users, X, Zap } from "lucide-react";
+import { BasePermissionsTab } from "./BasePermissionsTab";
 import { basesApi, type AutoRefillBase, type RefillDeviceResult } from "../../api/bases";
 import { mapsApi } from "../../api/maps";
 import { InfoTooltip } from "../../components/common/DisplayPrimitives";
@@ -318,6 +319,10 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
   const [refillStatus, setRefillStatus] = useState<RefillStatusKind>(() => readCachedRefillStatus().kind);
   const [canRefill, setCanRefill] = useState(false);
   const [canQueue, setCanQueue] = useState(false);
+  const [canEditPermissions, setCanEditPermissions] = useState(false);
+  // Which tab the expanded row is showing. Power is the default so expanding a
+  // row behaves exactly as it did before this feature existed.
+  const [expandedTab, setExpandedTab] = useState<"power" | "permissions">("power");
   const [cancelingId, setCancelingId] = useState("");
   // A list, not one key: each row shows its own progress, so the other rows stay
   // clickable and a second restart cannot erase the first one's spinner.
@@ -333,6 +338,7 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
   // what is on screen may not reflect reality.
   const [autoRefillUnavailable, setAutoRefillUnavailable] = useState(false);
   const requestIdRef = useRef(0);
+  const lastExpandedRef = useRef<string | null>(null);
   const skipNextSearchReset = useRef(true);
   const { pending: pendingRefills, refresh: refreshPendingRefills } = usePendingRefills(canQueue);
   const previousPendingTotal = useRef<number | null>(null);
@@ -364,6 +370,7 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
       setRows(nextRows);
       setCanRefill(Boolean(result.capabilities?.generatorRefill));
       setCanQueue(Boolean(result.capabilities?.generatorRefillQueue));
+      setCanEditPermissions(Boolean(result.capabilities?.basePermissions));
       setTotalCount(result.totalCount || 0);
       setTotalBases(result.totalBases || 0);
       setTotalPieces(result.totalPieces || 0);
@@ -680,6 +687,43 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
     }
   }
 
+  // Move focus into a row that has just opened. The expanded panel renders below
+  // the row, so without this the focus stays on the chevron and the content can
+  // open below the fold. Keyed on the base id alone: switching tabs already
+  // focuses the tab that was clicked, and re-focusing on every tab change would
+  // fight the user.
+  //
+  // Must stay above the `loading` early return -- a hook after it changes the
+  // hook count between renders.
+  useEffect(() => {
+    if (!expandedBaseId || lastExpandedRef.current === expandedBaseId) {
+      lastExpandedRef.current = expandedBaseId;
+      return;
+    }
+    lastExpandedRef.current = expandedBaseId;
+    // Synchronous, not deferred to a frame: the expanded row is committed by the
+    // time this effect runs, and a requestAnimationFrame callback never fires
+    // while the tab is backgrounded -- which would silently drop the focus move.
+    const tab = document.querySelector<HTMLButtonElement>(".bases-expanded-tab.active");
+    tab?.focus({ preventScroll: true });
+    // Bring the opened panel into view. The table lives in a `.table-wrap`
+    // scrollport with its own overflow-y, so the element that needs scrolling is
+    // usually that container rather than the window -- scrollIntoView walks every
+    // scrollable ancestor and handles both, which hand-rolled window.scrollBy
+    // arithmetic does not.
+    //
+    // block:"nearest" leaves an already-visible panel alone, so opening a row
+    // near the top never jumps the view, and aligns the top edge when the panel
+    // is taller than the scrollport (showing its start rather than its middle).
+    // No behavior:"smooth" -- it is compositor-driven and does not settle
+    // reliably in a backgrounded tab.
+    //
+    // Optional call: jsdom does not implement scrollIntoView, and scrolling is a
+    // nicety -- the focus move is the part that matters.
+    const panel = document.querySelector<HTMLElement>(".bases-table tbody tr.expanded-row");
+    (panel ?? tab)?.scrollIntoView?.({ block: "nearest" });
+  }, [expandedBaseId]);
+
   if (loading) {
     return <section className="panel">
       <div className="panel-title"><h2>Bases</h2></div>
@@ -722,7 +766,13 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
   }
 
   function toggleExpanded(id: string) {
-    setExpandedBaseId((current) => current === id ? null : id);
+    setExpandedBaseId((current) => {
+      // Opening a different base starts on Power again; leaving the previous
+      // row's tab selected would drop you into Permissions for a base you only
+      // wanted to glance at.
+      if (current !== id) setExpandedTab("power");
+      return current === id ? null : id;
+    });
   }
 
   function handleSort(column: string) {
@@ -822,6 +872,7 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
           coordinates: "Coordinates"
         }}
         tableClassName="bases-table"
+        wrapClassName="bases-table-wrap"
         headerTitles
         actionClassName="actions-column bases-actions-column"
         renderCell={renderBaseCell}
@@ -874,8 +925,16 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
           const base = row as BaseRow;
           const id = String(base.base_id);
           const isExpanded = expandedBaseId === id;
-          if (!base.generatorDataAvailable || !base.generatorCount) return null;
-          const label = `${isExpanded ? "Collapse" : "Show"} generator details for ${base.name || `base ${id}`}`;
+          const hasGeneratorDetail = base.generatorDataAvailable && Boolean(base.generatorCount);
+          // Before permissions editing, a base with no generators had nothing to
+          // expand into and so had no chevron. It does now, so the chevron has
+          // to appear for those rows too -- otherwise the only way into the
+          // Permissions tab for a generator-less base would be the pencil.
+          if (!hasGeneratorDetail && !canEditPermissions) return null;
+          const detail = hasGeneratorDetail && canEditPermissions ? "details"
+            : hasGeneratorDetail ? "generator details"
+            : "permissions";
+          const label = `${isExpanded ? "Collapse" : "Show"} ${detail} for ${base.name || `base ${id}`}`;
           return <button
             className="bases-expand-button"
             title={label}
@@ -893,10 +952,11 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
         isRowExpanded={(row) => expandedBaseId === String(row.base_id)}
         renderExpandedRow={(row) => {
           const base = row as BaseRow;
+          const id = String(base.base_id);
+          const renderPower = () => {
           if (!base.generatorDataAvailable) return <p className="muted">Generator data is currently unavailable.</p>;
           const generators = base.generators ?? [];
           if (!generators.length) return <p className="muted">No generators built at this base.</p>;
-          const id = String(base.base_id);
           const autoRefillEntry = autoRefillBases.get(id);
           const savingAutoRefill = savingAutoRefillId === id;
           const lastChecked = autoRefillEntry?.lastCheckedAt ? formatAgo(autoRefillEntry.lastCheckedAt) : "";
@@ -975,6 +1035,47 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
                   </dl>
                 </div>
               ))}
+            </div>
+          );
+          };
+          // Without the capability there is no second tab, so the row keeps its
+          // original shape rather than growing a tab strip with one tab in it.
+          if (!canEditPermissions) return renderPower();
+          return (
+            <div className="bases-expanded-tabs" onClick={(event) => event.stopPropagation()}>
+              <div className="bases-expanded-tablist" role="tablist" aria-label="Base details">
+                <button
+                  role="tab"
+                  id={`bases-tab-power-${id}`}
+                  aria-selected={expandedTab === "power"}
+                  aria-controls={`bases-panel-power-${id}`}
+                  className={`bases-expanded-tab${expandedTab === "power" ? " active" : ""}`}
+                  onClick={() => setExpandedTab("power")}
+                ><Zap size={15} aria-hidden="true" />Power</button>
+                <button
+                  role="tab"
+                  id={`bases-tab-permissions-${id}`}
+                  aria-selected={expandedTab === "permissions"}
+                  aria-controls={`bases-panel-permissions-${id}`}
+                  className={`bases-expanded-tab${expandedTab === "permissions" ? " active" : ""}`}
+                  onClick={() => setExpandedTab("permissions")}
+                ><Users size={15} aria-hidden="true" />Permissions</button>
+              </div>
+              {expandedTab === "power"
+                ? <div role="tabpanel" id={`bases-panel-power-${id}`} aria-labelledby={`bases-tab-power-${id}`}>{renderPower()}</div>
+                : <div role="tabpanel" id={`bases-panel-permissions-${id}`} aria-labelledby={`bases-tab-permissions-${id}`}>
+                    <BasePermissionsTab
+                      baseId={id}
+                      baseName={String(base.name || `base ${id}`)}
+                      // Owner and Shared With are rendered from the list
+                      // response, so a saved roster has to refetch or the row
+                      // above keeps showing the pre-edit names.
+                      onSaved={() => {
+                        basesCache = null;
+                        void load({ q: submittedQ, page, pageSize, sortColumn, sortDirection }, { silent: true });
+                      }}
+                    />
+                  </div>}
             </div>
           );
         }}

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -345,6 +345,10 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
   const [cancelingId, setCancelingId] = useState("");
   const [cancelingWaterId, setCancelingWaterId] = useState("");
   const [refillingWaterId, setRefillingWaterId] = useState("");
+  // Bumped after an immediate (non-queued) water refill so an already-open
+  // Water tab knows to refetch -- it fetches its own data independently of
+  // the bases list/row, so nothing else tells it a refill just landed.
+  const [waterRefreshToken, setWaterRefreshToken] = useState(0);
   // A list, not one key: each row shows its own progress, so the other rows stay
   // clickable and a second restart cannot erase the first one's spinner.
   const [restartingTargets, setRestartingTargets] = useState<string[]>(() => restartingTargetsCache);
@@ -610,6 +614,11 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
       writeRefillStatus(summarizeWaterRefill(response) || formatMutationResult(response), "ok");
       if (response.result?.queued) {
         await refreshPendingWaterRefills();
+      } else {
+        // Unlike generator fuel, water isn't part of the row/list data --
+        // BaseWaterTab fetches it separately -- so an immediate (non-queued)
+        // write needs its own signal to make an already-open Water tab refetch.
+        setWaterRefreshToken((token) => token + 1);
       }
     } catch (error) {
       const text = errorText(error);
@@ -1025,13 +1034,13 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
           </span>}
         </p>
         <p className="action-help-note">
-          Auto-refill queued 3 refills without raising the fuel or water on {stalledCombinedCount === 1 ? "this base" : "these bases"}. Refill manually to find out why, or turn auto-refill off and back on to resume trying.
+          Auto-refill queued 3 refills without raising the {stalledFuelCount > 0 && stalledWaterCount > 0 ? "fuel or water" : stalledFuelCount > 0 ? "fuel" : "water"} on {stalledCombinedCount === 1 ? "this base" : "these bases"}. Refill manually to find out why, or turn auto-refill off and back on to resume trying.
         </p>
       </div>}
       {combinedQueueTotal > 0 && <div className="bases-pending-refills">
         <p className="bases-pending-refills-title">
-          <Fuel size={16} aria-hidden="true" />
-          <Droplet size={16} aria-hidden="true" />
+          {pendingTotal > 0 && <Fuel size={16} aria-hidden="true" />}
+          {pendingWaterTotal > 0 && <Droplet size={16} aria-hidden="true" />}
           {combinedQueueTotal.toLocaleString()} refill{combinedQueueTotal === 1 ? "" : "s"} queued
         </p>
         <p className="action-help-note">
@@ -1340,6 +1349,7 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
                 ? <div role="tabpanel" id={`bases-panel-water-${id}`} aria-labelledby={`bases-tab-water-${id}`}>
                     <BaseWaterTab
                       baseId={id}
+                      refreshToken={waterRefreshToken}
                       autoRefill={{
                         supported: canQueueWater,
                         unavailable: autoRefillWaterUnrecoverable,

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronUp, Download, Fuel, Users, X, Zap } from "lucide-react";
+import { ChevronDown, ChevronUp, Download, Droplet, Fuel, Users, X, Zap } from "lucide-react";
 import { BasePermissionsTab } from "./BasePermissionsTab";
-import { basesApi, type AutoRefillBase, type RefillDeviceResult } from "../../api/bases";
+import { BaseWaterTab } from "./BaseWaterTab";
+import { basesApi, type AutoRefillBase, type AutoRefillWaterBase, type RefillDeviceResult, type RefillWaterDeviceResult } from "../../api/bases";
 import { mapsApi } from "../../api/maps";
 import { InfoTooltip } from "../../components/common/DisplayPrimitives";
 import { serverApi } from "../../api/server";
 import { setupApi, type Task } from "../../api/setup";
 import { apiDownload } from "../../api/client";
 import { DataTable, type SortDirection } from "../../components/common/DataTable";
-import { pendingRefillCountForPartition, usePendingRefills } from "../../lib/usePendingRefills";
+import { pendingRefillCountForPartition, usePendingRefills, usePendingWaterRefills } from "../../lib/usePendingRefills";
 
 type BasesPanelProps = {
   onError: (text: string) => void;
@@ -233,6 +234,22 @@ function summarizeRefill(response: {
   return `Added ${result.totalAdded} fuel unit${result.totalAdded === 1 ? "" : "s"} across ${changed.length} device${changed.length === 1 ? "" : "s"}. ${detail}${skipped ? ` · ${skipped} skipped (no inventory)` : ""}`;
 }
 
+// Mirrors summarizeRefill. No fuelName/capped/skipped -- water refill is a
+// plain jsonb_set straight to capacity, not a stack of discrete items.
+function summarizeWaterRefill(response: {
+  result?: { queued?: boolean; map?: string; totalAdded?: number; devices?: RefillWaterDeviceResult[] };
+}) {
+  const result = response.result;
+  if (result?.queued) {
+    return `Water refill queued for ${result.map || "this base"}. It applies the next time that map restarts or stops, so a running server cannot overwrite it.`;
+  }
+  if (!result || !Array.isArray(result.devices) || typeof result.totalAdded !== "number") return "";
+  const changed = result.devices.filter((device) => (device.added || 0) > 0);
+  if (!changed.length) return `All ${result.devices.length} container${result.devices.length === 1 ? " was" : "s were"} already full. Nothing added.`;
+  const detail = changed.map((device) => `${device.label}: +${device.added.toLocaleString()}`).join(" · ");
+  return `Added ${result.totalAdded.toLocaleString()} water across ${changed.length} container${changed.length === 1 ? "" : "s"}. ${detail}`;
+}
+
 function withCoordinates(row: Record<string, unknown>): BaseRow {
   const x = Math.round(Number(row.x) || 0);
   const y = Math.round(Number(row.y) || 0);
@@ -320,10 +337,14 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
   const [canRefill, setCanRefill] = useState(false);
   const [canQueue, setCanQueue] = useState(false);
   const [canEditPermissions, setCanEditPermissions] = useState(false);
+  const [canRefillWater, setCanRefillWater] = useState(false);
+  const [canQueueWater, setCanQueueWater] = useState(false);
   // Which tab the expanded row is showing. Power is the default so expanding a
   // row behaves exactly as it did before this feature existed.
-  const [expandedTab, setExpandedTab] = useState<"power" | "permissions">("power");
+  const [expandedTab, setExpandedTab] = useState<"power" | "water" | "permissions">("power");
   const [cancelingId, setCancelingId] = useState("");
+  const [cancelingWaterId, setCancelingWaterId] = useState("");
+  const [refillingWaterId, setRefillingWaterId] = useState("");
   // A list, not one key: each row shows its own progress, so the other rows stay
   // clickable and a second restart cannot erase the first one's spinner.
   const [restartingTargets, setRestartingTargets] = useState<string[]>(() => restartingTargetsCache);
@@ -337,10 +358,18 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
   // Distinct from "no bases enrolled": the enrollment read itself failed, so
   // what is on screen may not reflect reality.
   const [autoRefillUnavailable, setAutoRefillUnavailable] = useState(false);
+  // Mirrors the block above, for water auto-refill -- own enrollment state so
+  // the two subsystems never share or interfere with each other.
+  const [autoRefillWaterBases, setAutoRefillWaterBases] = useState<Map<string, AutoRefillWaterBase>>(new Map());
+  const [autoRefillWaterThreshold, setAutoRefillWaterThreshold] = useState(50);
+  const [autoRefillWaterIntervalHours, setAutoRefillWaterIntervalHours] = useState(24);
+  const [savingAutoRefillWaterId, setSavingAutoRefillWaterId] = useState("");
+  const [autoRefillWaterUnavailable, setAutoRefillWaterUnavailable] = useState(false);
   const requestIdRef = useRef(0);
   const lastExpandedRef = useRef<string | null>(null);
   const skipNextSearchReset = useRef(true);
   const { pending: pendingRefills, refresh: refreshPendingRefills } = usePendingRefills(canQueue);
+  const { pending: pendingWaterRefills, refresh: refreshPendingWaterRefills } = usePendingWaterRefills(canQueueWater);
   const previousPendingTotal = useRef<number | null>(null);
 
   useEffect(() => {
@@ -371,6 +400,8 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
       setCanRefill(Boolean(result.capabilities?.generatorRefill));
       setCanQueue(Boolean(result.capabilities?.generatorRefillQueue));
       setCanEditPermissions(Boolean(result.capabilities?.basePermissions));
+      setCanRefillWater(Boolean(result.capabilities?.waterRefill));
+      setCanQueueWater(Boolean(result.capabilities?.waterRefillQueue));
       setTotalCount(result.totalCount || 0);
       setTotalBases(result.totalBases || 0);
       setTotalPieces(result.totalPieces || 0);
@@ -555,6 +586,63 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
     }
   }
 
+  // Mirrors handleRefillGenerators. No generatorCount-style count in the
+  // confirm copy: the Water tab's own container list is fetched on demand,
+  // not part of this row's data, so there is nothing to count without an
+  // extra request just for the confirm dialog's wording.
+  async function handleRefillWater(base: BaseRow) {
+    const id = String(base.base_id);
+    const confirmed = await confirmAction(
+      `Refill water storage at "${base.name || `base ${id}`}" to full?`,
+      {
+        title: "Refill Water",
+        confirmLabel: "Refill",
+        warning: canQueueWater
+          ? "If this base's map is running, the refill is queued and applied the next time that map restarts or stops, so a live server cannot overwrite it. If the map is already down, it is written now. Blood is never touched -- only water."
+          : "Refill writes water straight to the database. A running game server will not show the new water in-game until the map server restarts. Blood is never touched -- only water."
+      }
+    );
+    if (!confirmed) return;
+    onError("");
+    setRefillingWaterId(id);
+    try {
+      const response = await basesApi.refillWater(id);
+      writeRefillStatus(summarizeWaterRefill(response) || formatMutationResult(response), "ok");
+      if (response.result?.queued) {
+        await refreshPendingWaterRefills();
+      }
+    } catch (error) {
+      const text = errorText(error);
+      writeRefillStatus(text, "fail");
+      onError(text);
+    } finally {
+      setRefillingWaterId("");
+    }
+  }
+
+  async function handleCancelQueuedWaterRefill(base: BaseRow) {
+    const id = String(base.base_id);
+    const label = base.name || `base ${id}`;
+    const confirmed = await confirmAction(`Cancel the queued water refill for "${label}"?`, {
+      title: "Cancel Queued Refill",
+      confirmLabel: "Cancel Refill"
+    });
+    if (!confirmed) return;
+    onError("");
+    setCancelingWaterId(id);
+    try {
+      await basesApi.cancelQueuedWaterRefill(id);
+      writeRefillStatus(`Queued water refill for "${label}" was canceled.`, "ok");
+      await refreshPendingWaterRefills();
+    } catch (error) {
+      const text = errorText(error);
+      writeRefillStatus(text, "fail");
+      onError(text);
+    } finally {
+      setCancelingWaterId("");
+    }
+  }
+
   const refreshAutoRefill = useCallback(async () => {
     try {
       const state = await basesApi.autoRefill();
@@ -578,6 +666,23 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
     if (!canQueue) return;
     void refreshAutoRefill();
   }, [canQueue, refreshAutoRefill]);
+
+  const refreshAutoRefillWater = useCallback(async () => {
+    try {
+      const state = await basesApi.autoRefillWater();
+      setAutoRefillWaterBases(new Map(state.bases.map((entry) => [String(entry.baseId), entry])));
+      setAutoRefillWaterThreshold(state.thresholdPercent);
+      setAutoRefillWaterIntervalHours(state.intervalHours);
+      setAutoRefillWaterUnavailable(false);
+    } catch {
+      setAutoRefillWaterUnavailable(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!canQueueWater) return;
+    void refreshAutoRefillWater();
+  }, [canQueueWater, refreshAutoRefillWater]);
 
   async function handleToggleAutoRefill(base: BaseRow, nextEnabled: boolean) {
     const id = String(base.base_id);
@@ -636,6 +741,60 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
     }
   }
 
+  // Mirrors handleToggleAutoRefill.
+  async function handleToggleAutoRefillWater(base: BaseRow, nextEnabled: boolean) {
+    const id = String(base.base_id);
+    const label = base.name || `base ${id}`;
+    if (nextEnabled) {
+      const confirmed = await confirmAction(
+        `Turn on water auto-refill for "${label}"?`,
+        {
+          title: "Auto-Refill Water",
+          confirmLabel: "Turn On",
+          warning: `Every ${autoRefillWaterIntervalHours}h this base is checked, and a refill is queued if any water container holds less than ${autoRefillWaterThreshold}% of its capacity. Queued refills are written the next time this base's map restarts or stops — auto-refill never restarts a map by itself. Blood is never touched -- only water.`
+        }
+      );
+      if (!confirmed) return;
+    }
+    onError("");
+    setSavingAutoRefillWaterId(id);
+    try {
+      const result = await basesApi.setAutoRefillWater(id, nextEnabled);
+      if (autoRefillWaterUnavailable) {
+        void refreshAutoRefillWater();
+      }
+      setAutoRefillWaterBases((current) => {
+        const next = new Map(current);
+        if (result.enabled) {
+          next.set(id, next.get(id) || {
+            baseId: Number(id),
+            enabledAt: new Date().toISOString(),
+            lastCheckedAt: "",
+            lastQueuedAt: "",
+            lastLowestPercent: null,
+            consecutiveQueues: 0,
+            stalledAt: ""
+          });
+        } else {
+          next.delete(id);
+        }
+        return next;
+      });
+      writeRefillStatus(
+        result.enabled
+          ? `Water auto-refill is on for "${label}". Checked every ${autoRefillWaterIntervalHours}h.`
+          : `Water auto-refill is off for "${label}".`,
+        "ok"
+      );
+    } catch (error) {
+      const text = errorText(error);
+      writeRefillStatus(text, "fail");
+      onError(text);
+    } finally {
+      setSavingAutoRefillWaterId("");
+    }
+  }
+
   async function handleRestartForQueue(group: { map: string; partitionId: number; partitionMap: string; dimensionIndex: number; count: number }) {
     const target = queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex);
     if (target.kind === "none") return;
@@ -666,6 +825,55 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
         // The flush races the restart's own write-safety window, so a
         // succeeded task does not guarantee the refill actually landed --
         // check the queue itself rather than assume.
+        const stillQueued = pendingRefillCountForPartition(refreshed, group.partitionId);
+        writeRefillStatus(
+          stillQueued
+            ? `${label} restarted. Its refills are still queued and will apply once the map is confirmed down.`
+            : `${label} restarted. Any refills queued for it have been applied.`,
+          "ok"
+        );
+      } else {
+        const text = `${label} restart ${finished.status}. Its refills are still queued.`;
+        writeRefillStatus(text, "fail");
+        onError(text);
+      }
+    } catch (error) {
+      const text = errorText(error);
+      writeRefillStatus(text, "fail");
+      onError(text);
+    } finally {
+      writeRestartingTarget(key, false);
+    }
+  }
+
+  // Mirrors handleRestartForQueue, for the water refill queue. Shares
+  // writeRestartingTarget/restartingTargets with the generator version --
+  // both key on map|partitionId, which is correct: restarting a partition
+  // applies whichever queue(s) had entries waiting on it.
+  async function handleRestartForWaterQueue(group: { map: string; partitionId: number; partitionMap: string; dimensionIndex: number; count: number }) {
+    const target = queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex);
+    if (target.kind === "none") return;
+    const key = `${group.map}|${group.partitionId}`;
+    const confirmed = await confirmAction(
+      `${target.label} now to apply ${group.count} queued water refill${group.count === 1 ? "" : "s"}?`,
+      {
+        title: "Restart Map",
+        confirmLabel: "Restart",
+        warning: "Players on this map are disconnected while it restarts."
+      }
+    );
+    if (!confirmed) return;
+    onError("");
+    writeRestartingTarget(key, true);
+    const label = group.partitionMap || group.map;
+    try {
+      writeRefillStatus(`Restarting ${label}, its queued refills apply while it is down`, "running");
+      const started = target.kind === "sietch" ? await mapsApi.restartSietch(String(target.partitionId))
+        : target.kind === "respawn" ? await mapsApi.respawn(String(target.partitionId), "RESTART MAP")
+        : await serverApi.restartService(target.service);
+      const finished = await waitForTask(started.task);
+      const refreshed = await refreshPendingWaterRefills();
+      if (finished.status === "succeeded") {
         const stillQueued = pendingRefillCountForPartition(refreshed, group.partitionId);
         writeRefillStatus(
           stillQueued
@@ -754,6 +962,21 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
   // scope as pendingRefills, so this counts stalled bases across the whole
   // battlegroup -- not just whatever page of the list happens to be loaded.
   const stalledAutoRefillCount = [...autoRefillBases.values()].filter((entry) => entry.stalledAt).length;
+
+  // Mirrors the block above, for the water refill queue.
+  const pendingWaterTotal = pendingWaterRefills?.total || 0;
+  const queuedWaterBaseIds = new Set((pendingWaterRefills?.pending || []).map((entry) => String(entry.baseId)));
+  const staleQueuedWater = (pendingWaterRefills?.pending || []).filter((entry) => {
+    const queuedAt = Date.parse(entry.queuedAt);
+    return Number.isFinite(queuedAt) && Date.now() - queuedAt > STALE_QUEUED_REFILL_MS;
+  });
+  const staleQueuedWaterCount = staleQueuedWater.length;
+  const staleWaterTargetKeys = new Set(staleQueuedWater.map((entry) => `${entry.map || "Unknown"}|${entry.partitionId}`));
+  const staleWaterHasRestartButton = (pendingWaterRefills?.byTarget || []).some((group) =>
+    staleWaterTargetKeys.has(`${group.map}|${group.partitionId}`)
+    && queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex).kind !== "none");
+  const autoRefillWaterUnrecoverable = autoRefillWaterUnavailable && autoRefillWaterBases.size === 0;
+  const stalledAutoRefillWaterCount = [...autoRefillWaterBases.values()].filter((entry) => entry.stalledAt).length;
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
   const rangeStart = totalCount === 0 ? 0 : page * pageSize + 1;
   const rangeEnd = totalCount === 0 ? 0 : rangeStart + rows.length - 1;
@@ -839,6 +1062,49 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
           {staleQueuedCount.toLocaleString()} queued over 24h — {staleQueuedCount === 1 ? "its map has" : "their maps have"} not been down since. {staleHasRestartButton ? "Restart above to apply." : "Restart from the Maps tab to apply."}
         </p>}
       </div>}
+      {stalledAutoRefillWaterCount > 0 && <div className="bases-stalled-banner" role="alert">
+        <p className="bases-stalled-banner-title">
+          <Droplet size={16} aria-hidden="true" />
+          {stalledAutoRefillWaterCount.toLocaleString()} base{stalledAutoRefillWaterCount === 1 ? " has" : "s have"} stalled water auto-refill
+        </p>
+        <p className="action-help-note">
+          Auto-refill queued 3 refills for {stalledAutoRefillWaterCount === 1 ? "this base" : "each of these bases"} without raising the water. Refill manually to find out why, or turn auto-refill off and back on to resume trying.
+        </p>
+      </div>}
+      {pendingWaterTotal > 0 && <div className="bases-pending-refills">
+        <p className="bases-pending-refills-title">
+          <Droplet size={16} aria-hidden="true" />
+          {pendingWaterTotal.toLocaleString()} water refill{pendingWaterTotal === 1 ? "" : "s"} queued
+        </p>
+        <p className="action-help-note">
+          Each one is written when its map next restarts. Restarting the battlegroup applies all of them; stopping leaves them queued.
+        </p>
+        <ul className="bases-pending-refills-list">
+          {(pendingWaterRefills?.byTarget || []).map((group) => {
+            const target = queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex);
+            const key = `${group.map}|${group.partitionId}`;
+            return <li key={key}>
+              <span>
+                {group.map}
+                {group.partitionMap && group.partitionMap !== group.map ? ` (${group.partitionMap})` : ""}
+                {group.partitionId ? ` · partition ${group.partitionId}` : ""}
+                <span className="muted"> — {group.count.toLocaleString()} queued</span>
+              </span>
+              {target.kind === "none"
+                ? <span className="muted">Restart this map from the Maps tab</span>
+                : restartingTargets.includes(key)
+                  ? <span className="bases-restarting-pill">
+                      <span className="spinner" aria-hidden="true" />
+                      <span className="loading-dots" role="status">Restarting</span>
+                    </span>
+                  : <button onClick={() => void handleRestartForWaterQueue(group)}>{target.label}</button>}
+            </li>;
+          })}
+        </ul>
+        {staleQueuedWaterCount > 0 && <p className="bases-pending-refills-stale" role="status">
+          {staleQueuedWaterCount.toLocaleString()} queued over 24h — {staleQueuedWaterCount === 1 ? "its map has" : "their maps have"} not been down since. {staleWaterHasRestartButton ? "Restart above to apply." : "Restart from the Maps tab to apply."}
+        </p>}
+      </div>}
       {refillResult && <p
         className={`inline-task-result bases-refill-status${refillStatus ? ` result-${refillStatus}` : ""}`}
         role={refillStatus === "fail" ? "alert" : "status"}
@@ -881,9 +1147,9 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
           const id = String(base.base_id);
           const refillable = canRefill && base.generatorDataAvailable && (Number(base.generatorCount) || 0) > 0;
           // Auto-refill is shown by restyling this button rather than by adding a
-          // control: the column is a fixed 96px and already full. The button
-          // stays clickable when enrolled, so turning automation on never costs
-          // the on-demand refill.
+          // control: the column is a fixed width and already holds one button per
+          // refillable resource. The button stays clickable when enrolled, so
+          // turning automation on never costs the on-demand refill.
           const autoRefillEntryForRow = autoRefillBases.get(id);
           const autoRefillOn = Boolean(autoRefillEntryForRow);
           const autoRefillStalled = Boolean(autoRefillEntryForRow?.stalledAt);
@@ -893,10 +1159,22 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
             : autoRefillStalled ? `Auto-refill has stalled after ${autoRefillEntryForRow?.consecutiveQueues || 3} refills that did not raise the fuel. Click to refill now.`
             : autoRefillOn ? `Auto-refill is on — checked every ${autoRefillIntervalHours}h below ${autoRefillThreshold}%. Click to refill now.`
             : "Refill Generators";
+          // Water isn't bundled into this row's data (fetched on demand in the
+          // Water tab instead), so there is no per-row "has water storage"
+          // signal to disable on the way generator's `refillable` does --
+          // this is enabled whenever the capability exists, and a base with
+          // none simply reports "No water storage was found" on click.
+          const autoRefillWaterEntryForRow = autoRefillWaterBases.get(id);
+          const autoRefillWaterOn = Boolean(autoRefillWaterEntryForRow);
+          const autoRefillWaterStalled = Boolean(autoRefillWaterEntryForRow?.stalledAt);
+          const refillWaterTitle = !canRefillWater ? "Water refill is unsupported on this database"
+            : autoRefillWaterStalled ? `Water auto-refill has stalled after ${autoRefillWaterEntryForRow?.consecutiveQueues || 3} refills that did not raise the water. Click to refill now.`
+            : autoRefillWaterOn ? `Water auto-refill is on — checked every ${autoRefillWaterIntervalHours}h below ${autoRefillWaterThreshold}%. Click to refill now.`
+            : "Refill Water";
           return <span className="icon-toggle-group">
-            {/* The actions column is a fixed 96px, so the queued state stays two
-                glyphs wide rather than a text pill: the banner above carries the
-                wording, and each glyph has its own tooltip. */}
+            {/* The actions column is a fixed width, so the queued state stays a
+                compact glyph pill rather than a text label: the banner above
+                carries the wording, and each glyph has its own tooltip. */}
             {queuedBaseIds.has(id)
               ? <span className="bases-queued-refill" title="Refill queued — applies when this map next restarts or stops">
                   <Fuel size={16} aria-label="Refill queued for this base" />
@@ -915,6 +1193,24 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
                   disabled={!refillable || refillingId === id}
                   onClick={(event) => { event.stopPropagation(); void handleRefillGenerators(base); }}
                 ><Fuel size={16} /></button>}
+            {queuedWaterBaseIds.has(id)
+              ? <span className="bases-queued-refill" title="Water refill queued — applies when this map next restarts or stops">
+                  <Droplet size={16} aria-label="Water refill queued for this base" />
+                  <button
+                    className="icon-toggle-button bases-queued-refill-cancel"
+                    title="Cancel Queued Refill"
+                    aria-label="Cancel Queued Water Refill"
+                    disabled={cancelingWaterId === id}
+                    onClick={(event) => { event.stopPropagation(); void handleCancelQueuedWaterRefill(base); }}
+                  ><X size={14} /></button>
+                </span>
+              : <button
+                  className={`icon-toggle-button${autoRefillWaterStalled ? " bases-auto-refill-stalled-icon" : autoRefillWaterOn ? " bases-auto-refill-on" : ""}`}
+                  title={refillWaterTitle}
+                  aria-label={autoRefillWaterStalled ? "Refill Water (auto-refill stalled)" : autoRefillWaterOn ? "Refill Water (auto-refill on)" : "Refill Water"}
+                  disabled={!canRefillWater || refillingWaterId === id}
+                  onClick={(event) => { event.stopPropagation(); void handleRefillWater(base); }}
+                ><Droplet size={16} /></button>}
             <button className="icon-toggle-button" title="Download Base as Blueprint" aria-label="Download Base as Blueprint" disabled={downloadingId === id} onClick={(event) => { event.stopPropagation(); void handleDownloadBlueprint(base); }}><Download size={16} /></button>
           </span>;
         }}
@@ -925,16 +1221,11 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
           const base = row as BaseRow;
           const id = String(base.base_id);
           const isExpanded = expandedBaseId === id;
-          const hasGeneratorDetail = base.generatorDataAvailable && Boolean(base.generatorCount);
-          // Before permissions editing, a base with no generators had nothing to
-          // expand into and so had no chevron. It does now, so the chevron has
-          // to appear for those rows too -- otherwise the only way into the
-          // Permissions tab for a generator-less base would be the pencil.
-          if (!hasGeneratorDetail && !canEditPermissions) return null;
-          const detail = hasGeneratorDetail && canEditPermissions ? "details"
-            : hasGeneratorDetail ? "generator details"
-            : "permissions";
-          const label = `${isExpanded ? "Collapse" : "Show"} ${detail} for ${base.name || `base ${id}`}`;
+          // The chevron always renders now: every base can always be expanded
+          // into at least the Water tab (fetched on demand, not gated on
+          // per-row data the way generators are), so there is no longer a case
+          // with nothing to expand into, and no need to pick a granular label.
+          const label = `${isExpanded ? "Collapse" : "Show"} details for ${base.name || `base ${id}`}`;
           return <button
             className="bases-expand-button"
             title={label}
@@ -1038,9 +1329,18 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
             </div>
           );
           };
-          // Without the capability there is no second tab, so the row keeps its
-          // original shape rather than growing a tab strip with one tab in it.
-          if (!canEditPermissions) return renderPower();
+
+          const autoRefillWaterEntry = autoRefillWaterBases.get(id);
+          const savingAutoRefillWater = savingAutoRefillWaterId === id;
+          const lastCheckedWater = autoRefillWaterEntry?.lastCheckedAt ? formatAgo(autoRefillWaterEntry.lastCheckedAt) : "";
+          const autoRefillWaterTooltip = `Checked every ${autoRefillWaterIntervalHours}h. Queues a refill when any water container drops below ${autoRefillWaterThreshold}%. Blood is never touched.`
+            + (autoRefillWaterEntry && lastCheckedWater ? ` Last checked ${lastCheckedWater}${autoRefillWaterEntry.lastLowestPercent === null ? "" : ` — lowest ${autoRefillWaterEntry.lastLowestPercent}%`}.` : "")
+            + (autoRefillWaterEntry && !lastCheckedWater ? " Not checked yet." : "")
+            + (autoRefillWaterUnavailable ? " Last known state — the latest read failed." : "");
+
+          // Power and Water always render (Water needs no capability the way
+          // Permissions does -- see baseWater's "no capability gate" note in
+          // the plan); Permissions only when the schema supports it.
           return (
             <div className="bases-expanded-tabs" onClick={(event) => event.stopPropagation()}>
               <div className="bases-expanded-tablist" role="tablist" aria-label="Base details">
@@ -1054,15 +1354,41 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
                 ><Zap size={15} aria-hidden="true" />Power</button>
                 <button
                   role="tab"
+                  id={`bases-tab-water-${id}`}
+                  aria-selected={expandedTab === "water"}
+                  aria-controls={`bases-panel-water-${id}`}
+                  className={`bases-expanded-tab${expandedTab === "water" ? " active" : ""}`}
+                  onClick={() => setExpandedTab("water")}
+                ><Droplet size={15} aria-hidden="true" />Water</button>
+                {canEditPermissions && <button
+                  role="tab"
                   id={`bases-tab-permissions-${id}`}
                   aria-selected={expandedTab === "permissions"}
                   aria-controls={`bases-panel-permissions-${id}`}
                   className={`bases-expanded-tab${expandedTab === "permissions" ? " active" : ""}`}
                   onClick={() => setExpandedTab("permissions")}
-                ><Users size={15} aria-hidden="true" />Permissions</button>
+                ><Users size={15} aria-hidden="true" />Permissions</button>}
               </div>
               {expandedTab === "power"
                 ? <div role="tabpanel" id={`bases-panel-power-${id}`} aria-labelledby={`bases-tab-power-${id}`}>{renderPower()}</div>
+                : expandedTab === "water"
+                ? <div role="tabpanel" id={`bases-panel-water-${id}`} aria-labelledby={`bases-tab-water-${id}`}>
+                    <BaseWaterTab
+                      baseId={id}
+                      autoRefill={{
+                        supported: canQueueWater,
+                        unavailable: autoRefillWaterUnrecoverable,
+                        enabled: Boolean(autoRefillWaterEntry),
+                        saving: savingAutoRefillWater,
+                        stalledAt: autoRefillWaterEntry?.stalledAt || "",
+                        consecutiveQueues: autoRefillWaterEntry?.consecutiveQueues || 0,
+                        canToggle: canRefillWater,
+                        tooltip: autoRefillWaterTooltip,
+                        onToggle: (enabled) => { void handleToggleAutoRefillWater(base, enabled); },
+                        onRetry: () => { void refreshAutoRefillWater(); }
+                      }}
+                    />
+                  </div>
                 : <div role="tabpanel" id={`bases-panel-permissions-${id}`} aria-labelledby={`bases-tab-permissions-${id}`}>
                     <BasePermissionsTab
                       baseId={id}

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -795,12 +795,20 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
     }
   }
 
-  async function handleRestartForQueue(group: { map: string; partitionId: number; partitionMap: string; dimensionIndex: number; count: number }) {
+  // Restarting a partition/service already flushes whichever queue(s) have
+  // entries waiting on it -- server.js's onMapDown hook fires both
+  // flushQueuedGeneratorRefills and flushQueuedWaterRefills unconditionally --
+  // so one restart call covers a target with fuel, water, or both queued, and
+  // the combined banner below only needs a single handler rather than two.
+  async function handleRestartForCombinedQueue(group: { map: string; partitionId: number; partitionMap: string; dimensionIndex: number; fuelCount: number; waterCount: number }) {
     const target = queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex);
     if (target.kind === "none") return;
     const key = `${group.map}|${group.partitionId}`;
+    const parts = [];
+    if (group.fuelCount) parts.push(`${group.fuelCount} queued generator refill${group.fuelCount === 1 ? "" : "s"}`);
+    if (group.waterCount) parts.push(`${group.waterCount} queued water refill${group.waterCount === 1 ? "" : "s"}`);
     const confirmed = await confirmAction(
-      `${target.label} now to apply ${group.count} queued generator refill${group.count === 1 ? "" : "s"}?`,
+      `${target.label} now to apply ${parts.join(" and ")}?`,
       {
         title: "Restart Map",
         confirmLabel: "Restart",
@@ -820,61 +828,15 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
       // Report what the restart actually did. Without this the running line
       // stands forever and a failed restart reads as a successful one.
       const finished = await waitForTask(started.task);
-      const refreshed = await refreshPendingRefills();
+      const [refreshedFuel, refreshedWater] = await Promise.all([refreshPendingRefills(), refreshPendingWaterRefills()]);
       if (finished.status === "succeeded") {
         // The flush races the restart's own write-safety window, so a
         // succeeded task does not guarantee the refill actually landed --
-        // check the queue itself rather than assume.
-        const stillQueued = pendingRefillCountForPartition(refreshed, group.partitionId);
-        writeRefillStatus(
-          stillQueued
-            ? `${label} restarted. Its refills are still queued and will apply once the map is confirmed down.`
-            : `${label} restarted. Any refills queued for it have been applied.`,
-          "ok"
+        // check both queues rather than assume.
+        const stillQueued = Boolean(
+          pendingRefillCountForPartition(refreshedFuel, group.partitionId)
+          || pendingRefillCountForPartition(refreshedWater, group.partitionId)
         );
-      } else {
-        const text = `${label} restart ${finished.status}. Its refills are still queued.`;
-        writeRefillStatus(text, "fail");
-        onError(text);
-      }
-    } catch (error) {
-      const text = errorText(error);
-      writeRefillStatus(text, "fail");
-      onError(text);
-    } finally {
-      writeRestartingTarget(key, false);
-    }
-  }
-
-  // Mirrors handleRestartForQueue, for the water refill queue. Shares
-  // writeRestartingTarget/restartingTargets with the generator version --
-  // both key on map|partitionId, which is correct: restarting a partition
-  // applies whichever queue(s) had entries waiting on it.
-  async function handleRestartForWaterQueue(group: { map: string; partitionId: number; partitionMap: string; dimensionIndex: number; count: number }) {
-    const target = queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex);
-    if (target.kind === "none") return;
-    const key = `${group.map}|${group.partitionId}`;
-    const confirmed = await confirmAction(
-      `${target.label} now to apply ${group.count} queued water refill${group.count === 1 ? "" : "s"}?`,
-      {
-        title: "Restart Map",
-        confirmLabel: "Restart",
-        warning: "Players on this map are disconnected while it restarts."
-      }
-    );
-    if (!confirmed) return;
-    onError("");
-    writeRestartingTarget(key, true);
-    const label = group.partitionMap || group.map;
-    try {
-      writeRefillStatus(`Restarting ${label}, its queued refills apply while it is down`, "running");
-      const started = target.kind === "sietch" ? await mapsApi.restartSietch(String(target.partitionId))
-        : target.kind === "respawn" ? await mapsApi.respawn(String(target.partitionId), "RESTART MAP")
-        : await serverApi.restartService(target.service);
-      const finished = await waitForTask(started.task);
-      const refreshed = await refreshPendingWaterRefills();
-      if (finished.status === "succeeded") {
-        const stillQueued = pendingRefillCountForPartition(refreshed, group.partitionId);
         writeRefillStatus(
           stillQueued
             ? `${label} restarted. Its refills are still queued and will apply once the map is confirmed down.`
@@ -948,20 +910,13 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
     const queuedAt = Date.parse(entry.queuedAt);
     return Number.isFinite(queuedAt) && Date.now() - queuedAt > STALE_QUEUED_REFILL_MS;
   });
-  const staleQueuedCount = staleQueued.length;
-  // Whether any stale entry actually has a restart button in the list above. A
-  // group whose partition does not resolve renders "Restart this map from the
-  // Maps tab" instead, so pointing at a button that is not there would be wrong.
   const staleTargetKeys = new Set(staleQueued.map((entry) => `${entry.map || "Unknown"}|${entry.partitionId}`));
-  const staleHasRestartButton = (pendingRefills?.byTarget || []).some((group) =>
-    staleTargetKeys.has(`${group.map}|${group.partitionId}`)
-    && queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex).kind !== "none");
   // With no enrollment read at all, the toggle cannot honestly show ON or OFF.
   const autoRefillUnrecoverable = autoRefillUnavailable && autoRefillBases.size === 0;
   // autoRefillBases is fetched globally (GET /api/bases/auto-refill), same
   // scope as pendingRefills, so this counts stalled bases across the whole
   // battlegroup -- not just whatever page of the list happens to be loaded.
-  const stalledAutoRefillCount = [...autoRefillBases.values()].filter((entry) => entry.stalledAt).length;
+  const stalledFuelBaseIds = new Set([...autoRefillBases.entries()].filter(([, entry]) => entry.stalledAt).map(([baseId]) => baseId));
 
   // Mirrors the block above, for the water refill queue.
   const pendingWaterTotal = pendingWaterRefills?.total || 0;
@@ -970,13 +925,53 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
     const queuedAt = Date.parse(entry.queuedAt);
     return Number.isFinite(queuedAt) && Date.now() - queuedAt > STALE_QUEUED_REFILL_MS;
   });
-  const staleQueuedWaterCount = staleQueuedWater.length;
   const staleWaterTargetKeys = new Set(staleQueuedWater.map((entry) => `${entry.map || "Unknown"}|${entry.partitionId}`));
-  const staleWaterHasRestartButton = (pendingWaterRefills?.byTarget || []).some((group) =>
-    staleWaterTargetKeys.has(`${group.map}|${group.partitionId}`)
-    && queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex).kind !== "none");
   const autoRefillWaterUnrecoverable = autoRefillWaterUnavailable && autoRefillWaterBases.size === 0;
-  const stalledAutoRefillWaterCount = [...autoRefillWaterBases.values()].filter((entry) => entry.stalledAt).length;
+  const stalledWaterBaseIds = new Set([...autoRefillWaterBases.entries()].filter(([, entry]) => entry.stalledAt).map(([baseId]) => baseId));
+
+  // Combined queue banner: one box covering both queues. Merge byTarget rows
+  // keyed on map|partitionId -- restarting a target already flushes
+  // whichever queue(s) are waiting on it (see handleRestartForCombinedQueue),
+  // so one restart button per target is correct even though the fuel/water
+  // counts come from two separate endpoints.
+  type CombinedQueueTarget = { map: string; partitionId: number; partitionMap: string; dimensionIndex: number; fuelCount: number; waterCount: number };
+  const combinedQueueTargets: CombinedQueueTarget[] = (() => {
+    const byKey = new Map<string, CombinedQueueTarget>();
+    for (const group of pendingRefills?.byTarget || []) {
+      byKey.set(`${group.map}|${group.partitionId}`, {
+        map: group.map, partitionId: group.partitionId, partitionMap: group.partitionMap, dimensionIndex: group.dimensionIndex,
+        fuelCount: group.count, waterCount: 0
+      });
+    }
+    for (const group of pendingWaterRefills?.byTarget || []) {
+      const key = `${group.map}|${group.partitionId}`;
+      const existing = byKey.get(key);
+      if (existing) existing.waterCount = group.count;
+      else byKey.set(key, {
+        map: group.map, partitionId: group.partitionId, partitionMap: group.partitionMap, dimensionIndex: group.dimensionIndex,
+        fuelCount: 0, waterCount: group.count
+      });
+    }
+    return [...byKey.values()];
+  })();
+  const combinedQueueTotal = pendingTotal + pendingWaterTotal;
+  // Whether any stale entry actually has a restart button in the list above. A
+  // group whose partition does not resolve renders "Restart this map from the
+  // Maps tab" instead, so pointing at a button that is not there would be wrong.
+  const combinedStaleTargetKeys = new Set([...staleTargetKeys, ...staleWaterTargetKeys]);
+  const combinedStaleCount = staleQueued.length + staleQueuedWater.length;
+  const combinedStaleHasRestartButton = combinedQueueTargets.some((group) =>
+    combinedStaleTargetKeys.has(`${group.map}|${group.partitionId}`)
+    && queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex).kind !== "none");
+
+  // Combined stalled auto-refill banner: the headline counts unique bases,
+  // not queue entries -- a base stalled on both fuel and water should not
+  // read as "2 bases have stalled auto-refill" when it is one base with two
+  // badges (each badge below does count occurrences, i.e. queue entries).
+  const stalledCombinedBaseIds = new Set([...stalledFuelBaseIds, ...stalledWaterBaseIds]);
+  const stalledCombinedCount = stalledCombinedBaseIds.size;
+  const stalledFuelCount = stalledFuelBaseIds.size;
+  const stalledWaterCount = stalledWaterBaseIds.size;
   const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
   const rangeStart = totalCount === 0 ? 0 : page * pageSize + 1;
   const rangeEnd = totalCount === 0 ? 0 : rangeStart + rows.length - 1;
@@ -1019,25 +1014,31 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
       <p className="action-help-note">
         Total Bases: {totalBases.toLocaleString()} · Total Building Pieces: {totalPieces.toLocaleString()} · Total Placeables: {totalPlaceables.toLocaleString()}
       </p>
-      {stalledAutoRefillCount > 0 && <div className="bases-stalled-banner" role="alert">
+      {stalledCombinedCount > 0 && <div className="bases-stalled-banner" role="alert">
         <p className="bases-stalled-banner-title">
-          <Fuel size={16} aria-hidden="true" />
-          {stalledAutoRefillCount.toLocaleString()} base{stalledAutoRefillCount === 1 ? " has" : "s have"} stalled auto-refill
+          {stalledCombinedCount.toLocaleString()} base{stalledCombinedCount === 1 ? " has" : "s have"} stalled auto-refill
+          {stalledFuelCount > 0 && <span className="bases-queue-badge bases-queue-badge-fuel">
+            <Fuel size={13} aria-hidden="true" />{stalledFuelCount.toLocaleString()} fuel
+          </span>}
+          {stalledWaterCount > 0 && <span className="bases-queue-badge bases-queue-badge-water">
+            <Droplet size={13} aria-hidden="true" />{stalledWaterCount.toLocaleString()} water
+          </span>}
         </p>
         <p className="action-help-note">
-          Auto-refill queued 3 refills for {stalledAutoRefillCount === 1 ? "this base" : "each of these bases"} without raising the fuel. Refill manually to find out why, or turn auto-refill off and back on to resume trying.
+          Auto-refill queued 3 refills without raising the fuel or water on {stalledCombinedCount === 1 ? "this base" : "these bases"}. Refill manually to find out why, or turn auto-refill off and back on to resume trying.
         </p>
       </div>}
-      {pendingTotal > 0 && <div className="bases-pending-refills">
+      {combinedQueueTotal > 0 && <div className="bases-pending-refills">
         <p className="bases-pending-refills-title">
           <Fuel size={16} aria-hidden="true" />
-          {pendingTotal.toLocaleString()} generator refill{pendingTotal === 1 ? "" : "s"} queued
+          <Droplet size={16} aria-hidden="true" />
+          {combinedQueueTotal.toLocaleString()} refill{combinedQueueTotal === 1 ? "" : "s"} queued
         </p>
         <p className="action-help-note">
           Each one is written when its map next restarts. Restarting the battlegroup applies all of them; stopping leaves them queued.
         </p>
         <ul className="bases-pending-refills-list">
-          {(pendingRefills?.byTarget || []).map((group) => {
+          {combinedQueueTargets.map((group) => {
             const target = queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex);
             const key = `${group.map}|${group.partitionId}`;
             return <li key={key}>
@@ -1045,8 +1046,13 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
                 {group.map}
                 {group.partitionMap && group.partitionMap !== group.map ? ` (${group.partitionMap})` : ""}
                 {group.partitionId ? ` · partition ${group.partitionId}` : ""}
-                <span className="muted"> — {group.count.toLocaleString()} queued</span>
               </span>
+              {group.fuelCount > 0 && <span className="bases-queue-badge bases-queue-badge-fuel">
+                <Fuel size={13} aria-hidden="true" />{group.fuelCount.toLocaleString()}
+              </span>}
+              {group.waterCount > 0 && <span className="bases-queue-badge bases-queue-badge-water">
+                <Droplet size={13} aria-hidden="true" />{group.waterCount.toLocaleString()}
+              </span>}
               {target.kind === "none"
                 ? <span className="muted">Restart this map from the Maps tab</span>
                 : restartingTargets.includes(key)
@@ -1054,55 +1060,12 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
                       <span className="spinner" aria-hidden="true" />
                       <span className="loading-dots" role="status">Restarting</span>
                     </span>
-                  : <button onClick={() => void handleRestartForQueue(group)}>{target.label}</button>}
+                  : <button onClick={() => void handleRestartForCombinedQueue(group)}>{target.label}</button>}
             </li>;
           })}
         </ul>
-        {staleQueuedCount > 0 && <p className="bases-pending-refills-stale" role="status">
-          {staleQueuedCount.toLocaleString()} queued over 24h — {staleQueuedCount === 1 ? "its map has" : "their maps have"} not been down since. {staleHasRestartButton ? "Restart above to apply." : "Restart from the Maps tab to apply."}
-        </p>}
-      </div>}
-      {stalledAutoRefillWaterCount > 0 && <div className="bases-stalled-banner" role="alert">
-        <p className="bases-stalled-banner-title">
-          <Droplet size={16} aria-hidden="true" />
-          {stalledAutoRefillWaterCount.toLocaleString()} base{stalledAutoRefillWaterCount === 1 ? " has" : "s have"} stalled water auto-refill
-        </p>
-        <p className="action-help-note">
-          Auto-refill queued 3 refills for {stalledAutoRefillWaterCount === 1 ? "this base" : "each of these bases"} without raising the water. Refill manually to find out why, or turn auto-refill off and back on to resume trying.
-        </p>
-      </div>}
-      {pendingWaterTotal > 0 && <div className="bases-pending-refills">
-        <p className="bases-pending-refills-title">
-          <Droplet size={16} aria-hidden="true" />
-          {pendingWaterTotal.toLocaleString()} water refill{pendingWaterTotal === 1 ? "" : "s"} queued
-        </p>
-        <p className="action-help-note">
-          Each one is written when its map next restarts. Restarting the battlegroup applies all of them; stopping leaves them queued.
-        </p>
-        <ul className="bases-pending-refills-list">
-          {(pendingWaterRefills?.byTarget || []).map((group) => {
-            const target = queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex);
-            const key = `${group.map}|${group.partitionId}`;
-            return <li key={key}>
-              <span>
-                {group.map}
-                {group.partitionMap && group.partitionMap !== group.map ? ` (${group.partitionMap})` : ""}
-                {group.partitionId ? ` · partition ${group.partitionId}` : ""}
-                <span className="muted"> — {group.count.toLocaleString()} queued</span>
-              </span>
-              {target.kind === "none"
-                ? <span className="muted">Restart this map from the Maps tab</span>
-                : restartingTargets.includes(key)
-                  ? <span className="bases-restarting-pill">
-                      <span className="spinner" aria-hidden="true" />
-                      <span className="loading-dots" role="status">Restarting</span>
-                    </span>
-                  : <button onClick={() => void handleRestartForWaterQueue(group)}>{target.label}</button>}
-            </li>;
-          })}
-        </ul>
-        {staleQueuedWaterCount > 0 && <p className="bases-pending-refills-stale" role="status">
-          {staleQueuedWaterCount.toLocaleString()} queued over 24h — {staleQueuedWaterCount === 1 ? "its map has" : "their maps have"} not been down since. {staleWaterHasRestartButton ? "Restart above to apply." : "Restart from the Maps tab to apply."}
+        {combinedStaleCount > 0 && <p className="bases-pending-refills-stale" role="status">
+          {combinedStaleCount.toLocaleString()} queued over 24h — {combinedStaleCount === 1 ? "its map has" : "their maps have"} not been down since. {combinedStaleHasRestartButton ? "Restart above to apply." : "Restart from the Maps tab to apply."}
         </p>}
       </div>}
       {refillResult && <p
@@ -1303,6 +1266,7 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
               <p className="bases-generator-reserve-note" role="note">
                 {QUEUED_RESERVE_EXPLANATION}
               </p>
+              <div className="bases-generator-cards">
               {generators.map((generator, index) => (
                 <div className="bases-generator-group" key={`${generator.type}-${index}`}>
                   <div className="bases-generator-group-title">{generator.name}</div>
@@ -1326,6 +1290,7 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
                   </dl>
                 </div>
               ))}
+              </div>
             </div>
           );
           };

--- a/console/web/src/lib/usePendingRefills.ts
+++ b/console/web/src/lib/usePendingRefills.ts
@@ -37,6 +37,38 @@ export function usePendingRefills(enabled = true) {
   return { pending, refresh };
 }
 
+// Mirrors usePendingRefills above for the water refill queue -- a separate
+// hook rather than a parameterized fetcher, matching the rest of this
+// codebase's per-resource duplication (WATER_TYPES vs GENERATOR_TYPES,
+// autoRefillWater.js vs autoRefill.js) over a shared abstraction.
+export function usePendingWaterRefills(enabled = true) {
+  const [pending, setPending] = useState<PendingRefills | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await basesApi.pendingWaterRefills();
+      setPending(next);
+      return next;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const tick = () => { if (!cancelled) void refresh(); };
+    tick();
+    const intervalId = window.setInterval(tick, PENDING_REFILL_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [enabled, refresh]);
+
+  return { pending, refresh };
+}
+
 export function pendingRefillCountForPartition(pending: PendingRefills | null, partitionId: number) {
   if (!pending || !partitionId) return 0;
   return pending.pending.filter((entry) => entry.partitionId === partitionId).length;

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -915,6 +915,8 @@ main { padding: 22px; min-width: 0; }
 .progress-row { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 12px; }
 .progress-track { height: 10px; overflow: hidden; border-radius: 999px; background: #0c0e10; border: 1px solid #302b25; }
 .progress-fill { height: 100%; border-radius: inherit; background: #c68b4a; transition: width .35s ease; }
+.progress-fill-water { background: #4a90c6; }
+.progress-fill-blood { background: #a03d3d; }
 .result-ok .progress-fill { background: #3d8b62; }
 .result-ok .progress-track { border-color: #3d8b62; }
 .result-ok .panel-title h4, .result-ok p, .result-ok .progress-row strong { color: #9be6bd; }
@@ -1750,6 +1752,20 @@ body.debug .technical-details { display: block; }
 }
 .bases-pending-refills-list button { padding: 5px 10px; font-size: 12px; }
 .bases-pending-refills-list .muted { color: var(--muted); }
+/* Distinguishes the fuel vs water counts inside the combined queue/stalled
+   banners -- same colors as the Water tab's progress bars, so a glance at
+   either surface reads the same way. */
+.bases-queue-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 6px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.bases-queue-badge-fuel { background: rgba(198, 139, 74, .18); color: var(--accent); }
+.bases-queue-badge-water { background: rgba(74, 144, 198, .18); color: #7fb2df; }
 .bases-queued-refill {
   display: inline-flex;
   align-items: center;
@@ -1782,11 +1798,6 @@ body.debug .technical-details { display: block; }
   flex-wrap: wrap;
   margin: 0 0 12px;
   padding: 0 0 12px;
-  /* .bases-generator-breakdown is a grid of 240px columns (one per generator
-     type). Without this, this block was squeezed into a single 240px cell
-     instead of spanning the row. Matches the same rule already on
-     .bases-generator-reserve-note in this grid. */
-  grid-column: 1 / -1;
 }
 /* Keep the Auto-Refill control at the far edge of the expanded row. When the
    row wraps on a phone, auto margin still right-aligns the control on its new
@@ -1801,10 +1812,9 @@ body.debug .technical-details { display: block; }
    other panels also use. Sized a notch below the toggle's own text so the
    description reads as secondary, not the loudest thing in the block.
    The rule explanation and last-checked status live in this element's title
-   attribute (a native hover tooltip) rather than as inline text: this row's
-   available width is whatever the grid handed it, sometimes just one 240px
-   column, which made a fixed-width inline note either wrap unpredictably or
-   (with a hard nowrap) silently truncate. A tooltip has no such constraint. */
+   attribute (a native hover tooltip) rather than as inline text: at narrow
+   viewport widths a fixed-width inline note either wraps unpredictably or
+   (with a hard nowrap) silently truncates. A tooltip has no such constraint. */
 .bases-auto-refill-toggle { min-height: 32px; padding: 3px 4px 3px 10px; }
 .bases-auto-refill-toggle .switch-label { font-size: 12px; }
 /* Wide enough for the "Saving" state, matching settings-server-listing-toggle. */
@@ -1837,9 +1847,8 @@ body.debug .technical-details { display: block; }
    otherwise believes fuel is handled while the base quietly stays empty. Left
    as inline text rather than folded into the toggle's tooltip -- unlike the
    rule explanation, this is urgent and per-base, so it should be visible
-   without hovering. Allowed to wrap (no nowrap/ellipsis) for the same reason
-   the row now uses grid-column: 1 / -1 above: available width is whatever the
-   grid hands this row, which is not always enough for one line. */
+   without hovering. Allowed to wrap (no nowrap/ellipsis): at narrow viewport
+   widths this row's available width is not always enough for one line. */
 .bases-auto-refill-stalled {
   flex: 1 1 100%;
   margin: 0;
@@ -2409,7 +2418,12 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 .bases-permissions-orphan { display: inline-flex; color: var(--warning); flex: 0 0 auto; }
 .bases-permissions-remove { border-color: var(--danger-strong); color: var(--danger-text); }
 .bases-permissions-add { display: grid; gap: 8px; }
-.bases-permissions-search-row { flex-wrap: wrap; }
+/* Overrides .action-row's align-items: center -- "Add as" has a label line
+   above its select that the bare input/buttons don't, so centering the row
+   left the select's bottom edge hanging lower than the rest. Bottom-aligning
+   (matching .action-line's convention for the same label-above-control
+   shape) puts every control's bottom edge on the same line. */
+.bases-permissions-search-row { flex-wrap: wrap; align-items: flex-end; }
 .bases-permissions-candidates {
   list-style: none;
   margin: 0;
@@ -2471,14 +2485,35 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 .bases-table td.expanded-row-cell {
   text-align: left;
 }
+/* A plain full-width column, not a grid: the auto-refill row and the reserve
+   note need the row's true full width (flex's default align-items: stretch
+   gives every direct child 100% width for free), while only the actual cards
+   below get wrapped into the capped auto-fit grid in .bases-generator-cards.
+   A single grid used to do both jobs via grid-column: 1 / -1 on those two
+   children, but that only reaches the edge of the grid's own tracks -- once
+   the cards' columns were capped at a fixed max-width (rather than 1fr) the
+   tracks stopped summing to the container's full width, so "span every
+   track" silently stopped meaning "reach the right edge" and both rows fell
+   short of it. */
 .bases-generator-breakdown {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
+  display: flex;
+  flex-direction: column;
   gap: 12px;
   width: 100%;
   padding: clamp(12px, 1.5vw, 18px);
   box-sizing: border-box;
+}
+.bases-generator-cards {
+  display: grid;
+  /* Capped at 280px rather than 1fr: with few groups (a base with one or two
+     water containers, in particular) an unbounded 1fr stretches each card to
+     fill the row instead of staying a card. */
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 280px));
+  gap: 12px;
   align-items: stretch;
+}
+.bases-generator-cards.bases-water-cards {
+  align-items: start;
 }
 .bases-uptime-event-inline {
   display: inline-flex;

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2545,7 +2545,6 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   line-height: 1.25;
 }
 .bases-generator-reserve-note {
-  grid-column: 1 / -1;
   margin: 0;
   color: var(--muted-warm);
   font-size: 12px;

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1645,7 +1645,10 @@ body.debug .technical-details { display: block; }
 .bases-table th:nth-child(9), .bases-table td:nth-child(9) { width: 6%; text-align: center; }
 .bases-table th:nth-child(10), .bases-table td:nth-child(10) { width: 6%; text-align: center; }
 .bases-table th:nth-child(11), .bases-table td:nth-child(11) { width: 10.5%; }
-.bases-table th.bases-actions-column, .bases-table td.bases-actions-column { width: 96px; }
+/* 96px fit two icon-toggle-buttons (Refill Generators, Download); a third
+   (Refill Water) plus the wider queued-refill pills need more room, so this
+   grew to comfortably fit all three at once, queued or not. */
+.bases-table th.bases-actions-column, .bases-table td.bases-actions-column { width: 148px; }
 .bases-table td { max-width: none; white-space: normal; overflow-wrap: anywhere; text-overflow: clip; }
 .bases-name, .bases-ellipsis-cell { display: block; overflow: visible; text-overflow: clip; white-space: normal; overflow-wrap: anywhere; }
 .bases-generator-summary { display: block; white-space: normal; overflow: visible; text-overflow: clip; line-height: 1.4; }
@@ -2378,6 +2381,7 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 }
 .bases-expanded-tab.active:hover { border-color: var(--border-strong); border-bottom-color: #25201b; }
 
+.bases-water { display: grid; gap: 12px; }
 .bases-permissions { display: grid; gap: 12px; }
 .bases-permissions-roster { display: grid; gap: 6px; }
 .bases-permissions-row {

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2286,6 +2286,160 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   color: #ad9f89;
   font-style: normal;
 }
+
+/* Folder-style tabs: the active one is a raised tab sitting on the panel,
+   reusing the same #25201b fill the app's buttons already use. The -1px margin
+   pulls it over the strip's bottom border so the tab and the content below it
+   read as one continuous surface. */
+/* Bases opts out of the shared .table-wrap height cap so the table grows with
+   its rows and the page scrolls instead of a container inside it. An expanded
+   row's panel is tall enough that the 620px cap left it fighting for room in a
+   nested scrollport. Row count stays bounded by the page-size control. */
+/* Two-class selector deliberately: a later grouped rule re-declares
+   `overflow: auto` on .table-wrap at equal specificity, so a single-class
+   override here would lose on source order. */
+.table-wrap.bases-table-wrap { max-height: none; overflow: visible; }
+
+/* Below this width the twelve columns have nowhere to go. The table has no
+   intrinsic minimum, so instead of overflowing it crushes -- cells collapse to
+   one character per line and "Advanced Sub-Fief" renders vertically. (That
+   predates the height-cap change: with no min-width the table always shrank to
+   its container, so the wrap's overflow-x never had anything to scroll.)
+   Give it a floor and let the container scroll horizontally again.
+   The sticky header does not survive here, because a sticky element is confined
+   to its nearest scrolling ancestor and that is now the wrap again -- readable
+   columns are worth more than a pinned header on a phone. */
+@media (max-width: 1100px) {
+  .table-wrap.bases-table-wrap { overflow: auto; }
+  .bases-table { min-width: 860px; }
+  /* The expanded panel is a cell of that 860px table, so without this it
+     inherits the width and pushes its own controls off-screen -- the rank
+     dropdown, remove button and player picker all end up past the right edge.
+     Sticky-left pins the panel to the visible edge while the columns scroll
+     underneath, and the width cap keeps its controls inside the scrollport. */
+  .bases-table td.expanded-row-cell { position: sticky; left: 0; }
+  .bases-table td.expanded-row-cell > * { max-width: calc(100vw - 76px); }
+}
+/* The shared `th` rule is already position:sticky, but an overflow:auto ancestor
+   confines a sticky element to that ancestor's scrollport -- so with the height
+   cap gone the header stuck to a container that no longer scrolls and rode off
+   with the page. Dropping the wrap's overflow makes the page itself the sticky
+   context, which is what keeps the header pinned while the rows scroll. */
+/* The search row pins above the table header so Search/Clear stay reachable
+   while scrolling a long list. It needs an opaque background of its own -- the
+   panel's is semi-transparent, so rows would scroll visibly through it. Its
+   margins become padding so the sticky box is one solid band with no gap for
+   rows to show through between it and the header below. */
+.bases-search-row {
+  position: sticky;
+  top: 0;
+  z-index: 4;
+  margin-block: 0;
+  padding-block: 12px;
+  background: var(--panel);
+}
+/* 67px = the search row's 43px of content plus its 24px of padding, so the
+   header parks directly beneath the search bar rather than under it. */
+.table-wrap.bases-table-wrap { margin-top: 0; }
+.bases-table-wrap .bases-table th { top: 67px; z-index: 3; }
+/* Below 900px the sidebar stops being a column and becomes a sticky header at
+   top:0 with z-index:100, so a search bar pinned to the same edge sits behind
+   it. Offsetting by the sidebar's height would break the moment the hamburger
+   expands it, so the bar simply scrolls with the page here -- which matches the
+   table header, itself not page-sticky at this width. */
+@media (max-width: 900px) {
+  .bases-search-row { position: static; }
+}
+
+.bases-expanded-tablist {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-strong);
+  margin-bottom: 14px;
+  padding-top: 8px;
+}
+.bases-expanded-tab {
+  width: auto;
+  min-width: 0;
+  border: 1px solid transparent;
+  border-radius: 6px 6px 0 0;
+  background: transparent;
+  color: var(--muted);
+  padding: 9px 16px;
+  font-size: 13px;
+  margin-bottom: -1px;
+}
+.bases-expanded-tab:hover { color: var(--muted-warm); border-color: transparent; }
+.bases-expanded-tab.active {
+  background: #25201b;
+  border-color: var(--border-strong);
+  border-bottom-color: #25201b;
+  color: var(--title);
+}
+.bases-expanded-tab.active:hover { border-color: var(--border-strong); border-bottom-color: #25201b; }
+
+.bases-permissions { display: grid; gap: 12px; }
+.bases-permissions-roster { display: grid; gap: 6px; }
+.bases-permissions-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 150px 38px;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  padding: 6px 10px;
+}
+.bases-permissions-row-owner { border-color: var(--border-strong); }
+.bases-permissions-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+.bases-permissions-row-owner .bases-permissions-name { color: var(--text-strong); }
+.bases-permissions-orphan { display: inline-flex; color: var(--warning); flex: 0 0 auto; }
+.bases-permissions-remove { border-color: var(--danger-strong); color: var(--danger-text); }
+.bases-permissions-add { display: grid; gap: 8px; }
+.bases-permissions-search-row { flex-wrap: wrap; }
+.bases-permissions-candidates {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+.bases-permissions-candidates li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 5px 10px;
+  font-size: 13px;
+}
+.bases-permissions-candidates li span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.bases-permissions-warning { margin: 0; }
+.bases-permissions-error { color: var(--danger-text); margin: 0; }
+.bases-permissions-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  justify-content: flex-end;
+}
+.bases-permissions-actions > .muted { margin-right: auto; font-size: 12px; }
+.bases-permissions-actions button { width: auto; }
 .bases-table th.bases-expand-column, .bases-table td.bases-expand-column {
   width: 32px;
   padding-inline: 4px;

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ reference. Everything else is marked **Current** and is expected to stay accurat
 - [PRE-AUGMENTED-GEAR.md](console/PRE-AUGMENTED-GEAR.md) — Current. API reference for granting gear with augments pre-applied.
 - [generator-fuel-burn-rates.md](console/generator-fuel-burn-rates.md) — Current. Per-generator fuel burn constants and where they live in code.
 - [generator-refill-caps.md](console/generator-refill-caps.md) — Current. Refill-generators endpoint behavior and per-type fuel caps.
+- [base-permissions.md](console/base-permissions.md) — Current. Editing base ownership and sharing: ranks, the config-driven roster cap, and why the change needs no map restart.
 
 ## Runtime (`runtime/`)
 

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -237,6 +237,23 @@ Complete reference for all HTTP API endpoints in the Dune Docker Console. All en
 | DELETE | `/api/bases/{baseId}/queued-refill` | Cancel a base's queued generator refill | `baseId` |
 | GET | `/api/bases/auto-refill` | Get per-base auto-refill enrollment state | None |
 | POST | `/api/bases/{baseId}/auto-refill` | Enable/disable auto-refill for a base | `baseId`, `enabled` |
+| GET | `/api/bases/{baseId}/permissions` | Get a base's permission roster (Owner, Co-Owners, Associates) | `baseId` |
+| PUT | `/api/bases/{baseId}/permissions` | Replace a base's permission roster | `baseId`, `entries[]` (`playerId`, `rank`) |
+| GET | `/api/bases/permission-candidates` | Search players eligible to be added to a roster | `q?`, `limit?` |
+
+`GET /api/bases` reports `capabilities.basePermissions`; the permission routes are
+unavailable when it is false (the schema lacks the required tables or the game's
+`permission_set_player_rank` / `permission_remove_player_rank` procedures).
+
+`PUT` takes the whole roster rather than a delta — the server diffs it against
+current state and applies only the difference. `rank` is `1` Owner, `2` Co-Owner,
+`3` Associate, and exactly one entry must be rank 1. `playerId` must be a player's
+`player_state.player_controller_id`; any other actor id belonging to the same
+account is rejected, because the game would ignore such a row. The roster size
+limit comes from live server config, not a constant.
+
+Changes reach a running map immediately — there is no restart queue, unlike the
+generator refill routes above. See [base-permissions.md](base-permissions.md).
 
 ### Storage
 

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -237,6 +237,12 @@ Complete reference for all HTTP API endpoints in the Dune Docker Console. All en
 | DELETE | `/api/bases/{baseId}/queued-refill` | Cancel a base's queued generator refill | `baseId` |
 | GET | `/api/bases/auto-refill` | Get per-base auto-refill enrollment state | None |
 | POST | `/api/bases/{baseId}/auto-refill` | Enable/disable auto-refill for a base | `baseId`, `enabled` |
+| GET | `/api/bases/{baseId}/water` | Get a base's water storage containers (count, volume, fill %; blood volume/fill for Blood Purifiers) | `baseId` |
+| POST | `/api/bases/{baseId}/refill-water` | Refill all base water storage (queued instead if the map isn't safely writable right now). Water only -- blood is never touched | `baseId` |
+| GET | `/api/bases/pending-water-refills` | List queued water refills, grouped by restart target | None |
+| DELETE | `/api/bases/{baseId}/queued-water-refill` | Cancel a base's queued water refill | `baseId` |
+| GET | `/api/bases/auto-refill-water` | Get per-base water auto-refill enrollment state | None |
+| POST | `/api/bases/{baseId}/auto-refill-water` | Enable/disable water auto-refill for a base | `baseId`, `enabled` |
 | GET | `/api/bases/{baseId}/permissions` | Get a base's permission roster (Owner, Co-Owners, Associates) | `baseId` |
 | PUT | `/api/bases/{baseId}/permissions` | Replace a base's permission roster | `baseId`, `entries[]` (`playerId`, `rank`) |
 | GET | `/api/bases/permission-candidates` | Search players eligible to be added to a roster | `q?`, `limit?` |

--- a/docs/console/base-permissions.md
+++ b/docs/console/base-permissions.md
@@ -1,0 +1,164 @@
+# Base permissions
+
+**Status:** Current | **Last Updated:** August 2026
+
+The Bases panel can edit who owns a base and who it is shared with. The editor
+lives in the **Permissions** tab of an expanded base row, alongside the existing
+**Power** tab.
+
+Unlike generator refills, permission changes are **not** queued for a map
+restart — they reach a running map immediately. See
+[Why there is no queue](#why-there-is-no-queue).
+
+## Ranks
+
+Permissions are rows in `dune.permission_actor_rank`, one per player per base:
+
+| Rank | Label | Notes |
+|---:|---|---|
+| 1 | Owner | Exactly one per base. Shown in the **Owner** column. |
+| 2 | Co-Owner | Shown in the **Shared With** column. |
+| 3 | Associate | Shown in the **Shared With** column. |
+
+The in-game Permissions panel displays `5` / `4` / `3` beside Owner / Co-Owner /
+Associate. Those are decoration, not database ranks — an in-game Co-Owner is
+stored as rank `2`, and no row ever holds a `4` or `5`.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/bases/:baseId/permissions` | The base's roster, with resolved names and rank labels. |
+| `PUT` | `/api/bases/:baseId/permissions` | Replace the roster. Body: `{ entries: [{ playerId, rank }] }`. |
+| `GET` | `/api/bases/permission-candidates?q=&limit=` | Player search for the add-player picker. |
+
+`PUT` takes a **whole roster**, not a delta. The server diffs it against current
+state and applies only the difference, so an unchanged row is never rewritten —
+every write emits a notification, and re-notifying an unchanged rank is pointless
+traffic to the game server.
+
+Audited as `bases.set-permissions`. Rate limited. No confirmation phrase, matching
+the guild mutations and the refill route: the change is reversible from the same
+editor.
+
+## What the server enforces
+
+Client-side rules are re-checked server-side; none of them are trusted from the
+request.
+
+- **Exactly one Owner.** `permission_set_player_rank` is a plain upsert, so
+  setting rank 1 for a second player would simply leave the base with two owners.
+  The outgoing Owner is demoted first, in the same transaction.
+- **The roster cap**, read from live server config (see below).
+- **Ranks limited to 1–3**, no duplicate players.
+- **Every player id must be a `player_controller_id`** (see below).
+
+## The roster cap comes from server config
+
+The game caps permissions per actor. Two settings exist:
+
+| Key | Section | Shipped default |
+|---|---|---:|
+| `permission_max_permissions_per_actor` | `/Script/DuneSandbox.PermissionSettings` | **32** |
+| `max_permissions_per_actor` | `/Script/DuneSandbox.DuneGameMode` (legacy) | 20 |
+
+`DefaultGame.ini` inside the server image defines `m_MaxPermissionsPerActor=32`
+under `[PermissionSettings]` only — there is no `DuneGameMode` form of the key —
+so the canonical field is the one the server enforces.
+`parseEffectivePermissionLimit` (`console/api/src/services/permissionSettings.js`)
+therefore reads the canonical key **first** and falls back to the legacy one,
+defaulting to 32.
+
+Note this is the **opposite** precedence to `parseEffectiveGuildMemberLimit`,
+where the legacy `DuneGameMode` field wins. Reading the legacy key first here
+would inherit its `20` and silently cap rosters below what the server permits.
+
+To raise the cap, edit `permission_max_permissions_per_actor` in the settings
+editor — the console reads it per save, so no release is needed.
+
+> **Footgun:** writing the *legacy* field through the Advanced Editor introduces
+> a `DuneGameMode` value defaulting to 20, which can lower the effective cap
+> below the shipped 32.
+
+## Two ids that are easy to confuse
+
+**The base id is not the permission actor id.** The id shown in the Bases table
+is `min(buildings.id)` for the claim; `permission_actor_rank.permission_actor_id`
+is the claim *actor* id (`dune.actors.id`). They differ for every base and by a
+varying offset — observed live: `70 → 354`, `1006 → 1004`, `1675 → 1717`,
+`3030 → 3116`. The actor is always resolved server-side from the base id; an
+actor id is never accepted from a client.
+
+**`player_id` must be a `player_controller_id`.** One account owns several
+`dune.actors` rows, and only the one matching
+`dune.player_state.player_controller_id` is a real permission holder. A rank row
+written against any other actor id of the same account is accepted by the
+procedure and then **ignored by the game**.
+
+This is easy to get wrong because the read path hides it: names resolve through
+`actors.owner_account_id`, and every actor row of an account maps to the same
+character name — so a bad row renders perfectly in the console while doing
+nothing in game. The roster marks such rows (`canonical: false`) rather than
+hiding them; the console can see them and the game client cannot.
+
+## Why there is no queue
+
+Generator refills are queued until a map is down because a running server
+rewrites its own state back to Postgres and would overwrite the refill.
+Permissions are different: the game ships stored procedures that **notify the
+running server**, and the console calls those rather than writing the table.
+
+- `dune.permission_set_player_rank(actor_id, player_id, rank, map_id)` — upserts
+  the rank row, refreshes the base marker, then
+  `pg_notify('permission_notify_channel', 'set_rank#{…}')`.
+- `dune.permission_remove_player_rank(actor_id, player_id)` — deletes the rank
+  row and the player's marker, then notifies.
+
+Every map server `LISTEN`s on that channel (`LogFarmNotification: Display:
+Listening for notification 'permission_notify_channel'` in the server log).
+Verified in-game: a rank change written this way moved a player between sections
+in the owner's open Permissions panel with no relog and no map restart.
+
+**Do not write `permission_actor_rank` directly.** Direct DML skips the marker
+refresh and the notification, producing exactly the silently-reverted behaviour
+the refill queue exists to avoid.
+
+`dune.permission_actor_takeover` is **not** a transfer path — it refuses any
+actor that already has a rank-1 owner and returns quietly via `RAISE NOTICE`, so
+calling it on an owned base looks successful while doing nothing. Ownership
+transfer is demote-then-promote through `permission_set_player_rank`.
+
+## Two implementation constraints
+
+**`search_path`.** The shipped procedures reference their tables unqualified and
+carry no `SET search_path` of their own. They resolve only because every client —
+the game servers and the console — connects as the `dune` role, whose default
+`"$user", public` path reaches the `dune` schema. Since every query the console
+writes is schema-qualified, this had never mattered before; `setBasePermissions`
+now issues `set local search_path to dune, public` inside its transaction so the
+feature survives `ADMIN_DATABASE_URL` pointing at a differently-named role.
+
+**Write order.** The marker refresh inside `permission_set_player_rank` resolves
+the owner with a `LIMIT 1` over rank-1 rows, so a moment with two rank-1 rows
+could stamp the wrong owner onto the base marker. Removals run first, then
+non-owner ranks, then the Owner last — at most one rank-1 row exists when the
+owner write lands. (`NOTIFY` is only delivered on commit, so the game never
+observes the intermediate state; the marker refresh, running inside the
+transaction, does.)
+
+**Locking** is a row lock on the claim actor (`dune.actors`), not on the rank
+rows: a base whose roster is being fully replaced may have no rank rows, and
+`for update` over zero rows serializes nothing.
+
+## Capability gating
+
+The panel hides the editor unless `listBases` reports `capabilities.basePermissions`.
+That requires `dune.permission_actor_rank`, `dune.permission_actor`, `dune.actors`,
+`dune.player_state` and `dune.map_names`, plus both stored procedures — probed
+once per list request rather than per row.
+
+## Related
+
+- [generator-refill-caps.md](generator-refill-caps.md) — the refill endpoint, and
+  the queue this feature deliberately does not use.
+- [API-REFERENCE.md](API-REFERENCE.md) — full HTTP API reference.

--- a/docs/console/base-permissions.md
+++ b/docs/console/base-permissions.md
@@ -150,6 +150,17 @@ transaction, does.)
 rows: a base whose roster is being fully replaced may have no rank rows, and
 `for update` over zero rows serializes nothing.
 
+## A base can be visible but unresolvable
+
+`building_instances.owner_entity_id` is nullable — it carries an
+`ON DELETE SET NULL` foreign key against `fgl_entities` — so a base can still
+have a row in `dune.buildings` (and so still appear in the Bases table) while
+its link down to a permission actor is broken. Opening the Permissions tab for
+such a base returns *"This base has no resolvable owner entity, so permission
+editing is unavailable for it,"* distinct from *"That base was not found"*
+(which means the base id itself doesn't exist). No such rows exist in
+production today; this is a documented edge case, not an active issue.
+
 ## Capability gating
 
 The panel hides the editor unless `listBases` reports `capabilities.basePermissions`.

--- a/docs/console/base-permissions.md
+++ b/docs/console/base-permissions.md
@@ -150,16 +150,25 @@ transaction, does.)
 rows: a base whose roster is being fully replaced may have no rank rows, and
 `for update` over zero rows serializes nothing.
 
-## A base can be visible but unresolvable
+## A base can exist but be unresolvable
 
 `building_instances.owner_entity_id` is nullable — it carries an
 `ON DELETE SET NULL` foreign key against `fgl_entities` — so a base can still
-have a row in `dune.buildings` (and so still appear in the Bases table) while
-its link down to a permission actor is broken. Opening the Permissions tab for
-such a base returns *"This base has no resolvable owner entity, so permission
-editing is unavailable for it,"* distinct from *"That base was not found"*
-(which means the base id itself doesn't exist). No such rows exist in
-production today; this is a documented edge case, not an active issue.
+have a row in `dune.buildings` while its link down to a permission actor is
+broken. **Such a base does not appear in the Bases table** — `listBases` still
+inner-joins the same chain, so it's excluded from the list entirely rather than
+shown with a broken Permissions tab. The distinct error instead surfaces from
+paths that resolve a base id directly: a `GET`/`PUT` to
+`/api/bases/:baseId/permissions` with a stale or copied id returns *"This base
+has no resolvable owner entity, so permission editing is unavailable for it,"*
+distinct from *"That base was not found"* (the base id itself doesn't exist).
+The same distinction applies to blueprint export and to the auto-refill
+scanner's existence check (`baseMapLocation`), both of which resolve the same
+join chain and must not conflate "link broken" with "base deleted" — the
+scanner in particular un-enrolls a base from auto-refill on the latter, so
+collapsing the two would silently drop a base that still exists and may still
+need fuel. No such rows exist in production today; this is a documented edge
+case, not an active issue.
 
 ## Capability gating
 


### PR DESCRIPTION
## Summary
- Adds a **Permissions** tab to the expanded base row: edit who owns a base and who it's shared with, writing directly through the game's own notifying stored procedures (no restart queue). New endpoints: `GET/PUT /api/bases/:baseId/permissions`, `GET /api/bases/permission-candidates`.
- Adds a **Water** tab: view water/blood storage, manual refill, and auto-refill enrollment for water cisterns and blood purifiers — mirrors the existing generator refill queue.
- All new routes documented in `docs/console/API-REFERENCE.md`; permissions feature also has its own doc at `docs/console/base-permissions.md`.

## Notable fixes along the way
- A pre-commit review found `basePermissionActor`'s base-resolution query could nondeterministically pick an orphaned building piece over a valid one on multi-piece bases. Fixed with an explicit `ORDER BY`, and generalized to two sibling functions (`baseMapLocation`, `exportBaseAsBlueprint`) with the same latent issue.
- CI then caught a stale test mock, and — after merging in the water-refill work — a real Postgres connection race from three integration-test suites concurrently creating/dropping throwaway databases against one CI Postgres instance. Hardened with a shared advisory lock (`console/api/test-support/pgIntegrationDb.js`).

## Test plan
- [x] `console/api` unit + integration tests (real Postgres, mutation-tested), run via the compliant containerized recipe
- [x] `console/web` component tests for the new Permissions tab
- [x] Manually verified in browser at desktop/tablet/mobile widths against a seeded test console
- [x] CI green across all 8 commits: `api-tests`, `web-tests`, `container-lifecycle`, `security-checks`, dependency audit, release validation