### PR TITLE
Add a read-only Base Inventory tab

### DIFF
--- a/console/api/src/adminCatalog.js
+++ b/console/api/src/adminCatalog.js
@@ -99,8 +99,25 @@ const itemImagePathCache = new Map();
 // checkout at /repo and points DUNE_DOCKER_DIR at it, so the files are live on
 // disk. What makes the stale window harmless is that updating the checkout
 // restarts the console container, not that the files cannot change.
+// An id becomes both a filesystem path and a URL below, so it may not carry
+// path structure. normalizeItem's own id regex does not cover this -- it admits
+// "." and "/", so "../../secret" satisfies it -- and baseInventory passes a raw
+// dune.items.template_id with no validation at all. Without this, resolve()
+// normalises the traversal away and existsSync probes outside the public
+// directory, while the returned string reaches an <img src>.
+//
+// Rejected ids resolve to the unavailable image rather than throwing, matching
+// what a missing file already does. Checked before the cache so a malformed id
+// cannot take a slot in it either.
+function isSafeItemImageId(id) {
+  const value = String(id ?? "");
+  if (!value || value.length > 240) return false;
+  if (/[\\/\0]/.test(value)) return false;
+  return value !== "." && value !== "..";
+}
+
 export function itemImagePath(repoRoot, id) {
-  if (!repoRoot) return "/images/items/image-unavailable.png";
+  if (!repoRoot || !isSafeItemImageId(id)) return "/images/items/image-unavailable.png";
   let byId = itemImagePathCache.get(repoRoot);
   if (!byId) {
     byId = new Map();

--- a/console/api/src/adminCatalog.js
+++ b/console/api/src/adminCatalog.js
@@ -82,7 +82,7 @@ function normalizeItem(item, repoRoot = "") {
   };
 }
 
-function itemImagePath(repoRoot, id) {
+export function itemImagePath(repoRoot, id) {
   if (!repoRoot) return "/images/items/image-unavailable.png";
   const filename = `${id}.png`;
   const relativePath = `images/items/${filename}`;

--- a/console/api/src/adminCatalog.js
+++ b/console/api/src/adminCatalog.js
@@ -82,10 +82,37 @@ function normalizeItem(item, repoRoot = "") {
   };
 }
 
+// repoRoot -> item id -> resolved path. The existsSync below is the entire cost
+// of a catalog response: listCatalogItems normalizes up to 10,000 rows in one
+// request and baseInventory resolves an icon per distinct template, and every
+// request repeated the same stats on the event loop.
+//
+// Keyed by repoRoot because it is a caller argument, not a constant, and nested
+// rather than joined into one string key so an item id can never collide with a
+// path separator. Both are bounded -- one repoRoot per process in practice, and
+// item ids come from the shipped catalog and the game's own template names.
+const itemImagePathCache = new Map();
+
+// Misses are cached too, so an image added to console/web/public after the
+// process started is not picked up until it restarts. Note that this directory
+// is NOT baked into the image -- docker-compose.web.yml bind-mounts the host
+// checkout at /repo and points DUNE_DOCKER_DIR at it, so the files are live on
+// disk. What makes the stale window harmless is that updating the checkout
+// restarts the console container, not that the files cannot change.
 export function itemImagePath(repoRoot, id) {
   if (!repoRoot) return "/images/items/image-unavailable.png";
+  let byId = itemImagePathCache.get(repoRoot);
+  if (!byId) {
+    byId = new Map();
+    itemImagePathCache.set(repoRoot, byId);
+  }
+  const cached = byId.get(id);
+  if (cached !== undefined) return cached;
+
   const filename = `${id}.png`;
   const relativePath = `images/items/${filename}`;
   const absolutePath = resolve(repoRoot, "console/web/public", relativePath);
-  return existsSync(absolutePath) ? `/${relativePath}` : "/images/items/image-unavailable.png";
+  const resolved = existsSync(absolutePath) ? `/${relativePath}` : "/images/items/image-unavailable.png";
+  byId.set(id, resolved);
+  return resolved;
 }

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3427,17 +3427,20 @@ end`;
 
 export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColumn = "name", sortDirection = "asc", includeGenerators = true } = {}) {
   const requiredTables = ["buildings", "building_instances", "actor_fgl_entities", "actors"];
-  for (const table of requiredTables) {
-    if (!(await tableExists(db, table))) {
-      return { ...unsupported("bases", requiredTables.map((t) => `dune.${t}`)), totalCount: 0, totalBases: 0, totalPieces: 0, totalPlaceables: 0 };
-    }
+  // One round-trip each and none of them depends on another, so probe them
+  // together rather than five times in series before any real work starts.
+  const [required, hasWorldPartition] = await Promise.all([
+    Promise.all(requiredTables.map((table) => tableExists(db, table))),
+    tableExists(db, "world_partition")
+  ]);
+  if (required.some((exists) => !exists)) {
+    return { ...unsupported("bases", requiredTables.map((t) => `dune.${t}`)), totalCount: 0, totalBases: 0, totalPieces: 0, totalPlaceables: 0 };
   }
   // A base's own a.map is the game's map name ("HaggaBasin"), which cannot tell
   // two instances of it apart. world_partition resolves the partition to the
   // name the rest of the console uses ("Survival_1") plus its dimension --
   // together, the identity of one running instance. Optional table: without it
   // the fields come back empty rather than the query failing.
-  const hasWorldPartition = await tableExists(db, "world_partition");
   const partitionSelect = hasWorldPartition
     ? "coalesce(wp.map, '') as partition_map, coalesce(wp.dimension_index, 0) as dimension_index,"
     : "'' as partition_map, 0 as dimension_index,";
@@ -6455,12 +6458,25 @@ function baseInventoryTypeParams() {
 // while every id here is a row id -- so an edit could not reach a running map
 // without a relog or a map restart.
 export async function baseInventory(db, baseId, { repoRoot = "" } = {}) {
-  for (const table of ["placeables", "inventories", "items"]) {
-    if (!(await tableExists(db, table))) {
-      throw new UnsupportedCapabilityError(`Base inventory requires dune.${table}.`);
-    }
-  }
   const target = intParam(baseId, "base id", 1);
+  // Independent probes, so one round-trip rather than three in series.
+  const required = ["placeables", "inventories", "items"];
+  const present = await Promise.all(required.map((table) => tableExists(db, table)));
+  const missing = required.filter((_, index) => !present[index]);
+  // A capability response rather than a throw, matching listBases and the rest
+  // of the read paths here: the tab can then say the schema cannot support this
+  // instead of rendering a failed request with a retry that can never succeed.
+  if (missing.length) {
+    return {
+      supported: false,
+      reason: `Unsupported by detected schema. Missing required table(s): ${missing.map((table) => `dune.${table}`).join(", ")}`,
+      baseId: target,
+      groups: [],
+      containers: [],
+      items: [],
+      totals: { items: 0, distinct: 0, containers: 0, usedSlots: 0, maxSlots: 0 }
+    };
+  }
   const [groups, buildingTypes, typeNames] = baseInventoryTypeParams();
 
   const result = await db.query(`
@@ -6507,6 +6523,12 @@ export async function baseInventory(db, baseId, { repoRoot = "" } = {}) {
   const containersById = new Map();
   const itemsByTemplate = new Map();
   const countedInventories = new Set();
+  // Side indexes over the arrays being built: a container's entry for a
+  // template, and an item's holder for a placeable. Without them each row
+  // rescans everything accumulated so far, which is quadratic in the distinct
+  // templates a base holds.
+  const containerEntries = new Map();
+  const itemHolders = new Map();
 
   for (const row of result.rows) {
     const placeableId = String(row.placeable_id);
@@ -6541,9 +6563,15 @@ export async function baseInventory(db, baseId, { repoRoot = "" } = {}) {
 
     const metadata = itemMetadata.get(templateId);
     const name = metadata?.name || templateId;
-    const existing = container.items.find((entry) => entry.templateId === templateId);
+    let entries = containerEntries.get(placeableId);
+    if (!entries) containerEntries.set(placeableId, entries = new Map());
+    const existing = entries.get(templateId);
     if (existing) existing.quantity += quantity;
-    else container.items.push({ templateId, name, quantity });
+    else {
+      const entry = { templateId, name, quantity };
+      entries.set(templateId, entry);
+      container.items.push(entry);
+    }
 
     let item = itemsByTemplate.get(templateId);
     if (!item) {
@@ -6559,15 +6587,21 @@ export async function baseInventory(db, baseId, { repoRoot = "" } = {}) {
       itemsByTemplate.set(templateId, item);
     }
     item.quantity += quantity;
-    const holder = item.containers.find((entry) => entry.placeableId === placeableId);
+    let holders = itemHolders.get(templateId);
+    if (!holders) itemHolders.set(templateId, holders = new Map());
+    const holder = holders.get(placeableId);
     if (holder) holder.quantity += quantity;
-    else item.containers.push({
-      placeableId,
-      name: container.name,
-      typeName: container.typeName,
-      group: container.group,
-      quantity
-    });
+    else {
+      const next = {
+        placeableId,
+        name: container.name,
+        typeName: container.typeName,
+        group: container.group,
+        quantity
+      };
+      holders.set(placeableId, next);
+      item.containers.push(next);
+    }
   }
 
   const byQuantityDesc = (left, right) => right.quantity - left.quantity || left.name.localeCompare(right.name);
@@ -6584,6 +6618,7 @@ export async function baseInventory(db, baseId, { repoRoot = "" } = {}) {
   }
 
   return {
+    supported: true,
     baseId: target,
     groups: BASE_INVENTORY_GROUP_ORDER.map((group) => {
       const owned = containers.filter((container) => container.group === group);

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3432,6 +3432,18 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
       return { ...unsupported("bases", requiredTables.map((t) => `dune.${t}`)), totalCount: 0, totalBases: 0, totalPieces: 0, totalPlaceables: 0 };
     }
   }
+  // A base's own a.map is the game's map name ("HaggaBasin"), which cannot tell
+  // two instances of it apart. world_partition resolves the partition to the
+  // name the rest of the console uses ("Survival_1") plus its dimension --
+  // together, the identity of one running instance. Optional table: without it
+  // the fields come back empty rather than the query failing.
+  const hasWorldPartition = await tableExists(db, "world_partition");
+  const partitionSelect = hasWorldPartition
+    ? "coalesce(wp.map, '') as partition_map, coalesce(wp.dimension_index, 0) as dimension_index,"
+    : "'' as partition_map, 0 as dimension_index,";
+  const partitionJoin = hasWorldPartition
+    ? "left join dune.world_partition wp on wp.partition_id = p.partition_id"
+    : "";
   const safePageSize = intParam(pageSize, "pageSize", 1, 200);
   const safePage = intParam(page, "page", 0);
   const offset = safePage * safePageSize;
@@ -3530,6 +3542,7 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
              ${finalOwnerSelect}
              p.map,
              p.partition_id,
+             ${partitionSelect}
              p.x,
              p.y,
              p.z,
@@ -3538,6 +3551,7 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
              ${finalPlaceableCount} as placeable_count,
              coalesce(shared.entries, '[]'::jsonb) as shared_with
       from paged p
+      ${partitionJoin}
       ${finalOwnerJoin}
       left join lateral (
         select jsonb_agg(jsonb_build_object('name', ps.character_name, 'rank', par.rank) order by par.rank asc, ps.character_name asc) as entries
@@ -3615,6 +3629,8 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
       rows: result.rows.map(({ total_count, sort_position, ...row }) => ({
         ...row,
         partition_id: Number(row.partition_id || 0),
+        partitionMap: String(row.partition_map || ""),
+        dimensionIndex: Number(row.dimension_index || 0),
         x: Number(row.x),
         y: Number(row.y),
         z: Number(row.z),

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -6477,8 +6477,17 @@ function baseInventoryTypeParams() {
 // without a relog or a map restart.
 export async function baseInventory(db, baseId, { repoRoot = "" } = {}) {
   const target = intParam(baseId, "base id", 1);
-  // Independent probes, so one round-trip rather than three in series.
-  const required = ["placeables", "inventories", "items"];
+  // Every table the query below touches, in the order it reaches them. The
+  // LEFT JOINs count too: Postgres resolves a relation at parse time, so a
+  // missing permission_actor raises exactly as hard as a missing placeables.
+  // permission_actor is the one that matters most here -- listBases probes the
+  // first three and actors, so a schema lacking only permission_actor lists
+  // bases fine and then fails on this tab alone.
+  // Independent probes, so one round-trip rather than seven in series.
+  const required = [
+    "buildings", "building_instances", "actor_fgl_entities",
+    "placeables", "inventories", "permission_actor", "items"
+  ];
   const present = await Promise.all(required.map((table) => tableExists(db, table)));
   const missing = required.filter((_, index) => !present[index]);
   // A capability response rather than a throw, matching listBases and the rest

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -6106,6 +6106,24 @@ function waterTypeParams() {
 // there is no fuel-cell-style consumable involved.
 export async function baseWater(db, baseId) {
   const target = intParam(baseId, "base id", 1);
+  // Every table the query below touches, including fgl_entities inside the
+  // lateral -- a missing one raises a bare Postgres error otherwise, which the
+  // tab could only render as a failed request with a retry that can never
+  // succeed. listBases probes four of these, but not placeables or
+  // fgl_entities, so a schema can list bases fine and still be unable to
+  // answer this: that is exactly the case the capability response is for.
+  const required = ["buildings", "building_instances", "actor_fgl_entities", "placeables", "actors", "fgl_entities"];
+  // Independent probes, so one round-trip rather than six in series.
+  const present = await Promise.all(required.map((table) => tableExists(db, table)));
+  const missing = required.filter((_, index) => !present[index]);
+  if (missing.length) {
+    return {
+      supported: false,
+      reason: `Unsupported by detected schema. Missing required table(s): ${missing.map((table) => `dune.${table}`).join(", ")}`,
+      baseId: target,
+      containers: []
+    };
+  }
   const [types, buildingTypes] = waterTypeParams();
   const bloodKeys = WATER_BUILDING_TYPE_PAIRS.map(([type]) => WATER_TYPES[type].bloodPropertyKey || null);
   const result = await db.query(`
@@ -6174,7 +6192,7 @@ export async function baseWater(db, baseId) {
     return entry;
   }).sort((left, right) => WATER_TYPE_ORDER.indexOf(left.type) - WATER_TYPE_ORDER.indexOf(right.type));
 
-  return { baseId: target, containers };
+  return { supported: true, baseId: target, containers };
 }
 
 // Every water device at a base, individually. Refill and the auto-refill scan

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { redact } from "./redact.js";
+import { itemImagePath } from "./adminCatalog.js";
 import { clampInt, writeJsonAtomic } from "./jsonStore.js";
 import { CARE_PACKAGE_SERVER_PERSONA, FUNCOM_GM_PERSONA } from "./systemPersonas.js";
 import {
@@ -6301,6 +6302,291 @@ export async function baseWaterFuelLevels(db, baseId) {
     deviceCount: entries.length,
     devices: entries,
     lowestPercent: entries.length ? Math.min(...entries.map((entry) => entry.percent)) : null
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Base inventory
+//
+// Classification is an explicit building_type allowlist, for the same reason
+// generator_spec's is (see the comment in portalGeneratorFuel): an unknown
+// placeable must not silently acquire a group and report an invented fill
+// level. Anything not listed here is omitted rather than bucketed.
+//
+// Grouping does NOT key on dune.inventories.inventory_type even though it
+// almost lines up (4 = storage, 12 = refining/crafting, 3 = fuel-and-module).
+// Recycler and Repair Station are inventory_type 3, the same as the oil
+// generators the Power tab owns -- keying on the type would file a 25-slot
+// Recycler holding the most items of anything outside storage under "fuel".
+//
+// Display names are this console's own: the game stores no type label. Every
+// unnamed placeable's dune.permission_actor.actor_name is literally
+// '##' || building_type, and a named one holds whatever the player typed
+// ("Ore Storage", "Aluminum Refinery"), which is why the '##%' filter below
+// mirrors listStorage's.
+//
+// Where a building_type disagrees with the player-facing name, the catalog
+// patent in runtime/data/admin-items.json wins -- it is the same source the
+// console already uses for item names. SpiceSilo_Placeable is the one that
+// matters: its patent is "Small Storage Container", and the data agrees, since
+// 195 of the 198 item rows across 40 of them in the reference dump were not
+// spice. "Spice Silo" is the internal blueprint name (BP_SpiceSiloContainer),
+// not a label any player sees.
+//
+// Every label below was read off the in-game build menu. Two were not
+// derivable from the data and would have been guessed wrong:
+// GenericContainer_Placeable is "Chest" (20 slots), not the "Medium Storage
+// Container" its position in the capacity ladder suggests -- that is a real
+// but separate 100-slot building. And the fabricators are nine buildings, not
+// five: the plain and Advanced variants coexist.
+//
+// Every building_type string below was verified against the shipped server
+// paks on the production host, where each building ships a
+// DA_BLD_<building_type>.uasset. That is what caught
+// AdvancedVehicleFabricator_Placeable being singular while its own base
+// building, VehiclesFabricator_Placeable, is plural.
+//
+// The reverse does not hold: that extraction is lossy (SpiceSilo_Placeable,
+// SmallOreRefinery_Placeable and Fabricator_Placeable all fail to appear in it
+// despite being live on the same server), so a type's absence from the paks is
+// not evidence against it. An allowlist entry that never matches is inert,
+// while a missing one silently hides a container.
+const BASE_INVENTORY_TYPES = {
+  storage: {
+    name: "Storage",
+    buildingTypes: {
+      storagecontainer_placeable: "Storage Container",
+      mediumstoragecontainer_placeable: "Medium Storage Container",
+      genericcontainer_placeable: "Chest",
+      // Two building types display as the same building. SpiceSilo is the
+      // legacy name every live placement still carries (48 of them on the
+      // production server, 0 of the other); SmallStorageContainer is the
+      // asset name shipped in the paks. Both are listed so a rename in a
+      // future patch cannot silently empty the tab.
+      spicesilo_placeable: "Small Storage Container",
+      smallstoragecontainer_placeable: "Small Storage Container"
+    }
+  },
+  refining: {
+    name: "Refining",
+    buildingTypes: {
+      smallorerefinery_placeable: "Small Ore Refinery",
+      mediumorerefinery_placeable: "Medium Ore Refinery",
+      largeorerefinery_placeable: "Large Ore Refinery",
+      smallchemicalrefinery_placeable: "Small Chemical Refinery",
+      mediumchemicalrefinery_placeable: "Medium Chemical Refinery",
+      // The base spice refinery builds as plain "Spice Refinery" -- Medium and
+      // Large are separate buildables, unlike the size-prefixed ore ones.
+      spicerefinery_placeable: "Spice Refinery",
+      mediumspicerefinery_placeable: "Medium Spice Refinery",
+      largespicerefinery_placeable: "Large Spice Refinery"
+    }
+  },
+  crafting: {
+    name: "Crafting",
+    buildingTypes: {
+      // Nine fabricators: a starter "Fabricator" plus four specialisations,
+      // each of which has a separate Advanced building. Do not take the
+      // catalog at face value here -- SurvivalFabricator_Patent is *named*
+      // "Advanced Survival Fabricator Patent" while AdvancedSurvivalFabricator_
+      // Patent carries that same display name, so one of the two entries is
+      // simply wrong. The build menu has both buildings and they are distinct.
+      fabricator_placeable: "Fabricator",
+      survivalfabricator_placeable: "Survival Fabricator",
+      vehiclesfabricator_placeable: "Vehicles Fabricator",
+      weaponsfabricator_placeable: "Weapons Fabricator",
+      wearablesfabricator_placeable: "Garment Fabricator",
+      advancedsurvivalfabricator_placeable: "Advanced Survival Fabricator",
+      // Singular "Vehicle" -- the game is inconsistent here, the base building
+      // is VehiclesFabricator_Placeable but the advanced one is
+      // AdvancedVehicleFabricator_Placeable. Verified in the shipped paks.
+      advancedvehiclefabricator_placeable: "Advanced Vehicle Fabricator",
+      advancedweaponsfabricator_placeable: "Advanced Weapons Fabricator",
+      advancedwearablesfabricator_placeable: "Advanced Garment Fabricator"
+    }
+  },
+  machines: {
+    name: "Machines",
+    buildingTypes: {
+      recycler_placeable: "Recycler",
+      repairstation_placeable: "Repair Station"
+    }
+  }
+};
+
+const BASE_INVENTORY_GROUP_ORDER = ["storage", "refining", "crafting", "machines"];
+
+const BASE_INVENTORY_TRIPLES = BASE_INVENTORY_GROUP_ORDER.flatMap((group) =>
+  Object.entries(BASE_INVENTORY_TYPES[group].buildingTypes).map(
+    ([buildingType, typeName]) => [group, buildingType, typeName]));
+
+// Shaped for unnest() so a building_type is never interpolated into the SQL.
+function baseInventoryTypeParams() {
+  return [
+    BASE_INVENTORY_TRIPLES.map(([group]) => group),
+    BASE_INVENTORY_TRIPLES.map(([, buildingType]) => buildingType),
+    BASE_INVENTORY_TRIPLES.map(([, , typeName]) => typeName)
+  ];
+}
+
+// Every stored item at a base, rolled up two ways off one query: by item
+// template (what does this base hold, and where) and by container (what is in
+// this box, and how full is it).
+//
+// Read-only by design. Item writes have no live-sync path -- no pg_notify
+// channel carries them, there are no triggers on dune.items or
+// dune.inventories, and the RMQ command bus addresses items by template name
+// while every id here is a row id -- so an edit could not reach a running map
+// without a relog or a map restart.
+export async function baseInventory(db, baseId, { repoRoot = "" } = {}) {
+  for (const table of ["placeables", "inventories", "items"]) {
+    if (!(await tableExists(db, table))) {
+      throw new UnsupportedCapabilityError(`Base inventory requires dune.${table}.`);
+    }
+  }
+  const target = intParam(baseId, "base id", 1);
+  const [groups, buildingTypes, typeNames] = baseInventoryTypeParams();
+
+  const result = await db.query(`
+    with requested_claims as (
+      select distinct b.id, afe.actor_id
+      from dune.buildings b
+      join dune.building_instances bi on bi.building_id = b.id
+      join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+      where b.id = $1
+    ), base_entities as (
+      select distinct rc.id, claim_afe.entity_id as owner_entity_id
+      from requested_claims rc
+      join dune.actor_fgl_entities claim_afe on claim_afe.actor_id = rc.actor_id
+    ), inventory_types as (
+      select * from unnest($2::text[], $3::text[], $4::text[]) as t(group_key, building_type, type_name)
+    ), containers as (
+      -- max_item_count >= 0 drops the second inventory every refinery and
+      -- fabricator carries. Both are inventory_type 12; the capped one holds
+      -- the ore and crafting inputs, while the uncapped one (max_item_count
+      -- = -1, dune.actor_inventories.component_name_hash 26344419) was empty
+      -- on all 44 of them in the reference dump. Keeping it would also mean
+      -- dividing a slot bar by a negative capacity.
+      select p.id as placeable_id, inv.id as inventory_id,
+             it.group_key, it.type_name, inv.max_item_count,
+             coalesce(max(case when pa.actor_name not like '##%' and pa.actor_name <> 'None'
+                          then pa.actor_name end), '') as container_name
+      from base_entities be
+      join dune.placeables p on p.owner_entity_id = be.owner_entity_id
+      join inventory_types it on it.building_type = lower(p.building_type)
+      join dune.inventories inv on inv.actor_id = p.id and inv.max_item_count >= 0
+      left join dune.permission_actor pa on pa.actor_id = p.id
+      where p.is_hologram = false
+      group by p.id, inv.id, it.group_key, it.type_name, inv.max_item_count
+    )
+    select c.placeable_id::text as placeable_id,
+           c.inventory_id::text as inventory_id,
+           c.group_key, c.type_name, c.container_name, c.max_item_count,
+           i.template_id, i.stack_size
+    from containers c
+    left join dune.items i on i.inventory_id = c.inventory_id
+    order by c.placeable_id, i.template_id`, [target, groups, buildingTypes, typeNames]);
+
+  const itemMetadata = adminItemMetadata();
+  const containersById = new Map();
+  const itemsByTemplate = new Map();
+  const countedInventories = new Set();
+
+  for (const row of result.rows) {
+    const placeableId = String(row.placeable_id);
+    let container = containersById.get(placeableId);
+    if (!container) {
+      container = {
+        placeableId,
+        name: row.container_name || "",
+        typeName: row.type_name,
+        group: row.group_key,
+        usedSlots: 0,
+        maxSlots: 0,
+        itemCount: 0,
+        items: []
+      };
+      containersById.set(placeableId, container);
+    }
+    // A placeable can back more than one surviving inventory, so capacity is
+    // summed per inventory rather than per row -- every item row repeats it.
+    const inventoryId = String(row.inventory_id);
+    if (!countedInventories.has(inventoryId)) {
+      countedInventories.add(inventoryId);
+      container.maxSlots += Math.max(0, Number(row.max_item_count) || 0);
+    }
+
+    // The left join emits one all-null item for an empty container.
+    const templateId = String(row.template_id || "");
+    if (!templateId) continue;
+    const quantity = Number(row.stack_size) || 0;
+    container.usedSlots += 1;
+    container.itemCount += quantity;
+
+    const metadata = itemMetadata.get(templateId);
+    const name = metadata?.name || templateId;
+    const existing = container.items.find((entry) => entry.templateId === templateId);
+    if (existing) existing.quantity += quantity;
+    else container.items.push({ templateId, name, quantity });
+
+    let item = itemsByTemplate.get(templateId);
+    if (!item) {
+      item = {
+        templateId,
+        name,
+        image: itemImagePath(repoRoot, templateId),
+        category: metadata?.category || "",
+        quantity: 0,
+        containerCount: 0,
+        containers: []
+      };
+      itemsByTemplate.set(templateId, item);
+    }
+    item.quantity += quantity;
+    const holder = item.containers.find((entry) => entry.placeableId === placeableId);
+    if (holder) holder.quantity += quantity;
+    else item.containers.push({
+      placeableId,
+      name: container.name,
+      typeName: container.typeName,
+      group: container.group,
+      quantity
+    });
+  }
+
+  const byQuantityDesc = (left, right) => right.quantity - left.quantity || left.name.localeCompare(right.name);
+  const containers = [...containersById.values()].sort((left, right) =>
+    BASE_INVENTORY_GROUP_ORDER.indexOf(left.group) - BASE_INVENTORY_GROUP_ORDER.indexOf(right.group) ||
+    right.itemCount - left.itemCount ||
+    left.placeableId.localeCompare(right.placeableId));
+  for (const container of containers) container.items.sort(byQuantityDesc);
+
+  const items = [...itemsByTemplate.values()].sort(byQuantityDesc);
+  for (const item of items) {
+    item.containers.sort(byQuantityDesc);
+    item.containerCount = item.containers.length;
+  }
+
+  return {
+    baseId: target,
+    groups: BASE_INVENTORY_GROUP_ORDER.map((group) => {
+      const owned = containers.filter((container) => container.group === group);
+      return {
+        key: group,
+        name: BASE_INVENTORY_TYPES[group].name,
+        containerCount: owned.length,
+        itemCount: owned.reduce((total, container) => total + container.itemCount, 0)
+      };
+    }),
+    containers,
+    items,
+    totals: {
+      items: containers.reduce((total, container) => total + container.itemCount, 0),
+      distinct: items.length,
+      containers: containers.length,
+      usedSlots: containers.reduce((total, container) => total + container.usedSlots, 0),
+      maxSlots: containers.reduce((total, container) => total + container.maxSlots, 0)
+    }
   };
 }
 

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -539,6 +539,7 @@ async function handleApi(req, res) {
   if (path.match(/^\/api\/bases\/[^/]+\/queued-refill$/) && req.method === "DELETE") return baseCancelQueuedRefillRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/auto-refill$/) && req.method === "POST") return baseAutoRefillToggleRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/water$/) && req.method === "GET") return baseWaterRoute(res, path);
+  if (path.match(/^\/api\/bases\/[^/]+\/inventory$/) && req.method === "GET") return baseInventoryRoute(res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/refill-water$/) && req.method === "POST") return baseRefillWaterRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/queued-water-refill$/) && req.method === "DELETE") return baseCancelQueuedWaterRefillRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/auto-refill-water$/) && req.method === "POST") return baseAutoRefillWaterToggleRoute(req, res, path);
@@ -2286,6 +2287,19 @@ async function baseWaterRoute(res, path) {
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
   try {
     return json(res, 200, { supported: true, ...(await duneDb.baseWater(db, baseId)) });
+  } catch (error) {
+    const status = error.unsupported ? 501 : 400;
+    return json(res, status, { supported: false, error: redact(error.message || error), reason: redact(error.message || error) });
+  }
+}
+
+// Read-only, so no directDbMutation wrapper and no confirmation phrase.
+// repoRoot is passed through only to resolve each item's catalog icon.
+async function baseInventoryRoute(res, path) {
+  const baseId = Number(decodeURIComponent(path.split("/")[3]));
+  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  try {
+    return json(res, 200, { supported: true, ...(await duneDb.baseInventory(db, baseId, { repoRoot: config.repoRoot })) });
   } catch (error) {
     const status = error.unsupported ? 501 : 400;
     return json(res, status, { supported: false, error: redact(error.message || error), reason: redact(error.message || error) });

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -2299,10 +2299,12 @@ async function baseInventoryRoute(res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
   try {
-    return json(res, 200, { supported: true, ...(await duneDb.baseInventory(db, baseId, { repoRoot: config.repoRoot })) });
+    // A schema without the inventory tables comes back as a 200 carrying
+    // supported:false, the same capability shape listBases uses -- only a real
+    // failure is an error status, so the tab's retry always means something.
+    return json(res, 200, await duneDb.baseInventory(db, baseId, { repoRoot: config.repoRoot }));
   } catch (error) {
-    const status = error.unsupported ? 501 : 400;
-    return json(res, status, { supported: false, error: redact(error.message || error), reason: redact(error.message || error) });
+    return json(res, 400, { supported: false, error: redact(error.message || error), reason: redact(error.message || error) });
   }
 }
 

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -2284,12 +2284,19 @@ async function baseAutoRefillToggleRoute(req, res, path) {
 
 async function baseWaterRoute(res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
-  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  // Same reasoning as baseInventoryRoute: match intParam so bad input stays a
+  // 400 and the catch is left to genuine failures.
+  if (!Number.isInteger(baseId) || baseId < 1 || baseId > Number.MAX_SAFE_INTEGER) {
+    return json(res, 400, { error: "Invalid base ID" });
+  }
   try {
-    return json(res, 200, { supported: true, ...(await duneDb.baseWater(db, baseId)) });
+    // A schema that cannot back this comes through as a 200 carrying
+    // supported:false, the same capability shape listBases and baseInventory
+    // use -- so an error status here means only a real failure, and the tab's
+    // Retry always has something it could fix.
+    return json(res, 200, await duneDb.baseWater(db, baseId));
   } catch (error) {
-    const status = error.unsupported ? 501 : 400;
-    return json(res, status, { supported: false, error: redact(error.message || error), reason: redact(error.message || error) });
+    return json(res, 500, { supported: false, error: redact(error.message || error), reason: redact(error.message || error) });
   }
 }
 
@@ -2297,14 +2304,23 @@ async function baseWaterRoute(res, path) {
 // repoRoot is passed through only to resolve each item's catalog icon.
 async function baseInventoryRoute(res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
-  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  // Matches intParam's contract rather than just isFinite: 4.5 and 1e20 both
+  // clear a finite/>=1 check and then throw inside baseInventory. Rejecting
+  // them here keeps bad client input on 400 and leaves the catch below for
+  // failures that are genuinely ours.
+  if (!Number.isInteger(baseId) || baseId < 1 || baseId > Number.MAX_SAFE_INTEGER) {
+    return json(res, 400, { error: "Invalid base ID" });
+  }
   try {
     // A schema without the inventory tables comes back as a 200 carrying
     // supported:false, the same capability shape listBases uses -- only a real
     // failure is an error status, so the tab's retry always means something.
     return json(res, 200, await duneDb.baseInventory(db, baseId, { repoRoot: config.repoRoot }));
   } catch (error) {
-    return json(res, 400, { supported: false, error: redact(error.message || error), reason: redact(error.message || error) });
+    // Nothing reaching here is the caller's fault: the id is already validated
+    // and an unsupported schema returns a 200 above, so what is left is a query
+    // or connection failure.
+    return json(res, 500, { supported: false, error: redact(error.message || error), reason: redact(error.message || error) });
   }
 }
 

--- a/console/api/test/adminCatalog.test.js
+++ b/console/api/test/adminCatalog.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { itemIsRankedSchematic, itemIsSchematic, itemRequiresDatabaseGrant, listCatalogItems, resolveCatalogItem } from "../src/adminCatalog.js";
+import { itemImagePath, itemIsRankedSchematic, itemIsSchematic, itemRequiresDatabaseGrant, listCatalogItems, resolveCatalogItem } from "../src/adminCatalog.js";
 
 function fixtureRepo() {
   const root = mkdtempSync(join(tmpdir(), "web-admin-catalog-"));
@@ -73,6 +73,33 @@ test("item image lookups are resolved once per repo root", () => {
   mkdirSync(otherImages, { recursive: true });
   writeFileSync(join(otherImages, "PlantFiber.png"), "");
   assert.equal(resolveCatalogItem(other, { itemId: "PlantFiber" }).image, "/images/items/PlantFiber.png");
+});
+
+// The id becomes both a filesystem path and an <img src>. normalizeItem's id
+// regex admits "." and "/", and baseInventory passes a raw template_id with no
+// validation, so this is the only thing standing between a crafted id and a
+// path outside the public directory.
+test("item image ids cannot escape the images directory", () => {
+  const root = fixtureRepo();
+  mkdirSync(join(root, "console/web/public/images/items"), { recursive: true });
+  // images/items sits five levels below the repo root, so this is the depth a
+  // crafted id needs to land back on it. The file has to genuinely exist or the
+  // assertion passes for the wrong reason -- an unreadable path and a rejected
+  // one both come back unavailable.
+  writeFileSync(join(root, "secret.png"), "");
+
+  const unavailable = "/images/items/image-unavailable.png";
+  for (const id of ["../../../../../secret", "..\\..\\..\\..\\..\\secret", "images/items/../../secret", "..", ".", "", "a/b"]) {
+    const resolved = itemImagePath(root, id);
+    assert.equal(resolved, unavailable, `id ${JSON.stringify(id)} must not resolve`);
+    // Belt and braces: whatever comes back is also a URL, so it must never
+    // carry path structure even if it did point at something real.
+    assert.ok(!resolved.includes(".."), `id ${JSON.stringify(id)} leaked traversal into the URL`);
+  }
+
+  // The ordinary path is untouched.
+  writeFileSync(join(root, "console/web/public/images/items/PlantFiber.png"), "");
+  assert.equal(itemImagePath(root, "PlantFiber"), "/images/items/PlantFiber.png");
 });
 
 test("ranked physical schematics are distinguished from Grade 0 live grants", () => {

--- a/console/api/test/adminCatalog.test.js
+++ b/console/api/test/adminCatalog.test.js
@@ -54,6 +54,27 @@ test("catalog marks schematics and augments for database grants", () => {
   assert.equal(itemIsSchematic(resolveCatalogItem(root, { itemName: "Armor Piercing Augment" })), false);
 });
 
+// Every normalized item stats its icon, and listCatalogItems normalizes up to
+// 10,000 of them per request. Memoisation is only observable by moving the
+// filesystem underneath the second lookup: it has to answer from the cache
+// rather than notice a file that appeared in between.
+test("item image lookups are resolved once per repo root", () => {
+  const root = fixtureRepo();
+  const images = join(root, "console/web/public/images/items");
+  mkdirSync(images, { recursive: true });
+
+  assert.equal(resolveCatalogItem(root, { itemId: "PlantFiber" }).image, "/images/items/image-unavailable.png");
+  writeFileSync(join(images, "PlantFiber.png"), "");
+  assert.equal(resolveCatalogItem(root, { itemId: "PlantFiber" }).image, "/images/items/image-unavailable.png");
+
+  // Keyed by repo root, not global: another root resolves the same id fresh.
+  const other = fixtureRepo();
+  const otherImages = join(other, "console/web/public/images/items");
+  mkdirSync(otherImages, { recursive: true });
+  writeFileSync(join(otherImages, "PlantFiber.png"), "");
+  assert.equal(resolveCatalogItem(other, { itemId: "PlantFiber" }).image, "/images/items/PlantFiber.png");
+});
+
 test("ranked physical schematics are distinguished from Grade 0 live grants", () => {
   const root = fixtureRepo();
   const schematic = resolveCatalogItem(root, { itemName: "Arhun K-28 Lasgun" });

--- a/console/api/test/baseInventory.test.js
+++ b/console/api/test/baseInventory.test.js
@@ -2,7 +2,15 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { baseInventory } from "../src/duneDb.js";
 
-const REQUIRED_TABLES = ["dune.placeables", "dune.inventories", "dune.items"];
+// Every table the query touches, including the LEFT JOINed ones -- a missing
+// relation raises at parse time regardless of join type. permission_actor is
+// the reachable gap: listBases probes buildings/building_instances/
+// actor_fgl_entities/actors, so a schema lacking only permission_actor lists
+// bases fine and fails on this tab alone.
+const REQUIRED_TABLES = [
+  "dune.buildings", "dune.building_instances", "dune.actor_fgl_entities",
+  "dune.placeables", "dune.inventories", "dune.permission_actor", "dune.items"
+];
 const BASE_ID = 1006;
 
 // Template ids deliberately absent from runtime/data/admin-items.json, so the
@@ -188,9 +196,13 @@ test("baseInventory drops the uncapped second inventory refineries carry", async
 // error indistinguishable from a transient failure.
 test("baseInventory reports unsupported when a required table is missing", async () => {
   for (const table of REQUIRED_TABLES) {
-    const result = await baseInventory(createDb({ missingTable: table }), BASE_ID);
+    const db = createDb({ missingTable: table });
+    const result = await baseInventory(db, BASE_ID);
     assert.equal(result.supported, false);
     assert.match(result.reason, new RegExp(table.replace(".", "\\.")));
+    // The point of probing is to never issue the query that would have raised
+    // "relation ... does not exist" -- answering after the fact would defeat it.
+    assert.equal(mainQuery(db), undefined, `${table} missing: the query must not run`);
     // Still shaped like a real response, so nothing downstream has to guard
     // every field before reading it.
     assert.deepEqual(result.containers, []);

--- a/console/api/test/baseInventory.test.js
+++ b/console/api/test/baseInventory.test.js
@@ -1,0 +1,201 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { baseInventory } from "../src/duneDb.js";
+
+const REQUIRED_TABLES = ["dune.placeables", "dune.inventories", "dune.items"];
+const BASE_ID = 1006;
+
+// Template ids deliberately absent from runtime/data/admin-items.json, so the
+// assertions below test this module's fallback rather than tracking whatever
+// the shipped catalog happens to call a real item this week.
+function row(overrides = {}) {
+  return {
+    placeable_id: "40001",
+    inventory_id: "500",
+    group_key: "storage",
+    type_name: "Storage Container",
+    container_name: "",
+    max_item_count: 45,
+    template_id: "TestOre",
+    stack_size: 10,
+    ...overrides
+  };
+}
+
+function createDb({ rows = [], missingTable = "" } = {}) {
+  const calls = [];
+  const db = {
+    calls,
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const table = String(values[0] || "");
+        return { rows: [{ exists: REQUIRED_TABLES.includes(table) && table !== missingTable }] };
+      }
+      return { rows };
+    }
+  };
+  return db;
+}
+
+function mainQuery(db) {
+  return db.calls.find((call) => call.text.includes("requested_claims"));
+}
+
+test("baseInventory rolls items up by template and by container", async () => {
+  const db = createDb({
+    rows: [
+      row({ placeable_id: "40001", inventory_id: "500", template_id: "TestOre", stack_size: 10 }),
+      row({ placeable_id: "40001", inventory_id: "500", template_id: "TestBar", stack_size: 3 }),
+      row({ placeable_id: "40002", inventory_id: "501", container_name: "Ore Stash", max_item_count: 20, template_id: "TestOre", stack_size: 25 }),
+      row({
+        placeable_id: "40003", inventory_id: "502", group_key: "refining",
+        type_name: "Small Ore Refinery", max_item_count: 5, template_id: "TestOre", stack_size: 7
+      })
+    ]
+  });
+
+  const result = await baseInventory(db, BASE_ID);
+
+  assert.equal(result.baseId, BASE_ID);
+  // Sorted by quantity descending: 42 of TestOre across three containers.
+  assert.deepEqual(result.items.map((item) => [item.templateId, item.quantity, item.containerCount]), [
+    ["TestOre", 42, 3],
+    ["TestBar", 3, 1]
+  ]);
+  assert.deepEqual(result.items[0].containers.map((holder) => [holder.placeableId, holder.quantity]), [
+    ["40002", 25],
+    ["40001", 10],
+    ["40003", 7]
+  ]);
+  // No catalog entry, so name falls back to the raw template id.
+  assert.equal(result.items[0].name, "TestOre");
+
+  assert.deepEqual(result.containers.map((container) => [container.placeableId, container.usedSlots, container.maxSlots]), [
+    ["40002", 1, 20],
+    ["40001", 2, 45],
+    ["40003", 1, 5]
+  ]);
+  assert.deepEqual(result.totals, { items: 45, distinct: 2, containers: 3, usedSlots: 4, maxSlots: 70 });
+  assert.deepEqual(result.groups, [
+    { key: "storage", name: "Storage", containerCount: 2, itemCount: 38 },
+    { key: "refining", name: "Refining", containerCount: 1, itemCount: 7 },
+    { key: "crafting", name: "Crafting", containerCount: 0, itemCount: 0 },
+    { key: "machines", name: "Machines", containerCount: 0, itemCount: 0 }
+  ]);
+});
+
+test("baseInventory keeps an empty container instead of dropping it", async () => {
+  // The left join against dune.items emits one all-null item row for a
+  // container holding nothing.
+  const db = createDb({
+    rows: [row({ placeable_id: "40010", inventory_id: "510", template_id: null, stack_size: null, max_item_count: 5, group_key: "machines", type_name: "Repair Station" })]
+  });
+
+  const result = await baseInventory(db, BASE_ID);
+
+  assert.deepEqual(result.containers, [{
+    placeableId: "40010",
+    name: "",
+    typeName: "Repair Station",
+    group: "machines",
+    usedSlots: 0,
+    maxSlots: 5,
+    itemCount: 0,
+    items: []
+  }]);
+  assert.deepEqual(result.items, []);
+  assert.equal(result.totals.containers, 1);
+  assert.equal(result.totals.distinct, 0);
+});
+
+test("baseInventory counts a container's capacity once per inventory, not per item row", async () => {
+  // Every item row repeats its inventory's max_item_count; summing blindly
+  // would report 135 slots for one 45-slot container.
+  const db = createDb({
+    rows: [
+      row({ template_id: "TestOre", stack_size: 1 }),
+      row({ template_id: "TestBar", stack_size: 1 }),
+      row({ template_id: "TestGem", stack_size: 1 })
+    ]
+  });
+
+  const result = await baseInventory(db, BASE_ID);
+
+  assert.equal(result.containers.length, 1);
+  assert.equal(result.containers[0].maxSlots, 45);
+  assert.equal(result.containers[0].usedSlots, 3);
+});
+
+test("baseInventory merges repeated stacks of one template within a container", async () => {
+  const db = createDb({
+    rows: [
+      row({ template_id: "TestOre", stack_size: 100 }),
+      row({ template_id: "TestOre", stack_size: 40 })
+    ]
+  });
+
+  const result = await baseInventory(db, BASE_ID);
+
+  assert.deepEqual(result.containers[0].items, [{ templateId: "TestOre", name: "TestOre", quantity: 140 }]);
+  assert.equal(result.containers[0].usedSlots, 2, "two stacks occupy two slots even when merged for display");
+  assert.equal(result.items[0].containerCount, 1);
+});
+
+test("baseInventory leaves the container name empty when the game holds only its default", async () => {
+  // dune.permission_actor.actor_name is '##' || building_type until a player
+  // renames the placeable; the SQL strips that, so "" reaches the frontend
+  // and it falls back to the type name.
+  const db = createDb({ rows: [row({ container_name: "" })] });
+
+  const result = await baseInventory(db, BASE_ID);
+
+  assert.equal(result.containers[0].name, "");
+  assert.equal(result.containers[0].typeName, "Storage Container");
+});
+
+test("baseInventory only ever asks for allowlisted building types", async () => {
+  const db = createDb({ rows: [] });
+  await baseInventory(db, BASE_ID);
+
+  const [, groups, buildingTypes] = mainQuery(db).values;
+  assert.ok(buildingTypes.includes("storagecontainer_placeable"));
+  assert.ok(buildingTypes.includes("spicesilo_placeable"));
+  assert.ok(buildingTypes.includes("smallorerefinery_placeable"));
+  assert.ok(buildingTypes.includes("recycler_placeable"));
+  assert.ok(buildingTypes.includes("repairstation_placeable"));
+  // The Power and Water tabs own these; an unrecognised placeable must not
+  // acquire a group by accident either.
+  assert.ok(!buildingTypes.includes("generator_placeable"));
+  assert.ok(!buildingTypes.includes("windtrap_placeable"));
+  assert.ok(!buildingTypes.includes("watercistern_placeable"));
+  assert.equal(groups.length, buildingTypes.length);
+  assert.deepEqual([...new Set(groups)], ["storage", "refining", "crafting", "machines"]);
+  // Refineries and fabricators are separate groups, not one "production" bucket.
+  assert.equal(groups[buildingTypes.indexOf("smallorerefinery_placeable")], "refining");
+  assert.equal(groups[buildingTypes.indexOf("survivalfabricator_placeable")], "crafting");
+});
+
+test("baseInventory drops the uncapped second inventory refineries carry", async () => {
+  const db = createDb({ rows: [] });
+  await baseInventory(db, BASE_ID);
+
+  assert.match(mainQuery(db).text, /inv\.max_item_count >= 0/);
+});
+
+test("baseInventory reports unsupported when a required table is missing", async () => {
+  for (const table of REQUIRED_TABLES) {
+    const db = createDb({ missingTable: table });
+    await assert.rejects(() => baseInventory(db, BASE_ID), (error) => {
+      assert.equal(error.unsupported, true);
+      assert.match(error.message, new RegExp(table.replace(".", "\\.")));
+      return true;
+    });
+  }
+});
+
+test("baseInventory rejects an invalid base id", async () => {
+  const db = createDb({ rows: [] });
+  await assert.rejects(() => baseInventory(db, 0));
+  await assert.rejects(() => baseInventory(db, "not-a-base"));
+});

--- a/console/api/test/baseInventory.test.js
+++ b/console/api/test/baseInventory.test.js
@@ -183,14 +183,19 @@ test("baseInventory drops the uncapped second inventory refineries carry", async
   assert.match(mainQuery(db).text, /inv\.max_item_count >= 0/);
 });
 
+// A capability response, not a throw: a schema that cannot back the tab is a
+// settled answer the UI states plainly, so it must not reach the caller as an
+// error indistinguishable from a transient failure.
 test("baseInventory reports unsupported when a required table is missing", async () => {
   for (const table of REQUIRED_TABLES) {
-    const db = createDb({ missingTable: table });
-    await assert.rejects(() => baseInventory(db, BASE_ID), (error) => {
-      assert.equal(error.unsupported, true);
-      assert.match(error.message, new RegExp(table.replace(".", "\\.")));
-      return true;
-    });
+    const result = await baseInventory(createDb({ missingTable: table }), BASE_ID);
+    assert.equal(result.supported, false);
+    assert.match(result.reason, new RegExp(table.replace(".", "\\.")));
+    // Still shaped like a real response, so nothing downstream has to guard
+    // every field before reading it.
+    assert.deepEqual(result.containers, []);
+    assert.deepEqual(result.items, []);
+    assert.deepEqual(result.totals, { items: 0, distinct: 0, containers: 0, usedSlots: 0, maxSlots: 0 });
   }
 });
 

--- a/console/api/test/baseRouteStatus.test.js
+++ b/console/api/test/baseRouteStatus.test.js
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { intParam } from "../src/db.js";
+
+// server.js is an entrypoint -- importing it starts a listener -- so the route
+// handlers cannot be called directly. operationsPermissionMatrix.test.js sets
+// the precedent of reading it as source instead. The guard's contract is real
+// logic though, and that is the part these status codes depend on, so it is
+// exercised for real below rather than string-matched.
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const serverSource = readFileSync(resolve(repoRoot, "console/api/src/server.js"), "utf8");
+
+const ROUTES = ["baseWaterRoute", "baseInventoryRoute"];
+
+function routeBody(name) {
+  const start = serverSource.indexOf(`async function ${name}(`);
+  assert.notEqual(start, -1, `${name} not found in server.js`);
+  const end = serverSource.indexOf("\n}\n", start);
+  assert.notEqual(end, -1, `could not find the end of ${name}`);
+  return serverSource.slice(start, end);
+}
+
+// The route's own guard is what makes a 500 in the catch honest. isFinite alone
+// admits 4.5 and 1e20, both of which clear it and then throw inside intParam --
+// so with the old guard a caller could provoke what would now be reported as a
+// server fault. Anything intParam rejects must be rejected by the guard first.
+test("the base route guard rejects everything intParam would", () => {
+  const guard = (baseId) => Number.isInteger(baseId) && baseId >= 1 && baseId <= Number.MAX_SAFE_INTEGER;
+
+  const cases = [4.5, 1e20, 0, -1, 0.5, Number.MAX_SAFE_INTEGER + 2, NaN, Infinity, 1, 5, 1006, Number.MAX_SAFE_INTEGER];
+  for (const baseId of cases) {
+    let intParamAccepts = true;
+    try { intParam(baseId, "base id", 1); } catch { intParamAccepts = false; }
+    assert.equal(guard(baseId), intParamAccepts,
+      `guard and intParam disagree on ${baseId}: guard=${guard(baseId)} intParam=${intParamAccepts}`);
+  }
+});
+
+test("both base read routes use that guard, not a bare isFinite check", () => {
+  for (const name of ROUTES) {
+    const body = routeBody(name);
+    assert.match(body, /!Number\.isInteger\(baseId\)[\s\S]*?baseId > Number\.MAX_SAFE_INTEGER/,
+      `${name} must match intParam's contract before the try block`);
+    assert.doesNotMatch(body, /Number\.isFinite\(baseId\) \|\| baseId < 1/,
+      `${name} still uses the looser isFinite guard, so bad input can reach the catch`);
+  }
+});
+
+// An unsupported schema returns 200 with supported:false, and bad input is
+// rejected above -- so a throw here is a query or connection failure, which is
+// ours, not the caller's.
+test("both base read routes answer a genuine failure with 500, not 400", () => {
+  for (const name of ROUTES) {
+    const body = routeBody(name);
+    const catchBlock = body.slice(body.indexOf("} catch (error) {"));
+    assert.match(catchBlock, /json\(res, 500,/, `${name} must report a real failure as 500`);
+    assert.doesNotMatch(catchBlock, /json\(res, 400,/, `${name} must not report a real failure as 400`);
+    // The payload itself is unchanged: redacted, and still carrying both keys
+    // the tab reads.
+    assert.match(catchBlock, /supported: false/);
+    assert.match(catchBlock, /error: redact\(/);
+    assert.match(catchBlock, /reason: redact\(/);
+  }
+});
+
+// The id check has to stay outside the try, or a rejected id would be counted
+// as a server fault by the block above.
+test("both base read routes keep id validation on 400, before the try", () => {
+  for (const name of ROUTES) {
+    const body = routeBody(name);
+    const guardAt = body.indexOf("Invalid base ID");
+    const tryAt = body.indexOf("try {");
+    assert.notEqual(guardAt, -1, `${name} lost its invalid-id response`);
+    assert.ok(guardAt < tryAt, `${name} must reject a bad id before the try block`);
+    assert.match(body.slice(0, tryAt), /json\(res, 400, \{ error: "Invalid base ID" \}\)/);
+  }
+});

--- a/console/api/test/baseWater.test.js
+++ b/console/api/test/baseWater.test.js
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { baseWater } from "../src/duneDb.js";
+
+// Every table the query touches, including fgl_entities inside the lateral.
+// buildings/building_instances/actor_fgl_entities/actors overlap listBases's
+// probe set; placeables and fgl_entities do not, which is why a schema can
+// list bases fine and still be unable to answer this one.
+const REQUIRED_TABLES = [
+  "dune.buildings", "dune.building_instances", "dune.actor_fgl_entities",
+  "dune.placeables", "dune.actors", "dune.fgl_entities"
+];
+const BASE_ID = 482;
+
+function createDb({ rows = [], missingTable = "" } = {}) {
+  const calls = [];
+  return {
+    calls,
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const table = String(values[0] || "");
+        return { rows: [{ exists: REQUIRED_TABLES.includes(table) && table !== missingTable }] };
+      }
+      return { rows };
+    }
+  };
+}
+
+function mainQuery(db) {
+  return db.calls.find((call) => call.text.includes("requested_claims"));
+}
+
+// A capability response, not a throw. Before this, a missing table reached the
+// route as a plain Error, so the 501 arm never fired and the tab rendered a
+// redacted "relation ... does not exist" beside a Retry button that could only
+// ever fail the same way.
+test("baseWater reports unsupported when a required table is missing", async () => {
+  for (const table of REQUIRED_TABLES) {
+    const db = createDb({ missingTable: table });
+    const result = await baseWater(db, BASE_ID);
+
+    assert.equal(result.supported, false);
+    assert.match(result.reason, new RegExp(table.replace(".", "\\.")));
+    assert.equal(result.baseId, BASE_ID);
+    // Still shaped like a real response, so the tab reads containers without
+    // guarding it first.
+    assert.deepEqual(result.containers, []);
+    // The point of probing is to never run the query that would have raised.
+    assert.equal(mainQuery(db), undefined);
+  }
+});
+
+test("baseWater runs the query and reports supported when every table is present", async () => {
+  const db = createDb({
+    rows: [
+      { water_type: "windtrap", container_count: 4, water_stored: 6000, blood_stored: null },
+      { water_type: "waterCistern", container_count: 1, water_stored: 1250, blood_stored: null }
+    ]
+  });
+
+  const result = await baseWater(db, BASE_ID);
+
+  assert.equal(result.supported, true);
+  assert.equal(result.baseId, BASE_ID);
+  assert.ok(mainQuery(db), "the real query must still run on a supported schema");
+  // WATER_TYPE_ORDER puts cisterns ahead of windtraps regardless of row order.
+  assert.deepEqual(result.containers.map((entry) => entry.type), ["waterCistern", "windtrap"]);
+  assert.equal(result.containers[0].stored, 1250);
+});
+
+test("baseWater rejects an invalid base id", async () => {
+  const db = createDb();
+  await assert.rejects(() => baseWater(db, 0));
+  await assert.rejects(() => baseWater(db, "not-a-base"));
+});

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -2219,8 +2219,65 @@ test("list bases returns rows with piece and placeable counts and a total count"
   assert.equal(result.totalPieces, 700);
   assert.equal(result.totalPlaceables, 140);
   assert.deepEqual(result.rows, [
-    { base_id: "1006", name: "Sietch One", base_type: "Sub-Fief", owner_name: "Leader One", map: "TheDeepDesert", partition_id: 8, x: 100, y: 200, z: 30, piece_count: 589, placeable_count: 126, shared_with: [{ name: "Ally Two", rank: 2, label: "Co-Owner" }], generatorDataAvailable: true, generatorCount: 0, fuelCells: 0, generatorRuntimeSeconds: 0, generatorUptimeMultiplier: 1, generatorUptimeEventLabel: "", generatorUptimeEventEndsAt: "", generatorUnstockedCount: 0, generatorAllUnstocked: false, generators: [] }
+    // partitionMap/dimensionIndex are empty here because this fake db reports
+    // no dune.world_partition -- the guarded branch, not a missing value.
+    { base_id: "1006", name: "Sietch One", base_type: "Sub-Fief", owner_name: "Leader One", map: "TheDeepDesert", partition_id: 8, partitionMap: "", dimensionIndex: 0, x: 100, y: 200, z: 30, piece_count: 589, placeable_count: 126, shared_with: [{ name: "Ally Two", rank: 2, label: "Co-Owner" }], generatorDataAvailable: true, generatorCount: 0, fuelCells: 0, generatorRuntimeSeconds: 0, generatorUptimeMultiplier: 1, generatorUptimeEventLabel: "", generatorUptimeEventEndsAt: "", generatorUnstockedCount: 0, generatorAllUnstocked: false, generators: [] }
   ]);
+});
+
+test("list bases resolves each base's partition to its map instance", async () => {
+  // Two bases on one game map but different partitions -- the case a.map alone
+  // cannot distinguish, and the reason partitionMap/dimensionIndex exist.
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) || name === "dune.world_partition" }] };
+      }
+      if (text.includes("total_bases")) {
+        return { rows: [{ total_bases: "2", total_pieces: "20", total_placeables: "8" }] };
+      }
+      if (text.includes("from paged p")) {
+        return { rows: [
+          { base_id: "5001", name: "PvP Outpost", base_type: "Sub-Fief", owner_name: "A", map: "DeepDesert", partition_id: "8", partition_map: "DeepDesert_1", dimension_index: "0", x: "1", y: "2", z: "3", total_count: "2", piece_count: "10", placeable_count: "4", shared_with: [] },
+          { base_id: "5002", name: "PvE Outpost", base_type: "Sub-Fief", owner_name: "B", map: "DeepDesert", partition_id: "59", partition_map: "DeepDesert_1", dimension_index: "1", x: "4", y: "5", z: "6", total_count: "2", piece_count: "10", placeable_count: "4", shared_with: [] }
+        ] };
+      }
+      return { rows: [] };
+    }
+  };
+
+  const result = await listBases(db, { includeGenerators: false });
+
+  assert.deepEqual(result.rows.map((row) => [row.base_id, row.map, row.partition_id, row.partitionMap, row.dimensionIndex]), [
+    ["5001", "DeepDesert", 8, "DeepDesert_1", 0],
+    ["5002", "DeepDesert", 59, "DeepDesert_1", 1]
+  ]);
+  // The join is only emitted when the optional table is present.
+  const paged = calls.find((call) => call.text.includes("from paged p"));
+  assert.match(paged.text, /left join dune\.world_partition wp on wp\.partition_id = p\.partition_id/);
+});
+
+test("list bases omits the partition join when world_partition is absent", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(String(values[0] || "")) }] };
+      }
+      if (text.includes("total_bases")) return { rows: [{ total_bases: "0", total_pieces: "0", total_placeables: "0" }] };
+      return { rows: [] };
+    }
+  };
+
+  await listBases(db, { includeGenerators: false });
+
+  const paged = calls.find((call) => call.text.includes("from paged p"));
+  assert.ok(!paged.text.includes("dune.world_partition"), "must not join a table this schema does not have");
+  assert.match(paged.text, /'' as partition_map/);
 });
 
 test("list bases groups multiple internal building records under one claim actor", async () => {

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -165,12 +165,16 @@ export type BaseInventoryItem = {
 };
 
 export type BaseInventory = {
+  // False when the database lacks dune.placeables/inventories/items. That is a
+  // 200 carrying `reason`, not an error status -- a schema that cannot support
+  // the tab is a settled answer, and retrying it would never change.
   supported: boolean;
   baseId: number;
   groups: BaseInventoryGroup[];
   containers: BaseInventoryContainer[];
   items: BaseInventoryItem[];
   totals: { items: number; distinct: number; containers: number; usedSlots: number; maxSlots: number };
+  // Only set alongside supported: false.
   reason?: string;
 };
 

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -107,6 +107,73 @@ export type AutoRefillWaterState = {
   bases: AutoRefillWaterBase[];
 };
 
+// Storage containers plus the refining, crafting and machine inventories at a
+// base. Generator and windtrap fuel is deliberately absent -- the Power and
+// Water tabs own it.
+export type BaseInventoryGroupKey = "storage" | "refining" | "crafting" | "machines";
+
+export type BaseInventoryGroup = {
+  key: BaseInventoryGroupKey;
+  name: string;
+  containerCount: number;
+  itemCount: number;
+};
+
+// One item template's total inside one container. NOT a stack: the backend
+// merges every dune.items row of the same template, so a container with 8
+// occupied slots holding 3 templates yields 3 of these. Stack count is
+// usedSlots.
+export type BaseInventoryEntry = {
+  templateId: string;
+  name: string;
+  quantity: number;
+};
+
+export type BaseInventoryContainer = {
+  placeableId: string;
+  // Empty until a player renames the placeable in-game: the game stores
+  // '##' || building_type as the default, which the backend strips.
+  name: string;
+  typeName: string;
+  group: BaseInventoryGroupKey;
+  usedSlots: number;
+  maxSlots: number;
+  itemCount: number;
+  items: BaseInventoryEntry[];
+};
+
+// How much of one item a single container holds. `name` is the container's,
+// not the item's -- the item is the parent -- and is empty for a placeable the
+// player has never renamed, same as BaseInventoryContainer.name.
+export type BaseInventoryHolder = {
+  placeableId: string;
+  name: string;
+  typeName: string;
+  group: BaseInventoryGroupKey;
+  quantity: number;
+};
+
+export type BaseInventoryItem = {
+  templateId: string;
+  // Falls back to templateId for anything missing from admin-items.json.
+  name: string;
+  image: string;
+  category: string;
+  quantity: number;
+  containerCount: number;
+  containers: BaseInventoryHolder[];
+};
+
+export type BaseInventory = {
+  supported: boolean;
+  baseId: number;
+  groups: BaseInventoryGroup[];
+  containers: BaseInventoryContainer[];
+  items: BaseInventoryItem[];
+  totals: { items: number; distinct: number; containers: number; usedSlots: number; maxSlots: number };
+  reason?: string;
+};
+
 // rank 1/2/3 = Owner/Co-Owner/Associate, confirmed in both directions against a
 // live server: the game's own Permissions panel writes exactly these values.
 // The 5/4/3 badges the game UI shows beside those labels are decoration, not
@@ -210,6 +277,10 @@ export const basesApi = {
   },
   water: (baseId: string) =>
     api<BaseWater>(`/api/bases/${encodeURIComponent(baseId)}/water`),
+  // Read-only. One response backs both the item rollup and the container
+  // cards, so switching between them never refetches.
+  inventory: (baseId: string) =>
+    api<BaseInventory>(`/api/bases/${encodeURIComponent(baseId)}/inventory`),
   // A refill for a map that is currently running comes back as
   // `result.queued`: the write is deferred to the next time that map is down.
   refillWater: (baseId: string) =>

--- a/console/web/src/api/maps.ts
+++ b/console/web/src/api/maps.ts
@@ -168,7 +168,10 @@ export const mapsApi = {
   resetUserSettings: (body: { scope: "engine" | "mapEngine" | "partitionEngine" | "global" | "map" | "partition"; map?: string; partitionId?: string; confirmation: string }) => post<{ task: Task }>("/api/maps/user-settings/reset", body),
   saveRawUserSettings: (body: { scope: "engine" | "game" | "global" | "profile"; map?: string; partitionId?: string; content: string }) => post<{ task: Task }>("/api/maps/user-settings/raw", body),
   sietches: () => api<{ stdout: string }>("/api/sietches"),
-  sietchDimensions: (map = "Survival_1", ids = false) => api<{ stdout: string }>(`/api/sietches/dimensions?map=${encodeURIComponent(map)}${ids ? "&ids=1" : ""}`),
+  // exitCode is surfaced because commandJson answers 200 even when the CLI
+  // fails: a caller that only reads stdout cannot tell "no sietches" from
+  // "the command did not run".
+  sietchDimensions: (map = "Survival_1", ids = false) => api<{ stdout: string; exitCode?: number }>(`/api/sietches/dimensions?map=${encodeURIComponent(map)}${ids ? "&ids=1" : ""}`),
   updateSietches: (body: Record<string, unknown>) => post<{ task: Task }>("/api/sietches/update", body),
   restartSietch: (partitionId: string) => post<{ task: Task }>("/api/sietches/update", { action: "restart", partitionId, confirmation: "RESTART SIETCH" }),
   deepdesert: () => api<{ stdout: string }>("/api/deepdesert"),

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -289,6 +289,28 @@ describe("BaseInventoryTab", () => {
     expect(itemRows()).toHaveLength(25);
   });
 
+  // An unreadable schema is a settled answer, not a failure: it arrives as a
+  // normal 200 and must not offer a Retry, which could only fail identically.
+  it("states an unsupported schema without offering a retry", async () => {
+    mockInventory({
+      supported: false,
+      reason: "Unsupported by detected schema. Missing required table(s): dune.items",
+      baseId: 1006,
+      groups: [],
+      containers: [],
+      items: [],
+      totals: { items: 0, distinct: 0, containers: 0, usedSlots: 0, maxSlots: 0 }
+    });
+    renderTab();
+
+    expect(await screen.findByText(/Missing required table\(s\): dune\.items/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+    // None of the tab's own controls render, so there is nothing to interact
+    // with that would imply the data is merely empty.
+    expect(screen.queryByRole("button", { name: "Containers" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Slots used")).not.toBeInTheDocument();
+  });
+
   it("says so plainly when a base stores nothing", async () => {
     mockInventory({
       ...PAYLOAD,

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { basesApi, type BaseInventory } from "../../api/bases";
 import { BaseInventoryTab } from "./BaseInventoryTab";
@@ -407,7 +408,31 @@ describe("BaseInventoryTab", () => {
     expect(screen.getByRole("dialog").textContent).toContain("Granite Stone");
   });
 
-  it("shows an empty container rather than hiding it", async () => {
+  // StrictMode double-invokes the load effect, so two requests are genuinely
+  // open at once and whichever settles last writes state. A first attempt that
+  // fails after the second succeeded must not replace the loaded tab with an
+  // error banner.
+  it("ignores a stale response that settles after a newer one", async () => {
+    const gates: Array<{ resolve: (v: unknown) => void; reject: (e: unknown) => void }> = [];
+    vi.mocked(basesApi.inventory).mockImplementation(() => new Promise((resolve, reject) => {
+      gates.push({ resolve, reject });
+    }) as never);
+
+    render(<StrictMode><BaseInventoryTab baseId="1006" /></StrictMode>);
+    await waitFor(() => expect(gates.length).toBe(2));
+
+    // Newest request wins the tab...
+    gates[1].resolve(PAYLOAD);
+    await loaded();
+
+    // ...and the older one failing afterwards must change nothing.
+    gates[0].reject(new Error("stale failure"));
+    await waitFor(() => expect(screen.getByText("Distinct")).toBeTruthy());
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(screen.queryByText(/stale failure/)).toBeNull();
+  });
+
+  it("shows a container's slot usage on its card", async () => {
     mockInventory();
     renderTab();
     await loaded();

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -1,0 +1,397 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { basesApi, type BaseInventory } from "../../api/bases";
+import { BaseInventoryTab } from "./BaseInventoryTab";
+
+vi.mock("../../api/bases", () => ({
+  basesApi: {
+    inventory: vi.fn()
+  }
+}));
+
+const IMAGE = "/images/items/image-unavailable.png";
+
+// One base holding the same template in two groups, so the group chips have
+// something to actually change.
+const PAYLOAD: BaseInventory = {
+  supported: true,
+  baseId: 1006,
+  groups: [
+    { key: "storage", name: "Storage", containerCount: 2, itemCount: 1240 },
+    { key: "refining", name: "Refining", containerCount: 1, itemCount: 420 },
+    // Empty groups are always present in the response; the chips filter them out.
+    { key: "crafting", name: "Crafting", containerCount: 0, itemCount: 0 },
+    { key: "machines", name: "Machines", containerCount: 0, itemCount: 0 }
+  ],
+  containers: [
+    {
+      placeableId: "40001", name: "Vault", typeName: "Storage Container", group: "storage",
+      usedSlots: 2, maxSlots: 45, itemCount: 1200,
+      items: [
+        { templateId: "Stone", name: "Granite Stone", quantity: 1000 },
+        { templateId: "MagnetiteOre", name: "Iron Ore", quantity: 200 }
+      ]
+    },
+    {
+      placeableId: "40002", name: "", typeName: "Small Storage Container", group: "storage",
+      usedSlots: 1, maxSlots: 10, itemCount: 40,
+      items: [{ templateId: "SpiceSand", name: "Spice Sand", quantity: 40 }]
+    },
+    {
+      placeableId: "40003", name: "", typeName: "Small Ore Refinery", group: "refining",
+      usedSlots: 1, maxSlots: 5, itemCount: 420,
+      items: [{ templateId: "MagnetiteOre", name: "Iron Ore", quantity: 420 }]
+    }
+  ],
+  items: [
+    {
+      templateId: "Stone", name: "Granite Stone", image: IMAGE, category: "resources",
+      quantity: 1000, containerCount: 1,
+      containers: [{ placeableId: "40001", name: "Vault", typeName: "Storage Container", group: "storage", quantity: 1000 }]
+    },
+    {
+      templateId: "MagnetiteOre", name: "Iron Ore", image: IMAGE, category: "resources",
+      quantity: 620, containerCount: 2,
+      containers: [
+        { placeableId: "40003", name: "", typeName: "Small Ore Refinery", group: "refining", quantity: 420 },
+        { placeableId: "40001", name: "Vault", typeName: "Storage Container", group: "storage", quantity: 200 }
+      ]
+    },
+    {
+      templateId: "SpiceSand", name: "Spice Sand", image: IMAGE, category: "resources",
+      quantity: 40, containerCount: 1,
+      containers: [{ placeableId: "40002", name: "", typeName: "Small Storage Container", group: "storage", quantity: 40 }]
+    }
+  ],
+  totals: { items: 1660, distinct: 3, containers: 3, usedSlots: 4, maxSlots: 60 }
+};
+
+function mockInventory(payload: BaseInventory = PAYLOAD) {
+  vi.mocked(basesApi.inventory).mockResolvedValue(payload as never);
+}
+
+function renderTab() {
+  render(<BaseInventoryTab baseId="1006" />);
+}
+
+// The totals row is the single "the tab has loaded" signal every test needs.
+async function loaded() {
+  await waitFor(() => expect(screen.getByText("Distinct")).toBeTruthy());
+}
+
+// The tab opens on Containers, so anything testing the rollup switches first.
+function showItems() {
+  fireEvent.click(screen.getByRole("button", { name: "Items" }));
+}
+
+function itemRows() {
+  return [...document.querySelectorAll(".bases-inventory-item-row")];
+}
+
+function cards() {
+  return [...document.querySelectorAll(".bases-inventory-cards .bases-generator-group")];
+}
+
+// Group names appear twice on screen -- once as a filter chip, once as a
+// section heading -- so both need addressing by role/class, never by text.
+function groupHeadings() {
+  return [...document.querySelectorAll(".bases-inventory-group-head h4")].map((node) => node.textContent);
+}
+
+function total(label: string) {
+  const term = [...document.querySelectorAll(".bases-inventory-totals dt")]
+    .find((node) => node.textContent === label);
+  return term?.nextElementSibling?.textContent;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("BaseInventoryTab", () => {
+  it("shows the totals and the item rollup once loaded", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    showItems();
+
+    expect(total("Items")).toBe("1,660");
+    expect(total("Distinct")).toBe("3");
+    expect(total("Containers")).toBe("3");
+    // 4 of 60 slots.
+    expect(total("Slots used")).toBe("7%");
+    expect(itemRows().map((row) => row.textContent)).toEqual([
+      expect.stringContaining("Granite Stone"),
+      expect.stringContaining("Iron Ore"),
+      expect.stringContaining("Spice Sand")
+    ]);
+  });
+
+  it("surfaces a load failure with a working retry", async () => {
+    vi.mocked(basesApi.inventory).mockRejectedValueOnce(new Error("database is unreachable"));
+    renderTab();
+
+    await waitFor(() => expect(screen.getByRole("alert")).toBeTruthy());
+    expect(screen.getByRole("alert").textContent).toContain("database is unreachable");
+
+    mockInventory();
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await loaded();
+    expect(basesApi.inventory).toHaveBeenCalledTimes(2);
+  });
+
+  it("expands an item to show which containers hold it", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    showItems();
+
+    fireEvent.click(itemRows()[1]);
+    const breakdown = document.querySelector(".bases-inventory-breakdown");
+    expect(breakdown?.textContent).toContain("Small Ore Refinery #40003");
+    expect(breakdown?.textContent).toContain("Vault");
+    expect(breakdown?.textContent).toContain("420");
+    expect(breakdown?.textContent).toContain("200");
+  });
+
+  it("switches between the item rollup and the container cards without refetching", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+
+    // Opens on Containers.
+    expect(itemRows()).toHaveLength(0);
+    expect(cards()).toHaveLength(3);
+    expect(groupHeadings()).toEqual(["Storage", "Refining"]);
+
+    showItems();
+    expect(cards()).toHaveLength(0);
+    expect(itemRows()).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole("button", { name: "Containers" }));
+    expect(cards()).toHaveLength(3);
+    expect(basesApi.inventory).toHaveBeenCalledTimes(1);
+  });
+
+  it("sorts containers by their displayed label within each group", async () => {
+    mockInventory({
+      ...PAYLOAD,
+      groups: [
+        { key: "storage", name: "Storage", containerCount: 4, itemCount: 0 },
+        { key: "refining", name: "Refining", containerCount: 0, itemCount: 0 },
+        { key: "crafting", name: "Crafting", containerCount: 0, itemCount: 0 },
+        { key: "machines", name: "Machines", containerCount: 0, itemCount: 0 }
+      ],
+      // Deliberately out of order, and mixing renamed with unrenamed: a
+      // rename has to file under the name shown on the card, and "#9" has to
+      // sort ahead of "#10" rather than lexically after it.
+      containers: [
+        { placeableId: "10", name: "", typeName: "Chest", group: "storage", usedSlots: 0, maxSlots: 20, itemCount: 0, items: [] },
+        { placeableId: "9", name: "", typeName: "Chest", group: "storage", usedSlots: 0, maxSlots: 20, itemCount: 0, items: [] },
+        { placeableId: "77", name: "Zeta Vault", typeName: "Storage Container", group: "storage", usedSlots: 0, maxSlots: 45, itemCount: 0, items: [] },
+        { placeableId: "88", name: "Alpha Vault", typeName: "Storage Container", group: "storage", usedSlots: 0, maxSlots: 45, itemCount: 0, items: [] }
+      ],
+      items: [],
+      totals: { items: 0, distinct: 0, containers: 4, usedSlots: 0, maxSlots: 130 }
+    });
+    renderTab();
+    await loaded();
+
+    const titles = cards().map((card) => card.querySelector(".bases-generator-group-title")?.textContent);
+    expect(titles).toEqual(["Alpha Vault", "Chest", "Chest", "Zeta Vault"]);
+    // The two Chests are ordered #9 before #10, not lexically.
+    expect(cards()[1].textContent).toContain("#9");
+    expect(cards()[2].textContent).toContain("#10");
+  });
+
+  it("names an unrenamed container by its type and id", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    fireEvent.click(screen.getByRole("button", { name: "Containers" }));
+
+    const silo = cards().find((card) => card.textContent?.includes("Small Storage Container"));
+    expect(silo?.textContent).toContain("#40002");
+  });
+
+  it("filters both views by group, restating quantities to the group's share", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    showItems();
+
+    fireEvent.click(screen.getByRole("button", { name: /Refining/ }));
+    // Only Iron Ore lives in a refining container, and only 420 of its 620.
+    const rows = itemRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].textContent).toContain("Iron Ore");
+    expect(rows[0].textContent).toContain("420");
+    expect(rows[0].textContent).not.toContain("620");
+
+    fireEvent.click(screen.getByRole("button", { name: "Containers" }));
+    expect(cards()).toHaveLength(1);
+    expect(cards()[0].textContent).toContain("Small Ore Refinery");
+
+    fireEvent.click(screen.getByRole("button", { name: "All" }));
+    expect(cards()).toHaveLength(3);
+  });
+
+  it("only filters on submit, and Clear restores everything", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    showItems();
+
+    const input = screen.getByLabelText("Filter base inventory");
+    fireEvent.change(input, { target: { value: "iron" } });
+    expect(itemRows()).toHaveLength(3);
+
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    expect(itemRows()).toHaveLength(1);
+    expect(itemRows()[0].textContent).toContain("Iron Ore");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+    expect(itemRows()).toHaveLength(3);
+    expect((input as HTMLInputElement).value).toBe("");
+  });
+
+  it("reports a filter that matches nothing", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    showItems();
+
+    fireEvent.change(screen.getByLabelText("Filter base inventory"), { target: { value: "sandworm" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(screen.getByText("No items match this filter.")).toBeTruthy();
+  });
+
+  it("caps the rollup and lifts the cap on demand", async () => {
+    const many = Array.from({ length: 30 }, (_, index) => ({
+      templateId: `Item${index}`,
+      name: `Item ${index}`,
+      image: IMAGE,
+      category: "resources",
+      quantity: 100 - index,
+      containerCount: 1,
+      containers: [{ placeableId: "40001", name: "Vault", typeName: "Storage Container", group: "storage" as const, quantity: 100 - index }]
+    }));
+    mockInventory({ ...PAYLOAD, items: many });
+    renderTab();
+    await loaded();
+    showItems();
+
+    expect(itemRows()).toHaveLength(25);
+    fireEvent.click(screen.getByRole("button", { name: "Show all 30 items" }));
+    expect(itemRows()).toHaveLength(30);
+    fireEvent.click(screen.getByRole("button", { name: "Show fewer items" }));
+    expect(itemRows()).toHaveLength(25);
+  });
+
+  it("says so plainly when a base stores nothing", async () => {
+    mockInventory({
+      ...PAYLOAD,
+      groups: PAYLOAD.groups.map((group) => ({ ...group, containerCount: 0, itemCount: 0 })),
+      containers: [],
+      items: [],
+      totals: { items: 0, distinct: 0, containers: 0, usedSlots: 0, maxSlots: 0 }
+    });
+    renderTab();
+    await loaded();
+
+    expect(screen.getByText("No storage at this base.")).toBeTruthy();
+    // A base with no containers has no group chips to offer beyond All.
+    expect(document.querySelectorAll(".bases-inventory-chip")).toHaveLength(1);
+
+    showItems();
+    expect(screen.getByText("No stored items at this base.")).toBeTruthy();
+  });
+
+  it("opens a container's contents in an overlay and closes it four ways", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+
+    const vault = cards().find((card) => card.textContent?.includes("Vault")) as HTMLElement;
+    // The button reports the stack count without opening anything.
+    expect(within(vault).getByRole("button", { name: /View Contents/ }).textContent).toContain("2 distinct");
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    function open() {
+      fireEvent.click(within(cards().find((c) => c.textContent?.includes("Vault")) as HTMLElement)
+        .getByRole("button", { name: /View Contents/ }));
+      return screen.getByRole("dialog");
+    }
+
+    const dialog = open();
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    // Header identifies the container, body lists every stack with quantities.
+    expect(within(dialog).getByRole("heading", { name: "Vault" })).toBeTruthy();
+    expect(dialog.textContent).toContain("Storage Container · #40001");
+    expect(within(dialog).getByText("Granite Stone")).toBeTruthy();
+    expect(within(dialog).getByText("1,000")).toBeTruthy();
+    expect(within(dialog).getByText("Iron Ore")).toBeTruthy();
+    expect(within(dialog).getByText("200")).toBeTruthy();
+    // Not the other containers' contents.
+    expect(within(dialog).queryByText("Spice Sand")).toBeNull();
+
+    fireEvent.click(within(dialog).getByRole("button", { name: "Close" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    open();
+    fireEvent.click(screen.getByRole("button", { name: "Close contents" }));
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    open();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+
+    open();
+    fireEvent.mouseDown(document.querySelector(".modal-overlay") as HTMLElement);
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+
+  it("offers no contents button for an empty container", async () => {
+    mockInventory({
+      ...PAYLOAD,
+      containers: [{
+        placeableId: "40009", name: "", typeName: "Repair Station", group: "machines",
+        usedSlots: 0, maxSlots: 5, itemCount: 0, items: []
+      }],
+      groups: PAYLOAD.groups.map((g) => g.key === "machines"
+        ? { ...g, containerCount: 1, itemCount: 0 }
+        : { ...g, containerCount: 0, itemCount: 0 })
+    });
+    renderTab();
+    await loaded();
+
+    expect(screen.queryByRole("button", { name: /View Contents/ })).toBeNull();
+    expect(cards()[0].textContent).toContain("Empty");
+  });
+
+  it("keeps the overlay open when a filter would exclude its container", async () => {
+    // The overlay resolves its container from the unfiltered response, so
+    // applying a group chip behind it must not blank the dialog.
+    mockInventory();
+    renderTab();
+    await loaded();
+
+    fireEvent.click(within(cards().find((c) => c.textContent?.includes("Vault")) as HTMLElement)
+      .getByRole("button", { name: /View Contents/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Refining/ }));
+
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(screen.getByRole("dialog").textContent).toContain("Granite Stone");
+  });
+
+  it("shows an empty container rather than hiding it", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    fireEvent.click(screen.getByRole("button", { name: "Containers" }));
+
+    const vault = cards().find((card) => card.textContent?.includes("Vault"));
+    expect(within(vault as HTMLElement).getByText("2 / 45")).toBeTruthy();
+  });
+});

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -89,7 +89,7 @@ function itemRows() {
 }
 
 function cards() {
-  return [...document.querySelectorAll(".bases-inventory-cards .bases-generator-group")];
+  return [...document.querySelectorAll(".bases-inventory-cards .bases-card")];
 }
 
 // Group names appear twice on screen -- once as a filter chip, once as a
@@ -197,7 +197,7 @@ describe("BaseInventoryTab", () => {
     renderTab();
     await loaded();
 
-    const titles = cards().map((card) => card.querySelector(".bases-generator-group-title")?.textContent);
+    const titles = cards().map((card) => card.querySelector(".bases-card-title")?.textContent);
     expect(titles).toEqual(["Alpha Vault", "Chest", "Chest", "Zeta Vault"]);
     // The two Chests are ordered #9 before #10, not lexically.
     expect(cards()[1].textContent).toContain("#9");

--- a/console/web/src/features/bases/BaseInventoryTab.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.tsx
@@ -68,20 +68,19 @@ export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
   const items = useMemo(() => {
     if (!data) return [] as BaseInventoryItem[];
     return data.items
-      .map((item) => (group === "all"
-        ? item
-        : {
-            ...item,
-            containers: item.containers.filter((holder) => holder.group === group)
-          }))
       // Filtering by group re-derives the quantity from the surviving
       // containers -- showing the base-wide total under a group chip would
       // claim stock the group does not hold.
-      .map((item) => (group === "all" ? item : {
-        ...item,
-        quantity: item.containers.reduce((total, holder) => total + holder.quantity, 0),
-        containerCount: item.containers.length
-      }))
+      .map((item) => {
+        if (group === "all") return item;
+        const containers = item.containers.filter((holder) => holder.group === group);
+        return {
+          ...item,
+          containers,
+          quantity: containers.reduce((total, holder) => total + holder.quantity, 0),
+          containerCount: containers.length
+        };
+      })
       .filter((item) => item.containers.length > 0)
       .filter((item) => !term ||
         item.name.toLowerCase().includes(term) ||
@@ -148,6 +147,15 @@ export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
     </p>;
   }
   if (!data) return null;
+  // A settled answer, not a failure: this database cannot back the tab, so it
+  // gets a plain statement and no Retry -- the request would fail identically
+  // every time. Genuine failures still land in the branch above, where Retry
+  // means something.
+  if (!data.supported) {
+    return <p className="muted" role="status">
+      {data.reason || "Base inventory is unsupported by the detected schema."}
+    </p>;
+  }
 
   const { totals } = data;
   const slotPercent = totals.maxSlots > 0 ? Math.round((totals.usedSlots / totals.maxSlots) * 100) : 0;

--- a/console/web/src/features/bases/BaseInventoryTab.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.tsx
@@ -155,7 +155,7 @@ export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
 
   return (
     <div className="bases-inventory" onClick={(event) => event.stopPropagation()}>
-      <div className="bases-inventory-content">
+      <div className="bases-tab-body">
         {/* Stated before the data rather than after it: it governs how to read
             everything below, and at the foot of a 27-card list it was never
             seen. */}
@@ -282,14 +282,14 @@ export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
                           bordered group and the rule-separated definition list
                           -- rather than a bespoke one, so the four tabs read
                           as one panel. */}
-                      <div className="bases-generator-cards bases-inventory-cards">
+                      <div className="bases-card-grid bases-inventory-cards">
                         {owned.map((container) => {
                           const percent = container.maxSlots > 0
                             ? Math.round((container.usedSlots / container.maxSlots) * 100)
                             : 0;
                           return (
-                            <div className="bases-generator-group" key={container.placeableId}>
-                              <div className="bases-generator-group-title">
+                            <div className="bases-card" key={container.placeableId}>
+                              <div className="bases-card-title">
                                 {container.name || container.typeName}
                               </div>
                               {/* The type sits under the name rather than in a
@@ -302,7 +302,7 @@ export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
                                   ? `${container.typeName} · #${container.placeableId}`
                                   : `#${container.placeableId}`}
                               </p>
-                              <dl className="bases-generator-stats">
+                              <dl className="bases-card-stats">
                                 <dt>Slots Used</dt>
                                 <dd>
                                   <div className="progress-row">

--- a/console/web/src/features/bases/BaseInventoryTab.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.tsx
@@ -1,0 +1,395 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Boxes, ChevronDown, ChevronRight, X } from "lucide-react";
+import {
+  basesApi,
+  type BaseInventory,
+  type BaseInventoryContainer,
+  type BaseInventoryGroupKey,
+  type BaseInventoryItem
+} from "../../api/bases";
+
+type BaseInventoryTabProps = {
+  baseId: string;
+};
+
+// The rollup is capped so the tab cannot blow out the height of an already
+// expanded table row; "Show all" lifts it.
+const ITEM_PREVIEW_LIMIT = 25;
+
+type GroupFilter = BaseInventoryGroupKey | "all";
+type ViewMode = "items" | "containers";
+
+function errorText(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// Falls back to the type when a placeable has never been renamed in-game --
+// the backend returns "" rather than the game's '##'-prefixed default.
+function containerLabel(container: { name: string; typeName: string; placeableId: string }) {
+  return container.name || `${container.typeName} #${container.placeableId}`;
+}
+
+export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [data, setData] = useState<BaseInventory | null>(null);
+  // Containers first: opening the tab is usually "what is at this base", and
+  // the cards answer that at a glance. The rollup is the follow-up question.
+  const [view, setView] = useState<ViewMode>("containers");
+  const [group, setGroup] = useState<GroupFilter>("all");
+  // Two-state search, matching every other server-shaped search box in the
+  // app: `q` is what is typed, `submittedQ` is what filters. The filtering
+  // itself is client-side -- the whole base already arrived in one response --
+  // but search-as-you-type is not the panel's vocabulary.
+  const [q, setQ] = useState("");
+  const [submittedQ, setSubmittedQ] = useState("");
+  const [expandedItem, setExpandedItem] = useState("");
+  // Placeable id whose contents overlay is open, "" for none.
+  const [contentsFor, setContentsFor] = useState("");
+  const [showAllItems, setShowAllItems] = useState(false);
+  const closeContentsRef = useRef<HTMLButtonElement>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError("");
+    try {
+      setData(await basesApi.inventory(baseId));
+    } catch (error) {
+      setLoadError(errorText(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [baseId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const term = submittedQ.trim().toLowerCase();
+
+  const items = useMemo(() => {
+    if (!data) return [] as BaseInventoryItem[];
+    return data.items
+      .map((item) => (group === "all"
+        ? item
+        : {
+            ...item,
+            containers: item.containers.filter((holder) => holder.group === group)
+          }))
+      // Filtering by group re-derives the quantity from the surviving
+      // containers -- showing the base-wide total under a group chip would
+      // claim stock the group does not hold.
+      .map((item) => (group === "all" ? item : {
+        ...item,
+        quantity: item.containers.reduce((total, holder) => total + holder.quantity, 0),
+        containerCount: item.containers.length
+      }))
+      .filter((item) => item.containers.length > 0)
+      .filter((item) => !term ||
+        item.name.toLowerCase().includes(term) ||
+        item.templateId.toLowerCase().includes(term));
+  }, [data, group, term]);
+
+  const containers = useMemo(() => {
+    if (!data) return [] as BaseInventoryContainer[];
+    return data.containers
+      .filter((container) => group === "all" || container.group === group)
+      .filter((container) => !term ||
+        containerLabel(container).toLowerCase().includes(term) ||
+        container.items.some((stack) => stack.name.toLowerCase().includes(term)))
+      // Sorted on the rendered label, not on name/typeName separately, so a
+      // renamed container files under the name on its card rather than
+      // disappearing into a block of its own type. numeric keeps "#9" ahead
+      // of "#10"; the cards are grouped into sections downstream, so this is
+      // already per-group.
+      .slice()
+      .sort((left, right) => containerLabel(left).localeCompare(
+        containerLabel(right), undefined, { numeric: true, sensitivity: "base" }));
+  }, [data, group, term]);
+
+  // Resolved from the unfiltered list: a group chip or search term applied
+  // after the overlay opened must not blank out what is on screen.
+  const openContainer = contentsFor
+    ? data?.containers.find((container) => container.placeableId === contentsFor) || null
+    : null;
+
+  // Item icons live on the rollup, keyed by template, so the overlay reuses
+  // them rather than the response carrying the same URL twice per container.
+  const imagesByTemplate = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const item of data?.items || []) map.set(item.templateId, item.image);
+    return map;
+  }, [data]);
+  const itemImage = (templateId: string) =>
+    imagesByTemplate.get(templateId) || "/images/items/image-unavailable.png";
+
+  // Matches ConfirmDialog: Escape closes, and focus moves to the close button
+  // so the overlay is reachable without a mouse.
+  useEffect(() => {
+    if (!openContainer) return undefined;
+    closeContentsRef.current?.focus();
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") setContentsFor("");
+    }
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [openContainer]);
+
+  function applySearch(next: string) {
+    setSubmittedQ(next);
+    setExpandedItem("");
+    setShowAllItems(false);
+  }
+
+  if (loading) {
+    return <p className="muted" role="status">Loading base inventory…</p>;
+  }
+  if (loadError) {
+    return <p className="bases-permissions-error" role="alert">
+      {loadError} <button onClick={() => void load()}>Retry</button>
+    </p>;
+  }
+  if (!data) return null;
+
+  const { totals } = data;
+  const slotPercent = totals.maxSlots > 0 ? Math.round((totals.usedSlots / totals.maxSlots) * 100) : 0;
+  const visibleItems = showAllItems ? items : items.slice(0, ITEM_PREVIEW_LIMIT);
+
+  return (
+    <div className="bases-inventory" onClick={(event) => event.stopPropagation()}>
+      <div className="bases-inventory-content">
+        {/* Stated before the data rather than after it: it governs how to read
+            everything below, and at the foot of a 27-card list it was never
+            seen. */}
+        <p className="bases-inventory-note muted">
+          Read-only. Base inventory has no live-sync path, so the console cannot write items here.
+        </p>
+
+        {/* summary-stats/summary-stat are the app's stat tiles, shared with
+            the player summary, so these read as boxes like everywhere else. */}
+        <dl className="bases-inventory-totals summary-stats">
+          <div className="summary-stat"><dt>Items</dt><dd>{totals.items.toLocaleString()}</dd></div>
+          <div className="summary-stat"><dt>Distinct</dt><dd>{totals.distinct.toLocaleString()}</dd></div>
+          <div className="summary-stat"><dt>Containers</dt><dd>{totals.containers.toLocaleString()}</dd></div>
+          <div className="summary-stat"><dt>Slots used</dt><dd>{totals.maxSlots > 0 ? `${slotPercent}%` : "—"}</dd></div>
+        </dl>
+
+        <div className="bases-inventory-controls">
+          <div className="bases-inventory-groups" role="group" aria-label="Filter by container group">
+            <button
+              className={`bases-inventory-chip${group === "all" ? " active" : ""}`}
+              aria-pressed={group === "all"}
+              onClick={() => { setGroup("all"); setShowAllItems(false); }}
+            >All</button>
+            {data.groups.filter((entry) => entry.containerCount > 0).map((entry) => (
+              <button
+                key={entry.key}
+                className={`bases-inventory-chip${group === entry.key ? " active" : ""}`}
+                aria-pressed={group === entry.key}
+                onClick={() => { setGroup(entry.key); setShowAllItems(false); }}
+              >{entry.name} <span className="bases-inventory-chip-count">{entry.containerCount}</span></button>
+            ))}
+          </div>
+          <div className="bases-inventory-views" role="group" aria-label="Inventory view">
+            <button
+              className={`bases-inventory-view${view === "items" ? " active" : ""}`}
+              aria-pressed={view === "items"}
+              onClick={() => setView("items")}
+            >Items</button>
+            <button
+              className={`bases-inventory-view${view === "containers" ? " active" : ""}`}
+              aria-pressed={view === "containers"}
+              onClick={() => setView("containers")}
+            >Containers</button>
+          </div>
+        </div>
+
+        <div className="bases-inventory-search">
+          <input
+            value={q}
+            aria-label="Filter base inventory"
+            placeholder={view === "items" ? "Filter items…" : "Filter containers…"}
+            onChange={(event) => setQ(event.target.value)}
+            onKeyDown={(event) => { if (event.key === "Enter") applySearch(q); }}
+          />
+          <button onClick={() => applySearch(q)}>Search</button>
+          <button onClick={() => { setQ(""); applySearch(""); }}>Clear</button>
+        </div>
+
+        {view === "items"
+          ? <div className="bases-inventory-items">
+              {!items.length
+                ? <p className="muted">{term || group !== "all" ? "No items match this filter." : "No stored items at this base."}</p>
+                : <>
+                    <div className="bases-inventory-item-head">
+                      <span /><span>Item</span><span>Qty</span><span>Containers</span>
+                    </div>
+                    {visibleItems.map((item) => {
+                      const open = expandedItem === item.templateId;
+                      return (
+                        <div key={item.templateId}>
+                          <button
+                            className="bases-inventory-item-row"
+                            aria-expanded={open}
+                            onClick={() => setExpandedItem(open ? "" : item.templateId)}
+                          >
+                            <span aria-hidden="true">{open ? <ChevronDown size={15} /> : <ChevronRight size={15} />}</span>
+                            <span className="bases-inventory-item-name">
+                              <img src={item.image} alt="" aria-hidden="true" />
+                              {item.name}
+                            </span>
+                            <span className="bases-inventory-qty">{item.quantity.toLocaleString()}</span>
+                            <span className="bases-inventory-count">{item.containerCount}</span>
+                          </button>
+                          {open && <div className="bases-inventory-breakdown">
+                            {item.containers.map((holder) => (
+                              <div key={holder.placeableId}>
+                                <span>{containerLabel(holder)}</span>
+                                <span>{holder.quantity.toLocaleString()}</span>
+                              </div>
+                            ))}
+                          </div>}
+                        </div>
+                      );
+                    })}
+                    {items.length > ITEM_PREVIEW_LIMIT && <button
+                      className="bases-inventory-show-all"
+                      onClick={() => setShowAllItems(!showAllItems)}
+                    >{showAllItems ? "Show fewer items" : `Show all ${items.length.toLocaleString()} items`}</button>}
+                  </>}
+            </div>
+          : <div className="bases-inventory-containers">
+              {!containers.length
+                ? <p className="muted">{term || group !== "all" ? "No containers match this filter." : "No storage at this base."}</p>
+                : data.groups.filter((entry) =>
+                    containers.some((container) => container.group === entry.key)).map((entry) => {
+                  const owned = containers.filter((container) => container.group === entry.key);
+                  // Distinct templates, not a total quantity: the summary tile
+                  // above already gives the base-wide count, and a group's
+                  // total is dominated by whichever stack happens to be
+                  // largest (one Solari stack buries everything else).
+                  const distinct = new Set(
+                    owned.flatMap((container) => container.items.map((stack) => stack.templateId))).size;
+                  return (
+                    <section key={entry.key}>
+                      <div className="bases-inventory-group-head">
+                        <h4>{entry.name}</h4>
+                        <span className="muted">
+                          {owned.length.toLocaleString()} {owned.length === 1 ? "container" : "containers"}
+                          {" · "}
+                          {distinct.toLocaleString()} distinct
+                        </span>
+                      </div>
+                      {/* Same card vocabulary as Power and Water -- the amber
+                          bordered group and the rule-separated definition list
+                          -- rather than a bespoke one, so the four tabs read
+                          as one panel. */}
+                      <div className="bases-generator-cards bases-inventory-cards">
+                        {owned.map((container) => {
+                          const percent = container.maxSlots > 0
+                            ? Math.round((container.usedSlots / container.maxSlots) * 100)
+                            : 0;
+                          return (
+                            <div className="bases-generator-group" key={container.placeableId}>
+                              <div className="bases-generator-group-title">
+                                {container.name || container.typeName}
+                              </div>
+                              {/* The type sits under the name rather than in a
+                                  labelled row. When a container has no custom
+                                  name the title is already the type, so the
+                                  subtitle carries only the id -- most
+                                  containers on a real base are unnamed. */}
+                              <p className="bases-inventory-card-subtitle">
+                                {container.name
+                                  ? `${container.typeName} · #${container.placeableId}`
+                                  : `#${container.placeableId}`}
+                              </p>
+                              <dl className="bases-generator-stats">
+                                <dt>Slots Used</dt>
+                                <dd>
+                                  <div className="progress-row">
+                                    <div className="progress-track">
+                                      <div className="progress-fill" style={{ width: `${Math.min(100, percent)}%` }} />
+                                    </div>
+                                    <span>{container.usedSlots.toLocaleString()} / {container.maxSlots.toLocaleString()}</span>
+                                  </div>
+                                </dd>
+                                <dt>Items</dt>
+                                <dd>{container.itemCount.toLocaleString()}</dd>
+                                {/* Label hidden but not removed: the row keeps
+                                    the same height as every other stat, and
+                                    the button below already says what it is. */}
+                                <dt className="bases-inventory-spacer-label" aria-hidden="true">Contents</dt>
+                                <dd>
+                                  {!container.items.length
+                                    ? <span className="muted">Empty</span>
+                                    : <button
+                                        className="bases-inventory-view-contents"
+                                        onClick={() => setContentsFor(container.placeableId)}
+                                      >
+                                        <Boxes size={14} aria-hidden="true" />
+                                        View Contents
+                                        {/* "distinct", never "stacks": the backend merges rows
+                                            of the same template, so this is below usedSlots
+                                            whenever a template occupies more than one slot
+                                            (8 slots collapsing to 3 templates is common). */}
+                                        <span className="muted">
+                                          {container.items.length.toLocaleString()} distinct
+                                        </span>
+                                      </button>}
+                                </dd>
+                              </dl>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    </section>
+                  );
+                })}
+            </div>}
+      </div>
+
+      {openContainer && <div className="modal-overlay" role="presentation" onMouseDown={() => setContentsFor("")}>
+        <section
+          className="confirm-modal bases-inventory-contents-modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="bases-inventory-contents-title"
+          onMouseDown={(event) => event.stopPropagation()}
+        >
+          <div className="confirm-modal-title">
+            <div>
+              <h3 id="bases-inventory-contents-title">{openContainer.name || openContainer.typeName}</h3>
+              <p className="bases-inventory-card-subtitle">
+                {openContainer.name
+                  ? `${openContainer.typeName} · #${openContainer.placeableId}`
+                  : `#${openContainer.placeableId}`}
+              </p>
+            </div>
+            <button ref={closeContentsRef} className="icon-action" aria-label="Close contents" onClick={() => setContentsFor("")}>
+              <X size={18} />
+            </button>
+          </div>
+
+          <dl className="bases-inventory-contents-summary">
+            <div><dt>Slots Used</dt><dd>{openContainer.usedSlots.toLocaleString()} / {openContainer.maxSlots.toLocaleString()}</dd></div>
+            <div><dt>Items</dt><dd>{openContainer.itemCount.toLocaleString()}</dd></div>
+            <div><dt>Distinct</dt><dd>{openContainer.items.length.toLocaleString()}</dd></div>
+          </dl>
+
+          <div className="bases-inventory-contents-list">
+            {openContainer.items.map((stack) => (
+              <div className="bases-inventory-contents-row" key={stack.templateId}>
+                <img src={itemImage(stack.templateId)} alt="" aria-hidden="true" />
+                <span className="bases-inventory-contents-name" title={stack.templateId}>{stack.name}</span>
+                <span className="bases-inventory-contents-qty">{stack.quantity.toLocaleString()}</span>
+              </div>
+            ))}
+          </div>
+
+          <div className="confirm-modal-actions">
+            <button onClick={() => setContentsFor("")}>Close</button>
+          </div>
+        </section>
+      </div>}
+    </div>
+  );
+}

--- a/console/web/src/features/bases/BaseInventoryTab.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.tsx
@@ -49,15 +49,28 @@ export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
   const [showAllItems, setShowAllItems] = useState(false);
   const closeContentsRef = useRef<HTMLButtonElement>(null);
 
+  // Only the newest request may write state. StrictMode double-invokes this
+  // effect, so two requests really are open at once here, and whichever settles
+  // last wins -- a first attempt that fails after a second one succeeded would
+  // otherwise replace good data with an error banner. Same requestIdRef pattern
+  // BasesPanel uses for its own overlapping loads.
+  const requestIdRef = useRef(0);
+
   const load = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     setLoading(true);
     setLoadError("");
     try {
-      setData(await basesApi.inventory(baseId));
+      const result = await basesApi.inventory(baseId);
+      if (requestIdRef.current !== requestId) return;
+      setData(result);
     } catch (error) {
+      if (requestIdRef.current !== requestId) return;
       setLoadError(errorText(error));
     } finally {
-      setLoading(false);
+      // Left to the newest request too, so an early finisher cannot clear the
+      // spinner while the request that will actually fill the tab is open.
+      if (requestIdRef.current === requestId) setLoading(false);
     }
   }, [baseId]);
 

--- a/console/web/src/features/bases/BaseWaterTab.test.tsx
+++ b/console/web/src/features/bases/BaseWaterTab.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { basesApi, type BaseWater } from "../../api/bases";
+import { BaseWaterTab, type BaseWaterAutoRefillProps } from "./BaseWaterTab";
+
+vi.mock("../../api/bases", () => ({ basesApi: { water: vi.fn() } }));
+
+const PAYLOAD: BaseWater = {
+  supported: true,
+  baseId: 1006,
+  containers: [{ type: "waterCistern", name: "Water Cistern", count: 1, stored: 1250, capacity: 5000, percent: 25 }]
+};
+
+// Auto-refill is BasesPanel's state; the tab only renders what it is handed.
+// Off here so these tests are about the load path and nothing else.
+const AUTO_REFILL: BaseWaterAutoRefillProps = {
+  supported: false,
+  unavailable: false,
+  enabled: false,
+  saving: false,
+  stalledAt: "",
+  consecutiveQueues: 0,
+  canToggle: false,
+  tooltip: "",
+  onToggle: () => {},
+  onRetry: () => {}
+};
+
+// Hands back the resolve/reject of every call, so a test can settle them out of
+// the order they were made.
+function gatedWater() {
+  const gates: Array<{ resolve: (value: BaseWater) => void; reject: (error: unknown) => void }> = [];
+  vi.mocked(basesApi.water).mockImplementation(() => new Promise((resolve, reject) => {
+    gates.push({ resolve, reject });
+  }) as never);
+  return gates;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("BaseWaterTab", () => {
+  // StrictMode double-invokes the load effect, so two requests are genuinely
+  // open at once and whichever settles last writes state.
+  it("ignores a stale response that settles after a newer one", async () => {
+    const gates = gatedWater();
+    render(<StrictMode><BaseWaterTab baseId="1006" autoRefill={AUTO_REFILL} /></StrictMode>);
+    await waitFor(() => expect(gates.length).toBe(2));
+
+    gates[1].resolve(PAYLOAD);
+    expect(await screen.findByText("1,250 / 5,000")).toBeInTheDocument();
+
+    // The older attempt failing afterwards must not replace the loaded levels.
+    gates[0].reject(new Error("stale failure"));
+    await waitFor(() => expect(screen.getByText("1,250 / 5,000")).toBeInTheDocument());
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(screen.queryByText(/stale failure/)).toBeNull();
+  });
+
+  // Unlike the Inventory tab, this one refetches on a mounted instance:
+  // BasesPanel bumps refreshToken after an immediate refill. A refill that
+  // lands while the first read is still open must not be overwritten by it.
+  it("keeps the refreshed levels when the request it replaced settles late", async () => {
+    const gates = gatedWater();
+    const { rerender } = render(
+      <BaseWaterTab baseId="1006" autoRefill={AUTO_REFILL} refreshToken={0} />);
+    await waitFor(() => expect(gates.length).toBe(1));
+
+    // Refill completes and bumps the token while the first read is still open.
+    rerender(<BaseWaterTab baseId="1006" autoRefill={AUTO_REFILL} refreshToken={1} />);
+    await waitFor(() => expect(gates.length).toBe(2));
+
+    gates[1].resolve({
+      ...PAYLOAD,
+      containers: [{ type: "waterCistern", name: "Water Cistern", count: 1, stored: 5000, capacity: 5000, percent: 100 }]
+    });
+    expect(await screen.findByText("5,000 / 5,000")).toBeInTheDocument();
+
+    // The pre-refill read arriving late would otherwise show the old level.
+    gates[0].resolve(PAYLOAD);
+    await waitFor(() => expect(screen.getByText("5,000 / 5,000")).toBeInTheDocument());
+    expect(screen.queryByText("1,250 / 5,000")).toBeNull();
+  });
+});

--- a/console/web/src/features/bases/BaseWaterTab.tsx
+++ b/console/web/src/features/bases/BaseWaterTab.tsx
@@ -62,7 +62,7 @@ export function BaseWaterTab({ baseId, autoRefill, refreshToken }: BaseWaterTabP
 
   return (
     <div className="bases-water" onClick={(event) => event.stopPropagation()}>
-      <div className="bases-generator-breakdown">
+      <div className="bases-tab-body">
         {autoRefill.supported && <div className="bases-auto-refill">
           {autoRefill.unavailable
             ? <p className="bases-auto-refill-unknown" role="status">
@@ -88,11 +88,11 @@ export function BaseWaterTab({ baseId, autoRefill, refreshToken }: BaseWaterTabP
 
         {!containers.length && <p className="muted">No water storage at this base.</p>}
 
-        <div className="bases-generator-cards bases-water-cards">
+        <div className="bases-card-grid bases-water-cards">
           {containers.map((container) => (
-            <div className="bases-generator-group" key={container.type}>
-              <div className="bases-generator-group-title">{container.name}</div>
-              <dl className="bases-generator-stats">
+            <div className="bases-card" key={container.type}>
+              <div className="bases-card-title">{container.name}</div>
+              <dl className="bases-card-stats">
                 <dt>Containers</dt>
                 <dd>{container.count.toLocaleString()}</dd>
                 <dt>Water Volume</dt>

--- a/console/web/src/features/bases/BaseWaterTab.tsx
+++ b/console/web/src/features/bases/BaseWaterTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { basesApi, type WaterContainerEntry } from "../../api/bases";
 import { InfoTooltip } from "../../components/common/DisplayPrimitives";
 
@@ -35,17 +35,35 @@ export function BaseWaterTab({ baseId, autoRefill, refreshToken }: BaseWaterTabP
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState("");
   const [containers, setContainers] = useState<WaterContainerEntry[]>([]);
+  const [unsupportedReason, setUnsupportedReason] = useState("");
+
+  // Only the newest request may write state. Two get to overlap here:
+  // StrictMode double-invokes the effect, and refreshToken re-runs it on a
+  // mounted instance after an immediate refill -- so whichever settles last
+  // would otherwise win, and a first attempt failing after a second succeeded
+  // would replace fresh levels with an error banner. Same requestIdRef pattern
+  // BasesPanel and BaseInventoryTab use.
+  const requestIdRef = useRef(0);
 
   const load = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     setLoading(true);
     setLoadError("");
+    setUnsupportedReason("");
     try {
       const result = await basesApi.water(baseId);
+      if (requestIdRef.current !== requestId) return;
+      setUnsupportedReason(result.supported === false
+        ? result.reason || "Water storage is unsupported by the detected schema."
+        : "");
       setContainers(result.containers || []);
     } catch (error) {
+      if (requestIdRef.current !== requestId) return;
       setLoadError(errorText(error));
     } finally {
-      setLoading(false);
+      // Left to the newest request too, so an early finisher cannot clear the
+      // spinner while the request that will actually fill the tab is open.
+      if (requestIdRef.current === requestId) setLoading(false);
     }
   }, [baseId]);
 
@@ -58,6 +76,14 @@ export function BaseWaterTab({ baseId, autoRefill, refreshToken }: BaseWaterTabP
     return <p className="bases-permissions-error" role="alert">
       {loadError} <button onClick={() => void load()}>Retry</button>
     </p>;
+  }
+  // A settled answer, not a failure: this database cannot back the tab, so it
+  // gets a plain statement and no Retry -- the request would fail identically
+  // every time. Genuine failures still land in the branch above, where Retry
+  // means something. The auto-refill toggle is suppressed with it, since it
+  // acts on the same devices this schema cannot describe.
+  if (unsupportedReason) {
+    return <p className="muted" role="status">{unsupportedReason}</p>;
   }
 
   return (

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -1043,6 +1043,33 @@ describe("BasesPanel water refill", () => {
     await waitFor(() => expect(basesApi.pendingWaterRefills).toHaveBeenCalled());
     expect(vi.mocked(basesApi.water).mock.calls.length).toBe(1);
   });
+
+  // A schema that cannot back the tab is a settled answer, not a transient
+  // failure: it arrives as a 200 carrying supported:false, so it must not be
+  // rendered in the error style with a Retry that could only fail identically.
+  it("states the reason with no Retry when the schema cannot back the Water tab", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue(waterCapableList({ base_id: "4004", name: "Sietch Unsupported" }));
+    vi.mocked(basesApi.water).mockResolvedValue({
+      supported: false,
+      reason: "Unsupported by detected schema. Missing required table(s): dune.placeables",
+      baseId: 4004,
+      containers: []
+    });
+
+    renderPanel();
+    await screen.findByText("Sietch Unsupported");
+    fireEvent.click(await screen.findByRole("button", { name: "Show details for Sietch Unsupported" }));
+    fireEvent.click(await screen.findByRole("tab", { name: "Water" }));
+
+    const notice = await screen.findByText(/Missing required table\(s\): dune\.placeables/);
+    expect(notice).toHaveAttribute("role", "status");
+    expect(screen.queryByRole("button", { name: "Retry" })).not.toBeInTheDocument();
+    // Not the empty-base wording either -- "no water storage" would read as a
+    // fact about this base rather than about the database.
+    expect(screen.queryByText("No water storage at this base.")).not.toBeInTheDocument();
+    // Auto-refill acts on the very devices this schema cannot describe.
+    expect(screen.queryByRole("checkbox", { name: /Auto-Refill/ })).not.toBeInTheDocument();
+  });
 });
 
 describe("BasesPanel combined fuel/water queue and stalled banners", () => {

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { basesApi, type AutoRefillBase } from "../../api/bases";
 import { mapsApi } from "../../api/maps";
@@ -1204,6 +1204,73 @@ describe("BasesPanel map column", () => {
 
     renderPanel();
     expect(await screen.findByText("PvP Outpost")).toBeInTheDocument();
+
+    expect(mapCells()).toEqual([
+      { map: "Deep Desert", instance: "Partition 8" },
+      { map: "Deep Desert", instance: "Partition 59" }
+    ]);
+  });
+
+  // Two bases on two different maps, which is what makes the id keyspace
+  // matter: a partition number is only unique once its map is fixed.
+  function mockOneBasePerMap() {
+    vi.mocked(basesApi.list).mockResolvedValue({
+      capabilities: { bases: true },
+      totalCount: 2,
+      totalBases: 2,
+      totalPieces: 20,
+      totalPlaceables: 8,
+      rows: [
+        { ...commonRow, base_id: "5001", name: "Basin Hold", map: "HaggaBasin", partition_id: 1, partitionMap: "Survival_1", dimensionIndex: 0, generatorDataAvailable: false, generatorCount: 0 },
+        { ...commonRow, base_id: "5002", name: "PvP Outpost", map: "DeepDesert", partition_id: 8, partitionMap: "DeepDesert_1", dimensionIndex: 0, generatorDataAvailable: false, generatorCount: 0 }
+      ]
+    } as never);
+  }
+
+  // Both assertions below are negative -- an instance name must NOT appear --
+  // so they need a sync point that does not depend on one arriving. A
+  // module-level cache means the panel mounts with the previous test's rows and
+  // fires this effect twice, so the call count is not usable either; wait for
+  // the call the current rows triggered, then drain the resolve pass.
+  async function settleInstanceNames(map: string) {
+    await waitFor(() => expect(vi.mocked(mapsApi.sietchDimensions)).toHaveBeenCalledWith(map, true));
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 0)); });
+  }
+
+  // The dimension table lists rows 0 and 1 while --ids comes back empty, so
+  // parseSietchRows keys those rows by dimension index. Pooled into one map
+  // across every partition map, DeepDesert_1's dimension 1 then answers the
+  // lookup for Survival_1's partition 1 and labels the Hagga Basin base
+  // "Deep Desert PvE".
+  it("does not label a base with another map's instance when partition ids are missing", async () => {
+    mockOneBasePerMap();
+    vi.mocked(mapsApi.sietchDimensions).mockImplementation((map?: string, ids?: boolean) =>
+      Promise.resolve({ stdout: map === "DeepDesert_1" && !ids ? DEEP_DESERT_TABLE : "" }) as never);
+
+    renderPanel();
+    expect(await screen.findByText("Basin Hold")).toBeInTheDocument();
+    await settleInstanceNames("Survival_1");
+
+    expect(mapCells()).toEqual([
+      // Never "Deep Desert PvE": that name is keyed by a dimension index, and
+      // this base is on a different map entirely.
+      { map: "Hagga Basin", instance: "Partition 1" },
+      { map: "Deep Desert", instance: "Partition 8" }
+    ]);
+  });
+
+  // commandJson answers 200 with an empty stdout when the CLI exits non-zero,
+  // so the failure is only visible in exitCode.
+  it("keeps the partition fallback when the CLI reports a non-zero exit", async () => {
+    mockTwoDeepDesertBases();
+    // Plausible stdout, but the command failed -- trusting it would publish
+    // instance names read from a stale or partial table.
+    vi.mocked(mapsApi.sietchDimensions).mockImplementation((_map?: string, ids?: boolean) =>
+      Promise.resolve({ stdout: ids ? DEEP_DESERT_IDS : DEEP_DESERT_TABLE, exitCode: 1 }) as never);
+
+    renderPanel();
+    expect(await screen.findByText("PvP Outpost")).toBeInTheDocument();
+    await settleInstanceNames("DeepDesert_1");
 
     expect(mapCells()).toEqual([
       { map: "Deep Desert", instance: "Partition 8" },

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { basesApi, type AutoRefillBase } from "../../api/bases";
+import { mapsApi } from "../../api/maps";
 import { BasesPanel } from "./BasesPanel";
 
 vi.mock("../../api/bases", () => ({
@@ -27,6 +28,14 @@ vi.mock("../../api/bases", () => ({
 
 vi.mock("../../api/client", () => ({
   apiDownload: vi.fn()
+}));
+
+vi.mock("../../api/maps", () => ({
+  mapsApi: {
+    sietchDimensions: vi.fn(),
+    restartSietch: vi.fn(),
+    respawn: vi.fn()
+  }
 }));
 
 function renderPanel(overrides: Partial<Parameters<typeof BasesPanel>[0]> = {}) {
@@ -1133,5 +1142,72 @@ describe("BasesPanel combined fuel/water queue and stalled banners", () => {
     expect(screen.getByText("1 fuel")).toBeInTheDocument();
     expect(screen.getByText("1 water")).toBeInTheDocument();
     expect(document.querySelectorAll(".bases-pending-refills")).toHaveLength(1);
+  });
+});
+
+describe("BasesPanel map column", () => {
+  // Verbatim `dune sietches dimensions DeepDesert_1` output from the live
+  // server, paired with its `--ids` output: two instances of one map, which is
+  // exactly the case the map name alone cannot distinguish.
+  const DEEP_DESERT_TABLE = [
+    "DIMENSION  DISPLAY NAME                     PASSWORD",
+    "0          Deep Desert PvP                  (unset)",
+    "1          Deep Desert PvE                  (unset)"
+  ].join("\n");
+  const DEEP_DESERT_IDS = "8\n59\n";
+
+  function mockTwoDeepDesertBases() {
+    vi.mocked(basesApi.list).mockResolvedValue({
+      capabilities: { bases: true },
+      totalCount: 2,
+      totalBases: 2,
+      totalPieces: 20,
+      totalPlaceables: 8,
+      rows: [
+        { ...commonRow, base_id: "5001", name: "PvP Outpost", map: "DeepDesert", partition_id: 8, partitionMap: "DeepDesert_1", dimensionIndex: 0, generatorDataAvailable: false, generatorCount: 0 },
+        { ...commonRow, base_id: "5002", name: "PvE Outpost", map: "DeepDesert", partition_id: 59, partitionMap: "DeepDesert_1", dimensionIndex: 1, generatorDataAvailable: false, generatorCount: 0 }
+      ]
+    } as never);
+  }
+
+  function mapCells() {
+    return [...document.querySelectorAll(".bases-map-cell")].map((cell) => ({
+      map: cell.querySelector(".bases-map-name")?.textContent,
+      instance: cell.querySelector(".bases-map-instance")?.textContent
+    }));
+  }
+
+  it("renders the friendly map name and upgrades the partition to its instance name", async () => {
+    mockTwoDeepDesertBases();
+    vi.mocked(mapsApi.sietchDimensions).mockImplementation((_map?: string, ids?: boolean) =>
+      Promise.resolve({ stdout: ids ? DEEP_DESERT_IDS : DEEP_DESERT_TABLE }) as never);
+
+    renderPanel();
+    expect(await screen.findByText("PvP Outpost")).toBeInTheDocument();
+
+    // "DeepDesert" is the game's internal name; the column shows the real one,
+    // keeping the raw value in the title for anyone matching against the DB.
+    await waitFor(() => expect(mapCells()).toEqual([
+      { map: "Deep Desert", instance: "Deep Desert PvP" },
+      { map: "Deep Desert", instance: "Deep Desert PvE" }
+    ]));
+    expect(document.querySelector(".bases-map-name")).toHaveAttribute("title", "DeepDesert");
+    // One pair of requests for the single distinct partition map, not per row.
+    expect(vi.mocked(mapsApi.sietchDimensions).mock.calls.map((call) => call[0])).toEqual(["DeepDesert_1", "DeepDesert_1"]);
+  });
+
+  it("falls back to the partition number when the instance names cannot be read", async () => {
+    // These endpoints shell out to the runtime CLI and are absent on a
+    // console-only install. The rows must still identify their instance.
+    mockTwoDeepDesertBases();
+    vi.mocked(mapsApi.sietchDimensions).mockRejectedValue(new Error("spawn runtime/scripts/dune ENOENT"));
+
+    renderPanel();
+    expect(await screen.findByText("PvP Outpost")).toBeInTheDocument();
+
+    expect(mapCells()).toEqual([
+      { map: "Deep Desert", instance: "Partition 8" },
+      { map: "Deep Desert", instance: "Partition 59" }
+    ]);
   });
 });

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -20,7 +20,8 @@ vi.mock("../../api/bases", () => ({
     cancelQueuedWaterRefill: vi.fn(),
     pendingWaterRefills: vi.fn(),
     autoRefillWater: vi.fn(),
-    setAutoRefillWater: vi.fn()
+    setAutoRefillWater: vi.fn(),
+    inventory: vi.fn()
   }
 }));
 
@@ -713,7 +714,48 @@ describe("BasesPanel permissions editing", () => {
     fireEvent.click(await screen.findByRole("button", { name: "Show details for Sietch One" }));
     expect(screen.getByRole("tab", { name: "Power" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Water" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Inventory" })).toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "Sub-Fief Permissions" })).not.toBeInTheDocument();
+  });
+
+  // Inventory sits between Water and Permissions, and is ungated the way Water
+  // is: the backend response, not the tab's absence, reports an unreadable
+  // schema.
+  it("opens the Inventory tab and loads that base's stored items", async () => {
+    mockList(false);
+    vi.mocked(basesApi.inventory).mockResolvedValue({
+      supported: true,
+      baseId: 1006,
+      groups: [
+        { key: "storage", name: "Storage", containerCount: 1, itemCount: 1000 },
+        { key: "refining", name: "Refining", containerCount: 0, itemCount: 0 },
+        { key: "crafting", name: "Crafting", containerCount: 0, itemCount: 0 },
+        { key: "machines", name: "Machines", containerCount: 0, itemCount: 0 }
+      ],
+      containers: [{
+        placeableId: "40001", name: "Vault", typeName: "Storage Container", group: "storage",
+        usedSlots: 1, maxSlots: 45, itemCount: 1000,
+        items: [{ templateId: "Stone", name: "Granite Stone", quantity: 1000 }]
+      }],
+      items: [{
+        templateId: "Stone", name: "Granite Stone", image: "/images/items/image-unavailable.png",
+        category: "resources", quantity: 1000, containerCount: 1,
+        containers: [{ placeableId: "40001", name: "Vault", typeName: "Storage Container", group: "storage", quantity: 1000 }]
+      }],
+      totals: { items: 1000, distinct: 1, containers: 1, usedSlots: 1, maxSlots: 45 }
+    } as never);
+
+    renderPanel();
+    fireEvent.click(await screen.findByRole("button", { name: "Show details for Sietch One" }));
+
+    const tabs = screen.getAllByRole("tab").map((tab) => tab.getAttribute("aria-label") || tab.textContent);
+    expect(tabs).toEqual(["Power", "Water", "Inventory"]);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Inventory" }));
+    // The tab opens on the container cards, not the item rollup.
+    expect(await screen.findByText("Vault")).toBeInTheDocument();
+    expect(document.querySelectorAll(".bases-inventory-cards .bases-generator-group")).toHaveLength(1);
+    await waitFor(() => expect(basesApi.inventory).toHaveBeenCalledWith("1006"));
   });
 
   // A base with no generators had no expand chevron before this feature. It
@@ -928,19 +970,19 @@ describe("BasesPanel water refill", () => {
     vi.mocked(basesApi.water)
       .mockResolvedValueOnce({
         supported: true,
-        baseId: 4002,
+        baseId: 1006,
         containers: [{ type: "waterCistern", name: "Water Cistern", count: 1, stored: 1250, capacity: 5000, percent: 25 }]
       })
       .mockResolvedValueOnce({
         supported: true,
-        baseId: 4002,
+        baseId: 1006,
         containers: [{ type: "waterCistern", name: "Water Cistern", count: 1, stored: 5000, capacity: 5000, percent: 100 }]
       });
     vi.mocked(basesApi.refillWater).mockResolvedValue({
       supported: true,
       result: {
         ok: true,
-        baseId: 4002,
+        baseId: 1006,
         totalAdded: 3750,
         devices: [{ placeableId: "9101", type: "waterCistern", label: "Water Cistern", before: 1250, after: 5000, added: 3750 }]
       }

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -119,7 +119,7 @@ describe("BasesPanel generator details", () => {
 
     expect(screen.getByText("Fuel-Powered Generator")).toBeInTheDocument();
     expect(screen.getByText("Spice-Powered Generator")).toBeInTheDocument();
-    expect(document.querySelectorAll(".bases-generator-group")).toHaveLength(2);
+    expect(document.querySelectorAll(".bases-card")).toHaveLength(2);
     expect(screen.getAllByText("Fuel Queued")).toHaveLength(2);
     expect(screen.getByText("1 Fuel Cell")).toBeInTheDocument();
     expect(screen.getByText("2 Spice-infused Fuel Cells")).toBeInTheDocument();
@@ -754,7 +754,7 @@ describe("BasesPanel permissions editing", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Inventory" }));
     // The tab opens on the container cards, not the item rollup.
     expect(await screen.findByText("Vault")).toBeInTheDocument();
-    expect(document.querySelectorAll(".bases-inventory-cards .bases-generator-group")).toHaveLength(1);
+    expect(document.querySelectorAll(".bases-inventory-cards .bases-card")).toHaveLength(1);
     await waitFor(() => expect(basesApi.inventory).toHaveBeenCalledWith("1006"));
   });
 

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { basesApi, type AutoRefillBase } from "../../api/bases";
 import { mapsApi } from "../../api/maps";
 import { BasesPanel } from "./BasesPanel";
+import { invalidateInstanceNames } from "../maps/instanceNames";
 
 vi.mock("../../api/bases", () => ({
   basesApi: {
@@ -67,6 +68,10 @@ const commonRow = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Instance names are cached at module scope so remounting the panel does not
+  // respawn the CLI. That cache outlives a single test, so a case asserting a
+  // cold lookup would otherwise read the previous case's resolved names.
+  invalidateInstanceNames();
 });
 
 describe("BasesPanel generator details", () => {

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -5,6 +5,8 @@ import { BasePermissionsTab } from "./BasePermissionsTab";
 import { BaseWaterTab } from "./BaseWaterTab";
 import { basesApi, type AutoRefillBase, type AutoRefillWaterBase, type RefillDeviceResult, type RefillWaterDeviceResult } from "../../api/bases";
 import { mapsApi } from "../../api/maps";
+import { friendlyMapName } from "../maps/mapNames";
+import { parseSietchRows } from "../maps/sietchRows";
 import { InfoTooltip } from "../../components/common/DisplayPrimitives";
 import { serverApi } from "../../api/server";
 import { setupApi, type Task } from "../../api/setup";
@@ -261,7 +263,23 @@ function withCoordinates(row: Record<string, unknown>): BaseRow {
 // Columns narrow enough to ellipsize; a title keeps the full value readable.
 const TOOLTIP_COLUMNS = new Set(["base_type", "owner_name", "coordinates"]);
 
-function renderBaseCell(row: Record<string, unknown>, column: string) {
+function renderBaseCell(row: Record<string, unknown>, column: string, instanceNames?: Map<string, string>) {
+  if (column === "map") {
+    const mapId = String(row.map || "");
+    if (!mapId) return <span className="muted">—</span>;
+    const partitionId = String(row.partition_id || "");
+    // The instance name if it has arrived, otherwise the partition number.
+    // Something identifying always renders, because two instances of one map
+    // are otherwise indistinguishable in this column.
+    const instance = (partitionId && instanceNames?.get(partitionId))
+      || (partitionId ? `Partition ${partitionId}` : "");
+    return (
+      <span className="bases-map-cell">
+        <span className="bases-map-name" title={mapId}>{friendlyMapName(mapId)}</span>
+        {instance && <span className="bases-map-instance" title={`Partition ${partitionId}`}>{instance}</span>}
+      </span>
+    );
+  }
   if (column === "name") {
     const name = String(row.name || "");
     return name ? <span className="bases-name" title={name}>{name}</span> : "—";
@@ -324,6 +342,11 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
   const [sortColumn, setSortColumn] = useState(() => basesCache?.sortColumn ?? "name");
   const [sortDirection, setSortDirection] = useState<SortDirection>(() => basesCache?.sortDirection ?? "asc");
   const [rows, setRows] = useState<BaseRow[]>(() => basesCache?.rows ?? []);
+  // partition id -> operator-chosen instance name ("Deep Desert PvE", "Sietch
+  // Abbir"). Loaded after the table renders, never blocking it: the names come
+  // from a CLI-backed endpoint, and the partition number alone already
+  // distinguishes instances if that call is slow or fails outright.
+  const [instanceNames, setInstanceNames] = useState<Map<string, string>>(new Map());
   const [totalCount, setTotalCount] = useState(() => basesCache?.totalCount ?? 0);
   const [totalBases, setTotalBases] = useState(() => basesCache?.totalBases ?? 0);
   const [totalPieces, setTotalPieces] = useState(() => basesCache?.totalPieces ?? 0);
@@ -474,6 +497,39 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
   }, [submittedQ, page, pageSize, sortColumn, sortDirection, load]);
+
+  // Upgrade "Partition 59" to "Deep Desert PvE" once the names arrive. One
+  // request pair per distinct partition map on the page (the dimension table
+  // plus its partition ids, which pair up by row order), fired after the table
+  // is already on screen. Failures are swallowed on purpose -- these endpoints
+  // shell out to the runtime CLI and are absent on a console-only install, and
+  // a missing instance name must never take the base list down with it.
+  const partitionMapsKey = [...new Set(rows
+    .map((row) => String(row.partitionMap || "").trim())
+    .filter(Boolean))].sort().join(",");
+  useEffect(() => {
+    const maps = partitionMapsKey ? partitionMapsKey.split(",") : [];
+    if (!maps.length) return undefined;
+    let cancelled = false;
+    void (async () => {
+      const resolved = new Map<string, string>();
+      await Promise.all(maps.map(async (map) => {
+        try {
+          const [table, ids] = await Promise.all([
+            mapsApi.sietchDimensions(map, false),
+            mapsApi.sietchDimensions(map, true)
+          ]);
+          for (const row of parseSietchRows(table.stdout || "", ids.stdout || "")) {
+            if (row.displayName) resolved.set(row.partitionId, row.displayName);
+          }
+        } catch {
+          // Leave this map on the partition-number fallback.
+        }
+      }));
+      if (!cancelled && resolved.size) setInstanceNames(resolved);
+    })();
+    return () => { cancelled = true; };
+  }, [partitionMapsKey]);
 
   // A background flush drains the queue whenever a map goes down, which can
   // happen without anyone touching this panel. When the count drops, the fuel
@@ -1130,7 +1186,7 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
         wrapClassName="bases-table-wrap"
         headerTitles
         actionClassName="actions-column bases-actions-column"
-        renderCell={renderBaseCell}
+        renderCell={(row, column) => renderBaseCell(row, column, instanceNames)}
         action={(row) => {
           const base = row as BaseRow;
           const id = String(base.base_id);

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -268,10 +268,13 @@ function renderBaseCell(row: Record<string, unknown>, column: string, instanceNa
     const mapId = String(row.map || "");
     if (!mapId) return <span className="muted">—</span>;
     const partitionId = String(row.partition_id || "");
+    // Looked up under the same map-scoped key the effect writes: a bare
+    // partition number is only unique once the map it belongs to is fixed.
+    const partitionMap = String(row.partitionMap || "").trim();
     // The instance name if it has arrived, otherwise the partition number.
     // Something identifying always renders, because two instances of one map
     // are otherwise indistinguishable in this column.
-    const instance = (partitionId && instanceNames?.get(partitionId))
+    const instance = (partitionId && partitionMap && instanceNames?.get(`${partitionMap}:${partitionId}`))
       || (partitionId ? `Partition ${partitionId}` : "");
     return (
       <span className="bases-map-cell">
@@ -519,8 +522,18 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
             mapsApi.sietchDimensions(map, false),
             mapsApi.sietchDimensions(map, true)
           ]);
+          // A non-zero exit still answers 200 with empty stdout, so a failed
+          // command is indistinguishable from a map with no sietches unless
+          // the code is checked. Treat it as unreadable and keep the fallback.
+          if (table.exitCode || ids.exitCode) return;
           for (const row of parseSietchRows(table.stdout || "", ids.stdout || "")) {
-            if (row.displayName) resolved.set(row.partitionId, row.displayName);
+            // Keyed by map as well as id, and only for ids that really came
+            // from the --ids output: a row that fell back to its dimension
+            // index would otherwise answer for another map's partition of the
+            // same number and label that base with this map's instance name.
+            if (row.displayName && row.partitionIdFromIds) {
+              resolved.set(`${map}:${row.partitionId}`, row.displayName);
+            }
           }
         } catch {
           // Leave this map on the partition-number fallback.

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronUp, Download, Droplet, Fuel, Users, X, Zap } from "lucide-react";
+import { Boxes, ChevronDown, ChevronUp, Download, Droplet, Fuel, Users, X, Zap } from "lucide-react";
+import { BaseInventoryTab } from "./BaseInventoryTab";
 import { BasePermissionsTab } from "./BasePermissionsTab";
 import { BaseWaterTab } from "./BaseWaterTab";
 import { basesApi, type AutoRefillBase, type AutoRefillWaterBase, type RefillDeviceResult, type RefillWaterDeviceResult } from "../../api/bases";
@@ -341,7 +342,7 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
   const [canQueueWater, setCanQueueWater] = useState(false);
   // Which tab the expanded row is showing. Power is the default so expanding a
   // row behaves exactly as it did before this feature existed.
-  const [expandedTab, setExpandedTab] = useState<"power" | "water" | "permissions">("power");
+  const [expandedTab, setExpandedTab] = useState<"power" | "water" | "inventory" | "permissions">("power");
   const [cancelingId, setCancelingId] = useState("");
   const [cancelingWaterId, setCancelingWaterId] = useState("");
   const [refillingWaterId, setRefillingWaterId] = useState("");
@@ -1350,6 +1351,14 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
                   className={`bases-expanded-tab${expandedTab === "water" ? " active" : ""}`}
                   onClick={() => setExpandedTab("water")}
                 ><Droplet size={15} aria-hidden="true" />Water</button>
+                <button
+                  role="tab"
+                  id={`bases-tab-inventory-${id}`}
+                  aria-selected={expandedTab === "inventory"}
+                  aria-controls={`bases-panel-inventory-${id}`}
+                  className={`bases-expanded-tab${expandedTab === "inventory" ? " active" : ""}`}
+                  onClick={() => setExpandedTab("inventory")}
+                ><Boxes size={15} aria-hidden="true" />Inventory</button>
                 {canEditPermissions && <button
                   role="tab"
                   id={`bases-tab-permissions-${id}`}
@@ -1386,6 +1395,10 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
                         onRetry: () => { void refreshAutoRefillWater(); }
                       }}
                     />
+                  </div>
+                : expandedTab === "inventory"
+                ? <div role="tabpanel" id={`bases-panel-inventory-${id}`} aria-labelledby={`bases-tab-inventory-${id}`}>
+                    <BaseInventoryTab baseId={id} />
                   </div>
                 : <div role="tabpanel" id={`bases-panel-permissions-${id}`} aria-labelledby={`bases-tab-permissions-${id}`}>
                     <BasePermissionsTab

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -4,9 +4,9 @@ import { BaseInventoryTab } from "./BaseInventoryTab";
 import { BasePermissionsTab } from "./BasePermissionsTab";
 import { BaseWaterTab } from "./BaseWaterTab";
 import { basesApi, type AutoRefillBase, type AutoRefillWaterBase, type RefillDeviceResult, type RefillWaterDeviceResult } from "../../api/bases";
-import { mapsApi } from "../../api/maps";
 import { friendlyMapName } from "../maps/mapNames";
-import { parseSietchRows } from "../maps/sietchRows";
+import { mapsApi } from "../../api/maps";
+import { cachedInstanceNames, resolveInstanceNames } from "../maps/instanceNames";
 import { InfoTooltip } from "../../components/common/DisplayPrimitives";
 import { serverApi } from "../../api/server";
 import { setupApi, type Task } from "../../api/setup";
@@ -350,6 +350,9 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
   // from a CLI-backed endpoint, and the partition number alone already
   // distinguishes instances if that call is slow or fails outright.
   const [instanceNames, setInstanceNames] = useState<Map<string, string>>(new Map());
+  // Bumped by the same refresh cycle that reloads the rows, so a stale TTL is
+  // re-checked on the panel's own schedule rather than only on remount.
+  const [instanceNamesTick, setInstanceNamesTick] = useState(0);
   const [totalCount, setTotalCount] = useState(() => basesCache?.totalCount ?? 0);
   const [totalBases, setTotalBases] = useState(() => basesCache?.totalBases ?? 0);
   const [totalPieces, setTotalPieces] = useState(() => basesCache?.totalPieces ?? 0);
@@ -450,6 +453,11 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
         totalPlaceables: result.totalPlaceables || 0,
         lastFetchedAt: Date.now()
       };
+      // Re-run the instance-name effect on the same cycle. Its own dependency
+      // (the set of partition maps) does not change when a sietch is renamed
+      // elsewhere, so without this the TTL would only ever be re-checked on a
+      // remount.
+      setInstanceNamesTick((tick) => tick + 1);
     } catch (error) {
       if (requestIdRef.current === requestId && !options.silent) onError(errorText(error));
     } finally {
@@ -513,36 +521,17 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
   useEffect(() => {
     const maps = partitionMapsKey ? partitionMapsKey.split(",") : [];
     if (!maps.length) return undefined;
+    const cached = cachedInstanceNames(maps);
+    if (cached) {
+      setInstanceNames(cached);
+      return undefined;
+    }
     let cancelled = false;
-    void (async () => {
-      const resolved = new Map<string, string>();
-      await Promise.all(maps.map(async (map) => {
-        try {
-          const [table, ids] = await Promise.all([
-            mapsApi.sietchDimensions(map, false),
-            mapsApi.sietchDimensions(map, true)
-          ]);
-          // A non-zero exit still answers 200 with empty stdout, so a failed
-          // command is indistinguishable from a map with no sietches unless
-          // the code is checked. Treat it as unreadable and keep the fallback.
-          if (table.exitCode || ids.exitCode) return;
-          for (const row of parseSietchRows(table.stdout || "", ids.stdout || "")) {
-            // Keyed by map as well as id, and only for ids that really came
-            // from the --ids output: a row that fell back to its dimension
-            // index would otherwise answer for another map's partition of the
-            // same number and label that base with this map's instance name.
-            if (row.displayName && row.partitionIdFromIds) {
-              resolved.set(`${map}:${row.partitionId}`, row.displayName);
-            }
-          }
-        } catch {
-          // Leave this map on the partition-number fallback.
-        }
-      }));
-      if (!cancelled && resolved.size) setInstanceNames(resolved);
-    })();
+    void resolveInstanceNames(maps).then((resolved) => {
+      if (!cancelled && resolved) setInstanceNames(resolved);
+    });
     return () => { cancelled = true; };
-  }, [partitionMapsKey]);
+  }, [partitionMapsKey, instanceNamesTick]);
 
   // A background flush drains the queue whenever a map goes down, which can
   // happen without anyone touching this panel. When the count drops, the fuel

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1253,7 +1253,7 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
             + (autoRefillEntry && !lastChecked ? " Not checked yet." : "")
             + (autoRefillUnavailable ? " Last known state — the latest read failed." : "");
           return (
-            <div className="bases-generator-breakdown">
+            <div className="bases-tab-body">
               {/* Hidden entirely without the queue capability: automating a
                   refill that cannot wait for a safe window would write into a
                   possibly-live base, which is the hazard the queue prevents. */}
@@ -1292,11 +1292,11 @@ export function BasesPanel({ onError, confirmAction, formatMutationResult }: Bas
               <p className="bases-generator-reserve-note" role="note">
                 {QUEUED_RESERVE_EXPLANATION}
               </p>
-              <div className="bases-generator-cards">
+              <div className="bases-card-grid">
               {generators.map((generator, index) => (
-                <div className="bases-generator-group" key={`${generator.type}-${index}`}>
-                  <div className="bases-generator-group-title">{generator.name}</div>
-                  <dl className="bases-generator-stats">
+                <div className="bases-card" key={`${generator.type}-${index}`}>
+                  <div className="bases-card-title">{generator.name}</div>
+                  <dl className="bases-card-stats">
                     <dt>Generators</dt>
                     <dd>{generator.generatorCount.toLocaleString()}</dd>
                     <dt>Fuel Queued</dt>

--- a/console/web/src/features/maps/MapsPanel.sietchDrafts.test.tsx
+++ b/console/web/src/features/maps/MapsPanel.sietchDrafts.test.tsx
@@ -1,0 +1,174 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mapsApi } from "../../api/maps";
+import { MapsPanel } from "./MapsPanel";
+import { invalidateInstanceNames } from "./instanceNames";
+
+// The first full MapsPanel mount in the suite. It exists because the bug it
+// covers is invisible from the pure helpers: sietchWriteGuard.test.ts asserted
+// the fallback draft survived and passed, while the panel was discarding it in
+// loadSietches' post-save refresh.
+
+// Auto-stubs every mapsApi method on first access. The default has to resolve
+// something shaped permissively: the panel's mount fans out to a dozen
+// endpoints with different response shapes (command output, {rows},
+// {placements}), and a method returning undefined takes the whole render down.
+vi.mock("../../api/maps", () => ({
+  mapsApi: new Proxy({} as Record<string, unknown>, {
+    get: (target, prop: string) => {
+      if (!target[prop]) {
+        target[prop] = vi.fn().mockResolvedValue({
+          stdout: "", exitCode: 0,
+          rows: [], placements: [], tradeCenters: [], partitions: [], fields: [],
+          // The settings schema is read as `schema ? schema.partition : ...`, so
+          // a truthy object without these throws during render rather than
+          // falling back.
+          partition: [], game: [], engine: [], global: [],
+          capabilities: {}, values: {}, sampledAt: ""
+        });
+      }
+      return target[prop];
+    }
+  })
+}));
+vi.mock("../../api/setup", () => ({ setupApi: new Proxy({} as Record<string, unknown>, {
+  get: (target, prop: string) => {
+    if (!target[prop]) target[prop] = vi.fn().mockResolvedValue({});
+    return target[prop];
+  }
+}) }));
+vi.mock("../../lib/usePendingRefills", () => ({
+  usePendingRefills: () => ({ pending: null, refresh: () => {} }),
+  pendingRefillCountForMap: () => 0,
+  pendingRefillCountForPartition: () => 0
+}));
+
+// Real `dune sietches dimensions Survival_1` output. The --ids output is one
+// line short, so dimension 2 falls back to its dimension index and becomes an
+// unwritable row -- the case the write guard refuses and this test protects.
+const TABLE = [
+  "DIMENSION  DISPLAY NAME                     PASSWORD",
+  "0          Hagga Basin                      (unset)",
+  "1          Sietch Abbir                     (set)",
+  "2          The Kulon Show                   (unset)"
+].join("\n");
+const PARTIAL_IDS = "1\n31\n";
+
+const MAPS_JSON = JSON.stringify({
+  maps: [{ map: "Survival_1", status: "Ready", mode: "Core Map", memory: "12 GB", partitionId: "" }]
+});
+
+function stubMapsApi() {
+  const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+  // Only the endpoints this test actually depends on; everything else keeps the
+  // permissive auto-stub above.
+  api.status.mockResolvedValue({
+    maps: { stdout: MAPS_JSON },
+    services: { stdout: "" },
+    readiness: { stdout: "" }
+  });
+  api.sietchDimensions.mockImplementation((_map?: string, ids?: boolean) =>
+    Promise.resolve({ stdout: ids ? PARTIAL_IDS : TABLE, exitCode: 0 }));
+  api.updateSietches.mockResolvedValue({ task: { id: "task-1", status: "succeeded" } });
+  return api;
+}
+
+function renderMapsPanel() {
+  const props = {
+    onError: vi.fn(),
+    confirmAction: vi.fn().mockResolvedValue(true),
+    confirmSettingsRestart: vi.fn().mockResolvedValue(true),
+    // A prop, so no task polling is needed -- the sequence settles at once.
+    waitForTaskWithUpdates: vi.fn().mockImplementation((task: { id: string }) =>
+      Promise.resolve({ ...task, status: "succeeded" })),
+    taskTechnicalDetails: vi.fn().mockReturnValue("")
+  };
+  render(<MapsPanel {...props} />);
+  return props;
+}
+
+// Each sietch renders a child row; its Edit button opens the inline panel that
+// holds that row's Name input and Save button.
+function sietchRow(partitionId: string) {
+  const meta = [...document.querySelectorAll(".sietch-child-meta")]
+    .find((node) => node.textContent?.startsWith(`Partition ${partitionId} /`));
+  return meta?.closest("tr") as HTMLElement;
+}
+
+async function openSietch(partitionId: string) {
+  const row = await waitFor(() => {
+    const found = sietchRow(partitionId);
+    expect(found).toBeTruthy();
+    return found;
+  });
+  fireEvent.click(within(row).getByRole("button", { name: "Edit" }));
+}
+
+function nameInput() {
+  const label = [...document.querySelectorAll(".inline-edit-panel label")]
+    .find((node) => node.textContent?.startsWith("Name"));
+  return label?.querySelector("input") as HTMLInputElement;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invalidateInstanceNames();
+});
+
+describe("MapsPanel sietch drafts", () => {
+  it("keeps a fallback row's pending edit when another sietch is saved", async () => {
+    const api = stubMapsApi();
+    renderMapsPanel();
+
+    // Partition "2" fell back to its dimension index, so the guard will refuse
+    // to write it. Leave an edit pending on it.
+    await openSietch("2");
+    fireEvent.change(nameInput(), { target: { value: "Renamed Fallback" } });
+    expect(nameInput().value).toBe("Renamed Fallback");
+
+    // Now edit and save the verified row. Opening it closes the panel above,
+    // but the draft lives in panel state, not in the panel body.
+    await openSietch("31");
+    fireEvent.change(nameInput(), { target: { value: "Renamed Verified" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Sietch Settings" }));
+
+    await waitFor(() => expect(api.updateSietches).toHaveBeenCalled());
+
+    // Only the verified partition is written -- never the fallback one, whose
+    // id would land on whatever partition happens to share that number.
+    const written = api.updateSietches.mock.calls.map(([body]) => body.partitionId);
+    expect(written).toEqual(["31"]);
+    expect(written).not.toContain("2");
+
+    // The refresh at the end of the save reloads every row. The fallback edit
+    // must still be pending afterwards, because nothing else will tell the
+    // operator it was dropped.
+    await waitFor(() => expect(api.sietchDimensions.mock.calls.length).toBeGreaterThan(2));
+    await openSietch("2");
+    await waitFor(() => expect(nameInput().value).toBe("Renamed Fallback"));
+  });
+
+  it("keeps every pending edit when the save fails", async () => {
+    const api = stubMapsApi();
+    const props = renderMapsPanel();
+    // The sequence runs the action, then reports the task as failed.
+    props.waitForTaskWithUpdates.mockImplementation((task: { id: string }) =>
+      Promise.resolve({ ...task, status: "failed", errorMessage: "boom" }));
+
+    await openSietch("2");
+    fireEvent.change(nameInput(), { target: { value: "Renamed Fallback" } });
+
+    await openSietch("31");
+    fireEvent.change(nameInput(), { target: { value: "Renamed Verified" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Sietch Settings" }));
+
+    await waitFor(() => expect(api.updateSietches).toHaveBeenCalled());
+    await waitFor(() => expect(api.sietchDimensions.mock.calls.length).toBeGreaterThan(2));
+
+    // A failed save must not take the edits with it -- they are what the
+    // operator needs in order to retry.
+    await waitFor(() => expect(nameInput().value).toBe("Renamed Verified"));
+    await openSietch("2");
+    await waitFor(() => expect(nameInput().value).toBe("Renamed Fallback"));
+  });
+});

--- a/console/web/src/features/maps/MapsPanel.sietchDrafts.test.tsx
+++ b/console/web/src/features/maps/MapsPanel.sietchDrafts.test.tsx
@@ -2,7 +2,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mapsApi } from "../../api/maps";
 import { MapsPanel } from "./MapsPanel";
-import { invalidateInstanceNames } from "./instanceNames";
+import { cachedInstanceNames, invalidateInstanceNames, resolveInstanceNames } from "./instanceNames";
 
 // The first full MapsPanel mount in the suite. It exists because the bug it
 // covers is invisible from the pure helpers: sietchWriteGuard.test.ts asserted
@@ -170,5 +170,27 @@ describe("MapsPanel sietch drafts", () => {
     await waitFor(() => expect(nameInput().value).toBe("Renamed Verified"));
     await openSietch("2");
     await waitFor(() => expect(nameInput().value).toBe("Renamed Fallback"));
+  });
+
+  it("invalidates names again after an accepted sietch write finishes", async () => {
+    stubMapsApi();
+    const props = renderMapsPanel();
+    let finishTask!: () => void;
+    const taskCompletion = new Promise<void>((resolve) => { finishTask = resolve; });
+    props.waitForTaskWithUpdates.mockImplementation(async (task: { id: string }) => {
+      // Simulate the Bases tab resolving the old name after the API accepted
+      // the write but before the background task actually changed it.
+      await resolveInstanceNames(["Survival_1"]);
+      await taskCompletion;
+      return { ...task, status: "succeeded" };
+    });
+
+    await openSietch("31");
+    fireEvent.change(nameInput(), { target: { value: "Renamed Verified" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save Sietch Settings" }));
+
+    await waitFor(() => expect(cachedInstanceNames(["Survival_1"])).not.toBeNull());
+    finishTask();
+    await waitFor(() => expect(cachedInstanceNames(["Survival_1"])).toBeNull());
   });
 });

--- a/console/web/src/features/maps/MapsPanel.sietchNames.test.ts
+++ b/console/web/src/features/maps/MapsPanel.sietchNames.test.ts
@@ -10,8 +10,8 @@ describe("Sietch display names", () => {
     ].join("\n");
 
     expect(parseSietchRows(output, "1\n31\n")).toEqual([
-      { partitionId: "1", dimension: "0", displayName: "Awesome Map", password: "", passwordSet: true, active: true },
-      { partitionId: "31", dimension: "1", displayName: "The Kulon Show", password: "", passwordSet: false, active: true },
+      { partitionId: "1", partitionIdFromIds: true, dimension: "0", displayName: "Awesome Map", password: "", passwordSet: true, active: true },
+      { partitionId: "31", partitionIdFromIds: true, dimension: "1", displayName: "The Kulon Show", password: "", passwordSet: false, active: true },
     ]);
   });
 

--- a/console/web/src/features/maps/MapsPanel.sietchWriteGuard.test.ts
+++ b/console/web/src/features/maps/MapsPanel.sietchWriteGuard.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { blockedSietchEdits, sietchDraftChanges } from "./MapsPanel";
+import { parseSietchRows } from "./sietchRows";
+
+// Real `dune sietches dimensions Survival_1 --active-only` output. The real
+// partitions are 1, 31 and 55 -- deliberately not equal to their dimension
+// indices, which is what makes the fallback dangerous.
+const SURVIVAL_TABLE = [
+  "DIMENSION  DISPLAY NAME                     PASSWORD",
+  "0          Hagga Basin                      (unset)",
+  "1          Sietch Abbir                     (set)",
+  "2          The Kulon Show                   (unset)"
+].join("\n");
+
+const IDS_READ = "1\n31\n55\n";
+// `sietches dimensions --ids` is a separate CLI invocation from the one that
+// prints the table, and the API answers 200 with empty stdout when it fails.
+const IDS_UNREADABLE = "";
+
+function draftsFor(rows: ReturnType<typeof parseSietchRows>, overrides: Record<string, Partial<{ displayName: string; password: string }>> = {}) {
+  return Object.fromEntries(rows.map((row) => [
+    row.partitionId,
+    { displayName: row.displayName, password: row.password, ...overrides[row.partitionId] }
+  ]));
+}
+
+describe("blockedSietchEdits", () => {
+  // Case 1: only the name is dirty. survivalSietchActions skips the row, so
+  // without this the bulk Save built zero actions and returned silently --
+  // the operator saw nothing happen and no reason why.
+  it("reports an edited row whose partition id fell back to a dimension index", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_UNREADABLE);
+    const drafts = draftsFor(rows, { "1": { displayName: "Renamed Sietch" } });
+
+    expect(blockedSietchEdits(rows, drafts, {}).map((row) => row.displayName)).toEqual(["Sietch Abbir"]);
+  });
+
+  // Case 2: the edit sits alongside changes that *are* writable. The bulk Save
+  // must refuse the whole thing rather than apply the writable ones and drop
+  // this row, which would report success while discarding the edit.
+  it("reports the edited row even when other pending changes could be written", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_UNREADABLE);
+    const drafts = draftsFor(rows, {
+      "1": { displayName: "Renamed Sietch" },
+      "2": { displayName: "Also Renamed" }
+    });
+
+    expect(blockedSietchEdits(rows, drafts, {})).toHaveLength(2);
+  });
+
+  // The guard must not over-block: with the ids unreadable but nothing edited,
+  // an active-sietch-count save is still legitimate and must go through.
+  it("reports nothing when the unwritable rows were left alone", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_UNREADABLE);
+
+    expect(blockedSietchEdits(rows, draftsFor(rows), {})).toEqual([]);
+    expect(blockedSietchEdits(rows, {}, {})).toEqual([]);
+  });
+
+  it("reports a touched password as an edit", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_UNREADABLE);
+    const drafts = draftsFor(rows, { "2": { password: "new-secret" } });
+
+    // Untouched, the masked/blank draft is not an edit.
+    expect(blockedSietchEdits(rows, drafts, {})).toEqual([]);
+    expect(blockedSietchEdits(rows, drafts, { "2": true }).map((row) => row.displayName)).toEqual(["The Kulon Show"]);
+  });
+
+  it("reports nothing once the partition ids are readable", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_READ);
+    const drafts = draftsFor(rows, { "31": { displayName: "Renamed Sietch" } });
+
+    expect(rows.every((row) => row.partitionIdFromIds)).toBe(true);
+    expect(blockedSietchEdits(rows, drafts, {})).toEqual([]);
+  });
+
+  // saveSelectedMapSettings carries only the primary sietch's fields, so it
+  // asks about that partition alone.
+  it("scopes to one partition when asked", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_UNREADABLE);
+    const drafts = draftsFor(rows, { "1": { displayName: "Renamed Sietch" } });
+
+    expect(blockedSietchEdits(rows, drafts, {}, "1")).toHaveLength(1);
+    expect(blockedSietchEdits(rows, drafts, {}, "0")).toEqual([]);
+  });
+});
+
+describe("sietchDraftChanges", () => {
+  // The action builder and the guard share this, so they cannot disagree about
+  // what counts as an edit.
+  it("falls back to the row's own values when no draft exists", () => {
+    const [row] = parseSietchRows("0          Hagga Basin                      (unset)", "1\n");
+    const changes = sietchDraftChanges(row, {}, {});
+
+    expect(changes.draft).toEqual({ displayName: "Hagga Basin", password: "" });
+    expect(changes.nameChanged).toBe(false);
+    expect(changes.passwordChanged).toBe(false);
+  });
+
+  it("separates a name change from a password change", () => {
+    const [row] = parseSietchRows("0          Hagga Basin                      (unset)", "1\n");
+    const drafts = { "1": { displayName: "Renamed", password: "hunter2" } };
+
+    expect(sietchDraftChanges(row, drafts, {}).nameChanged).toBe(true);
+    expect(sietchDraftChanges(row, drafts, {}).passwordChanged).toBe(false);
+    expect(sietchDraftChanges(row, drafts, { "1": true }).passwordChanged).toBe(true);
+  });
+});

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -17,8 +17,11 @@ import {
   blockedSietchEdits,
   isSietchWriteTarget,
   parseSietchRows,
+  reconcileSietchDrafts,
+  reconcileSietchPasswordTouched,
   sietchDraftChanges,
   sietchPasswordDraftChanged,
+  writableSietchEdits,
   type SietchRow
 } from "./sietchRows";
 
@@ -47,6 +50,11 @@ type MapsTaskSequenceOptions = {
   memoryUpdates?: Array<{ map: string; partitionId?: string; memory: string }>;
   resultScope?: MapsResultScope;
   resultTarget?: string;
+  // Partitions this sequence writes sietch name/password for. The refresh at
+  // the end reloads every row, so without this it replaced every draft --
+  // discarding pending edits on rows the save never touched. Omit it when the
+  // sequence writes no sietch fields at all; then nothing is discarded.
+  writtenPartitionIds?: string[];
 };
 type PersistedMapsTask = { taskId?: string; result: HomeTaskResult | null; runningTitle?: string; successTitle?: string; resultScope?: MapsResultScope };
 type SpicefieldDraft = { maxActive: string; maxPrimed: string; spawningActive: boolean; spawnWeight: string };
@@ -511,7 +519,9 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
             persistMapsTask(null);
             void refreshMapRuntime().catch(() => undefined);
             void loadLiveMemory().catch(() => undefined);
-            void loadSietches().catch(() => undefined);
+            // Handoff means the writes were accepted, so the written rows can
+            // take the server's values -- but only those rows.
+            void loadSietches({ writtenPartitionIds: options.writtenPartitionIds || [] }).catch(() => undefined);
           }
           return;
         }
@@ -544,7 +554,12 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     persistMapsTask(null);
     await loadMaps();
     if (next.status === "succeeded") applyOptimisticMemoryUpdates(options.memoryUpdates);
-    await loadSietches();
+    // This runs after the loop breaks on failure too, so a failed save used to
+    // wipe the drafts along with showing the error. Only a succeeded sequence
+    // may discard anything, and then only the partitions it wrote.
+    await loadSietches({
+      writtenPartitionIds: next.status === "succeeded" ? (options.writtenPartitionIds || []) : []
+    });
   }
   async function loadMaps() {
     if (mapsLoadRef.current) return mapsLoadRef.current;
@@ -629,7 +644,14 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     setRawGame(raw.content || "");
     setRawGameOriginal(raw.content || "");
   }
-  async function loadSietches(options: { preserveDrafts?: boolean } = {}) {
+  // Three draft policies, deliberately distinct:
+  //   preserveDrafts      -- background polling; whatever is on screen wins.
+  //   writtenPartitionIds -- after a save; only the partitions actually written
+  //                          take the server's values, everything else stays
+  //                          pending (see reconcileSietchDrafts).
+  //   neither             -- full reset, for a mount or an explicit refresh
+  //                          where there is nothing pending to protect.
+  async function loadSietches(options: { preserveDrafts?: boolean; writtenPartitionIds?: string[] } = {}) {
     const [list, dimensions, ids] = await Promise.all([mapsApi.sietches(), mapsApi.sietchDimensions("Survival_1"), mapsApi.sietchDimensions("Survival_1", true)]);
     // A non-zero exit still answers 200 with empty stdout, so a failed command
     // is only visible in exitCode. Discard its output rather than parsing
@@ -647,6 +669,13 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       }
       if (options.preserveDrafts) {
         setSietchDrafts((current) => ({ ...drafts, ...current }));
+      } else if (options.writtenPartitionIds) {
+        // Functional updates on purpose: a save is long enough for the operator
+        // to type into another row while it runs, and the closure this ran from
+        // would not see that edit.
+        const written = options.writtenPartitionIds;
+        setSietchDrafts((current) => reconcileSietchDrafts(rows, current, written));
+        setSietchPasswordTouched((current) => reconcileSietchPasswordTouched(current, written));
       } else {
         setSietchDrafts(drafts);
         setSietchPasswordTouched({});
@@ -901,6 +930,7 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     run(loadMemoryBalancer);
     run(() => loadMemorySwap());
     run(loadRuntimeSettings);
+    // Full reset is right here: this is the mount, so there is nothing pending.
     run(loadSietches);
     run(loadSpicefields);
     void loadCombatState("DeepDesert_1").catch(() => {});
@@ -940,6 +970,9 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       setMapsResult(next);
       persistMapsTask(null);
       await loadMaps();
+      // A task resumed from a previous mount: the persisted record carries no
+      // written-partition set, so there is nothing to reconcile against and a
+      // full reset is the only honest option.
       await loadSietches();
     })().catch((error) => {
       if (isMissingPersistedTaskError(error)) {
@@ -1300,7 +1333,13 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
         {
           saveAcceptedMessage: successMessage,
           memoryUpdates: memoryChanged ? [{ map: rowName, memory: memoryCliValue(memory) }] : [],
-          resultTarget: mapResultTarget(rowName)
+          resultTarget: mapResultTarget(rowName),
+          // This form only carries the primary sietch's fields, so that is the
+          // only partition whose draft the refresh may replace.
+          writtenPartitionIds: rowName === "Survival_1" && primarySurvivalSietch
+            ? writableSietchEdits(survivalSietchRows, sietchDrafts, sietchPasswordTouched, primarySurvivalSietch.partitionId)
+              .map((sietch) => sietch.partitionId)
+            : []
         }
       );
     }
@@ -1325,9 +1364,9 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       };
     }
     if (includePartitions) {
-      for (const sietch of survivalSietchRows) {
-        if (!isSietchWriteTarget(sietch)) continue;
-        if (partitionId && sietch.partitionId !== partitionId) continue;
+      // The same helper the post-save refresh uses to decide which drafts it
+      // may discard, so the two can never disagree about what was written.
+      for (const sietch of writableSietchEdits(survivalSietchRows, sietchDrafts, sietchPasswordTouched, partitionId)) {
         const { draft, nameChanged, passwordChanged } = sietchDraftChanges(sietch, sietchDrafts, sietchPasswordTouched);
         const targetName = sietchTargetDisplayName(sietch, draft.displayName);
         if (nameChanged && passwordChanged) {
@@ -1397,7 +1436,12 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       await runTaskSequenceAndRefresh(actions, `Saving ${sietchTargetDisplayName(sietch, draft.displayName)} Settings`, "Sietch Saved", {
         saveAcceptedMessage: successMessage,
         memoryUpdates: memoryChanged ? [{ map: "Survival_1", partitionId: sietch.partitionId, memory: memoryCliValue(memory) }] : [],
-        resultTarget: mapResultTarget("Survival_1", sietch.partitionId)
+        resultTarget: mapResultTarget("Survival_1", sietch.partitionId),
+        // Derived from sietchActions' own source, so a pending edit on any
+        // other row -- including a fallback row the guard refused -- survives
+        // this save's refresh.
+        writtenPartitionIds: writableSietchEdits(survivalSietchRows, sietchDrafts, sietchPasswordTouched, sietch.partitionId)
+          .map((row) => row.partitionId)
       });
     }
   }

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -38,6 +38,8 @@ function PendingRefillBadge({ count }: { count: number }) {
 type HomeTaskResult = { status: "running" | "succeeded" | "failed" | "stopped"; title: string; message?: string; details?: string; warnings?: string[] };
 type MapsResultScope = "maps" | "modifiers";
 type MapsTaskQueueState = { phase: "queued" | "running"; title: string };
+type MapsTaskResponse = { task: Task; invalidatesInstanceNamesOnSuccess?: boolean };
+type MapsTaskAction = { label: string; run: () => Promise<MapsTaskResponse> };
 type MapsTaskOptions = {
   memoryUpdates?: Array<{ map: string; partitionId?: string; memory: string }>;
   resultScope?: MapsResultScope;
@@ -290,7 +292,7 @@ function alwaysOnParallelismLimit(settings: MapRuntimeSettings | null, protectio
 function updateSietches(body: Record<string, unknown>) {
   return mapsApi.updateSietches(body).then((result) => {
     invalidateInstanceNames();
-    return result;
+    return { ...result, invalidatesInstanceNamesOnSuccess: true };
   });
 }
 
@@ -472,11 +474,11 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     await loadUserEngine();
     if (userGameMapName) await loadSelectedSettings(userGameMapName, userGamePartitionId);
   }
-  async function runTaskSequenceAndRefresh(actions: Array<{ label: string; run: () => Promise<{ task: Task }> }>, runningTitle = "Applying Map Changes", successTitle = "Map Changes Applied", options: MapsTaskSequenceOptions = {}) {
+  async function runTaskSequenceAndRefresh(actions: MapsTaskAction[], runningTitle = "Applying Map Changes", successTitle = "Map Changes Applied", options: MapsTaskSequenceOptions = {}) {
     if (!actions.length) return;
     await enqueueMapsTask(options.resultTarget || "", runningTitle, () => runTaskSequenceAndRefreshNow(actions, runningTitle, successTitle, options));
   }
-  async function runTaskSequenceAndRefreshNow(actions: Array<{ label: string; run: () => Promise<{ task: Task }> }>, runningTitle: string, successTitle: string, options: MapsTaskSequenceOptions) {
+  async function runTaskSequenceAndRefreshNow(actions: MapsTaskAction[], runningTitle: string, successTitle: string, options: MapsTaskSequenceOptions) {
     const resultScope = options.resultScope || "maps";
     const resultTarget = options.resultTarget || "";
     const savingMessage = "Saving settings.";
@@ -538,6 +540,12 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
         setMapsResult(nextProgress);
         persistMapsTask({ taskId: task.id, result: nextProgress, runningTitle, successTitle, resultScope });
       });
+      if (final.status === "succeeded" && response.invalidatesInstanceNamesOnSuccess) {
+        // The first invalidation happens when the task is accepted so stale
+        // names are not served during the write. Repeat it after completion:
+        // a lookup made while the task was running may have read the old name.
+        invalidateInstanceNames();
+      }
       if (final?.warnings?.length) collectedWarnings.push(...final.warnings);
       if (final.status !== "succeeded") break;
     }
@@ -1291,7 +1299,7 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       return onError(SIETCH_PARTITION_IDS_UNREADABLE);
     }
     const running = mapRuntimeNeedsLiveApply(row.status);
-    const actions: Array<{ label: string; run: () => Promise<{ task: Task }> }> = [];
+    const actions: MapsTaskAction[] = [];
     if (modeChanged || memoryChanged) {
       actions.push({
         label: `Saving ${rowName}${partitionId ? ` partition ${partitionId}` : ""} map settings`,
@@ -1345,8 +1353,8 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     }
   }
   function survivalSietchActions({ includeActive, includePartitions, partitionId }: { includeActive: boolean; includePartitions: boolean; partitionId?: string }) {
-    const actions: Array<{ label: string; run: () => Promise<{ task: Task }> }> = [];
-    let activeAction: { label: string; run: () => Promise<{ task: Task }> } | null = null;
+    const actions: MapsTaskAction[] = [];
+    let activeAction: MapsTaskAction | null = null;
     if (includeActive && activeSietches && activeSietchesDirty) {
       const requestedActive = Number(activeSietches);
       const currentActive = Number(currentActiveSietches) || survivalSietchRows.length;
@@ -1400,7 +1408,7 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     const originalMemory = memoryInputValue(partitionMemoryValue(memoryText, sietch.partitionId, String(parent.memory || "")));
     const memoryChanged = memory !== originalMemory;
     const running = mapRuntimeNeedsLiveApply(parent.status);
-    const actions: Array<{ label: string; run: () => Promise<{ task: Task }> }> = [];
+    const actions: MapsTaskAction[] = [];
     if (memoryChanged) {
       actions.push({
         label: `Saving RAM for ${sietch.displayName}`,

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -1110,11 +1110,6 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
   const activeSietchesDirty = activeSietches !== currentActiveSietches;
   const primarySietchDraft = primarySurvivalSietch ? sietchDrafts[primarySurvivalSietch.partitionId] || { displayName: primarySurvivalSietch.displayName, password: primarySurvivalSietch.password } : null;
   const primarySietchDirty = Boolean(primarySurvivalSietch && primarySietchDraft && (primarySietchDraft.displayName !== primarySurvivalSietch.displayName || sietchPasswordDraftChanged(primarySurvivalSietch, primarySietchDraft, Boolean(sietchPasswordTouched[primarySurvivalSietch.partitionId]))));
-  const sietchesDirty = activeSietchesDirty || partitionOptions.some((sietch) => {
-    const draft = sietchDrafts[sietch.partitionId] || { displayName: sietch.displayName, password: sietch.password };
-    const passwordTouched = Boolean(sietchPasswordTouched[sietch.partitionId]);
-    return draft.displayName !== sietch.displayName || sietchPasswordDraftChanged(sietch, draft, passwordTouched);
-  });
   const rawEngineDirty = normalizeRawIniContent(rawEngine) !== normalizeRawIniContent(rawEngineOriginal);
   const rawGameDirty = normalizeRawIniContent(rawGame) !== normalizeRawIniContent(rawGameOriginal);
   const modifierDirtySummary = [
@@ -1338,24 +1333,6 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     }
     if (activeAction) actions.push(activeAction);
     return actions;
-  }
-  async function saveSurvivalSietches() {
-    // Refuse before building anything: skipping the unwritable rows would let a
-    // dirty active-sietch count save on its own and report the whole thing as
-    // saved, silently dropping the edited names and passwords.
-    if (blockedSietchEdits(survivalSietchRows, sietchDrafts, sietchPasswordTouched).length) {
-      return onError(SIETCH_PARTITION_IDS_UNREADABLE);
-    }
-    const actions = survivalSietchActions({ includeActive: true, includePartitions: true });
-    if (!actions.length) return;
-    if (await confirmAction(`Save ${actions.length} Survival_1 Sietch change${actions.length === 1 ? "" : "s"}?`)) {
-      const activeChanged = Boolean(activeSietches && activeSietchesDirty);
-      await runTaskSequenceAndRefresh(actions, "Saving Sietch Changes", "Sietches Saved", {
-        saveAcceptedMessage: activeChanged
-          ? "Sietch changes saved successfully. The sietch is starting and may take a few minutes to appear in-game after it is running."
-          : "Sietch settings saved successfully. Changes may take a short time to appear in-game."
-      });
-    }
   }
   async function saveSietchSettings(sietch: SietchRow) {
     if (!isSietchWriteTarget(sietch)) return onError(SIETCH_PARTITION_IDS_UNREADABLE);

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -1236,6 +1236,12 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     const activeSietchesDecreased = activeChanged && Number.isFinite(requestedActiveSietches) && requestedActiveSietches < currentActiveCount;
     const primaryChanged = rowName === "Survival_1" && primarySietchDirty;
     if (!modeChanged && !memoryChanged && !activeChanged && !primaryChanged) return;
+    // This save carries the primary sietch's name and password alongside the
+    // map settings, so it refuses on the same terms as the sietch Save.
+    if (rowName === "Survival_1" && primarySurvivalSietch
+      && blockedSietchEdits(survivalSietchRows, sietchDrafts, sietchPasswordTouched, primarySurvivalSietch.partitionId).length) {
+      return onError(SIETCH_PARTITION_IDS_UNREADABLE);
+    }
     const running = mapRuntimeNeedsLiveApply(row.status);
     const actions: Array<{ label: string; run: () => Promise<{ task: Task }> }> = [];
     if (modeChanged || memoryChanged) {
@@ -1307,9 +1313,7 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       for (const sietch of survivalSietchRows) {
         if (!isSietchWriteTarget(sietch)) continue;
         if (partitionId && sietch.partitionId !== partitionId) continue;
-        const draft = sietchDrafts[sietch.partitionId] || { displayName: sietch.displayName, password: sietch.password };
-        const nameChanged = draft.displayName !== sietch.displayName;
-        const passwordChanged = sietchPasswordDraftChanged(sietch, draft, Boolean(sietchPasswordTouched[sietch.partitionId]));
+        const { draft, nameChanged, passwordChanged } = sietchDraftChanges(sietch, sietchDrafts, sietchPasswordTouched);
         const targetName = sietchTargetDisplayName(sietch, draft.displayName);
         if (nameChanged && passwordChanged) {
           actions.push({
@@ -1336,6 +1340,12 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     return actions;
   }
   async function saveSurvivalSietches() {
+    // Refuse before building anything: skipping the unwritable rows would let a
+    // dirty active-sietch count save on its own and report the whole thing as
+    // saved, silently dropping the edited names and passwords.
+    if (blockedSietchEdits(survivalSietchRows, sietchDrafts, sietchPasswordTouched).length) {
+      return onError(SIETCH_PARTITION_IDS_UNREADABLE);
+    }
     const actions = survivalSietchActions({ includeActive: true, includePartitions: true });
     if (!actions.length) return;
     if (await confirmAction(`Save ${actions.length} Survival_1 Sietch change${actions.length === 1 ? "" : "s"}?`)) {
@@ -2203,6 +2213,46 @@ function sietchPasswordDraftChanged(row: SietchRow, draft: { password: string },
   if (!touched) return false;
   if (row.passwordSet) return draft.password !== SIETCH_PASSWORD_MASK;
   return Boolean(draft.password);
+}
+
+// The draft a row is being edited with, plus which of its fields differ from
+// what the server reported. One definition, shared by the code that builds
+// sietch write actions and the code that refuses to build them, so the two can
+// never disagree about what "edited" means.
+export function sietchDraftChanges(
+  row: SietchRow,
+  drafts: Record<string, { displayName: string; password: string }>,
+  passwordTouched: Record<string, boolean> = {}
+) {
+  const draft = drafts[row.partitionId] || { displayName: row.displayName, password: row.password };
+  return {
+    draft,
+    nameChanged: draft.displayName !== row.displayName,
+    passwordChanged: sietchPasswordDraftChanged(row, draft, Boolean(passwordTouched[row.partitionId]))
+  };
+}
+
+// Rows the operator has edited that cannot be written safely, because their
+// partition id fell back to a dimension index (see isSietchWriteTarget).
+//
+// survivalSietchActions skips those rows when building actions. On its own that
+// would make a bulk Save drop the edit without saying so: with nothing else
+// dirty the Save does nothing at all, and with the active-sietch count also
+// dirty that unrelated change still runs and the save reports success while the
+// edited fields are discarded. Callers refuse the whole save instead, matching
+// what the per-sietch Save and Restart already do.
+export function blockedSietchEdits(
+  rows: SietchRow[],
+  drafts: Record<string, { displayName: string; password: string }>,
+  passwordTouched: Record<string, boolean> = {},
+  partitionId?: string
+) {
+  return rows.filter((row) => {
+    if (isSietchWriteTarget(row)) return false;
+    if (partitionId && row.partitionId !== partitionId) return false;
+    const { nameChanged, passwordChanged } = sietchDraftChanges(row, drafts, passwordTouched);
+    return nameChanged || passwordChanged;
+  });
 }
 
 function sietchHasPassword(row: SietchRow | null | undefined, draft?: { password: string }) {

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -9,9 +9,18 @@ import { titleCaseWords } from "../players/playerAdminUtils";
 import { pendingRefillCountForMap, pendingRefillCountForPartition, usePendingRefills } from "../../lib/usePendingRefills";
 import type { PendingRefills } from "../../api/bases";
 import { friendlyMapName, hasFriendlyMapName } from "./mapNames";
+import { invalidateInstanceNames } from "./instanceNames";
 // Re-exported so existing importers (and MapsPanel.sietchNames.test.ts) keep working.
 export { parseSietchRows, type SietchRow } from "./sietchRows";
-import { isSietchWriteTarget, parseSietchRows, type SietchRow } from "./sietchRows";
+import {
+  SIETCH_PASSWORD_MASK,
+  blockedSietchEdits,
+  isSietchWriteTarget,
+  parseSietchRows,
+  sietchDraftChanges,
+  sietchPasswordDraftChanged,
+  type SietchRow
+} from "./sietchRows";
 
 // Taking a partition down is when any generator refill queued for a base on it
 // gets written, so every control that does so says what is waiting on it.
@@ -264,6 +273,17 @@ function alwaysOnParallelismLimit(settings: MapRuntimeSettings | null, protectio
   const reserve = reserveMode === "automatic" ? settings?.automaticHostMemoryReserveGiB || 4 : Number(reserveValue);
   if (!physical || !Number.isFinite(reserve) || reserve < 1 || reserve >= physical) return settings?.maxAlwaysOnStartupParallelism || 1;
   return Math.max(1, Math.min(16, Math.floor((physical - reserve) / 16)));
+}
+
+// Every sietch mutation goes through here so the Bases panel's cached instance
+// names cannot outlive a rename. Routed through one wrapper rather than five
+// call sites because a missed one is invisible until someone notices a stale
+// label on another tab.
+function updateSietches(body: Record<string, unknown>) {
+  return mapsApi.updateSietches(body).then((result) => {
+    invalidateInstanceNames();
+    return result;
+  });
 }
 
 export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, waitForTaskWithUpdates, taskTechnicalDetails }: MapsPanelProps) {
@@ -1294,14 +1314,14 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
       if (requestedActive > survivalSietchRows.length) {
         actions.push({
           label: `Creating ${requestedActive} available sietch dimensions`,
-          run: () => mapsApi.updateSietches({ action: "set-max", map: "Survival_1", count: requestedActive, confirmation: "UPDATE SIETCHES" })
+          run: () => updateSietches({ action: "set-max", map: "Survival_1", count: requestedActive, confirmation: "UPDATE SIETCHES" })
         });
       }
       activeAction = {
         label: requestedActive < currentActive
           ? `Despawning extra sietch${currentActive - requestedActive === 1 ? "" : "es"} and setting active sietches to ${requestedActive}`
           : `Activating ${requestedActive} sietch${requestedActive === 1 ? "" : "es"}`,
-        run: () => mapsApi.updateSietches({ action: "set-active", map: "Survival_1", count: requestedActive, confirmation: "UPDATE SIETCHES" })
+        run: () => updateSietches({ action: "set-active", map: "Survival_1", count: requestedActive, confirmation: "UPDATE SIETCHES" })
       };
     }
     if (includePartitions) {
@@ -1313,20 +1333,20 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
         if (nameChanged && passwordChanged) {
           actions.push({
             label: `Saving settings for ${targetName}`,
-            run: () => mapsApi.updateSietches({ action: "set-settings", partitionId: sietch.partitionId, displayName: draft.displayName, password: draft.password, confirmation: "UPDATE SIETCHES" })
+            run: () => updateSietches({ action: "set-settings", partitionId: sietch.partitionId, displayName: draft.displayName, password: draft.password, confirmation: "UPDATE SIETCHES" })
           });
           continue;
         }
         if (nameChanged) {
           actions.push({
             label: `Saving name for ${targetName}`,
-            run: () => mapsApi.updateSietches({ action: "set-display", partitionId: sietch.partitionId, displayName: draft.displayName, confirmation: "UPDATE SIETCHES" })
+            run: () => updateSietches({ action: "set-display", partitionId: sietch.partitionId, displayName: draft.displayName, confirmation: "UPDATE SIETCHES" })
           });
         }
         if (passwordChanged) {
           actions.push({
             label: `Saving password for ${targetName}`,
-            run: () => mapsApi.updateSietches({ action: "set-password", partitionId: sietch.partitionId, password: draft.password, confirmation: "UPDATE SIETCHES" })
+            run: () => updateSietches({ action: "set-password", partitionId: sietch.partitionId, password: draft.password, confirmation: "UPDATE SIETCHES" })
           });
         }
       }
@@ -2186,52 +2206,6 @@ export function MemoryUsageBar({ row, fallback, configuredLimit, swapEnabled = f
   </div>;
 }
 
-function sietchPasswordDraftChanged(row: SietchRow, draft: { password: string }, touched = false) {
-  if (!touched) return false;
-  if (row.passwordSet) return draft.password !== SIETCH_PASSWORD_MASK;
-  return Boolean(draft.password);
-}
-
-// The draft a row is being edited with, plus which of its fields differ from
-// what the server reported. One definition, shared by the code that builds
-// sietch write actions and the code that refuses to build them, so the two can
-// never disagree about what "edited" means.
-export function sietchDraftChanges(
-  row: SietchRow,
-  drafts: Record<string, { displayName: string; password: string }>,
-  passwordTouched: Record<string, boolean> = {}
-) {
-  const draft = drafts[row.partitionId] || { displayName: row.displayName, password: row.password };
-  return {
-    draft,
-    nameChanged: draft.displayName !== row.displayName,
-    passwordChanged: sietchPasswordDraftChanged(row, draft, Boolean(passwordTouched[row.partitionId]))
-  };
-}
-
-// Rows the operator has edited that cannot be written safely, because their
-// partition id fell back to a dimension index (see isSietchWriteTarget).
-//
-// survivalSietchActions skips those rows when building actions. On its own that
-// would make a bulk Save drop the edit without saying so: with nothing else
-// dirty the Save does nothing at all, and with the active-sietch count also
-// dirty that unrelated change still runs and the save reports success while the
-// edited fields are discarded. Callers refuse the whole save instead, matching
-// what the per-sietch Save and Restart already do.
-export function blockedSietchEdits(
-  rows: SietchRow[],
-  drafts: Record<string, { displayName: string; password: string }>,
-  passwordTouched: Record<string, boolean> = {},
-  partitionId?: string
-) {
-  return rows.filter((row) => {
-    if (isSietchWriteTarget(row)) return false;
-    if (partitionId && row.partitionId !== partitionId) return false;
-    const { nameChanged, passwordChanged } = sietchDraftChanges(row, drafts, passwordTouched);
-    return nameChanged || passwordChanged;
-  });
-}
-
 function sietchHasPassword(row: SietchRow | null | undefined, draft?: { password: string }) {
   return Boolean(row?.passwordSet || row?.password || (draft?.password && draft.password !== SIETCH_PASSWORD_MASK));
 }
@@ -2429,7 +2403,6 @@ export function valuesForDirtyFields(original: Record<string, string>, draft: Re
     .map((field) => [field.id, String(draft[field.id] ?? field.default ?? "")]));
 }
 
-const SIETCH_PASSWORD_MASK = "********";
 
 // Shown instead of writing when isSietchWriteTarget rejects a row, so a
 // refused Restart or Save says why rather than appearing to do nothing.

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -9,6 +9,9 @@ import { titleCaseWords } from "../players/playerAdminUtils";
 import { pendingRefillCountForMap, pendingRefillCountForPartition, usePendingRefills } from "../../lib/usePendingRefills";
 import type { PendingRefills } from "../../api/bases";
 import { friendlyMapName, hasFriendlyMapName } from "./mapNames";
+// Re-exported so existing importers (and MapsPanel.sietchNames.test.ts) keep working.
+export { parseSietchRows, type SietchRow } from "./sietchRows";
+import { parseSietchRows, type SietchRow } from "./sietchRows";
 
 // Taking a partition down is when any generator refill queued for a base on it
 // gets written, so every control that does so says what is waiting on it.
@@ -2391,41 +2394,7 @@ export function valuesForDirtyFields(original: Record<string, string>, draft: Re
     .map((field) => [field.id, String(draft[field.id] ?? field.default ?? "")]));
 }
 
-type SietchRow = { partitionId: string; dimension: string; displayName: string; password: string; passwordSet: boolean; active: boolean };
 const SIETCH_PASSWORD_MASK = "********";
-
-export function parseSietchRows(text: string, idsText = ""): SietchRow[] {
-  const rows: SietchRow[] = [];
-  const ids = idsText.split(/\r?\n/).map((line) => line.trim()).filter((line) => /^\d+$/.test(line));
-  let dimensionIndex = 0;
-  for (const line of text.split(/\r?\n/)) {
-    if (/^\s*DIMENSION\b/i.test(line)) continue;
-    const tableMatch = line.match(/^\s*(\d+)\s+(.+?)\s+(\((?:un)?set\))\s*$/i);
-    if (tableMatch) {
-      const dimension = tableMatch[1];
-      const partitionId = ids[dimensionIndex] || dimension;
-      const displayName = tableMatch[2].trim();
-      const passwordSet = /^\(set\)$/i.test(tableMatch[3]);
-      rows.push({ partitionId, dimension, displayName, password: "", passwordSet, active: true });
-      dimensionIndex += 1;
-      continue;
-    }
-    const partitionMatch = line.match(/\b(?:partition|id)\s*[:=]?\s*(\d+)\b/i) || line.match(/^\s*(\d+)\s+/);
-    if (!partitionMatch) continue;
-    const dimension = partitionMatch[1];
-    const partitionId = ids[dimensionIndex] || partitionMatch[1];
-    const displayName = (line.match(/\b(?:display|name)\s*[:=]\s*([^|,\t]+)/i)?.[1] || line.match(/\bSietch\s+([A-Za-z0-9 _-]+)/i)?.[0] || `Sietch ${partitionId}`).trim();
-    const passwordValue = (line.match(/\bpassword\s*[:=]\s*([^|,\t]+)/i)?.[1] || line.match(/\((?:un)?set\)\s*$/i)?.[0] || "").trim();
-    const passwordSet = /\(set\)|\bset\b|true|yes/i.test(passwordValue) || /\(set\)\s*$/i.test(line);
-    const password = /\(set\)|\(unset\)|\bset\b|\bunset\b/i.test(passwordValue) ? "" : passwordValue;
-    const active = !/\binactive|disabled|stopped\b/i.test(line);
-    rows.push({ partitionId, dimension, displayName, password, passwordSet: passwordSet || Boolean(password), active });
-    dimensionIndex += 1;
-  }
-  const unique = new globalThis.Map<string, SietchRow>();
-  for (const row of rows) unique.set(row.partitionId, row);
-  return [...unique.values()].sort((a, b) => Number(a.dimension) - Number(b.dimension));
-}
 
 function memoryForMap(rows: LiveMapMemoryRow[], map: string, row?: Record<string, unknown>) {
   const normalized = normalizeMapKey(map);

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -11,7 +11,7 @@ import type { PendingRefills } from "../../api/bases";
 import { friendlyMapName, hasFriendlyMapName } from "./mapNames";
 // Re-exported so existing importers (and MapsPanel.sietchNames.test.ts) keep working.
 export { parseSietchRows, type SietchRow } from "./sietchRows";
-import { parseSietchRows, type SietchRow } from "./sietchRows";
+import { isSietchWriteTarget, parseSietchRows, type SietchRow } from "./sietchRows";
 
 // Taking a partition down is when any generator refill queued for a base on it
 // gets written, so every control that does so says what is waiting on it.
@@ -611,10 +611,15 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
   }
   async function loadSietches(options: { preserveDrafts?: boolean } = {}) {
     const [list, dimensions, ids] = await Promise.all([mapsApi.sietches(), mapsApi.sietchDimensions("Survival_1"), mapsApi.sietchDimensions("Survival_1", true)]);
+    // A non-zero exit still answers 200 with empty stdout, so a failed command
+    // is only visible in exitCode. Discard its output rather than parsing
+    // whatever it managed to print.
+    const dimensionsText = dimensions.exitCode ? "" : (dimensions.stdout || "");
+    const idsText = ids.exitCode ? "" : (ids.stdout || "");
     setSietchesText(list.stdout || "");
-    setSietchDimensionsText(dimensions.stdout || "");
-    setSietchDimensionIdsText(ids.stdout || "");
-    const rows = parseSietchRows(dimensions.stdout || list.stdout || "", ids.stdout || "");
+    setSietchDimensionsText(dimensionsText);
+    setSietchDimensionIdsText(idsText);
+    const rows = parseSietchRows(dimensionsText || list.stdout || "", idsText);
     const drafts = Object.fromEntries(rows.map((row) => [row.partitionId, { displayName: row.displayName, password: row.password }]));
     if (rows.length) {
       if (!options.preserveDrafts) {
@@ -1300,6 +1305,7 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     }
     if (includePartitions) {
       for (const sietch of survivalSietchRows) {
+        if (!isSietchWriteTarget(sietch)) continue;
         if (partitionId && sietch.partitionId !== partitionId) continue;
         const draft = sietchDrafts[sietch.partitionId] || { displayName: sietch.displayName, password: sietch.password };
         const nameChanged = draft.displayName !== sietch.displayName;
@@ -1342,6 +1348,7 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
     }
   }
   async function saveSietchSettings(sietch: SietchRow) {
+    if (!isSietchWriteTarget(sietch)) return onError(SIETCH_PARTITION_IDS_UNREADABLE);
     const parent = mapRows.find((row) => String(row.map || "") === "Survival_1") || {};
     const draft = sietchDrafts[sietch.partitionId] || { displayName: sietch.displayName, password: sietch.password };
     const originalMemory = memoryInputValue(partitionMemoryValue(memoryText, sietch.partitionId, String(parent.memory || "")));
@@ -1389,6 +1396,7 @@ export function MapsPanel({ onError, confirmAction, confirmSettingsRestart, wait
   }
   async function restartSietch(sietch: SietchRow, resultTarget: string) {
     if (!sietch.active) return;
+    if (!isSietchWriteTarget(sietch)) return onError(SIETCH_PARTITION_IDS_UNREADABLE);
     const label = sietch.displayName || `Partition ${sietch.partitionId}`;
     if (!(await confirmAction(`Restart ${label}?`, {
       title: "Restart Sietch",
@@ -2395,6 +2403,11 @@ export function valuesForDirtyFields(original: Record<string, string>, draft: Re
 }
 
 const SIETCH_PASSWORD_MASK = "********";
+
+// Shown instead of writing when isSietchWriteTarget rejects a row, so a
+// refused Restart or Save says why rather than appearing to do nothing.
+const SIETCH_PARTITION_IDS_UNREADABLE =
+  "Sietch partition IDs could not be read from the server, so this change cannot be applied to the right Sietch. Reload the Maps tab and try again.";
 
 function memoryForMap(rows: LiveMapMemoryRow[], map: string, row?: Record<string, unknown>) {
   const normalized = normalizeMapKey(map);

--- a/console/web/src/features/maps/instanceNames.test.ts
+++ b/console/web/src/features/maps/instanceNames.test.ts
@@ -51,6 +51,24 @@ describe("instance names", () => {
     expect(cachedInstanceNames(["DeepDesert_1"])).toBeNull();
   });
 
+  it("does not restore a lookup invalidated while its requests are in flight", async () => {
+    let resolveTable!: (value: { stdout: string; exitCode: number }) => void;
+    let resolveIds!: (value: { stdout: string; exitCode: number }) => void;
+    vi.mocked(mapsApi.sietchDimensions).mockImplementation((_map?: string, wantIds?: boolean) =>
+      new Promise((resolve) => {
+        if (wantIds) resolveIds = resolve;
+        else resolveTable = resolve;
+      }) as never);
+
+    const pending = resolveInstanceNames(["DeepDesert_1"]);
+    invalidateInstanceNames();
+    resolveTable({ stdout: TABLE, exitCode: 0 });
+    resolveIds({ stdout: "8\n59\n", exitCode: 0 });
+
+    await expect(pending).resolves.toBeNull();
+    expect(cachedInstanceNames(["DeepDesert_1"])).toBeNull();
+  });
+
   it("does not answer a lookup for a different set of maps", async () => {
     respond();
     await resolveInstanceNames(["DeepDesert_1"]);

--- a/console/web/src/features/maps/instanceNames.test.ts
+++ b/console/web/src/features/maps/instanceNames.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mapsApi } from "../../api/maps";
+import { cachedInstanceNames, invalidateInstanceNames, resolveInstanceNames } from "./instanceNames";
+
+vi.mock("../../api/maps", () => ({ mapsApi: { sietchDimensions: vi.fn() } }));
+
+const TABLE = [
+  "DIMENSION  DISPLAY NAME                     PASSWORD",
+  "0          Deep Desert PvP                  (unset)",
+  "1          Deep Desert PvE                  (unset)"
+].join("\n");
+
+function respond(table = TABLE, ids = "8\n59\n", exitCode = 0) {
+  vi.mocked(mapsApi.sietchDimensions).mockImplementation((_map?: string, wantIds?: boolean) =>
+    Promise.resolve({ stdout: wantIds ? ids : table, exitCode }) as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invalidateInstanceNames();
+});
+
+describe("instance names", () => {
+  it("resolves names keyed by map and partition", async () => {
+    respond();
+    expect([...(await resolveInstanceNames(["DeepDesert_1"]))!]).toEqual([
+      ["DeepDesert_1:8", "Deep Desert PvP"],
+      ["DeepDesert_1:59", "Deep Desert PvE"]
+    ]);
+  });
+
+  it("serves a repeat lookup from cache without touching the CLI", async () => {
+    respond();
+    await resolveInstanceNames(["DeepDesert_1"]);
+    const calls = vi.mocked(mapsApi.sietchDimensions).mock.calls.length;
+
+    expect(cachedInstanceNames(["DeepDesert_1"])?.get("DeepDesert_1:8")).toBe("Deep Desert PvP");
+    expect(vi.mocked(mapsApi.sietchDimensions).mock.calls).toHaveLength(calls);
+  });
+
+  // The reason this module exists: renaming a sietch changes nothing the Bases
+  // panel keys on, so without an explicit signal a remount would keep serving
+  // the old label and the operator would have no way to force a refresh.
+  it("drops the cache when a sietch is written", async () => {
+    respond();
+    await resolveInstanceNames(["DeepDesert_1"]);
+    expect(cachedInstanceNames(["DeepDesert_1"])).not.toBeNull();
+
+    invalidateInstanceNames();
+
+    expect(cachedInstanceNames(["DeepDesert_1"])).toBeNull();
+  });
+
+  it("does not answer a lookup for a different set of maps", async () => {
+    respond();
+    await resolveInstanceNames(["DeepDesert_1"]);
+
+    expect(cachedInstanceNames(["Survival_1"])).toBeNull();
+    // Order is not part of the identity.
+    expect(cachedInstanceNames(["DeepDesert_1"])).not.toBeNull();
+  });
+
+  // A non-zero exit still answers 200 with a body, so trusting stdout alone
+  // would publish names read from a failed command.
+  it("resolves nothing when the command failed", async () => {
+    respond(TABLE, "8\n59\n", 1);
+    expect(await resolveInstanceNames(["DeepDesert_1"])).toBeNull();
+    expect(cachedInstanceNames(["DeepDesert_1"])).toBeNull();
+  });
+
+  it("resolves nothing when the partition ids could not be read", async () => {
+    respond(TABLE, "");
+    expect(await resolveInstanceNames(["DeepDesert_1"])).toBeNull();
+  });
+});

--- a/console/web/src/features/maps/instanceNames.ts
+++ b/console/web/src/features/maps/instanceNames.ts
@@ -17,6 +17,7 @@ import { parseSietchRows } from "./sietchRows";
 const TTL_MS = 5 * 60 * 1000;
 
 let cache: { key: string; names: Map<string, string>; at: number } | null = null;
+let cacheGeneration = 0;
 
 // Callers hold a list of partition maps; the cache key must not depend on the
 // order they happened to appear in.
@@ -28,6 +29,7 @@ function cacheKey(maps: string[]) {
 // scope outlives an individual case.
 export function invalidateInstanceNames() {
   cache = null;
+  cacheGeneration += 1;
 }
 
 export function cachedInstanceNames(maps: string[]) {
@@ -40,6 +42,7 @@ export function cachedInstanceNames(maps: string[]) {
 // on purpose: these endpoints are absent on a console-only install, and a
 // missing instance name must never take the caller's list down with it.
 export async function resolveInstanceNames(maps: string[]) {
+  const generation = cacheGeneration;
   const resolved = new Map<string, string>();
   await Promise.all(maps.map(async (map) => {
     try {
@@ -63,6 +66,10 @@ export async function resolveInstanceNames(maps: string[]) {
       // Leave this map on its caller's fallback.
     }
   }));
+  // A sietch write may invalidate the cache while these CLI requests are in
+  // flight. Never let a response started before that write restore the old
+  // names, or return those stale names to the caller that initiated it.
+  if (generation !== cacheGeneration) return null;
   if (!resolved.size) return null;
   cache = { key: cacheKey(maps), names: resolved, at: Date.now() };
   return resolved;

--- a/console/web/src/features/maps/instanceNames.ts
+++ b/console/web/src/features/maps/instanceNames.ts
@@ -1,0 +1,69 @@
+import { mapsApi } from "../../api/maps";
+import { parseSietchRows } from "./sietchRows";
+
+// `${partitionMap}:${partitionId}` -> the operator-chosen instance name
+// ("Deep Desert PvE"). Two instances of one map are identical in a base's map
+// column alone, so this is what actually identifies the row.
+//
+// Held at module scope because the panels that read it are lazy-loaded and
+// remount on every tab switch, while resolving a name shells out to the runtime
+// CLI -- two docker execs per partition map. Without the cache, every visit
+// respawned them.
+//
+// Invalidated on write, not just by the clock: renaming a sietch happens on the
+// Maps tab and changes nothing the Bases panel keys on, so a remount would
+// otherwise keep serving the old label with no way for the operator to force a
+// refresh. The TTL is only a backstop for changes made outside this console.
+const TTL_MS = 5 * 60 * 1000;
+
+let cache: { key: string; names: Map<string, string>; at: number } | null = null;
+
+// Callers hold a list of partition maps; the cache key must not depend on the
+// order they happened to appear in.
+function cacheKey(maps: string[]) {
+  return [...new Set(maps)].sort().join(",");
+}
+
+// Call after any sietch mutation. Also the reset hook for tests, whose module
+// scope outlives an individual case.
+export function invalidateInstanceNames() {
+  cache = null;
+}
+
+export function cachedInstanceNames(maps: string[]) {
+  if (!cache || cache.key !== cacheKey(maps)) return null;
+  return Date.now() - cache.at < TTL_MS ? cache.names : null;
+}
+
+// Resolves every map in parallel and returns null when nothing could be read,
+// so callers keep whatever fallback they already show. Failures are swallowed
+// on purpose: these endpoints are absent on a console-only install, and a
+// missing instance name must never take the caller's list down with it.
+export async function resolveInstanceNames(maps: string[]) {
+  const resolved = new Map<string, string>();
+  await Promise.all(maps.map(async (map) => {
+    try {
+      const [table, ids] = await Promise.all([
+        mapsApi.sietchDimensions(map, false),
+        mapsApi.sietchDimensions(map, true)
+      ]);
+      // A non-zero exit still answers 200 with empty stdout, so a failed command
+      // is indistinguishable from a map with no sietches unless the code is
+      // checked. Treat it as unreadable and keep the fallback.
+      if (table.exitCode || ids.exitCode) return;
+      for (const row of parseSietchRows(table.stdout || "", ids.stdout || "")) {
+        // Keyed by map as well as id, and only for ids that really came from
+        // the --ids output: a row that fell back to its dimension index would
+        // otherwise answer for another map's partition of the same number.
+        if (row.displayName && row.partitionIdFromIds) {
+          resolved.set(`${map}:${row.partitionId}`, row.displayName);
+        }
+      }
+    } catch {
+      // Leave this map on its caller's fallback.
+    }
+  }));
+  if (!resolved.size) return null;
+  cache = { key: cacheKey(maps), names: resolved, at: Date.now() };
+  return resolved;
+}

--- a/console/web/src/features/maps/mapNames.ts
+++ b/console/web/src/features/maps/mapNames.ts
@@ -1,4 +1,13 @@
+// Two keyspaces resolve through this one table. Most callers hold a *service*
+// id (survival_1, sh_arrakeen) from the runtime; anything reading dune.actors
+// instead holds the *game's* map name (HaggaBasin, DeepDesert), which is a
+// different string for the same place. Both are listed so callers need not
+// know which kind of id they were handed.
 const MAP_FRIENDLY_NAMES: Readonly<Record<string, string>> = Object.freeze({
+  haggabasin: "Hagga Basin",
+  deepdesert: "Deep Desert",
+  harkovillage: "Harko Village",
+  overland: "Overland",
   survival_1: "Hagga Basin",
   overmap: "Overland",
   sh_arrakeen: "Arrakeen",

--- a/console/web/src/features/maps/sietchRows.test.ts
+++ b/console/web/src/features/maps/sietchRows.test.ts
@@ -79,6 +79,43 @@ describe("parseSietchRows", () => {
       ["1", false]
     ]);
   });
+
+  // A short --ids output makes a real id collide with a later row's fallback
+  // whenever that id equals the later row's dimension index -- i.e. whenever
+  // partition 1 is in play, which it is on every stock Survival_1. Rows are
+  // deduplicated by partitionId because the draft layer is keyed by it, so one
+  // of the pair has to go; it must not be the row whose id is real.
+  it("keeps the real id over a colliding dimension-index fallback", () => {
+    const table = [
+      "DIMENSION  DISPLAY NAME                     PASSWORD",
+      "0          Sietch Abbir                     (unset)",
+      "1          Sietch Alraab                    (unset)"
+    ].join("\n");
+
+    // Dimension 0 is partition 1; dimension 1 falls back to its index, also "1".
+    expect(parseSietchRows(table, "1\n")).toEqual([
+      { partitionId: "1", partitionIdFromIds: true, dimension: "0", displayName: "Sietch Abbir", password: "", passwordSet: false, active: true }
+    ]);
+  });
+
+  // `dune sietches list` is a per-map summary -- MAP / MAX DIMENSIONS / ACTIVE
+  // DIMENSIONS / MEMORY / TYPE -- with no partition ids in it at all. Captured
+  // verbatim from the live server. loadSietches falls back to this output when
+  // `sietches dimensions` returns nothing, so it is worth pinning that the
+  // fallback yields no rows rather than rows with invented ids.
+  it("yields nothing from the per-map `sietches list` output", () => {
+    const list = [
+      "MAP                          MAX DIMENSIONS ACTIVE DIMENSIONS  MEMORY     TYPE",
+      "Survival_1                   2              1                  16g        Always-On",
+      "Overmap                      1              1                  3g         Always-On",
+      "SH_Arrakeen                  1              Managed            3g         Dedicated Scaling",
+      "DeepDesert_1                 2              2                  15Gi       Dedicated Scaling",
+      "CB_Ecolab_Bronze_Green_089   1              Managed            6Gi        Dedicated Scaling",
+      "CB_Dungeon_ThePit            1              Managed            2Gi        Dedicated Scaling"
+    ].join("\n");
+
+    expect(parseSietchRows(list, "")).toEqual([]);
+  });
 });
 
 describe("isSietchWriteTarget", () => {

--- a/console/web/src/features/maps/sietchRows.test.ts
+++ b/console/web/src/features/maps/sietchRows.test.ts
@@ -58,7 +58,25 @@ describe("parseSietchRows", () => {
   it("falls back to the dimension when no partition ids are supplied", () => {
     const table = "0          Solo Sietch                      (unset)";
     expect(parseSietchRows(table)).toEqual([
-      { partitionId: "0", dimension: "0", displayName: "Solo Sietch", password: "", passwordSet: false, active: true }
+      // partitionIdFromIds false: this id is a dimension index wearing the
+      // partition field, unique only within this one map.
+      { partitionId: "0", partitionIdFromIds: false, dimension: "0", displayName: "Solo Sietch", password: "", passwordSet: false, active: true }
+    ]);
+  });
+
+  // The --ids call can succeed with fewer ids than the table has rows. Rows
+  // past the end must be marked as fallbacks too, not just an all-empty ids
+  // list -- BasesPanel pools rows from several maps and keys on this flag.
+  it("marks only the rows an id actually covered", () => {
+    const table = [
+      "DIMENSION  DISPLAY NAME                     PASSWORD",
+      "0          Deep Desert PvP                  (unset)",
+      "1          Deep Desert PvE                  (unset)"
+    ].join("\n");
+
+    expect(parseSietchRows(table, "8\n").map((row) => [row.partitionId, row.partitionIdFromIds])).toEqual([
+      ["8", true],
+      ["1", false]
     ]);
   });
 });

--- a/console/web/src/features/maps/sietchRows.test.ts
+++ b/console/web/src/features/maps/sietchRows.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { parseSietchRows } from "./sietchRows";
+
+describe("parseSietchRows", () => {
+  // Verbatim `dune sietches dimensions DeepDesert_1` output and its --ids
+  // companion, captured from the live server.
+  it("pairs each dimension with the partition id at the same index", () => {
+    const table = [
+      "DIMENSION  DISPLAY NAME                     PASSWORD",
+      "0          Deep Desert PvP                  (unset)",
+      "1          Deep Desert PvE                  (unset)"
+    ].join("\n");
+
+    expect(parseSietchRows(table, "8\n59\n").map((row) => [row.partitionId, row.displayName])).toEqual([
+      ["8", "Deep Desert PvP"],
+      ["59", "Deep Desert PvE"]
+    ]);
+  });
+
+  // Display names are whatever the operator typed. Nothing here may assume a
+  // "Sietch " prefix, ASCII, single spacing, or that the name is not itself a
+  // number -- every one of these is a name a server owner could set.
+  it("preserves arbitrary operator-chosen names", () => {
+    const table = [
+      "DIMENSION  DISPLAY NAME                     PASSWORD",
+      "0          Awesome Map                      (unset)",
+      "1          The Kulon Show                   (set)",
+      "2          12345                            (unset)",
+      "3          Bob's (unset) Palace             (unset)",
+      "4          Sietch   double  spaces          (unset)",
+      "5          Ünïcôdé Sïétch                   (unset)",
+      "6          a                                (unset)"
+    ].join("\n");
+
+    expect(parseSietchRows(table, "1\n31\n55\n7\n8\n9\n10\n").map((row) => row.displayName)).toEqual([
+      "Awesome Map",
+      "The Kulon Show",
+      "12345",
+      // The (unset) marker is anchored to end-of-line, so a name containing
+      // one of its own survives intact.
+      "Bob's (unset) Palace",
+      "Sietch   double  spaces",
+      "Ünïcôdé Sïétch",
+      "a"
+    ]);
+  });
+
+  it("reads the password flag per row", () => {
+    const table = [
+      "DIMENSION  DISPLAY NAME                     PASSWORD",
+      "0          Locked Sietch                    (set)",
+      "1          Open Sietch                      (unset)"
+    ].join("\n");
+
+    expect(parseSietchRows(table, "1\n2\n").map((row) => row.passwordSet)).toEqual([true, false]);
+  });
+
+  it("falls back to the dimension when no partition ids are supplied", () => {
+    const table = "0          Solo Sietch                      (unset)";
+    expect(parseSietchRows(table)).toEqual([
+      { partitionId: "0", dimension: "0", displayName: "Solo Sietch", password: "", passwordSet: false, active: true }
+    ]);
+  });
+});

--- a/console/web/src/features/maps/sietchRows.test.ts
+++ b/console/web/src/features/maps/sietchRows.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseSietchRows } from "./sietchRows";
+import { isSietchWriteTarget, parseSietchRows } from "./sietchRows";
 
 describe("parseSietchRows", () => {
   // Verbatim `dune sietches dimensions DeepDesert_1` output and its --ids
@@ -78,5 +78,38 @@ describe("parseSietchRows", () => {
       ["8", true],
       ["1", false]
     ]);
+  });
+});
+
+describe("isSietchWriteTarget", () => {
+  // Real `dune sietches dimensions Survival_1 --active-only` shape: three
+  // dimensions whose partitions are 1, 31 and 55 -- deliberately not equal to
+  // their dimension indices, which is what makes the fallback dangerous.
+  const SURVIVAL_TABLE = [
+    "DIMENSION  DISPLAY NAME                     PASSWORD",
+    "0          Hagga Basin                      (unset)",
+    "1          Sietch Abbir                     (set)",
+    "2          The Kulon Show                   (unset)"
+  ].join("\n");
+
+  it("accepts every row when the partition ids were read", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, "1\n31\n55\n");
+    expect(rows.filter(isSietchWriteTarget).map((row) => row.partitionId)).toEqual(["1", "31", "55"]);
+  });
+
+  // `sietches dimensions --ids` is a separate CLI invocation from the one that
+  // prints the table, and the API answers 200 with empty stdout when it fails.
+  // The rows still parse, but their partition ids are dimension indices: using
+  // one as a write target would rename dimension 1 by sending partition "1",
+  // which is a different sietch entirely.
+  it("rejects every row when the partition ids could not be read", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, "");
+    expect(rows.map((row) => row.partitionId)).toEqual(["0", "1", "2"]);
+    expect(rows.filter(isSietchWriteTarget)).toEqual([]);
+  });
+
+  it("rejects only the rows the ids output did not cover", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, "1\n31\n");
+    expect(rows.filter(isSietchWriteTarget).map((row) => row.partitionId)).toEqual(["1", "31"]);
   });
 });

--- a/console/web/src/features/maps/sietchRows.ts
+++ b/console/web/src/features/maps/sietchRows.ts
@@ -73,6 +73,74 @@ export function blockedSietchEdits(
   });
 }
 
+// The exact complement of blockedSietchEdits: rows a save will really write.
+// Same three conditions, with the write-target test inverted.
+//
+// One definition for both, because two callers need to agree on it and used to
+// derive it separately: the code that builds the write actions, and the code
+// that decides which drafts the post-save refresh may discard. When those
+// disagreed, a save for one partition reset every draft on the panel.
+export function writableSietchEdits(
+  rows: SietchRow[],
+  drafts: Record<string, { displayName: string; password: string }>,
+  passwordTouched: Record<string, boolean> = {},
+  partitionId?: string
+) {
+  return rows.filter((row) => {
+    if (!isSietchWriteTarget(row)) return false;
+    if (partitionId && row.partitionId !== partitionId) return false;
+    const { nameChanged, passwordChanged } = sietchDraftChanges(row, drafts, passwordTouched);
+    return nameChanged || passwordChanged;
+  });
+}
+
+// What the drafts should be after a save's refresh reloads the sietch rows.
+//
+// A save writes one partition, but the refresh reloads them all. Replacing
+// every draft with the server's values therefore discarded pending edits on
+// rows the save never touched -- including the fallback rows the write guard
+// had just refused, so the guard's warning was followed by the edit silently
+// disappearing.
+//
+// Written partitions take the server's values: that write landed, so the
+// server is now the truth. Every other row keeps whatever is pending. Pass an
+// empty writtenPartitionIds to keep everything, which is what a failed save
+// wants.
+//
+// Split from reconcileSietchPasswordTouched below rather than returning both,
+// so each depends on exactly one piece of React state and can be applied as a
+// plain functional setState against the newest value. Combined, one of them
+// would have had to read the other through a stale closure.
+export function reconcileSietchDrafts(
+  freshRows: SietchRow[],
+  currentDrafts: Record<string, { displayName: string; password: string }>,
+  writtenPartitionIds: string[]
+) {
+  const written = new Set(writtenPartitionIds);
+  const drafts: Record<string, { displayName: string; password: string }> = {};
+  for (const row of freshRows) {
+    const pending = currentDrafts[row.partitionId];
+    drafts[row.partitionId] = !written.has(row.partitionId) && pending
+      ? pending
+      : { displayName: row.displayName, password: row.password };
+  }
+  return drafts;
+}
+
+// A written partition's password now matches the server, so its touched flag
+// goes; an untouched row never had one. Everything still pending keeps it,
+// because sietchPasswordDraftChanged reads it to tell an edited password from
+// the mask.
+export function reconcileSietchPasswordTouched(
+  currentTouched: Record<string, boolean>,
+  writtenPartitionIds: string[]
+) {
+  const written = new Set(writtenPartitionIds);
+  return Object.fromEntries(
+    Object.entries(currentTouched).filter(([partitionId, touched]) => touched && !written.has(partitionId))
+  );
+}
+
 // Parses the fixed-width table `dune sietches dimensions <map>` prints, pairing
 // each row with the partition id at the same index from the `--ids` output:
 //

--- a/console/web/src/features/maps/sietchRows.ts
+++ b/console/web/src/features/maps/sietchRows.ts
@@ -1,5 +1,12 @@
 export type SietchRow = {
   partitionId: string;
+  // False when the `--ids` output ran out and partitionId fell back to the
+  // dimension index. A dimension index is only unique *within one map*, so a
+  // caller pooling rows from several maps (BasesPanel) must drop these rather
+  // than key on them -- otherwise DeepDesert_1's dimension 1 answers to the
+  // lookup for Survival_1's partition 1 and labels a Hagga Basin base
+  // "Deep Desert PvE".
+  partitionIdFromIds: boolean;
   dimension: string;
   displayName: string;
   password: string;
@@ -30,7 +37,15 @@ export function parseSietchRows(text: string, idsText = ""): SietchRow[] {
       const partitionId = ids[dimensionIndex] || dimension;
       const displayName = tableMatch[2].trim();
       const passwordSet = /^\(set\)$/i.test(tableMatch[3]);
-      rows.push({ partitionId, dimension, displayName, password: "", passwordSet, active: true });
+      rows.push({
+        partitionId,
+        partitionIdFromIds: Boolean(ids[dimensionIndex]),
+        dimension,
+        displayName,
+        password: "",
+        passwordSet,
+        active: true
+      });
       dimensionIndex += 1;
       continue;
     }
@@ -43,7 +58,15 @@ export function parseSietchRows(text: string, idsText = ""): SietchRow[] {
     const passwordSet = /\(set\)|\bset\b|true|yes/i.test(passwordValue) || /\(set\)\s*$/i.test(line);
     const password = /\(set\)|\(unset\)|\bset\b|\bunset\b/i.test(passwordValue) ? "" : passwordValue;
     const active = !/\binactive|disabled|stopped\b/i.test(line);
-    rows.push({ partitionId, dimension, displayName, password, passwordSet: passwordSet || Boolean(password), active });
+    rows.push({
+      partitionId,
+      partitionIdFromIds: Boolean(ids[dimensionIndex]),
+      dimension,
+      displayName,
+      password,
+      passwordSet: passwordSet || Boolean(password),
+      active
+    });
     dimensionIndex += 1;
   }
   const unique = new globalThis.Map<string, SietchRow>();

--- a/console/web/src/features/maps/sietchRows.ts
+++ b/console/web/src/features/maps/sietchRows.ts
@@ -80,7 +80,21 @@ export function parseSietchRows(text: string, idsText = ""): SietchRow[] {
     });
     dimensionIndex += 1;
   }
+  // Deduplicated by partitionId because the whole draft layer is keyed by it
+  // (sietchDrafts[partitionId], sietchPasswordTouched[partitionId]) -- two rows
+  // sharing an id would share one draft, so an edit to either would show in
+  // both. One of a colliding pair therefore has to go.
+  //
+  // Two rows collide when the `--ids` output is shorter than the table: a real
+  // id from --ids equals a later row's dimension-index fallback, which is what
+  // happens whenever partition 1 is in play. Keep the row whose id actually
+  // came from --ids -- plain last-wins would drop the one sietch whose
+  // partition is known and leave an unwritable row standing in its place.
   const unique = new globalThis.Map<string, SietchRow>();
-  for (const row of rows) unique.set(row.partitionId, row);
+  for (const row of rows) {
+    const existing = unique.get(row.partitionId);
+    if (existing?.partitionIdFromIds && !row.partitionIdFromIds) continue;
+    unique.set(row.partitionId, row);
+  }
   return [...unique.values()].sort((a, b) => Number(a.dimension) - Number(b.dimension));
 }

--- a/console/web/src/features/maps/sietchRows.ts
+++ b/console/web/src/features/maps/sietchRows.ts
@@ -14,6 +14,17 @@ export type SietchRow = {
   active: boolean;
 };
 
+// Whether a row may be used as the target of a write (rename, set password,
+// save settings, restart). Only rows whose partition id really came from the
+// `--ids` output qualify: a row that fell back to its dimension index would
+// send that index as a partition id and land on whichever partition happens to
+// carry the same number, so renaming dimension 1 would rename partition 1.
+// Reads are unaffected -- a fallback row still renders, it just cannot be
+// written to.
+export function isSietchWriteTarget(row: SietchRow) {
+  return row.partitionIdFromIds;
+}
+
 // Parses the fixed-width table `dune sietches dimensions <map>` prints, pairing
 // each row with the partition id at the same index from the `--ids` output:
 //

--- a/console/web/src/features/maps/sietchRows.ts
+++ b/console/web/src/features/maps/sietchRows.ts
@@ -25,6 +25,54 @@ export function isSietchWriteTarget(row: SietchRow) {
   return row.partitionIdFromIds;
 }
 
+export const SIETCH_PASSWORD_MASK = "********";
+
+export function sietchPasswordDraftChanged(row: SietchRow, draft: { password: string }, touched = false) {
+  if (!touched) return false;
+  if (row.passwordSet) return draft.password !== SIETCH_PASSWORD_MASK;
+  return Boolean(draft.password);
+}
+
+// The draft a row is being edited with, plus which of its fields differ from
+// what the server reported. One definition, shared by the code that builds
+// sietch write actions and the code that refuses to build them, so the two can
+// never disagree about what "edited" means.
+export function sietchDraftChanges(
+  row: SietchRow,
+  drafts: Record<string, { displayName: string; password: string }>,
+  passwordTouched: Record<string, boolean> = {}
+) {
+  const draft = drafts[row.partitionId] || { displayName: row.displayName, password: row.password };
+  return {
+    draft,
+    nameChanged: draft.displayName !== row.displayName,
+    passwordChanged: sietchPasswordDraftChanged(row, draft, Boolean(passwordTouched[row.partitionId]))
+  };
+}
+
+// Rows the operator has edited that cannot be written safely, because their
+// partition id fell back to a dimension index (see isSietchWriteTarget).
+//
+// survivalSietchActions skips those rows when building actions. On its own that
+// would make a bulk Save drop the edit without saying so: with nothing else
+// dirty the Save does nothing at all, and with the active-sietch count also
+// dirty that unrelated change still runs and the save reports success while the
+// edited fields are discarded. Callers refuse the whole save instead, matching
+// what the per-sietch Save and Restart already do.
+export function blockedSietchEdits(
+  rows: SietchRow[],
+  drafts: Record<string, { displayName: string; password: string }>,
+  passwordTouched: Record<string, boolean> = {},
+  partitionId?: string
+) {
+  return rows.filter((row) => {
+    if (isSietchWriteTarget(row)) return false;
+    if (partitionId && row.partitionId !== partitionId) return false;
+    const { nameChanged, passwordChanged } = sietchDraftChanges(row, drafts, passwordTouched);
+    return nameChanged || passwordChanged;
+  });
+}
+
 // Parses the fixed-width table `dune sietches dimensions <map>` prints, pairing
 // each row with the partition id at the same index from the `--ids` output:
 //

--- a/console/web/src/features/maps/sietchRows.ts
+++ b/console/web/src/features/maps/sietchRows.ts
@@ -1,0 +1,52 @@
+export type SietchRow = {
+  partitionId: string;
+  dimension: string;
+  displayName: string;
+  password: string;
+  passwordSet: boolean;
+  active: boolean;
+};
+
+// Parses the fixed-width table `dune sietches dimensions <map>` prints, pairing
+// each row with the partition id at the same index from the `--ids` output:
+//
+//   DIMENSION  DISPLAY NAME      PASSWORD        ids
+//   0          Deep Desert PvP   (unset)         8
+//   1          Deep Desert PvE   (unset)         59
+//
+// Display names are operator-chosen and arbitrary -- "Awesome Map" and
+// "The Kulon Show" are real -- so nothing here may assume a "Sietch " prefix.
+// Lives in its own module rather than in MapsPanel so the Bases panel can label
+// map instances without pulling that whole lazily-loaded chunk in with it.
+export function parseSietchRows(text: string, idsText = ""): SietchRow[] {
+  const rows: SietchRow[] = [];
+  const ids = idsText.split(/\r?\n/).map((line) => line.trim()).filter((line) => /^\d+$/.test(line));
+  let dimensionIndex = 0;
+  for (const line of text.split(/\r?\n/)) {
+    if (/^\s*DIMENSION\b/i.test(line)) continue;
+    const tableMatch = line.match(/^\s*(\d+)\s+(.+?)\s+(\((?:un)?set\))\s*$/i);
+    if (tableMatch) {
+      const dimension = tableMatch[1];
+      const partitionId = ids[dimensionIndex] || dimension;
+      const displayName = tableMatch[2].trim();
+      const passwordSet = /^\(set\)$/i.test(tableMatch[3]);
+      rows.push({ partitionId, dimension, displayName, password: "", passwordSet, active: true });
+      dimensionIndex += 1;
+      continue;
+    }
+    const partitionMatch = line.match(/\b(?:partition|id)\s*[:=]?\s*(\d+)\b/i) || line.match(/^\s*(\d+)\s+/);
+    if (!partitionMatch) continue;
+    const dimension = partitionMatch[1];
+    const partitionId = ids[dimensionIndex] || partitionMatch[1];
+    const displayName = (line.match(/\b(?:display|name)\s*[:=]\s*([^|,\t]+)/i)?.[1] || line.match(/\bSietch\s+([A-Za-z0-9 _-]+)/i)?.[0] || `Sietch ${partitionId}`).trim();
+    const passwordValue = (line.match(/\bpassword\s*[:=]\s*([^|,\t]+)/i)?.[1] || line.match(/\((?:un)?set\)\s*$/i)?.[0] || "").trim();
+    const passwordSet = /\(set\)|\bset\b|true|yes/i.test(passwordValue) || /\(set\)\s*$/i.test(line);
+    const password = /\(set\)|\(unset\)|\bset\b|\bunset\b/i.test(passwordValue) ? "" : passwordValue;
+    const active = !/\binactive|disabled|stopped\b/i.test(line);
+    rows.push({ partitionId, dimension, displayName, password, passwordSet: passwordSet || Boolean(password), active });
+    dimensionIndex += 1;
+  }
+  const unique = new globalThis.Map<string, SietchRow>();
+  for (const row of rows) unique.set(row.partitionId, row);
+  return [...unique.values()].sort((a, b) => Number(a.dimension) - Number(b.dimension));
+}

--- a/console/web/src/features/maps/sietchWriteGuard.test.ts
+++ b/console/web/src/features/maps/sietchWriteGuard.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { blockedSietchEdits, isSietchWriteTarget, parseSietchRows, sietchDraftChanges } from "./sietchRows";
+import {
+  blockedSietchEdits,
+  isSietchWriteTarget,
+  parseSietchRows,
+  reconcileSietchDrafts,
+  reconcileSietchPasswordTouched,
+  sietchDraftChanges,
+  writableSietchEdits
+} from "./sietchRows";
 
 // Real `dune sietches dimensions Survival_1 --active-only` output. The real
 // partitions are 1, 31 and 55 -- deliberately not equal to their dimension
@@ -99,8 +107,10 @@ describe("blockedSietchEdits", () => {
     expect(isSietchWriteTarget(rows[2])).toBe(false);
     expect(blockedSietchEdits(rows, drafts, {}, "2").map((row) => row.displayName)).toEqual(["The Kulon Show"]);
 
-    // Nothing here mutates drafts, so the fallback edit is still pending and
-    // still rendered after the verified row is saved.
+    // These helpers are pure, so the fallback edit is untouched here. Whether
+    // it survives the *save* is a caller-level question about loadSietches'
+    // refresh -- covered in MapsPanel.sietchDrafts.test.tsx, because it cannot
+    // be seen from this level and was in fact broken while this file passed.
     expect(drafts["2"].displayName).toBe("Renamed Fallback");
     expect(sietchDraftChanges(rows[2], drafts, {}).nameChanged).toBe(true);
   });
@@ -113,6 +123,100 @@ describe("blockedSietchEdits", () => {
 
     expect(blockedSietchEdits(rows, drafts, {}, "1")).toHaveLength(1);
     expect(blockedSietchEdits(rows, drafts, {}, "0")).toEqual([]);
+  });
+});
+
+describe("writableSietchEdits", () => {
+  // The exact complement of blockedSietchEdits: between them they must account
+  // for every edited row and never claim the same one.
+  it("is the complement of blockedSietchEdits over the same rows", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_PARTIAL);
+    const drafts = draftsFor(rows, {
+      "1": { displayName: "Renamed Verified A" },
+      "31": { displayName: "Renamed Verified B" },
+      "2": { displayName: "Renamed Fallback" }
+    });
+
+    const writable = writableSietchEdits(rows, drafts, {}).map((row) => row.partitionId);
+    const blocked = blockedSietchEdits(rows, drafts, {}).map((row) => row.partitionId);
+
+    expect(writable).toEqual(["1", "31"]);
+    expect(blocked).toEqual(["2"]);
+    expect(writable.filter((id) => blocked.includes(id))).toEqual([]);
+    expect([...writable, ...blocked].sort()).toEqual(["1", "2", "31"]);
+  });
+
+  it("reports only rows that are actually edited, and honours the partition scope", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_PARTIAL);
+
+    // Clean drafts write nothing, so a save must not claim to have written them.
+    expect(writableSietchEdits(rows, draftsFor(rows), {})).toEqual([]);
+
+    const drafts = draftsFor(rows, { "1": { displayName: "Renamed" } });
+    expect(writableSietchEdits(rows, drafts, {}, "1").map((row) => row.partitionId)).toEqual(["1"]);
+    expect(writableSietchEdits(rows, drafts, {}, "31")).toEqual([]);
+  });
+
+  it("counts a touched password as an edit, like the guard does", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_PARTIAL);
+    const drafts = draftsFor(rows, { "31": { password: "new-secret" } });
+
+    expect(writableSietchEdits(rows, drafts, {})).toEqual([]);
+    expect(writableSietchEdits(rows, drafts, { "31": true }).map((row) => row.partitionId)).toEqual(["31"]);
+  });
+});
+
+describe("reconcileSietchDrafts", () => {
+  // The bug this exists for: a save writes one partition, the refresh reloads
+  // them all, and replacing every draft discarded the pending edits the save
+  // never touched -- including fallback rows the guard had just refused.
+  it("keeps pending edits on rows the save did not write", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_PARTIAL);
+    const current = draftsFor(rows, {
+      "31": { displayName: "Renamed Verified" },
+      "2": { displayName: "Renamed Fallback" }
+    });
+
+    const next = reconcileSietchDrafts(rows, current, ["31"]);
+
+    // Written: the server is the truth now.
+    expect(next["31"].displayName).toBe("Sietch Abbir");
+    // Not written: still pending, still on screen.
+    expect(next["2"].displayName).toBe("Renamed Fallback");
+    // Untouched rows come back as the server reported them.
+    expect(next["1"].displayName).toBe("Hagga Basin");
+  });
+
+  it("keeps everything when nothing was written, which is what a failed save needs", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_PARTIAL);
+    const current = draftsFor(rows, {
+      "31": { displayName: "Renamed Verified" },
+      "2": { displayName: "Renamed Fallback" }
+    });
+
+    const next = reconcileSietchDrafts(rows, current, []);
+
+    expect(next["31"].displayName).toBe("Renamed Verified");
+    expect(next["2"].displayName).toBe("Renamed Fallback");
+  });
+
+  it("is keyed on the fresh rows, so a partition that vanished is dropped", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_PARTIAL);
+    const current = { ...draftsFor(rows), "999": { displayName: "Gone", password: "" } };
+
+    expect(Object.keys(reconcileSietchDrafts(rows, current, [])).sort()).toEqual(["1", "2", "31"]);
+  });
+});
+
+describe("reconcileSietchPasswordTouched", () => {
+  // sietchPasswordDraftChanged reads this flag to tell an edited password from
+  // the mask, so dropping it for a still-pending row would silently discard
+  // that password edit even though the draft text survived.
+  it("drops the flag only for written partitions", () => {
+    const touched = { "31": true, "2": true, "1": false };
+
+    expect(reconcileSietchPasswordTouched(touched, ["31"])).toEqual({ "2": true });
+    expect(reconcileSietchPasswordTouched(touched, [])).toEqual({ "2": true, "31": true });
   });
 });
 

--- a/console/web/src/features/maps/sietchWriteGuard.test.ts
+++ b/console/web/src/features/maps/sietchWriteGuard.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { blockedSietchEdits, sietchDraftChanges } from "./MapsPanel";
-import { parseSietchRows } from "./sietchRows";
+import { blockedSietchEdits, parseSietchRows, sietchDraftChanges } from "./sietchRows";
 
 // Real `dune sietches dimensions Survival_1 --active-only` output. The real
 // partitions are 1, 31 and 55 -- deliberately not equal to their dimension

--- a/console/web/src/features/maps/sietchWriteGuard.test.ts
+++ b/console/web/src/features/maps/sietchWriteGuard.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { blockedSietchEdits, parseSietchRows, sietchDraftChanges } from "./sietchRows";
+import { blockedSietchEdits, isSietchWriteTarget, parseSietchRows, sietchDraftChanges } from "./sietchRows";
 
 // Real `dune sietches dimensions Survival_1 --active-only` output. The real
 // partitions are 1, 31 and 55 -- deliberately not equal to their dimension
@@ -15,6 +15,9 @@ const IDS_READ = "1\n31\n55\n";
 // `sietches dimensions --ids` is a separate CLI invocation from the one that
 // prints the table, and the API answers 200 with empty stdout when it fails.
 const IDS_UNREADABLE = "";
+// The realistic middle case: the --ids output is short, so the rows it covers
+// carry real partition ids and the rest fall back to their dimension index.
+const IDS_PARTIAL = "1\n31\n";
 
 function draftsFor(rows: ReturnType<typeof parseSietchRows>, overrides: Record<string, Partial<{ displayName: string; password: string }>> = {}) {
   return Object.fromEntries(rows.map((row) => [
@@ -71,6 +74,35 @@ describe("blockedSietchEdits", () => {
 
     expect(rows.every((row) => row.partitionIdFromIds)).toBe(true);
     expect(blockedSietchEdits(rows, drafts, {})).toEqual([]);
+  });
+
+  // Partial ids are the realistic failure: one map's rows split between
+  // verified and fallen-back. Editing a fallback row must not quietly ride
+  // along with a save aimed at a verified one, and the edit must survive that
+  // save so it is still on screen to be dealt with.
+  it("keeps a fallback row's edit out of a verified row's save, and does not discard it", () => {
+    const rows = parseSietchRows(SURVIVAL_TABLE, IDS_PARTIAL);
+    // Two real ids, then a row that fell back to its dimension index.
+    expect(rows.map((row) => [row.partitionId, isSietchWriteTarget(row)]))
+      .toEqual([["1", true], ["31", true], ["2", false]]);
+
+    const drafts = draftsFor(rows, {
+      "2": { displayName: "Renamed Fallback" },
+      "31": { displayName: "Renamed Verified" }
+    });
+
+    // Saving the verified row is scoped to it, so the unwritable edit elsewhere
+    // neither blocks it nor gets written by it.
+    expect(blockedSietchEdits(rows, drafts, {}, "31")).toEqual([]);
+    // The fallback row's own Save is refused instead -- isSietchWriteTarget is
+    // what saveSietchSettings and restartSietch check before writing.
+    expect(isSietchWriteTarget(rows[2])).toBe(false);
+    expect(blockedSietchEdits(rows, drafts, {}, "2").map((row) => row.displayName)).toEqual(["The Kulon Show"]);
+
+    // Nothing here mutates drafts, so the fallback edit is still pending and
+    // still rendered after the verified row is saved.
+    expect(drafts["2"].displayName).toBe("Renamed Fallback");
+    expect(sietchDraftChanges(rows[2], drafts, {}).nameChanged).toBe(true);
   });
 
   // saveSelectedMapSettings carries only the primary sietch's fields, so it

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -11,6 +11,13 @@
   --text-strong: #fff1d4;
   --muted: #ad9f89;
   --muted-warm: #ceb894;
+  /* A neutral, not a fourth amber step: the title, field labels and muted
+     tones are all the same warm family, so another one read as a blurred
+     block rather than a hierarchy. --text blended 75% toward the card
+     background -- a solid value, not opacity, which would drift against the
+     differently-tinted surfaces these sit on. 8.40:1, still brighter than
+     the labels beneath it so title > subtitle > label survives. */
+  --text-subtle: #bebcb6;
   --title: #ffd08a;
   --accent: #c68b4a;
   --accent-strong: #d49a5c;
@@ -1665,7 +1672,7 @@ body.debug .technical-details { display: block; }
    muted tone as the inventory card subtitle. */
 .bases-map-cell { display: grid; gap: 1px; min-width: 0; }
 .bases-map-name { overflow-wrap: anywhere; }
-.bases-map-instance { color: #bebcb6; font-size: 11.5px; overflow-wrap: anywhere; }
+.bases-map-instance { color: var(--text-subtle); font-size: 11.5px; overflow-wrap: anywhere; }
 .bases-generator-summary { display: block; white-space: normal; overflow: visible; text-overflow: clip; line-height: 1.4; }
 .bases-fuel-alert { color: var(--danger-text); }
 .bases-pagination-footer { margin-top: 12px; margin-bottom: 0; align-items: center; }
@@ -2430,21 +2437,14 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
    Power, Water, Inventory and Permissions line their content up. */
 .bases-inventory { display: grid; width: 100%; min-width: 0; }
 /* Sits directly under .bases-card-title, which already carries the
-   4px bottom margin, so this only needs to close that gap back up.
-
-   Deliberately NOT an amber: the title, the field labels and the muted tones
-   are all the same warm family, so a fourth amber step read as one blurred
-   block rather than as a hierarchy. This is --text blended 75% toward the card
-   background -- a solid value, not opacity, which would drift against the
-   differently-tinted surfaces this card sits on. 8.40:1, still brighter than
-   the labels below it so title > subtitle > label survives. */
+   4px bottom margin, so this only needs to close that gap back up. */
 .bases-inventory-card-subtitle {
   margin: -2px 0 0;
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
   min-width: 0;
-  color: #bebcb6;
+  color: var(--text-subtle);
   font-size: 12px;
   line-height: 1.25;
   overflow-wrap: anywhere;

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -562,8 +562,11 @@ main { padding: 22px; min-width: 0; }
 .summary-hero-meta > span:last-child { color: #e8e0cd; }
 .summary-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 10px; }
 .summary-stat { background: #171a1d; border: 1px solid #302b25; border-radius: 8px; padding: 12px; display: grid; gap: 4px; }
-.summary-stat span { color: #ad9f89; font-size: 13px; }
-.summary-stat strong { color: #fff1d4; font-size: 22px; font-weight: 600; overflow-wrap: anywhere; }
+/* dt/dd accepted alongside span/strong so a label/value pair can be marked up
+   as a definition list without duplicating the tile's styling. */
+.summary-stat span, .summary-stat dt { color: #ad9f89; font-size: 13px; }
+.summary-stat strong, .summary-stat dd { color: #fff1d4; font-size: 22px; font-weight: 600; overflow-wrap: anywhere; }
+.summary-stat dd { margin: 0; }
 .summary-cols { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 14px; }
 .summary-block { display: grid; gap: 8px; align-content: start; }
 .summary-block-label { color: #c68b4a; text-transform: uppercase; font-size: 12px; letter-spacing: 0.05em; }
@@ -2414,6 +2417,199 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 
 .bases-water { display: grid; gap: 12px; }
 
+/* Inventory. The inset clamp() matches .bases-generator-breakdown and
+   .bases-permissions-content exactly -- that identical value is what makes
+   Power, Water, Inventory and Permissions line their content up. */
+.bases-inventory { display: grid; width: 100%; min-width: 0; }
+.bases-inventory-content {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: clamp(12px, 1.5vw, 18px);
+}
+/* Sits directly under .bases-generator-group-title, which already carries the
+   4px bottom margin, so this only needs to close that gap back up.
+
+   Deliberately NOT an amber: the title, the field labels and the muted tones
+   are all the same warm family, so a fourth amber step read as one blurred
+   block rather than as a hierarchy. This is --text blended 75% toward the card
+   background -- a solid value, not opacity, which would drift against the
+   differently-tinted surfaces this card sits on. 8.40:1, still brighter than
+   the labels below it so title > subtitle > label survives. */
+.bases-inventory-card-subtitle {
+  margin: -2px 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+  color: #bebcb6;
+  font-size: 12px;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+/* The tiles are .summary-stats / .summary-stat, shared with the player
+   summary. Only the dl's own default margin needs clearing. */
+.bases-inventory-totals { margin: 0; }
+.bases-inventory-totals .summary-stat { min-width: 0; }
+
+.bases-inventory-controls { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+.bases-inventory-groups { display: flex; flex-wrap: wrap; gap: 6px; min-width: 0; }
+.bases-inventory-chip {
+  width: auto;
+  border-radius: 999px;
+  padding: 5px 13px;
+  font-size: 12px;
+  background: var(--panel-muted);
+  border-color: var(--border);
+  color: var(--muted);
+}
+.bases-inventory-chip.active { background: #9b5f2a; border-color: var(--accent-strong); color: var(--text-strong); }
+.bases-inventory-chip-count { color: inherit; opacity: .75; }
+
+/* Pushed to the trailing edge so the chips (a filter) and the view switch (a
+   different axis entirely) never read as one control group. */
+.bases-inventory-views { display: inline-flex; margin-left: auto; border: 1px solid var(--border-strong); border-radius: 6px; overflow: hidden; }
+.bases-inventory-view {
+  width: auto;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  padding: 6px 14px;
+}
+.bases-inventory-view + .bases-inventory-view { border-left: 1px solid var(--border-strong); }
+.bases-inventory-view.active { background: #25201b; color: var(--title); }
+
+.bases-inventory-search { display: flex; gap: 8px; }
+.bases-inventory-search input { flex: 1; min-width: 0; }
+.bases-inventory-search button { flex: 0 0 auto; }
+
+/* Caret first: it is the affordance for the row, so it reads before the label
+   rather than trailing 400px away at the far right. Its 22px + the 8px gap put
+   the item name at 40px from the row edge, which is where the expanded
+   breakdown indents to. */
+.bases-inventory-item-head,
+.bases-inventory-item-row {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) 90px 92px;
+  gap: 8px;
+  align-items: center;
+  text-align: left;
+}
+.bases-inventory-item-head { padding: 6px 10px; color: var(--muted); font-size: 11px; border-bottom: 1px solid var(--border); }
+.bases-inventory-item-head > span:nth-child(3), .bases-inventory-item-head > span:nth-child(4) { text-align: right; }
+.bases-inventory-item-row {
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  background: transparent;
+  color: var(--text);
+  font-size: 13px;
+  padding: 9px 10px;
+}
+.bases-inventory-item-row:hover { border-color: var(--border); background: var(--panel-muted); }
+.bases-inventory-item-name { display: flex; align-items: center; gap: 8px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bases-inventory-item-name img { width: 22px; height: 22px; flex: 0 0 22px; object-fit: contain; border-radius: 4px; background: #25201b; }
+.bases-inventory-qty, .bases-inventory-count { text-align: right; }
+.bases-inventory-count { color: var(--muted); }
+.bases-inventory-breakdown { background: var(--panel-muted); padding: 6px 10px 9px 40px; border-bottom: 1px solid var(--border); }
+.bases-inventory-breakdown > div { display: flex; justify-content: space-between; gap: 12px; color: var(--muted-warm); font-size: 12px; padding: 4px 0; }
+.bases-inventory-show-all { width: 100%; margin-top: 10px; background: transparent; border-color: transparent; color: var(--muted-warm); font-size: 12px; }
+.bases-inventory-show-all:hover { border-color: var(--border-strong); }
+
+.bases-inventory-containers { display: grid; gap: 16px; }
+/* The count sits beside the heading, not pushed to the far edge: across a
+   full-width grid the two ends were far enough apart to read as unrelated. */
+.bases-inventory-group-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 10px; margin-bottom: 9px; }
+.bases-inventory-group-head h4 { margin: 0; color: var(--muted-warm); font-size: 12px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; }
+.bases-inventory-group-head span { font-size: 12px; }
+/* The cards themselves are .bases-generator-group / .bases-generator-stats,
+   shared with Power and Water. Only the track sizing differs: a container's
+   Contents line carries three item names, and real template names ("Melange
+   Spiced Food", "Micro-sandwich Fabric") are much longer than a water type's,
+   so the 280px cap those tabs use would truncate almost every line.
+
+   Two classes, not one: .bases-generator-cards is declared further down this
+   file and would otherwise win the tie at equal specificity. */
+.bases-generator-cards.bases-inventory-cards { grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 380px)); }
+/* color: transparent rather than display:none or font-size:0 -- the glyphs
+   still generate the line box, so this row keeps the exact height of every
+   other stat label and the card stays aligned with its neighbours.
+
+   Qualified with dt: the bare class loses to `.bases-generator-stats dt`,
+   which sets the label colour at higher specificity. */
+.bases-generator-stats dt.bases-inventory-spacer-label { color: transparent; user-select: none; }
+
+/* Sized to its label rather than the card: a full-width button in a dd read as
+   the card's primary action, competing with the card itself. */
+.bases-inventory-view-contents {
+  width: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 11px;
+  font-size: 12px;
+  border-color: var(--border-strong);
+  background: transparent;
+  color: #f7e7c7;
+}
+.bases-inventory-view-contents .muted { font-size: 11.5px; }
+
+/* Taller and wider than .confirm-modal's 440px: this is a scrolling list, not
+   a sentence and two buttons. */
+.bases-inventory-contents-modal {
+  width: min(560px, calc(100vw - 32px));
+  max-height: min(72vh, 720px);
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  padding-left: 24px;
+  padding-right: 24px;
+}
+.bases-inventory-contents-modal .confirm-modal-title { align-items: start; }
+.bases-inventory-contents-modal .confirm-modal-title > div { min-width: 0; }
+.bases-inventory-contents-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+.bases-inventory-contents-summary > div { background: var(--panel-muted); border-radius: 8px; padding: 8px 10px; min-width: 0; }
+.bases-inventory-contents-summary dt { color: var(--muted-warm); font-size: 11.5px; }
+.bases-inventory-contents-summary dd { margin: 2px 0 0; color: var(--text); font-size: 15px; }
+
+/* The only scroll region in the dialog, so a 45-stack container cannot push
+   the Close button off screen.
+
+   scrollbar-gutter reserves the track whether or not it is needed, so a short
+   container and a long one align identically instead of the rows shifting
+   12px when the scrollbar appears. The padding-right then holds the quantity
+   column clear of that track -- without it the numbers sit under the
+   scrollbar, which is exactly where they are hardest to read. */
+.bases-inventory-contents-list {
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  display: grid;
+  align-content: start;
+  padding-right: 10px;
+}
+.bases-inventory-contents-row {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  gap: 10px;
+  align-items: center;
+  padding: 7px 2px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+.bases-inventory-contents-row:last-child { border-bottom: 0; }
+.bases-inventory-contents-row img { width: 24px; height: 24px; object-fit: contain; border-radius: 4px; background: #25201b; }
+.bases-inventory-contents-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bases-inventory-contents-qty { color: var(--muted-warm); font-variant-numeric: tabular-nums; }
+.bases-inventory-note { margin: 0; font-size: 12px; }
+
 /* Permissions is a single reading column with the Revert/Save bar full-bleed
    beneath it. The inset padding lives on .bases-permissions-content rather than
    here, so the bar reaches both edges of the tab panel without negative margins
@@ -2845,14 +3041,17 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   font-size: 12px;
   line-height: 1.4;
 }
+/* Border is the sidebar's --border-strong, not a bright amber. At two or three
+   cards the amber read as definition; at twenty-seven (a real base's storage)
+   it read as noise, with every card competing for attention. The faint amber
+   wash plus the radius carry the card shape on their own. */
 .bases-generator-group {
   min-width: 0;
   max-width: 100%;
-  border: 1px solid rgba(255, 208, 138, .72);
+  border: 1px solid var(--border-strong);
   border-radius: 8px;
   padding: 12px;
   background: rgba(255, 208, 138, .045);
-  box-shadow: inset 0 0 0 1px rgba(255, 208, 138, .06);
   overflow: hidden;
 }
 .bases-generator-group-title {

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1658,6 +1658,14 @@ body.debug .technical-details { display: block; }
 .bases-table th.bases-actions-column, .bases-table td.bases-actions-column { width: 148px; }
 .bases-table td { max-width: none; white-space: normal; overflow-wrap: anywhere; text-overflow: clip; }
 .bases-name, .bases-ellipsis-cell { display: block; overflow: visible; text-overflow: clip; white-space: normal; overflow-wrap: anywhere; }
+
+/* Map over instance. Two instances of one map are identical in the map column
+   alone -- production runs DeepDesert_1 as both "Deep Desert PvP" and "Deep
+   Desert PvE" -- so the instance line is what actually identifies the row. Same
+   muted tone as the inventory card subtitle. */
+.bases-map-cell { display: grid; gap: 1px; min-width: 0; }
+.bases-map-name { overflow-wrap: anywhere; }
+.bases-map-instance { color: #bebcb6; font-size: 11.5px; overflow-wrap: anywhere; }
 .bases-generator-summary { display: block; white-space: normal; overflow: visible; text-overflow: clip; line-height: 1.4; }
 .bases-fuel-alert { color: var(--danger-text); }
 .bases-pagination-footer { margin-top: 12px; margin-bottom: 0; align-items: center; }

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2417,17 +2417,11 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 
 .bases-water { display: grid; gap: 12px; }
 
-/* Inventory. The inset clamp() matches .bases-generator-breakdown and
+/* Inventory. The inset clamp() matches .bases-tab-body and
    .bases-permissions-content exactly -- that identical value is what makes
    Power, Water, Inventory and Permissions line their content up. */
 .bases-inventory { display: grid; width: 100%; min-width: 0; }
-.bases-inventory-content {
-  display: grid;
-  gap: 12px;
-  min-width: 0;
-  padding: clamp(12px, 1.5vw, 18px);
-}
-/* Sits directly under .bases-generator-group-title, which already carries the
+/* Sits directly under .bases-card-title, which already carries the
    4px bottom margin, so this only needs to close that gap back up.
 
    Deliberately NOT an amber: the title, the field labels and the muted tones
@@ -2526,22 +2520,22 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 .bases-inventory-group-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 10px; margin-bottom: 9px; }
 .bases-inventory-group-head h4 { margin: 0; color: var(--muted-warm); font-size: 12px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; }
 .bases-inventory-group-head span { font-size: 12px; }
-/* The cards themselves are .bases-generator-group / .bases-generator-stats,
+/* The cards themselves are .bases-card / .bases-card-stats,
    shared with Power and Water. Only the track sizing differs: a container's
    Contents line carries three item names, and real template names ("Melange
    Spiced Food", "Micro-sandwich Fabric") are much longer than a water type's,
    so the 280px cap those tabs use would truncate almost every line.
 
-   Two classes, not one: .bases-generator-cards is declared further down this
+   Two classes, not one: .bases-card-grid is declared further down this
    file and would otherwise win the tie at equal specificity. */
-.bases-generator-cards.bases-inventory-cards { grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 380px)); }
+.bases-card-grid.bases-inventory-cards { grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 380px)); }
 /* color: transparent rather than display:none or font-size:0 -- the glyphs
    still generate the line box, so this row keeps the exact height of every
    other stat label and the card stays aligned with its neighbours.
 
-   Qualified with dt: the bare class loses to `.bases-generator-stats dt`,
+   Qualified with dt: the bare class loses to `.bases-card-stats dt`,
    which sets the label colour at higher specificity. */
-.bases-generator-stats dt.bases-inventory-spacer-label { color: transparent; user-select: none; }
+.bases-card-stats dt.bases-inventory-spacer-label { color: transparent; user-select: none; }
 
 /* Sized to its label rather than the card: a full-width button in a dd read as
    the card's primary action, competing with the card itself. */
@@ -2614,7 +2608,7 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
    beneath it. The inset padding lives on .bases-permissions-content rather than
    here, so the bar reaches both edges of the tab panel without negative margins
    -- which would be unsafe under the position: sticky expanded cell below. The
-   clamp() matches .bases-generator-breakdown's exactly, which is what makes
+   clamp() matches .bases-tab-body's exactly, which is what makes
    Power, Water and Permissions inset their content identically. */
 .bases-permissions {
   /* Keep the editor and its action bar aligned while allowing both to use the
@@ -2979,22 +2973,26 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 /* A plain full-width column, not a grid: the auto-refill row and the reserve
    note need the row's true full width (flex's default align-items: stretch
    gives every direct child 100% width for free), while only the actual cards
-   below get wrapped into the capped auto-fit grid in .bases-generator-cards.
+   below get wrapped into the capped auto-fit grid in .bases-card-grid.
    A single grid used to do both jobs via grid-column: 1 / -1 on those two
    children, but that only reaches the edge of the grid's own tracks -- once
    the cards' columns were capped at a fixed max-width (rather than 1fr) the
    tracks stopped summing to the container's full width, so "span every
    track" silently stopped meaning "reach the right edge" and both rows fell
    short of it. */
-.bases-generator-breakdown {
+/* The padded body every expanded-row tab renders into -- Power, Water and
+   Inventory. The clamp() is what makes all of them inset identically, and
+   --bases-permissions-inset holds the same value for the fourth. */
+.bases-tab-body {
   display: flex;
   flex-direction: column;
   gap: 12px;
   width: 100%;
+  min-width: 0;
   padding: clamp(12px, 1.5vw, 18px);
   box-sizing: border-box;
 }
-.bases-generator-cards {
+.bases-card-grid {
   display: grid;
   /* Capped at 280px rather than 1fr: with few groups (a base with one or two
      water containers, in particular) an unbounded 1fr stretches each card to
@@ -3003,7 +3001,7 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   gap: 12px;
   align-items: stretch;
 }
-.bases-generator-cards.bases-water-cards {
+.bases-card-grid.bases-water-cards {
   align-items: start;
 }
 .bases-uptime-event-inline {
@@ -3045,7 +3043,7 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
    cards the amber read as definition; at twenty-seven (a real base's storage)
    it read as noise, with every card competing for attention. The faint amber
    wash plus the radius carry the card shape on their own. */
-.bases-generator-group {
+.bases-card {
   min-width: 0;
   max-width: 100%;
   border: 1px solid var(--border-strong);
@@ -3054,7 +3052,7 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   background: rgba(255, 208, 138, .045);
   overflow: hidden;
 }
-.bases-generator-group-title {
+.bases-card-title {
   min-width: 0;
   color: #ffd08a;
   font-weight: 700;
@@ -3064,14 +3062,14 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 }
 /* A definition-list grid, not a nested <table>: cells inside .bases-table
    inherit the outer column widths, centring and row borders. */
-.bases-generator-stats {
+.bases-card-stats {
   display: grid;
   grid-template-columns: 1fr;
   width: 100%;
   min-width: 0;
   margin: 0;
 }
-.bases-generator-stats dt {
+.bases-card-stats dt {
   min-width: 0;
   color: var(--muted-warm);
   padding: 6px 0 0;
@@ -3079,7 +3077,7 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   line-height: 1.25;
   overflow-wrap: anywhere;
 }
-.bases-generator-stats dd {
+.bases-card-stats dd {
   min-width: 0;
   margin: 0;
   padding: 0 0 6px;
@@ -3089,7 +3087,7 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
   line-height: 1.25;
   overflow-wrap: anywhere;
 }
-.bases-generator-stats dd:last-child {
+.bases-card-stats dd:last-child {
   border-bottom: 0;
 }
 .inventory-augment-input-line {

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ reference. Everything else is marked **Current** and is expected to stay accurat
 - [generator-fuel-burn-rates.md](console/generator-fuel-burn-rates.md) — Current. Per-generator fuel burn constants and where they live in code.
 - [generator-refill-caps.md](console/generator-refill-caps.md) — Current. Refill-generators endpoint behavior and per-type fuel caps.
 - [base-permissions.md](console/base-permissions.md) — Current. Editing base ownership and sharing: ranks, the config-driven roster cap, and why the change needs no map restart.
+- [base-inventory.md](console/base-inventory.md) — Current. The read-only base Inventory tab: which placeables count as storage, the two inventories every refinery carries, and why the tab cannot write.
 
 ## Runtime (`runtime/`)
 

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -246,6 +246,7 @@ Complete reference for all HTTP API endpoints in the Dune Docker Console. All en
 | DELETE | `/api/bases/{baseId}/queued-water-refill` | Cancel a base's queued water refill | `baseId` |
 | GET | `/api/bases/auto-refill-water` | Get per-base water auto-refill enrollment state | None |
 | POST | `/api/bases/{baseId}/auto-refill-water` | Enable/disable water auto-refill for a base | `baseId`, `enabled` |
+| GET | `/api/bases/{baseId}/inventory` | Get a base's stored items, rolled up by item template and by container (storage, refining, crafting, machines). Read-only | `baseId` |
 | GET | `/api/bases/{baseId}/permissions` | Get a base's permission roster (Owner, Co-Owners, Associates) | `baseId` |
 | POST | `/api/bases/{baseId}/system-custodian` | Transfer ownership to the detected Server or GM system custodian while preserving the roster | `baseId` |
 | PUT | `/api/bases/{baseId}/permissions` | Replace a base's permission roster | `baseId`, `entries[]` (`playerId`, `rank`) |
@@ -264,6 +265,11 @@ limit comes from live server config, not a constant.
 
 Changes reach a running map immediately — there is no restart queue, unlike the
 generator refill routes above. See [base-permissions.md](base-permissions.md).
+
+`GET /api/bases/{baseId}/inventory` covers storage containers plus refinery,
+fabricator and machine inventories; generator and windtrap fuel belong to the
+refill and water routes above. It is read-only — inventory writes have no path
+to a running map. See [base-inventory.md](base-inventory.md).
 
 ### Storage
 

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -277,6 +277,12 @@ fabricator and machine inventories; generator and windtrap fuel belong to the
 refill and water routes above. It is read-only — inventory writes have no path
 to a running map. See [base-inventory.md](base-inventory.md).
 
+Both `GET /api/bases/{baseId}/water` and `GET /api/bases/{baseId}/inventory`
+answer **200 with `supported: false` and a `reason`** when the detected schema
+lacks a table they need, rather than an error status — the same capability shape
+`/api/bases` uses. An error status from either means a genuine failure, so the
+tab can offer a retry only where retrying could actually help.
+
 ### Storage
 
 | Method | Route | Description | Parameters |

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -252,6 +252,12 @@ Complete reference for all HTTP API endpoints in the Dune Docker Console. All en
 | PUT | `/api/bases/{baseId}/permissions` | Replace a base's permission roster | `baseId`, `entries[]` (`playerId`, `rank`) |
 | GET | `/api/bases/permission-candidates` | Search players eligible to be added to a roster | `q?`, `limit?` |
 
+Each `GET /api/bases` row carries `partitionMap` and `dimensionIndex` alongside
+`map` and `partition_id`. `map` is the game's own name (`HaggaBasin`) and cannot
+distinguish two instances of one map; `partitionMap` is the name the rest of the
+console uses (`Survival_1`), and `partition_id` identifies the single running
+instance. Both are empty on a schema without `dune.world_partition`.
+
 `GET /api/bases` reports `capabilities.basePermissions`; the permission routes are
 unavailable when it is false (the schema lacks the required tables or the game's
 `permission_set_player_rank` / `permission_remove_player_rank` procedures).

--- a/docs/console/base-inventory.md
+++ b/docs/console/base-inventory.md
@@ -1,0 +1,95 @@
+# Base Inventory
+
+The **Inventory** tab on an expanded base row (Bases panel → expand a base → Power / Water / Inventory / Sub-Fief Permissions) lists everything stored at that base. It is read-only.
+
+Backed by `GET /api/bases/{baseId}/inventory` → `duneDb.baseInventory()`.
+
+## What counts as base inventory
+
+Classification is an explicit `building_type` allowlist in `BASE_INVENTORY_TYPES` (`console/api/src/duneDb.js`), in four groups:
+
+| Group | `building_type` (lowercased) → label |
+|---|---|
+| Storage | `storagecontainer` → Storage Container · `mediumstoragecontainer`† → Medium Storage Container (100 slots) · `genericcontainer` → **Chest** · `spicesilo` and `smallstoragecontainer`† → **Small Storage Container** |
+| Refining | `smallorerefinery` · `mediumorerefinery` · `largeorerefinery`† · `smallchemicalrefinery` · `mediumchemicalrefinery` → matching names; `spicerefinery` → Spice Refinery · `mediumspicerefinery`† · `largespicerefinery`† |
+| Crafting | `fabricator` → Fabricator · `survivalfabricator` · `vehiclesfabricator` · `weaponsfabricator` · `wearablesfabricator` → Garment Fabricator · plus `advancedsurvivalfabricator`†, `advancedvehiclefabricator`† (singular), `advancedweaponsfabricator`†, `advancedwearablesfabricator`† → Advanced … |
+| Machines | `recycler` → Recycler · `repairstation` → Repair Station |
+
+All suffixed `_placeable`. † marks a type not present in any database seen so far — it is in the allowlist because the game ships it, not because it has been observed in use.
+
+Every string was verified against the shipped server paks, where each building carries a `DA_BLD_<building_type>.uasset`:
+
+```bash
+docker exec dune-server-survival-1 bash -c 'cat /home/dune/server/DuneSandbox/Content/Paks/*.pak | grep -aoE "DA_BLD_[A-Za-z0-9_]+_Placeable" | sed "s/^DA_BLD_//" | sort -u'
+```
+
+That is what caught `AdvancedVehicleFabricator_Placeable` being **singular** while its own base building, `VehiclesFabricator_Placeable`, is plural. The reverse does not hold: the extraction is lossy — `SpiceSilo_Placeable`, `SmallOreRefinery_Placeable` and `Fabricator_Placeable` all fail to appear despite being live on the same server, and a handful of results come back truncated at compression boundaries (`MediumorageContainer_Placeable`, `RepairSta_Placeable`). Presence is proof; absence is not.
+
+`SpiceSilo_Placeable` and `SmallStorageContainer_Placeable` are both listed and both labelled "Small Storage Container": the former is the legacy name every live placement still carries (48 on production against 0 of the latter), the latter is the asset name shipped in the paks. Anything not listed is omitted rather than bucketed, matching the allowlist reasoning in `portalGeneratorFuel`'s `generator_spec` CTE — an unrecognised placeable must not acquire a group and report an invented fill level.
+
+Generator and windtrap fuel is deliberately absent; the Power and Water tabs own it.
+
+## Why not classify on `inventory_type`
+
+`dune.inventories.inventory_type` almost separates these groups on its own — verified against a real dump (373 placeables, 535 inventories, 493 `dune.actor_inventories` rows):
+
+| `inventory_type` | `component_name_hash` | What it is |
+|---|---|---|
+| 4 | `1264785389` | Storage containers — `StorageContainer` 45 slots, `GenericContainer` 20, `SpiceSilo` 10 |
+| 12 | `710548` and `26344419` | Refinery and fabricator inventories, two per placeable (split into the Refining and Crafting groups) |
+| 3 | `1264785389` | Fuel and module slots — generators, wind turbines, windtraps — **and** `Recycler` and `RepairStation` |
+
+Keying on the type would file a 25-slot `Recycler` — which held more items than anything outside storage in the reference dump — under "fuel", alongside the oil generators the Power tab already covers. Hence the building-type allowlist.
+
+## The second refinery inventory
+
+Every refinery and fabricator carries **two** `inventory_type = 12` inventories:
+
+- `component_name_hash = 710548`, `max_item_count` 5 or 10 — holds the ore and crafting inputs.
+- `component_name_hash = 26344419`, `max_item_count = -1` — empty on all 44 of them in the reference dump.
+
+The query filters `inv.max_item_count >= 0`, which drops the second one. That agrees with the hash split on every row and avoids depending on `dune.actor_inventories`; it also keeps a slot bar from dividing by a negative capacity.
+
+## Container names
+
+`dune.permission_actor.actor_name` holds `'##' || building_type` for any placeable a player has never renamed, and whatever the player typed otherwise (real examples from the dump: "Ore Storage", "Aluminum Refinery", "Refinery Output NO ORES"). The query strips the `##`-prefixed defaults and `'None'`, exactly as `listStorage` does, and returns `""`; the frontend falls back to `<type name> #<placeable id>`.
+
+The game stores **no** display name for a placeable *type*, so the type labels in `BASE_INVENTORY_TYPES` are this console's own. Where a `building_type` disagrees with the player-facing name, the catalog patent in `runtime/data/admin-items.json` wins — it is the same source the console already uses for item names.
+
+`SpiceSilo_Placeable` is the case that matters. Its patent is named **"Small Storage Container"**, and the data agrees: across the 40 of them in the reference dump, 195 of 198 item rows were *not* spice — clothing, tools, ingots, bloodsacks. It is a general-purpose 10-slot container, and "Spice Silo" is only the internal blueprint name (`BP_SpiceSiloContainer`). The tab labels it "Small Storage Container".
+
+Every label was ultimately read off the in-game build menu. Two would have been guessed wrong from the data alone, and both are worth recording:
+
+**`GenericContainer_Placeable` is "Chest", not "Medium Storage Container".** Its 20 slots sit exactly between the confirmed 10-slot Small and 45-slot Storage Container, so the capacity ladder argues convincingly for "medium" — and is wrong. The real Medium Storage Container is a separate building with **100 slots**, which puts it *above* Storage Container rather than between.
+
+**The fabricators are nine buildings, not five.** The plain and Advanced variants coexist in the build menu. The catalog cannot be taken at face value here: `SurvivalFabricator_Patent` is *named* "Advanced Survival Fabricator Patent" while a distinct `AdvancedSurvivalFabricator_Patent` carries the same display name, so one of the two entries is simply wrong. Reading the duplicate as "there is only an advanced tier" produces four wrong labels.
+
+`SpiceRefinery_Placeable` is plain "Spice Refinery"; Medium and Large are separate buildables, unlike the size-prefixed ore refineries.
+
+## Why read-only
+
+Base inventory writes have no live-sync path:
+
+- No `pg_notify` routine covers inventory or buildings. The game's 8 notify channels are guild, landsraad, party, permission, taxation, faction, vehicle_recovery, player_info.
+- There are zero triggers on `dune.items`, `dune.inventories`, `dune.buildings`, `dune.placeables`.
+- The RMQ command bus has no per-item edit or delete. `AddItemToInventory` addresses items by *template name*; every id here is a row id.
+
+So an edit could not reach a running map without a relog or a map restart. The tab states this inline rather than offering writes that would silently not apply.
+
+## Response shape
+
+```
+{ supported, baseId,
+  groups:     [{ key, name, containerCount, itemCount }],
+  containers: [{ placeableId, name, typeName, group, usedSlots, maxSlots, itemCount,
+                 items: [{ templateId, name, quantity }] }],
+  items:      [{ templateId, name, image, category, quantity, containerCount,
+                 containers: [{ placeableId, name, typeName, group, quantity }] }],
+  totals:     { items, distinct, containers, usedSlots, maxSlots } }
+```
+
+One response backs both views, so switching between Items and Containers never refetches. Item `name`/`category` come from `adminItemMetadata()` over `runtime/data/admin-items.json`, falling back to the raw `template_id`; `image` resolves through `itemImagePath()` and falls back to `image-unavailable.png`.
+
+`usedSlots` counts item *rows* — one stack occupies one slot — while `quantity` sums `stack_size`. Capacity is summed once per inventory, not per item row, since every row repeats its inventory's `max_item_count`.
+
+**A container's `items[]` is not its stacks.** Rows sharing a template are merged into one entry, so `items.length` is the number of distinct templates and is **≤ `usedSlots`**. On the reference base, Chem Storage fills 8 slots with 3 templates, and 5 of 17 containers disagree the same way. The UI therefore says "3 distinct", never "3 stacks" — the stack count is `usedSlots`, already shown as Slots Used. The type is named `BaseInventoryEntry` rather than `…Stack` for the same reason.


### PR DESCRIPTION
Adds a read-only Inventory tab to the expanded base row, showing what a base
holds — storage containers plus refining, crafting and machine inventories —
rolled up either by item template or by container. Backed by a new
`GET /api/bases/{baseId}/inventory`.

Classification is an explicit `building_type` allowlist rather than
`inventory_type`: Recycler and Repair Station are type 3, the same as the oil
generators the Power tab owns. All 24 types were verified against the shipped
server paks and a live database; unrecognised placeables are omitted rather
than guessed at.

Read-only by design — item writes have no live-sync path: no `pg_notify`
channel carries them, there are no triggers on `dune.items`/`dune.inventories`,
and the RMQ command bus addresses items by template name while every id here is
a row id.

Also in this branch:

- **Map column** now identifies *which* instance of a map a base is on. It
  showed `dune.actors.map`, which is identical for every instance — a server
  running two Deep Desert instances showed both as "DeepDesert". Resolved
  through `world_partition` and labelled with the operator-chosen instance
  name, falling back to the partition number.
- **Sietch partition ids** — `parseSietchRows` falls back to the dimension
  index when the `--ids` output is short or empty, and those indices were
  pooled across all maps, so one map's dimension index could label another
  map's base. The same fallback reached every sietch write: a rename, password
  change or restart could land on a different partition than the one being
  edited. Such rows are no longer valid write targets, and the save is refused
  with a message rather than skipped — a bulk Save that skipped them either did
  nothing at all or applied an unrelated active-count change while silently
  discarding the edited fields. Reads are unaffected; the sietch list still
  renders in full.
- **`itemImagePath`** ran an uncached `existsSync` per item id, so a catalog
  response repeated up to 10,000 synchronous stats per call.
- **`bases-generator-*` card classes** renamed to `bases-card-*` now that three
  tabs share them. No visual change.

Docs in `docs/console/base-inventory.md`, with `API-REFERENCE.md` and the docs
index updated.

271 frontend tests pass; the backend suite is green on Linux apart from 5
pre-existing failures that require a live database, unchanged from baseline.
