### PR TITLE
Rework the Sub-Fief Permissions tab and split queued refill counts by resource

### DIFF
--- a/console/web/src/features/bases/BasePermissionsTab.test.tsx
+++ b/console/web/src/features/bases/BasePermissionsTab.test.tsx
@@ -1,0 +1,303 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { basesApi, type BasePermissionEntry, type BasePermissionRank } from "../../api/bases";
+import { BasePermissionsTab } from "./BasePermissionsTab";
+
+vi.mock("../../api/bases", () => ({
+  basesApi: {
+    permissions: vi.fn(),
+    setPermissions: vi.fn(),
+    transferToSystemCustodian: vi.fn(),
+    permissionCandidates: vi.fn()
+  }
+}));
+
+type SystemCustodian = { available: boolean; playerId?: string; name?: string; reason?: string };
+
+function entry(playerId: string, name: string, rank: BasePermissionRank, canonical = true): BasePermissionEntry {
+  return { playerId, name, rank, label: "", canonical };
+}
+
+function mockRoster(entries: BasePermissionEntry[], systemCustodian?: SystemCustodian) {
+  vi.mocked(basesApi.permissions).mockResolvedValue({
+    supported: true,
+    baseId: 1006,
+    actorId: "1004",
+    map: "DeepDesert",
+    mapNameId: 7,
+    systemCustodian,
+    entries
+  } as never);
+}
+
+function renderTab(overrides: Partial<Parameters<typeof BasePermissionsTab>[0]> = {}) {
+  const props = {
+    baseId: "1006",
+    baseName: "Sietch One",
+    onSaved: vi.fn(),
+    confirmAction: vi.fn().mockResolvedValue(true),
+    ...overrides
+  };
+  render(<BasePermissionsTab {...props} />);
+  return props;
+}
+
+// The Owner is in the hero card, everyone else is in the roster, so waiting on
+// the hero name is the single "the tab has loaded" signal every test needs.
+function ownerName() {
+  return document.querySelector(".bases-permissions-owner-name");
+}
+
+const DEFAULT_ROSTER = [
+  entry("4", "DarkShark", 1),
+  entry("29", "Yaida", 2),
+  entry("31", "Stilgar", 3)
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("BasePermissionsTab layout", () => {
+  it("puts the Owner in the hero card and everyone else in the roster", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+
+    expect(await screen.findByText("DarkShark", { selector: ".bases-permissions-owner-name" })).toBeInTheDocument();
+    // The Owner has no rank control and no remove button -- promoting someone
+    // else is the only way to change who owns the base.
+    expect(screen.queryByRole("radiogroup", { name: "Rank for DarkShark" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Remove DarkShark" })).not.toBeInTheDocument();
+
+    expect(screen.getAllByRole("radiogroup")).toHaveLength(2);
+    expect(screen.getByRole("radiogroup", { name: "Rank for Yaida" })).toBeInTheDocument();
+    expect(screen.getByRole("radiogroup", { name: "Rank for Stilgar" })).toBeInTheDocument();
+  });
+
+  it("checks exactly the segment matching each player's rank", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+    await screen.findByRole("radio", { name: "Co-Owner for Yaida" });
+
+    expect(screen.getByRole("radio", { name: "Owner for Yaida" })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: "Co-Owner for Yaida" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Associate for Yaida" })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: "Associate for Stilgar" })).toBeChecked();
+  });
+
+  // Regression test for the radio `name` attribute. If two rows shared one group
+  // name the browser would treat them as one set, and selecting a rank in one
+  // row would silently clear the other's.
+  it("keeps each row's rank group independent of the others", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Associate for Yaida" }));
+    await waitFor(() => expect(screen.getByRole("radio", { name: "Associate for Yaida" })).toBeChecked());
+    expect(screen.getByRole("radio", { name: "Associate for Stilgar" })).toBeChecked();
+  });
+
+  it("swaps the hero and the roster on promote, and swaps them back", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Owner for Yaida" }));
+    await waitFor(() => expect(ownerName()).toHaveTextContent("Yaida"));
+    expect(screen.getByRole("radio", { name: "Co-Owner for DarkShark" })).toBeChecked();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Owner for DarkShark" }));
+    await waitFor(() => expect(ownerName()).toHaveTextContent("DarkShark"));
+    expect(screen.getByRole("radio", { name: "Co-Owner for Yaida" })).toBeChecked();
+  });
+
+  it.each([
+    { entries: [entry("4", "DarkShark", 1), entry("29", "Yaida", 2), entry("31", "Stilgar", 3), entry("32", "Chani", 3)], count: "Shared with · 3", meta: "1 co-owner, 2 associates" },
+    { entries: [entry("4", "DarkShark", 1), entry("31", "Stilgar", 3)], count: "Shared with · 1", meta: "1 associate" },
+    { entries: [entry("4", "DarkShark", 1), entry("29", "Yaida", 2), entry("30", "Duncan", 2)], count: "Shared with · 2", meta: "2 co-owners" }
+  ])("summarises the roster as $count / $meta", async ({ entries, count, meta }) => {
+    mockRoster(entries);
+    renderTab();
+    expect(await screen.findByText(count)).toBeInTheDocument();
+    expect(screen.getByText(meta)).toBeInTheDocument();
+  });
+
+  it("renders no breakdown at all when the base is shared with nobody", async () => {
+    mockRoster([entry("4", "DarkShark", 1)]);
+    renderTab();
+    expect(await screen.findByText("Shared with · 0")).toBeInTheDocument();
+    expect(document.querySelector(".bases-permissions-section-meta")).toBeNull();
+    expect(screen.getByText("This base is not shared with anyone else.")).toBeInTheDocument();
+  });
+
+  // The slot holds space for the dirty warning / no-owner alert / task result so
+  // the Revert and Save buttons never move as those come and go.
+  it("keeps the reserved banner slot mounted on a clean roster", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+    await screen.findByText("Shared with · 2");
+    expect(document.querySelector(".bases-permissions-banner-slot")).not.toBeNull();
+  });
+});
+
+describe("BasePermissionsTab ranks the editor cannot represent", () => {
+  // permission_set_player_rank is a plain upsert, so a base the game wrote
+  // directly can carry two rank-1 rows. Filtering the roster by rank would drop
+  // the second from the screen while leaving it in the draft that Save submits.
+  it("keeps a duplicate Owner row visible and removable", async () => {
+    mockRoster([entry("4", "DarkShark", 1), entry("9", "Shadout", 1), entry("31", "Stilgar", 3)]);
+    renderTab();
+
+    expect(await screen.findByText("DarkShark", { selector: ".bases-permissions-owner-name" })).toBeInTheDocument();
+    // The second rank-1 row is on the roster rather than silently dropped.
+    expect(screen.getByRole("radiogroup", { name: "Rank for Shadout" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Remove Shadout" })).toBeEnabled();
+    expect(screen.getByText("Shared with · 2")).toBeInTheDocument();
+    // Not "1 associate" -- a rank-1 row is not an Associate.
+    expect(screen.getByText("1 associate, 1 of another rank")).toBeInTheDocument();
+  });
+
+  it("resolves a duplicate Owner by promoting it", async () => {
+    mockRoster([entry("4", "DarkShark", 1), entry("9", "Shadout", 1)]);
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Owner for Shadout" }));
+    await waitFor(() => expect(ownerName()).toHaveTextContent("Shadout"));
+    expect(screen.getByRole("radio", { name: "Co-Owner for DarkShark" })).toBeChecked();
+    expect(screen.queryByText(/of another rank/)).not.toBeInTheDocument();
+  });
+
+  // listBasePermissions selects par.rank with no filter, and duneDb.js keeps a
+  // `Rank ${n}` label fallback precisely because ranks outside 1-3 occur.
+  it("surfaces a rank outside 1-3 instead of rendering a blank control", async () => {
+    const odd = { ...entry("31", "Stilgar", 7 as never), label: "Rank 7" };
+    mockRoster([entry("4", "DarkShark", 1), entry("29", "Yaida", 2), odd]);
+    renderTab();
+
+    expect(await screen.findByText("Rank 7")).toBeInTheDocument();
+    // No segment claims to represent it.
+    expect(screen.getByRole("radio", { name: "Owner for Stilgar" })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: "Co-Owner for Stilgar" })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: "Associate for Stilgar" })).not.toBeChecked();
+    // Counted apart from the associates rather than swelling their tally.
+    expect(screen.getByText("1 co-owner, 1 of another rank")).toBeInTheDocument();
+  });
+});
+
+describe("BasePermissionsTab ownerless state", () => {
+  it("flags a base with no Owner and refuses to save it", async () => {
+    mockRoster([entry("29", "Yaida", 2)]);
+    renderTab();
+
+    expect(await screen.findByText("No Owner set")).toBeInTheDocument();
+    expect(document.querySelector(".bases-permissions-owner-card")).toHaveClass("bases-permissions-owner-card-empty");
+    expect(screen.getByRole("alert")).toHaveTextContent("This base has no Owner.");
+
+    // Dirty but still unsaveable -- the missing Owner is the blocker, not the
+    // absence of edits.
+    fireEvent.click(screen.getByRole("radio", { name: "Associate for Yaida" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Revert" })).toBeEnabled());
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
+  });
+});
+
+describe("BasePermissionsTab system custodian", () => {
+  it("shows the custodian pill in the hero when the custodian owns the base", async () => {
+    mockRoster(
+      [entry("900000201", "Server", 1), entry("29", "Yaida", 2)],
+      { available: true, playerId: "900000201", name: "Server" }
+    );
+    renderTab();
+
+    await screen.findByText("Server", { selector: ".bases-permissions-owner-name" });
+    expect(ownerName()?.querySelector(".bases-permissions-system-label")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Owned by Server" })).toBeDisabled();
+  });
+
+  it("shows the custodian pill on the roster row when the custodian is not the Owner", async () => {
+    mockRoster(
+      [entry("4", "DarkShark", 1), entry("900000201", "Server", 3)],
+      { available: true, playerId: "900000201", name: "Server" }
+    );
+    renderTab();
+
+    await screen.findByText("DarkShark", { selector: ".bases-permissions-owner-name" });
+    expect(ownerName()?.querySelector(".bases-permissions-system-label")).toBeNull();
+    expect(document.querySelector(".bases-permissions-row .bases-permissions-system-label")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Transfer to Server" })).toBeEnabled();
+  });
+
+  // The reason paragraph moved into the hero card when the standalone custodian
+  // section was absorbed. It is the easiest thing to lose in that refactor.
+  it("keeps the unavailability reason inside the owner card", async () => {
+    mockRoster(
+      [entry("4", "DarkShark", 1)],
+      { available: false, reason: "No supported system custodian was found." }
+    );
+    renderTab();
+
+    const reason = await screen.findByText("No supported system custodian was found.");
+    expect(document.querySelector(".bases-permissions-owner-card")).toContainElement(reason);
+    expect(screen.getByRole("button", { name: "Transfer to Custodian" })).toBeDisabled();
+  });
+});
+
+describe("BasePermissionsTab entry warnings", () => {
+  // Only covered for an Associate before -- an Owner the game ignores is the
+  // more urgent case, because the base is effectively unowned in-game.
+  it("flags a non-canonical Owner from inside the hero card", async () => {
+    mockRoster([entry("4", "DarkShark", 1, false), entry("29", "Yaida", 2)]);
+    renderTab();
+
+    const warning = await screen.findByLabelText("Ignored by the game");
+    expect(document.querySelector(".bases-permissions-owner-card")).toContainElement(warning);
+  });
+});
+
+describe("BasePermissionsTab saving", () => {
+  it("disables every control while a save is in flight", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    // Never resolves, so the saving state stays observable.
+    vi.mocked(basesApi.setPermissions).mockReturnValue(new Promise(() => {}) as never);
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Associate for Yaida" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Saving…" })).toBeInTheDocument());
+    screen.getAllByRole("radio").forEach((radio) => expect(radio).toBeDisabled());
+    expect(screen.getByRole("button", { name: "Remove Yaida" })).toBeDisabled();
+  });
+
+  it("restores the original segment on Revert without calling the server", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Associate for Yaida" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Revert" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+
+    await waitFor(() => expect(screen.getByRole("radio", { name: "Co-Owner for Yaida" })).toBeChecked());
+    expect(basesApi.setPermissions).not.toHaveBeenCalled();
+  });
+});
+
+describe("BasePermissionsTab load states", () => {
+  it("reports loading, then the roster", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+    expect(screen.getByText("Loading permissions…")).toBeInTheDocument();
+    expect(await screen.findByText("Shared with · 2")).toBeInTheDocument();
+  });
+
+  it("offers a working Retry when the roster fails to load", async () => {
+    vi.mocked(basesApi.permissions).mockRejectedValueOnce(new Error("Permissions are unavailable."));
+    renderTab();
+
+    expect(await screen.findByText(/Permissions are unavailable\./)).toBeInTheDocument();
+    mockRoster(DEFAULT_ROSTER);
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByText("Shared with · 2")).toBeInTheDocument();
+    expect(basesApi.permissions).toHaveBeenCalledTimes(2);
+  });
+});

--- a/console/web/src/features/bases/BasePermissionsTab.tsx
+++ b/console/web/src/features/bases/BasePermissionsTab.tsx
@@ -26,14 +26,27 @@ const RANK_LABELS: Record<BasePermissionRank, string> = {
 
 const RANK_OPTIONS: BasePermissionRank[] = [OWNER_RANK, CO_OWNER_RANK, ASSOCIATE_RANK];
 
-type DraftEntry = { playerId: string; name: string; rank: BasePermissionRank; canonical: boolean };
+// Abbreviated for the segmented control, which has to fit three options in the
+// width one <select> used to take. The full RANK_LABELS word carries the
+// accessible name -- see RankSegments.
+const RANK_SEGMENT_LABELS: Record<BasePermissionRank, string> = {
+  1: "Own",
+  2: "Co-own",
+  3: "Assoc"
+};
+
+// `label` is the server's own rendering of the rank ("Owner", or "Rank 7" for
+// anything outside 1-3). Carried through so a rank the segmented control cannot
+// represent is still readable on screen -- see unknownRankLabel.
+type DraftEntry = { playerId: string; name: string; rank: BasePermissionRank; canonical: boolean; label: string };
 
 function toDraft(entries: BasePermissionEntry[]): DraftEntry[] {
   return entries.map((entry) => ({
     playerId: entry.playerId,
     name: entry.name,
     rank: entry.rank,
-    canonical: entry.canonical
+    canonical: entry.canonical,
+    label: entry.label || ""
   }));
 }
 
@@ -49,6 +62,142 @@ function sameRoster(left: DraftEntry[], right: DraftEntry[]) {
 
 function errorText(error: unknown) {
   return error instanceof Error ? error.message : String(error);
+}
+
+function plural(count: number, word: string) {
+  return `${count} ${word}${count === 1 ? "" : "s"}`;
+}
+
+// "1 co-owner, 4 associates", skipping whichever count is zero so a base shared
+// with associates only does not advertise "0 co-owners". Empty when nobody is
+// on the roster -- the caller drops the element rather than rendering "".
+// `other` covers rows the game stored outside rank 1-3 plus any duplicate Owner;
+// they are real roster members and have to be counted, but calling them
+// Associates would put a rank on them that nobody chose.
+function formatShareBreakdown(coOwners: number, associates: number, other = 0) {
+  const parts: string[] = [];
+  if (coOwners) parts.push(plural(coOwners, "co-owner"));
+  if (associates) parts.push(plural(associates, "associate"));
+  if (other) parts.push(`${other} of another rank`);
+  return parts.join(", ");
+}
+
+// The three segments cover rank 1-3 only. Anything else the game stored has no
+// segment to check, so the control would render blank with no way to read the
+// real rank -- show it instead of silently dropping it.
+function unknownRankLabel(entry: DraftEntry) {
+  if (RANK_OPTIONS.includes(entry.rank)) return "";
+  return entry.label || `Rank ${entry.rank}`;
+}
+
+// Shared by the Owner hero card and the roster rows so the custodian pill and
+// the ignored-entry warning follow a player between the two as their rank
+// changes, instead of being duplicated in both places and drifting apart.
+function EntryName({ entry, isSystemCustodian, className }: {
+  entry: DraftEntry;
+  isSystemCustodian: boolean;
+  className: string;
+}) {
+  return (
+    <span className={className} title={entry.name || entry.playerId}>
+      {entry.name || `Player ${entry.playerId}`}
+      {unknownRankLabel(entry) && <span
+        className="bases-permissions-rank-unknown"
+        title="The game stored a rank this editor cannot represent. Changing it below replaces it with the rank you pick."
+      >{unknownRankLabel(entry)}</span>}
+      {isSystemCustodian && <span className="bases-permissions-system-label">System Custodian</span>}
+      {!entry.canonical && <span className="bases-permissions-orphan" title="This entry does not match a known player character, so the game ignores it. Removing it is safe.">
+        <TriangleAlert size={13} aria-label="Ignored by the game" />
+      </span>}
+    </span>
+  );
+}
+
+// Native radios rather than aria-pressed buttons: the browser supplies arrow-key
+// navigation and a single roving tab stop per group for free, so a five-member
+// roster costs five tab stops before Save instead of fifteen. aria-pressed would
+// also announce "toggle, pressed" with no set position, which is wrong for one
+// mutually exclusive value.
+function RankSegments({ entry, baseId, disabled, onChange }: {
+  entry: DraftEntry;
+  baseId: string;
+  disabled: boolean;
+  onChange: (rank: BasePermissionRank) => void;
+}) {
+  const who = entry.name || entry.playerId;
+  // baseId is in the group name so two rosters rendered at once could never
+  // merge two players' radios into one browser group, where selecting in one
+  // row would silently clear the other.
+  const groupName = `bases-rank-${baseId}-${entry.playerId}`;
+  return (
+    <div className="bases-rank-segments" role="radiogroup" aria-label={`Rank for ${who}`}>
+      {RANK_OPTIONS.map((rank) => (
+        <label className="bases-rank-segment" key={rank}>
+          <input
+            type="radio"
+            name={groupName}
+            value={rank}
+            checked={entry.rank === rank}
+            disabled={disabled}
+            // Full rank word in the accessible name, abbreviation on screen.
+            // Each abbreviation is a prefix of the full label, so the
+            // label-in-name requirement still holds for voice control.
+            aria-label={`${RANK_LABELS[rank]} for ${who}`}
+            onChange={() => onChange(rank)}
+            // Clicking an already-checked radio fires no change event, which
+            // would strand a base carrying two rank-1 rows: the duplicate's
+            // "Own" segment renders checked, so the click that is supposed to
+            // demote the other Owner would do nothing. onChange is still what
+            // arrow-key navigation fires, so both are needed. changeRank is
+            // idempotent for a rank the entry already holds.
+            onClick={() => onChange(rank)}
+          />
+          <span aria-hidden="true">{RANK_SEGMENT_LABELS[rank]}</span>
+        </label>
+      ))}
+    </div>
+  );
+}
+
+// The Owner is the one thing an admin opens this tab to check, so it gets its
+// own card instead of being one row among many. The custodian transfer lives
+// here too -- it only ever changes the Owner, and as a section of its own it
+// was the loudest thing on the tab despite being a rare action.
+function OwnerHeroCard({ owner, isCustodian, systemCustodian, saving, dirty, onTransfer }: {
+  owner: DraftEntry | undefined;
+  isCustodian: boolean;
+  systemCustodian: { available: boolean; playerId?: string; name?: string; reason?: string };
+  saving: boolean;
+  dirty: boolean;
+  onTransfer: () => void;
+}) {
+  const custodianName = systemCustodian.name || "Custodian";
+  const ownedByCustodian = Boolean(owner && owner.playerId === systemCustodian.playerId);
+  return (
+    <div className={`bases-permissions-owner-card${owner ? "" : " bases-permissions-owner-card-empty"}`}>
+      <div className="bases-permissions-owner-identity">
+        <span className="bases-permissions-owner-eyebrow">Owner</span>
+        {owner
+          ? <EntryName entry={owner} isSystemCustodian={isCustodian} className="bases-permissions-owner-name" />
+          : <span className="bases-permissions-owner-name bases-permissions-owner-none">No Owner set</span>}
+      </div>
+      <button
+        className="warning"
+        // Still enabled on an ownerless base: that state arrives from the
+        // server with a clean draft, so parking ownership on the custodian is
+        // the fastest legitimate way out of it.
+        disabled={!systemCustodian.available || ownedByCustodian || saving || dirty}
+        title={dirty
+          ? "Save or revert roster changes first"
+          : ownedByCustodian
+          ? `This base is already owned by the ${systemCustodian.name || "detected"} system custodian`
+          : `Park ownership on the reserved ${systemCustodian.name || "detected"} system identity, preserving the current permission roster`}
+        onClick={onTransfer}
+      >{ownedByCustodian ? `Owned by ${custodianName}` : systemCustodian.available ? `Transfer to ${custodianName}` : "Transfer to Custodian"}</button>
+      {!systemCustodian.available && systemCustodian.reason &&
+        <p className="bases-permissions-error bases-permissions-owner-note">{systemCustodian.reason}</p>}
+    </div>
+  );
 }
 
 export function BasePermissionsTab({ baseId, baseName, onSaved, confirmAction }: BasePermissionsTabProps) {
@@ -119,7 +268,8 @@ export function BasePermissionsTab({ baseId, baseName, onSaved, confirmAction }:
   function addCandidate(candidate: BasePermissionCandidate) {
     setDraft((current) => {
       if (current.some((entry) => entry.playerId === candidate.playerId)) return current;
-      const next = [...current, { playerId: candidate.playerId, name: candidate.name, rank: addRank, canonical: true }];
+      // No label: the rank is one this editor picked, so RANK_LABELS covers it.
+      const next = [...current, { playerId: candidate.playerId, name: candidate.name, rank: addRank, canonical: true, label: "" }];
       // Adding straight to Owner has to demote the incumbent for the same
       // reason changeRank does.
       if (addRank !== OWNER_RANK) return next;
@@ -213,130 +363,147 @@ export function BasePermissionsTab({ baseId, baseName, onSaved, confirmAction }:
   }
 
   const alreadyOnRoster = new Set(draft.map((entry) => entry.playerId));
+  // The roster holds every entry except the one the hero card is showing --
+  // keyed on that entry's id, not on "rank is not Owner". A base whose rows the
+  // game wrote directly can carry a second rank-1 row (permission_set_player_rank
+  // is a plain upsert), and filtering by rank would drop it from the screen while
+  // leaving it in the draft that Save submits. Keeping it as a row makes it
+  // visible, removable, and fixable: its "Own" segment demotes the incumbent.
+  const nonOwners = sortDraft(draft.filter((entry) => entry.playerId !== owner?.playerId));
+  const coOwnerCount = nonOwners.filter((entry) => entry.rank === CO_OWNER_RANK).length;
+  const associateCount = nonOwners.filter((entry) => entry.rank === ASSOCIATE_RANK).length;
+  // Anything the game stored outside 1-3, plus any duplicate Owner row. Counted
+  // separately rather than folded into the associate tally, which would state
+  // something false about a rank nobody chose.
+  const otherRankCount = nonOwners.length - coOwnerCount - associateCount;
+  const shareBreakdown = formatShareBreakdown(coOwnerCount, associateCount, otherRankCount);
+  const ownerIsCustodian = Boolean(systemCustodian.available && owner && owner.playerId === systemCustodian.playerId);
 
   return (
     <div className="bases-permissions" onClick={(event) => event.stopPropagation()}>
-      <p className="action-help-note">
-        Exactly one Owner. Promoting a player demotes the current Owner to Co-Owner. Changes apply to the running map immediately.
-      </p>
+      <div className="bases-permissions-content">
+        <p className="action-help-note">
+          Exactly one Owner. Promoting a player demotes the current Owner to Co-Owner. Changes apply to the running map immediately. Transferring to the system custodian parks ownership on a reserved identity and keeps the roster intact.
+        </p>
 
-      <div className="bases-permissions-roster">
-        {sortDraft(draft).map((entry) => {
-          const isOwner = entry.rank === OWNER_RANK;
-          const isSystemCustodian = systemCustodian.available && entry.playerId === systemCustodian.playerId;
-          return (
-            <div className={`bases-permissions-row${isOwner ? " bases-permissions-row-owner" : ""}`} key={entry.playerId}>
-              <span className="bases-permissions-name" title={entry.name || entry.playerId}>
-                {entry.name || `Player ${entry.playerId}`}
-                {isSystemCustodian && <span className="bases-permissions-system-label">System Custodian</span>}
-                {!entry.canonical && <span className="bases-permissions-orphan" title="This entry does not match a known player character, so the game ignores it. Removing it is safe.">
-                  <TriangleAlert size={13} aria-label="Ignored by the game" />
-                </span>}
-              </span>
-              <select
-                value={String(entry.rank)}
+        <OwnerHeroCard
+          owner={owner}
+          isCustodian={ownerIsCustodian}
+          systemCustodian={systemCustodian}
+          saving={saving}
+          dirty={dirty}
+          onTransfer={() => void transferToSystemCustodian()}
+        />
+
+        <div className="bases-permissions-section-head">
+          <span className="bases-permissions-section-title">Shared with · {nonOwners.length}</span>
+          {shareBreakdown && <span className="bases-permissions-section-meta">{shareBreakdown}</span>}
+        </div>
+
+        <div className="bases-permissions-roster">
+          {nonOwners.map((entry) => (
+            <div className="bases-permissions-row" key={entry.playerId}>
+              <EntryName
+                entry={entry}
+                className="bases-permissions-name"
+                isSystemCustodian={systemCustodian.available && entry.playerId === systemCustodian.playerId}
+              />
+              <RankSegments
+                entry={entry}
+                baseId={baseId}
                 disabled={saving}
-                aria-label={`Rank for ${entry.name || entry.playerId}`}
-                onChange={(event) => changeRank(entry.playerId, Number(event.target.value) as BasePermissionRank)}
-              >
-                {RANK_OPTIONS.map((rank) => <option key={rank} value={rank}>{RANK_LABELS[rank]}</option>)}
-              </select>
+                onChange={(rank) => changeRank(entry.playerId, rank)}
+              />
               <button
                 className="icon-toggle-button bases-permissions-remove"
-                // Removing the Owner would leave the base ownerless, which the
-                // server rejects. Promote a replacement first -- that demotes
-                // this one automatically and frees the button.
-                disabled={isOwner || saving}
-                title={isOwner ? "Promote another player to Owner before removing this one" : `Remove ${entry.name || entry.playerId}`}
+                disabled={saving}
+                title={`Remove ${entry.name || entry.playerId}`}
                 aria-label={`Remove ${entry.name || entry.playerId}`}
                 onClick={() => removeEntry(entry.playerId)}
               ><Trash2 size={15} /></button>
             </div>
-          );
-        })}
-        {!draft.length && <p className="muted">This base has no permission entries.</p>}
-      </div>
-
-      <div className="bases-permissions-add">
-        <div className="action-row bases-permissions-search-row">
-          <input
-            value={candidateQuery}
-            placeholder="Search a player to add"
-            disabled={saving}
-            onChange={(event) => setCandidateQuery(event.target.value)}
-            onKeyDown={(event) => { if (event.key === "Enter") void submitCandidateSearch(); }}
-          />
-          <button disabled={searching || saving} onClick={() => void submitCandidateSearch()}>Search</button>
-          <button disabled={!candidateQuery && !searched} onClick={clearCandidateSearch}>Clear</button>
-          <label className="compact-select">
-            Add as
-            <select value={String(addRank)} disabled={saving} onChange={(event) => setAddRank(Number(event.target.value) as BasePermissionRank)}>
-              {RANK_OPTIONS.map((rank) => <option key={rank} value={rank}>{RANK_LABELS[rank]}</option>)}
-            </select>
-          </label>
-        </div>
-        {searched && !candidates.length && <p className="muted">No players matched that search.</p>}
-        {candidates.length > 0 && <ul className="bases-permissions-candidates">
-          {candidates.map((candidate) => (
-            <li key={candidate.playerId}>
-              <span>{candidate.name}</span>
-              <button
-                className="icon-toggle-button"
-                disabled={alreadyOnRoster.has(candidate.playerId) || saving}
-                title={alreadyOnRoster.has(candidate.playerId) ? "Already on this base" : `Add ${candidate.name} as ${RANK_LABELS[addRank]}`}
-                aria-label={`Add ${candidate.name}`}
-                onClick={() => addCandidate(candidate)}
-              ><Plus size={15} /></button>
-            </li>
           ))}
-        </ul>}
-      </div>
-
-      <div className="bases-system-custodian">
-        <div>
-          <strong>System Custodian</strong>
-          <p className="muted">Park ownership on a detected reserved system identity while preserving the current permission roster.</p>
-          {!systemCustodian.available && systemCustodian.reason && <p className="bases-permissions-error">{systemCustodian.reason}</p>}
+          {!nonOwners.length && <p className="muted">This base is not shared with anyone else.</p>}
         </div>
-        <button
-          className="warning"
-          disabled={!systemCustodian.available || owner?.playerId === systemCustodian.playerId || saving || dirty}
-          title={dirty ? "Save or revert roster changes first" : owner?.playerId === systemCustodian.playerId ? `This base is already owned by the ${systemCustodian.name || "detected"} system custodian` : `Transfer ownership to the ${systemCustodian.name || "detected"} system custodian`}
-          onClick={() => void transferToSystemCustodian()}
-        >{owner?.playerId === systemCustodian.playerId ? `Owned by ${systemCustodian.name || "Custodian"}` : systemCustodian.available ? `Transfer to ${systemCustodian.name || "Custodian"}` : "Transfer to Custodian"}</button>
+
+        <div className="bases-permissions-add">
+          <div className="action-row bases-permissions-search-row">
+            <input
+              value={candidateQuery}
+              placeholder="Search a player to add"
+              disabled={saving}
+              onChange={(event) => setCandidateQuery(event.target.value)}
+              onKeyDown={(event) => { if (event.key === "Enter") void submitCandidateSearch(); }}
+            />
+            <button disabled={searching || saving} onClick={() => void submitCandidateSearch()}>Search</button>
+            <button disabled={!candidateQuery && !searched} onClick={clearCandidateSearch}>Clear</button>
+            <label className="compact-select">
+              Add as
+              <select value={String(addRank)} disabled={saving} onChange={(event) => setAddRank(Number(event.target.value) as BasePermissionRank)}>
+                {RANK_OPTIONS.map((rank) => <option key={rank} value={rank}>{RANK_LABELS[rank]}</option>)}
+              </select>
+            </label>
+          </div>
+          {searched && !candidates.length && <p className="muted">No players matched that search.</p>}
+          {candidates.length > 0 && <ul className="bases-permissions-candidates">
+            {candidates.map((candidate) => (
+              <li key={candidate.playerId}>
+                <span>{candidate.name}</span>
+                <button
+                  className="icon-toggle-button"
+                  disabled={alreadyOnRoster.has(candidate.playerId) || saving}
+                  title={alreadyOnRoster.has(candidate.playerId) ? "Already on this base" : `Add ${candidate.name} as ${RANK_LABELS[addRank]}`}
+                  aria-label={`Add ${candidate.name}`}
+                  onClick={() => addCandidate(candidate)}
+                ><Plus size={15} /></button>
+              </li>
+            ))}
+          </ul>}
+        </div>
+
+        {/* Reserved slot. All three of these mount and unmount, and each one
+            used to shove the action bar down and back up as it came and went
+            mid-edit. Holding the space keeps the bar still. */}
+        <div className="bases-permissions-banner-slot">
+          {dirty && <p className="confirm-modal-warning bases-permissions-warning" role="status">
+            Saving writes to the live database and notifies the running map server. An online player may need to reopen the base's panel to see the change.
+          </p>}
+          {!owner && <p className="bases-permissions-error" role="alert">
+            This base has no Owner. Set one before saving.
+          </p>}
+          {status && <p
+            className={`inline-task-result${statusKind ? ` result-${statusKind}` : ""}`}
+            role={statusKind === "fail" ? "alert" : "status"}
+            onAnimationEnd={() => {
+              // The shared success animation fades opacity only. Remove this
+              // result after that fade so an invisible flex item does not keep
+              // reserving space in the permissions layout. Failures remain
+              // until the next action so their details are not lost.
+              if (statusKind !== "ok") return;
+              setStatus("");
+              setStatusKind("");
+            }}
+          >
+            <strong>{status}</strong>
+          </p>}
+        </div>
       </div>
 
-      {dirty && <p className="confirm-modal-warning bases-permissions-warning" role="status">
-        Saving writes to the live database and notifies the running map server. An online player may need to reopen the base's panel to see the change.
-      </p>}
-      {!owner && <p className="bases-permissions-error" role="alert">
-        This base has no Owner. Set one before saving.
-      </p>}
-      {status && <p
-        className={`inline-task-result${statusKind ? ` result-${statusKind}` : ""}`}
-        role={statusKind === "fail" ? "alert" : "status"}
-        onAnimationEnd={() => {
-          // The shared success animation fades opacity only. Remove this result
-          // after that fade so an invisible flex item does not keep reserving
-          // space in the permissions layout. Failures remain until the next
-          // action so their details are not lost.
-          if (statusKind !== "ok") return;
-          setStatus("");
-          setStatusKind("");
-        }}
-      >
-        <strong>{status}</strong>
-      </p>}
-
+      {/* The bar itself stays full-bleed so its rule and fill span the tab, but
+          the controls sit in a wrapper sharing the content column's width, so
+          Save lines up with the right edge of the roster rows above it rather
+          than drifting off toward the far side of a wide screen. */}
       <div className="bases-permissions-actions">
-        <span className="muted">{dirty ? "Unsaved changes" : ""}</span>
-        <button disabled={!dirty || saving} onClick={() => setDraft(saved)}>Revert</button>
-        <button
-          className="update-action"
-          disabled={!dirty || !owner || saving}
-          title={`Save permissions for ${baseName}`}
-          onClick={() => void save()}
-        >{saving ? "Saving…" : "Save changes"}</button>
+        <div className="bases-permissions-actions-inner">
+          <span className="muted">{dirty ? "Unsaved changes" : ""}</span>
+          <button disabled={!dirty || saving} onClick={() => setDraft(saved)}>Revert</button>
+          <button
+            className="update-action"
+            disabled={!dirty || !owner || saving}
+            title={`Save permissions for ${baseName}`}
+            onClick={() => void save()}
+          >{saving ? "Saving…" : "Save changes"}</button>
+        </div>
       </div>
     </div>
   );

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -1005,8 +1005,9 @@ describe("BasesPanel combined fuel/water queue and stalled banners", () => {
 
     renderPanel();
 
-    expect(await screen.findByText("1 refill queued")).toBeInTheDocument();
-    // The banner's title icons and each row's badges are gated on
+    expect(await screen.findByText("Refills queued")).toBeInTheDocument();
+    expect(screen.getByText("1 water")).toBeInTheDocument();
+    // The banner's title badges and each row's badges are gated on
     // fuelCount/waterCount independently -- with zero fuel queued, no "fuel"
     // badge should render alongside the water one.
     expect(screen.queryByText(/\d+ fuel\b/)).not.toBeInTheDocument();
@@ -1071,8 +1072,11 @@ describe("BasesPanel combined fuel/water queue and stalled banners", () => {
     renderPanel();
 
     // One target, one queued fuel refill and one queued water refill: a single
-    // combined banner, not two separate ones.
-    expect(await screen.findByText("2 refills queued")).toBeInTheDocument();
+    // combined banner, not two separate ones, and the title splits the total
+    // per resource rather than reporting a bare "2".
+    expect(await screen.findByText("Refills queued")).toBeInTheDocument();
+    expect(screen.getByText("1 fuel")).toBeInTheDocument();
+    expect(screen.getByText("1 water")).toBeInTheDocument();
     expect(document.querySelectorAll(".bases-pending-refills")).toHaveLength(1);
   });
 });

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -684,8 +684,8 @@ describe("BasesPanel permissions editing", () => {
   // then switch to Permissions.
   async function openPermissionsTab() {
     fireEvent.click(await screen.findByRole("button", { name: "Show details for Sietch One" }));
-    fireEvent.click(await screen.findByRole("tab", { name: "Permissions" }));
-    await waitFor(() => expect(screen.getByRole("tab", { name: "Permissions" })).toHaveAttribute("aria-selected", "true"));
+    fireEvent.click(await screen.findByRole("tab", { name: "Sub-Fief Permissions" }));
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Sub-Fief Permissions" })).toHaveAttribute("aria-selected", "true"));
   }
 
   function mockRoster() {
@@ -713,7 +713,7 @@ describe("BasesPanel permissions editing", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Show details for Sietch One" }));
     expect(screen.getByRole("tab", { name: "Power" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Water" })).toBeInTheDocument();
-    expect(screen.queryByRole("tab", { name: "Permissions" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("tab", { name: "Sub-Fief Permissions" })).not.toBeInTheDocument();
   });
 
   // A base with no generators had no expand chevron before this feature. It
@@ -730,9 +730,11 @@ describe("BasesPanel permissions editing", () => {
     mockRoster();
     renderPanel();
     await openPermissionsTab();
-    // The roster's own control, not the name text -- "DarkShark" also appears in
-    // the Owner cell of the row above.
-    expect(await screen.findByRole("combobox", { name: "Rank for DarkShark" })).toBeInTheDocument();
+    // DarkShark is the Owner, so he is in the hero card and not the roster. The
+    // selector scopes past the Owner cell of the collapsed row above, which
+    // also says "DarkShark".
+    expect(await screen.findByText("DarkShark", { selector: ".bases-permissions-owner-name" })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Co-Owner for Yaida" })).toBeChecked();
   });
 
   it("defaults to the Power tab when the row is expanded normally", async () => {
@@ -750,12 +752,14 @@ describe("BasesPanel permissions editing", () => {
     mockRoster();
     renderPanel();
     await openPermissionsTab();
-    const yaidaRank = await screen.findByRole("combobox", { name: "Rank for Yaida" });
-    fireEvent.change(yaidaRank, { target: { value: "1" } });
+    fireEvent.click(await screen.findByRole("radio", { name: "Owner for Yaida" }));
     await waitFor(() => {
-      expect(screen.getByRole("combobox", { name: "Rank for Yaida" })).toHaveValue("1");
-      expect(screen.getByRole("combobox", { name: "Rank for DarkShark" })).toHaveValue("2");
+      expect(screen.getByText("Yaida", { selector: ".bases-permissions-owner-name" })).toBeInTheDocument();
+      expect(screen.getByRole("radio", { name: "Co-Owner for DarkShark" })).toBeChecked();
     });
+    // The new Owner leaves the roster entirely -- there is no second place a
+    // rank can be edited, so the one-owner rule cannot be violated on screen.
+    expect(screen.queryByRole("radio", { name: "Owner for Yaida" })).not.toBeInTheDocument();
   });
 
   it("blocks removing the owner and enables Save only once the roster is dirty", async () => {
@@ -763,7 +767,10 @@ describe("BasesPanel permissions editing", () => {
     mockRoster();
     renderPanel();
     await openPermissionsTab();
-    expect(await screen.findByRole("button", { name: "Remove DarkShark" })).toBeDisabled();
+    // The Owner has no remove control at all now -- promoting a replacement is
+    // the only way to free him, which is what the old disabled button said.
+    expect(await screen.findByText("DarkShark", { selector: ".bases-permissions-owner-name" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Remove DarkShark" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Remove Yaida" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
 
@@ -780,7 +787,7 @@ describe("BasesPanel permissions editing", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Remove Yaida" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Revert" })).toBeEnabled());
     fireEvent.click(screen.getByRole("button", { name: "Revert" }));
-    await waitFor(() => expect(screen.getByRole("combobox", { name: "Rank for Yaida" })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole("radio", { name: "Co-Owner for Yaida" })).toBeChecked());
     expect(basesApi.setPermissions).not.toHaveBeenCalled();
   });
 
@@ -816,7 +823,10 @@ describe("BasesPanel permissions editing", () => {
     await waitFor(() => expect(basesApi.transferToSystemCustodian).toHaveBeenCalledWith("1006"));
     expect(basesApi.permissionCandidates).not.toHaveBeenCalled();
     expect(await screen.findByText("Ownership was transferred to the Server system custodian.")).toBeInTheDocument();
-    expect(screen.getByText("System Custodian", { selector: ".bases-system-custodian strong" })).toBeInTheDocument();
+    // The custodian control now lives in the Owner hero card rather than a
+    // section of its own -- assert the placement, not just its presence.
+    expect(document.querySelector(".bases-permissions-owner-card"))
+      .toContainElement(screen.getByRole("button", { name: "Transfer to Server" }));
   });
 
   it("disables the custodian transfer when Server is unavailable", async () => {
@@ -863,6 +873,9 @@ describe("BasesPanel permissions editing", () => {
 
   // A roster row naming a non-canonical actor is one the game ignores. The
   // console can see it and the game client cannot, so it must be visible here.
+  // Both entries below are named "DarkShark" on purpose, and it is load-bearing
+  // that one of them is the Owner: the Owner renders in the hero card, so only
+  // one node ends up carrying the warning and findByLabelText stays unambiguous.
   it("flags a roster entry the game ignores", async () => {
     mockList(true);
     vi.mocked(basesApi.permissions).mockResolvedValue({

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1356,8 +1356,15 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
                   aria-selected={expandedTab === "permissions"}
                   aria-controls={`bases-panel-permissions-${id}`}
                   className={`bases-expanded-tab${expandedTab === "permissions" ? " active" : ""}`}
+                  // The label wraps onto two deliberate lines, so name the tab
+                  // explicitly rather than letting the accessible name be
+                  // assembled from two adjacent inline spans.
+                  aria-label="Sub-Fief Permissions"
                   onClick={() => setExpandedTab("permissions")}
-                ><Users size={15} aria-hidden="true" />Permissions</button>}
+                ><Users size={15} aria-hidden="true" /><span className="bases-expanded-tab-lines">
+                  <span>Sub-Fief</span>
+                  <span>Permissions</span>
+                </span></button>}
               </div>
               {expandedTab === "power"
                 ? <div role="tabpanel" id={`bases-panel-power-${id}`} aria-labelledby={`bases-tab-power-${id}`}>{renderPower()}</div>

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1038,13 +1038,29 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
         </p>
       </div>}
       {combinedQueueTotal > 0 && <div className="bases-pending-refills">
+        {/* Per-resource counts rather than two bare icons over a combined
+            total: "2 refills queued" beside a fuel and a water icon does not
+            say which is which, and the split is what decides whether you go
+            looking at generators or at water containers. Same badge vocabulary
+            as the stalled banner above and the per-map rows below. */}
         <p className="bases-pending-refills-title">
-          {pendingTotal > 0 && <Fuel size={16} aria-hidden="true" />}
-          {pendingWaterTotal > 0 && <Droplet size={16} aria-hidden="true" />}
-          {combinedQueueTotal.toLocaleString()} refill{combinedQueueTotal === 1 ? "" : "s"} queued
+          {/* Explicit spaces around the badges: they are inline elements, so
+              without them the text content reads "Refills queued2 fuel1 water"
+              to a screen reader and to anyone copying it. */}
+          Refills queued
+          {pendingTotal > 0 && <> <span className="bases-queue-badge bases-queue-badge-fuel">
+            <Fuel size={13} aria-hidden="true" />{pendingTotal.toLocaleString()} fuel
+          </span></>}
+          {pendingWaterTotal > 0 && <> <span className="bases-queue-badge bases-queue-badge-water">
+            <Droplet size={13} aria-hidden="true" />{pendingWaterTotal.toLocaleString()} water
+          </span></>}
         </p>
         <p className="action-help-note">
-          Each one is written when its map next restarts. Restarting the battlegroup applies all of them; stopping leaves them queued.
+          {/* No battlegroup-level advice here: this banner only offers the
+              per-map restart buttons below, so pointing at a control that
+              lives on another page is noise. Server Control's note still
+              covers the battlegroup case, next to the button that does it. */}
+          Each one is written when its map next restarts.
         </p>
         <ul className="bases-pending-refills-list">
           {combinedQueueTargets.map((group) => {

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
-import { Fuel, Play, Trash2 } from "lucide-react";
+import { Droplet, Fuel, Play, Trash2 } from "lucide-react";
 import { serverApi, type PerformanceSnapshot } from "../../api/server";
 import { setupApi, type Task } from "../../api/setup";
 import { PortChecklist } from "../../components/PortChecklist";
@@ -10,7 +10,7 @@ import { KeyValueGrid, StatusPill, TechnicalDetails } from "../../components/com
 import { formatDisplayValue, formatUiSentence, friendlyColumnName, stripAnsi, summarizeCommandText, titleCase } from "../../lib/display";
 import { friendlyServiceName } from "../../lib/serviceDisplay";
 import { conciseTaskError, funcomTokenMismatchDetected } from "../../lib/taskDisplay";
-import { usePendingRefills } from "../../lib/usePendingRefills";
+import { usePendingRefills, usePendingWaterRefills } from "../../lib/usePendingRefills";
 
 export type HomeLoadResult = { statusLoaded: boolean; readinessLoaded: boolean; statusError: string; readinessError: string; statusText: string; readinessText: string };
 export type HomeTaskResult = { status: "running" | "succeeded" | "failed" | "stopped"; title: string; message?: string; details?: string };
@@ -22,11 +22,26 @@ export type RestartLifecycleState = { stopObserved: boolean; startObserved: bool
 // booted, which the background flush uses. Both battlegroup control rows say so.
 function PendingRefillNote() {
   const { pending } = usePendingRefills();
-  const total = pending?.total || 0;
+  const { pending: pendingWater } = usePendingWaterRefills();
+  const fuelTotal = pending?.total || 0;
+  const waterTotal = pendingWater?.total || 0;
+  const total = fuelTotal + waterTotal;
   if (!total) return null;
+  // Split per resource rather than reporting one number: both queues flush on
+  // the same restart, but which one is waiting decides whether an operator
+  // goes looking at generators or at water containers. Same badge vocabulary
+  // as the Bases panel's queue banner.
   return <p className="action-help-note pending-refill-note">
-    <Fuel size={14} aria-hidden="true" />
-    {total.toLocaleString()} generator refill{total === 1 ? "" : "s"} queued across all maps. Restarting the battlegroup applies {total === 1 ? "it" : "them"}; stopping leaves {total === 1 ? "it" : "them"} queued.
+    {fuelTotal > 0 && <span className="bases-queue-badge bases-queue-badge-fuel">
+      <Fuel size={13} aria-hidden="true" />{fuelTotal.toLocaleString()} fuel
+    </span>}
+    {waterTotal > 0 && <> <span className="bases-queue-badge bases-queue-badge-water">
+      <Droplet size={13} aria-hidden="true" />{waterTotal.toLocaleString()} water
+    </span></>}
+    {/* Explicit space: the badges are inline elements, so without it the
+        paragraph's text content reads "1 waterrefills queued" to a screen
+        reader and to anyone copying it. The CSS margin is visual only. */}
+    {" "}refill{total === 1 ? "" : "s"} queued across all maps. Restarting the battlegroup applies {total === 1 ? "it" : "them"}; stopping leaves {total === 1 ? "it" : "them"} queued.
   </p>;
 }
 type ConfirmAction = (message: string, options?: { title?: string; confirmLabel?: string; cancelLabel?: string; danger?: boolean }) => Promise<boolean>;

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2394,6 +2394,14 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   font-size: 13px;
   margin-bottom: -1px;
 }
+/* Stacks "Sub-Fief" over "Permissions". The tablist is a flex row with the
+   default align-items: stretch, so the taller tab sets the height and the
+   single-line tabs stay vertically centred against it. */
+.bases-expanded-tab-lines {
+  display: grid;
+  justify-items: start;
+  line-height: 1.2;
+}
 .bases-expanded-tab:hover { color: var(--muted-warm); border-color: transparent; }
 .bases-expanded-tab.active {
   background: #25201b;
@@ -2404,11 +2412,148 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 .bases-expanded-tab.active:hover { border-color: var(--border-strong); border-bottom-color: #25201b; }
 
 .bases-water { display: grid; gap: 12px; }
-.bases-permissions { display: grid; gap: 12px; }
-.bases-permissions-roster { display: grid; gap: 6px; }
+
+/* Permissions is a single reading column with the Revert/Save bar full-bleed
+   beneath it. The inset padding lives on .bases-permissions-content rather than
+   here, so the bar reaches both edges of the tab panel without negative margins
+   -- which would be unsafe under the position: sticky expanded cell below. The
+   clamp() matches .bases-generator-breakdown's exactly, which is what makes
+   Power, Water and Permissions inset their content identically. */
+.bases-permissions {
+  /* Both the reading column and the action bar's controls measure themselves
+     against these, so Save always lands on the same right edge as the roster
+     rows. Change the column width here and the bar follows. */
+  --bases-permissions-measure: 720px;
+  --bases-permissions-inset: clamp(12px, 1.5vw, 18px);
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+.bases-permissions-content {
+  display: grid;
+  gap: 12px;
+  width: 100%;
+  /* A cap, not a width. Under 1100px the expanded cell already clamps its
+     children to calc(100vw - 76px) (see .bases-table td.expanded-row-cell > *
+     below); on a phone that is ~300px, so the viewport cap wins outright and
+     this is inert. Every child sets min-width: 0 so the shrink lands on
+     ellipsis rather than on overflow -- intrinsic minimum width, not
+     max-width, is what would actually push past the scrollport. */
+  max-width: var(--bases-permissions-measure);
+  min-width: 0;
+  padding: var(--bases-permissions-inset);
+  box-sizing: border-box;
+}
+
+/* Owner hero. Same amber vocabulary as the standalone custodian section it
+   replaced: that section held nothing but the transfer button, and ownership
+   having two homes on one tab was why the tab read as flat. */
+/* Auto-placement rather than grid-template-areas. Naming a "note" row would
+   declare it whether or not the custodian-reason note renders, and an explicit
+   empty row still takes its row-gap -- 8px of dead space under the owner name
+   on every base that has a working custodian, which is the normal case. The
+   note spans both columns via grid-column instead, so its row only exists when
+   the note does. */
+.bases-permissions-owner-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--warning);
+  border-radius: 8px;
+  background: rgba(169, 121, 50, .08);
+}
+.bases-permissions-owner-card-empty {
+  border-color: var(--danger-strong);
+  background: rgba(167, 73, 73, .08);
+}
+.bases-permissions-owner-identity {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+.bases-permissions-owner-eyebrow {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+.bases-permissions-owner-name {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-strong);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+.bases-permissions-owner-none { color: var(--danger-text); font-style: italic; font-weight: 400; }
+.bases-permissions-owner-card > button { width: auto; flex: 0 0 auto; }
+.bases-permissions-owner-note { grid-column: 1 / -1; margin: 0; font-size: 12px; }
+
+.bases-permissions-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.bases-permissions-section-title {
+  color: var(--title);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: .02em;
+  white-space: nowrap;
+}
+.bases-permissions-section-meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: right;
+}
+
+/* Capping the roster is what pins the action bar: bases opts out of the shared
+   table height cap (.table-wrap.bases-table-wrap below), so there is no
+   scrollport for position: sticky to attach to. Bounding the one list that can
+   grow without limit keeps the bar in normal flow and still on screen. The
+   220px on .bases-permissions-candidates is the same trick.
+   overscroll-behavior stops a flick at the end of the roster from scrolling the
+   whole bases table underneath it. */
+.bases-permissions-roster {
+  display: grid;
+  gap: 6px;
+  align-content: start;
+  /* Five rows without a scrollbar. A row is 52px (a 38px icon button plus 6px
+     padding and 1px border each side) and the gap is 6px, so five come to
+     5*52 + 4*6 = 284px; the rest is headroom. A sixth row overflows to ~342px,
+     which leaves part of a row showing as the cue that the list scrolls. Badges
+     on a row do not change its height -- the button sets it. */
+  max-height: 300px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  /* No scrollbar gutter. A reserved right inset would hold the rows 4px short
+     of the owner card, the section header and the Save button on every roster
+     that fits -- now the common case -- for the sake of the one that does not.
+     When it does overflow, overflow-y: auto takes the scrollbar's width out of
+     the content box anyway, which is the same breathing room. */
+}
 .bases-permissions-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 150px 38px;
+  grid-template-columns: minmax(0, 1fr) auto 38px;
   align-items: center;
   gap: 8px;
   border: 1px solid var(--border);
@@ -2416,7 +2561,6 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   background: var(--panel);
   padding: 6px 10px;
 }
-.bases-permissions-row-owner { border-color: var(--border-strong); }
 .bases-permissions-name {
   display: flex;
   align-items: center;
@@ -2427,10 +2571,64 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   white-space: nowrap;
   font-size: 13px;
 }
-.bases-permissions-row-owner .bases-permissions-name { color: var(--text-strong); }
 .bases-permissions-orphan { display: inline-flex; color: var(--warning); flex: 0 0 auto; }
-.bases-permissions-system-label { padding: 2px 6px; border: 1px solid var(--warning); border-radius: 999px; color: #ffd08a; font-size: 10px; font-weight: 800; letter-spacing: .03em; text-transform: uppercase; }
+.bases-permissions-system-label { flex: 0 0 auto; padding: 2px 6px; border: 1px solid var(--warning); border-radius: 999px; color: #ffd08a; font-size: 10px; font-weight: 800; letter-spacing: .03em; text-transform: uppercase; }
+/* A rank the three segments cannot represent, shown so the row is not silently
+   blank. Danger-toned rather than amber: unlike the custodian pill this marks
+   something that will be overwritten as soon as anyone touches the control. */
+.bases-permissions-rank-unknown { flex: 0 0 auto; padding: 2px 6px; border: 1px solid var(--danger-strong); border-radius: 999px; color: var(--danger-text); font-size: 10px; font-weight: 800; letter-spacing: .03em; text-transform: uppercase; }
 .bases-permissions-remove { border-color: var(--danger-strong); color: var(--danger-text); }
+
+/* Segmented rank control. The radios are real <input type="radio"> so the
+   browser supplies arrow-key navigation and one-tab-stop roving focus for free;
+   they are hidden the same way .switch-checkbox input is, and the wrapping
+   <label> is what gets painted. The checked fill is button.active's #9b5f2a so
+   a selected segment reads as the same "on" state used elsewhere. */
+.bases-rank-segments {
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  min-width: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  background: #151719;
+  overflow: hidden;
+}
+.bases-rank-segment {
+  position: relative;
+  /* Overrides the global `label { display: grid; gap: 6px }`. */
+  display: flex;
+  gap: 0;
+  align-items: center;
+  justify-content: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border-left: 1px solid var(--border);
+  color: var(--muted-warm);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+.bases-rank-segment:first-child { border-left: 0; }
+.bases-rank-segment input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+}
+.bases-rank-segment:hover { background: rgba(198, 139, 74, .12); color: var(--text-strong); }
+.bases-rank-segment:has(input:checked) { background: #9b5f2a; color: var(--text-strong); }
+/* outline-offset is negative because .bases-rank-segments clips with
+   overflow: hidden -- an outset ring would be cut off on the end segments. */
+.bases-rank-segment:has(input:focus-visible) { outline: 2px solid var(--accent-strong); outline-offset: -2px; }
+.bases-rank-segments:has(input:disabled) { opacity: .45; }
+.bases-rank-segment:has(input:disabled) { cursor: not-allowed; }
+
 .bases-permissions-add { display: grid; gap: 8px; }
 /* Overrides .action-row's align-items: center -- "Add as" has a label line
    above its select that the bare input/buttons don't, so centering the row
@@ -2446,6 +2644,7 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   gap: 4px;
   max-height: 220px;
   overflow-y: auto;
+  overscroll-behavior: contain;
 }
 .bases-permissions-candidates li {
   display: grid;
@@ -2462,19 +2661,73 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* Reserved slot. The dirty warning, the no-owner alert and the task result all
+   mount and unmount, and each one shoved the action bar down and back up as it
+   came and went. Holding the space means the bar never moves; min-height (not
+   height) so a warning that wraps to three lines on a narrow viewport still
+   grows instead of clipping. */
+.bases-permissions-banner-slot {
+  display: grid;
+  align-content: center;
+  gap: 8px;
+  min-height: 66px;
+}
 .bases-permissions-warning { margin: 0; }
 .bases-permissions-error { color: var(--danger-text); margin: 0; }
-.bases-system-custodian { display: flex; align-items: center; justify-content: space-between; gap: 16px; padding: 12px; border: 1px solid var(--warning); border-radius: 8px; background: rgba(169, 121, 50, .08); }
-.bases-system-custodian p { margin: 4px 0 0; }
-.bases-system-custodian button { flex: 0 0 auto; }
+/* .inline-task-result is built for the flex action rows in Maps/Server; here it
+   stands alone in the reserved slot, so drop the flex sizing it assumes. */
+.bases-permissions-banner-slot .inline-task-result {
+  align-self: auto;
+  flex: 0 1 auto;
+  max-width: none;
+  margin: 0;
+}
+
+/* The action bar is a sibling of the capped content column, not a child, so its
+   rule and fill span the full tab panel and it reads as a footer rather than as
+   one more item in the list above it. Only the fill is full-bleed: the controls
+   inside sit in a wrapper carrying the same measure and inset as the content
+   column, so Save's right edge matches the roster rows' instead of drifting to
+   the far side of a wide screen. */
 .bases-permissions-actions {
+  padding: 10px 0;
+  border-top: 1px solid var(--border-strong);
+  background: var(--panel-soft);
+}
+.bases-permissions-actions-inner {
   display: flex;
   align-items: center;
   gap: 10px;
   justify-content: flex-end;
+  max-width: var(--bases-permissions-measure);
+  min-width: 0;
+  padding: 0 var(--bases-permissions-inset);
+  box-sizing: border-box;
 }
-.bases-permissions-actions > .muted { margin-right: auto; font-size: 12px; }
+.bases-permissions-actions-inner > .muted { margin-right: auto; font-size: 12px; }
 .bases-permissions-actions button { width: auto; }
+
+/* Below this the row's three columns cannot hold a name, three segments and a
+   trash button side by side -- inside the expanded cell the available width is
+   calc(100vw - 76px), which is ~300px on a phone. Stack the control under the
+   name and let it span the full row. */
+@media (max-width: 560px) {
+  .bases-permissions-row {
+    grid-template-columns: minmax(0, 1fr) 38px;
+    grid-template-areas: "name remove" "rank rank";
+    row-gap: 6px;
+  }
+  .bases-permissions-name { grid-area: name; }
+  .bases-rank-segments { grid-area: rank; display: grid; }
+  .bases-permissions-remove { grid-area: remove; }
+  /* One column: auto-placement stacks identity, button and note in source
+     order, and the note's grid-column: 1 / -1 still resolves to that column. */
+  .bases-permissions-owner-card {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
+  }
+  .bases-permissions-owner-card > button { width: 100%; }
+}
 .bases-table th.bases-expand-column, .bases-table td.bases-expand-column {
   width: 32px;
   padding-inline: 4px;

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1658,11 +1658,23 @@ body.debug .technical-details { display: block; }
 .bases-fuel-alert { color: var(--danger-text); }
 .bases-pagination-footer { margin-top: 12px; margin-bottom: 0; align-items: center; }
 .bases-pagination-footer .action-help-note { margin: 0; }
-.pending-refill-note, .pending-refill-badge {
+.pending-refill-badge {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   color: var(--title);
+}
+/* Deliberately not a flex row. The sentence has to wrap inside the narrow Home
+   card, and as a flex item it wrapped as one block shoved to the right of the
+   badges rather than flowing around them. Normal inline flow lets the badges
+   sit in the text like chips at any width. */
+.pending-refill-note {
+  display: block;
+  color: var(--title);
+}
+.pending-refill-note .bases-queue-badge {
+  margin-right: 6px;
+  vertical-align: 1px;
 }
 .pending-refill-badge {
   gap: 4px;

--- a/docs/console/base-permissions.md
+++ b/docs/console/base-permissions.md
@@ -3,8 +3,8 @@
 **Status:** Current | **Last Updated:** August 2026
 
 The Bases panel can edit who owns a base and who it is shared with. The editor
-lives in the **Permissions** tab of an expanded base row, alongside the existing
-**Power** tab.
+lives in the **Sub-Fief Permissions** tab of an expanded base row, alongside the
+existing **Power** tab.
 
 Unlike generator refills, permission changes are **not** queued for a map
 restart — they reach a running map immediately. See
@@ -58,7 +58,7 @@ request.
 
 ## System custodian
 
-The Permissions tab offers a transfer action when it detects a supported
+The Sub-Fief Permissions tab offers a transfer action when it detects a supported
 reserved identity. It prefers the RedBlink `Server` persona (`9000002xx`) and
 falls back to Funcom's `GM` persona (`9000001xx`), which is present in some
 battlegroup databases instead. Detection uses the complete stable
@@ -181,7 +181,7 @@ rows: a base whose roster is being fully replaced may have no rank rows, and
 have a row in `dune.buildings` while its link down to a permission actor is
 broken. **Such a base does not appear in the Bases table** — `listBases` still
 inner-joins the same chain, so it's excluded from the list entirely rather than
-shown with a broken Permissions tab. The distinct error instead surfaces from
+shown with a broken Sub-Fief Permissions tab. The distinct error instead surfaces from
 paths that resolve a base id directly: a `GET`/`PUT` to
 `/api/bases/:baseId/permissions` with a stale or copied id returns *"This base
 has no resolvable owner entity, so permission editing is unavailable for it,"*


### PR DESCRIPTION
Two independent changes to the Bases panel, one commit each.

## Report queued refills per resource

The queue banner showed a fuel icon and a water icon above a combined total, so "2 refills queued" never said which resource was waiting — and that split decides whether you go looking at generators or at water containers. Each icon now carries its own count, reusing the badge vocabulary the stalled banner and per-map rows already use.

The Server Control and Home note had the same gap and only ever counted generator refills; it now reads the water queue too. The banner also drops its battlegroup advice, since it offers only per-map restart buttons.

Reported by yacketrj.

## Rework the Sub-Fief Permissions tab

Rank was readable only by reading a `<select>` on every row, so a large roster gave no quick answer to "who owns this base". The Owner moves into its own card, absorbing the System Custodian transfer so ownership has one home instead of two competing ones; the rest of the roster becomes a compact scrolling list with a segmented rank control. The tab is renamed to Sub-Fief Permissions.

Two correctness fixes fall out of the rewrite:

- A duplicate rank-1 row stays visible in the roster rather than being filtered off screen while remaining in the draft that Save submits.
- A rank outside 1–3 — which `listBasePermissions` can return, hence duneDb's `Rank N` label fallback — is counted and labelled separately instead of being reported as an Associate.

## Testing

`npm test` (233 passing) and `npm run build` pass on each commit independently, not just the branch head. Adds `BasePermissionsTab.test.tsx` with 16 cases covering the owner/roster split, segment state, per-row radio group isolation, the duplicate-owner and out-of-range-rank paths, and the custodian placements.

Also verified live in the console container against a restored production database: tab insets match Power/Water, the action bar holds still when banners appear, five roster rows fit without scrolling, and no horizontal overflow inside the expanded row down to 420px.