### PR TITLE
feat(exchange): read-only Market Board

### DIFF
--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -49,6 +49,7 @@ export const NAMESPACES = {
   STORAGE:     "storage",
   BLUEPRINTS:  "blueprints",
   VEHICLES:    "vehicles",
+  EXCHANGE:    "exchange",
 };
 
 // ---- Actions: route → action mapping ----
@@ -147,6 +148,13 @@ export const ROUTE_ACTIONS = {
 
   // --- Vehicles ---
   "GET /api/vehicles":                         "vehicles:read",
+
+  // --- Exchange (Market Board) — read-only board + console-local filter config ---
+  "GET /api/exchange/items":                   "exchange:read",
+  "GET /api/exchange/listings":                "exchange:read",
+  "GET /api/exchange/stats":                   "exchange:read",
+  "GET /api/exchange/config":                  "exchange:read",
+  "POST /api/exchange/config":                 "exchange:write-config",
 
   // --- Players (mutations) ---
   "POST /api/players/kick-all-online":         "players:kick-all",

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -4149,7 +4149,7 @@ function craftingRecipeCatalog() {
   return craftingRecipeCatalogCache;
 }
 
-function adminItemMetadata() {
+export function adminItemMetadata() {
   if (adminItemMetadataCache) return adminItemMetadataCache;
   const metadata = new Map();
   try {

--- a/console/api/src/policy.js
+++ b/console/api/src/policy.js
@@ -192,6 +192,7 @@ const DEFAULT_POLICIES = {
         "storage:*",
         "blueprints:*",
         "vehicles:*",
+        "exchange:*",
         "maps:*",
         "sietches:*",
         "deepdesert:*",
@@ -223,6 +224,7 @@ const DEFAULT_POLICIES = {
         "storage:read",
         "blueprints:read",
         "vehicles:read",
+        "exchange:read",
         "logs:*",
         "landsraad:read",
         "admin:broadcast",
@@ -245,6 +247,7 @@ const DEFAULT_POLICIES = {
         "storage:read",
         "blueprints:read",
         "vehicles:read",
+        "exchange:read",
         "landsraad:read",
       ]},
     ]
@@ -264,6 +267,7 @@ const DEFAULT_POLICIES = {
         "storage:read",
         "blueprints:read",
         "vehicles:read",
+        "exchange:read",
         "landsraad:read",
       ]},
     ]

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -49,6 +49,7 @@ import { grantAddonItem } from "./addonItemGrants.js";
 import { EDA_EXCHANGE_BOT_ADDON_ID, ADDON_SCHEDULER_PERMISSION, createAddonJobScheduler, probeBuybackEligibility, readBuybackSchedule, saveBuybackSchedule } from "./addonJobs.js";
 import { createPublicDirectoryReporter, normalizeDiscordInvite, readDirectorySettings } from "./services/publicDirectory.js";
 import { choamTerminalOverview, installChoamTerminals, removeChoamTerminals } from "./services/choamTerminals.js";
+import { exchangeStats, listExchangeItems, listExchangeListings, readExchangeConfig, saveExchangeConfig } from "./services/exchange.js";
 import { autoRefillPublicState, createAutoRefillScheduler, setBaseAutoRefill } from "./services/autoRefill.js";
 import { autoRefillWaterPublicState, createAutoRefillWaterScheduler, setBaseAutoRefillWater } from "./services/autoRefillWater.js";
 import { calculateAlwaysOnHostMemorySafety } from "./services/hostMemorySafety.js";
@@ -749,6 +750,36 @@ async function handleApi(req, res) {
   if (path === "/api/maps/choam-terminals" && req.method === "POST") return mapsChoamTerminalInstallRoute(req, res);
   if (path === "/api/maps/choam-terminals" && req.method === "DELETE") return mapsChoamTerminalRemoveRoute(req, res);
   if (path === "/api/maps/choam-terminals") return dbJson(res, () => choamTerminalOverview(db));
+  if (path === "/api/exchange/items") return dbJson(res, () => {
+    const exchangeConfig = readExchangeConfig(config.repoRoot);
+    return listExchangeItems(db, {
+      q: url.searchParams.get("q") || "",
+      page: url.searchParams.get("page") || 0,
+      pageSize: url.searchParams.get("pageSize") || 50,
+      sortColumn: url.searchParams.get("sortColumn") || "display_name",
+      sortDirection: url.searchParams.get("sortDirection") || "asc",
+      owner: url.searchParams.get("owner") || "player",
+      botOwnerIds: exchangeConfig.botOwnerIds,
+      blacklist: exchangeConfig.blacklistedOwnerIds,
+      repoRoot: config.repoRoot
+    });
+  });
+  if (path === "/api/exchange/listings") return dbJson(res, () => {
+    const exchangeConfig = readExchangeConfig(config.repoRoot);
+    return listExchangeListings(db, {
+      templateId: url.searchParams.get("templateId") || "",
+      qualityLevel: url.searchParams.get("quality") || "",
+      owner: url.searchParams.get("owner") || "all",
+      botOwnerIds: exchangeConfig.botOwnerIds,
+      blacklist: exchangeConfig.blacklistedOwnerIds
+    });
+  });
+  if (path === "/api/exchange/stats") return dbJson(res, () => {
+    const exchangeConfig = readExchangeConfig(config.repoRoot);
+    return exchangeStats(db, { botOwnerIds: exchangeConfig.botOwnerIds, blacklist: exchangeConfig.blacklistedOwnerIds });
+  });
+  if (path === "/api/exchange/config" && req.method === "GET") return json(res, 200, readExchangeConfig(config.repoRoot));
+  if (path === "/api/exchange/config" && req.method === "POST") return exchangeConfigSaveRoute(req, res);
   if (path === "/api/maps/user-settings/schema") return userSettingsSchemaRoute(res);
   if (path === "/api/maps/user-settings/restart-pending") return json(res, 200, { pending: existsSync(resolve(config.repoRoot, "runtime/generated/landsraad-restart-required")) });
   if (path === "/api/maps/user-settings/values") return userSettingsValuesRoute(res, url);
@@ -1161,6 +1192,21 @@ async function mapsChoamTerminalRemoveRoute(req, res) {
   if (!applyMutationRateLimit(req, res, "maps.choam-terminals.remove")) return;
   audit(config, req, "maps.choam-terminals.remove", { tradeCenterKey: body.tradeCenterKey });
   return dbJson(res, () => removeChoamTerminals(db, body));
+}
+
+async function exchangeConfigSaveRoute(req, res) {
+  const body = await readJson(req);
+  if (!applyMutationRateLimit(req, res, "exchange.config")) return;
+  audit(config, req, "exchange.config", {
+    botOwnerIds: Array.isArray(body?.botOwnerIds) ? body.botOwnerIds.length : 0,
+    blacklistedOwnerIds: Array.isArray(body?.blacklistedOwnerIds) ? body.blacklistedOwnerIds.length : 0
+  });
+  try {
+    return json(res, 200, saveExchangeConfig(config.repoRoot, body));
+  } catch (error) {
+    const payload = apiErrorPayload(error, 400);
+    return json(res, payload.status, { supported: false, ...payload.body });
+  }
 }
 
 async function safeCommand(operation, payload = {}) {

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -758,9 +758,11 @@ async function handleApi(req, res) {
       pageSize: url.searchParams.get("pageSize") || 50,
       sortColumn: url.searchParams.get("sortColumn") || "display_name",
       sortDirection: url.searchParams.get("sortDirection") || "asc",
-      owner: url.searchParams.get("owner") || "player",
+      owner: url.searchParams.get("owner") || "all",
+      category: url.searchParams.get("category") || "",
       botOwnerIds: exchangeConfig.botOwnerIds,
       blacklist: exchangeConfig.blacklistedOwnerIds,
+      includeNpcBroker: exchangeConfig.includeNpcBroker,
       repoRoot: config.repoRoot
     });
   });
@@ -771,12 +773,13 @@ async function handleApi(req, res) {
       qualityLevel: url.searchParams.get("quality") || "",
       owner: url.searchParams.get("owner") || "all",
       botOwnerIds: exchangeConfig.botOwnerIds,
-      blacklist: exchangeConfig.blacklistedOwnerIds
+      blacklist: exchangeConfig.blacklistedOwnerIds,
+      includeNpcBroker: exchangeConfig.includeNpcBroker
     });
   });
   if (path === "/api/exchange/stats") return dbJson(res, () => {
     const exchangeConfig = readExchangeConfig(config.repoRoot);
-    return exchangeStats(db, { botOwnerIds: exchangeConfig.botOwnerIds, blacklist: exchangeConfig.blacklistedOwnerIds });
+    return exchangeStats(db, { botOwnerIds: exchangeConfig.botOwnerIds, blacklist: exchangeConfig.blacklistedOwnerIds, includeNpcBroker: exchangeConfig.includeNpcBroker });
   });
   if (path === "/api/exchange/config" && req.method === "GET") return json(res, 200, readExchangeConfig(config.repoRoot));
   if (path === "/api/exchange/config" && req.method === "POST") return exchangeConfigSaveRoute(req, res);

--- a/console/api/src/services/exchange.js
+++ b/console/api/src/services/exchange.js
@@ -146,6 +146,12 @@ async function queryAggregatedItems(db, { owner, botIds, blacklist, includeNpcBr
   const ownerSql = ownerClause(owner, botIds, includeNpcBroker, params);
   params.push(blacklist);
   const blockParam = `$${params.length}::bigint[]`;
+  // The INNER join to dune_exchange_sell_orders is load-bearing: it scopes the board
+  // to ACTIVE sell listings. Orders that have been fulfilled have no sell_orders row
+  // (they live in dune_exchange_fulfilled_orders) and are intentionally excluded.
+  // Stock is items.stack_size (the live remaining stack); initial_stack_size is only a
+  // fallback for the rare case of a missing items row, and reflects the original (not
+  // remaining) quantity — harmless today because every active order has an items row.
   const result = await db.query(`
     select o.template_id,
            o.quality_level,

--- a/console/api/src/services/exchange.js
+++ b/console/api/src/services/exchange.js
@@ -1,0 +1,318 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { intParam } from "../db.js";
+import { adminItemMetadata, tableExists } from "../duneDb.js";
+import { itemImagePath } from "../adminCatalog.js";
+import { writeJsonAtomic } from "../jsonStore.js";
+import { redact } from "../redact.js";
+
+// The Market Board is a READ-ONLY viewer over the game's own CHOAM exchange
+// tables (the game writes them; we never mutate them here). Data model verified
+// against a real dump: dune_exchange_orders holds one row per order with
+// is_npc_order / item_price / quality_level / owner_id / item_id / template_id;
+// dune_exchange_sell_orders carries initial_stack_size; stock comes from
+// items.stack_size. Seller identity resolves the same way the Players page does:
+// actors.owner_account_id -> player_state.character_name.
+const REQUIRED_TABLES = ["dune_exchange_orders", "dune_exchange_sell_orders", "items", "actors", "player_state"];
+
+const OWNER_FILTERS = new Set(["player", "bot", "all"]);
+
+// owner_id is a bigint (beyond JS safe-int range), so ids are handled as
+// digit-strings everywhere and passed to Postgres as bigint[] parameters.
+const MAX_IDS = 1000;
+
+const EXCHANGE_CONFIG_PATH = "runtime/generated/exchange-config.json";
+
+// Sort keys the board accepts. display_name/category/tier are catalog-derived
+// (not DB columns), which is why sorting happens in the service after enrichment
+// rather than in SQL. Keys must match the frontend ExchangeTable column ids.
+const EXCHANGE_SORT_COLUMNS = {
+  display_name: "str",
+  template_id: "str",
+  category: "str",
+  quality_level: "num",
+  tier: "num",
+  lowest_price: "num",
+  total_stock: "num",
+  listing_count: "num"
+};
+
+// Short-TTL cache of the enriched, unfiltered aggregate keyed by owner +
+// config version, so rapid paging/sorting/searching runs the GROUP BY at most
+// once per window. The active-market set is bounded by the item catalog, so this
+// stays small. Process-local, like the console's other in-memory caches.
+const AGG_CACHE_TTL_MS = 30_000;
+const aggregateCache = new Map();
+
+function configFile(repoRoot) {
+  return resolve(repoRoot || "", EXCHANGE_CONFIG_PATH);
+}
+
+// Digit-string owner ids: validate, dedupe, cap. Lenient by default (drops junk);
+// pass throwOnInvalid for the save path so bad input is rejected, not silently
+// swallowed.
+function coerceIdList(value, { throwOnInvalid = false } = {}) {
+  const out = [];
+  const seen = new Set();
+  for (const raw of Array.isArray(value) ? value : []) {
+    const id = String(raw).trim();
+    if (!/^\d{1,19}$/.test(id)) {
+      if (throwOnInvalid) throw Object.assign(new Error(`Invalid owner id: ${id.slice(0, 32) || "(empty)"}. Enter numeric owner ids only.`), { statusCode: 400 });
+      continue;
+    }
+    if (seen.has(id)) continue;
+    if (out.length >= MAX_IDS) {
+      if (throwOnInvalid) throw Object.assign(new Error(`Too many owner ids (max ${MAX_IDS}).`), { statusCode: 400 });
+      break;
+    }
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+async function exchangeSupported(db) {
+  for (const table of REQUIRED_TABLES) {
+    if (!(await tableExists(db, table))) return false;
+  }
+  return true;
+}
+
+function unsupported() {
+  return {
+    capabilities: { exchange: false },
+    rows: [],
+    reason: `Unsupported by detected schema. Missing required table(s): ${REQUIRED_TABLES.map((t) => `dune.${t}`).join(", ")}`
+  };
+}
+
+// Leading tier token (T6_Foo -> 6). Many templates carry no tier prefix; those
+// stay null so they sort last / render as a dash.
+function parseTier(templateId) {
+  const match = /^T(\d{1,2})_/i.exec(templateId);
+  return match ? Number(match[1]) : null;
+}
+
+function num(value) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+// player  -> real player sell orders (not NPC, not a configured bot id)
+// bot     -> the in-game NPC broker OR any configured bot owner id
+// all     -> no owner predicate
+// Blacklisted owner ids are always excluded, on every owner value.
+function ownerPredicate(owner, botParam) {
+  if (owner === "player") return `not o.is_npc_order and o.owner_id <> all(${botParam})`;
+  if (owner === "bot") return `(o.is_npc_order or o.owner_id = any(${botParam}))`;
+  return "true";
+}
+
+function enrichItem(row, metadata, repoRoot) {
+  const templateId = String(row.template_id || "");
+  const meta = metadata.get(templateId);
+  return {
+    template_id: templateId,
+    quality_level: num(row.quality_level),
+    display_name: meta?.name || templateId,
+    category: meta?.category || "",
+    tier: parseTier(templateId),
+    lowest_price: num(row.lowest_price),
+    total_stock: num(row.total_stock),
+    npc_stock: num(row.npc_stock),
+    listing_count: num(row.listing_count),
+    icon: itemImagePath(repoRoot, templateId)
+  };
+}
+
+async function queryAggregatedItems(db, { owner, botIds, blacklist, repoRoot }) {
+  const params = [];
+  params.push(botIds);
+  const botParam = `$${params.length}::bigint[]`;
+  params.push(blacklist);
+  const blockParam = `$${params.length}::bigint[]`;
+  const result = await db.query(`
+    select o.template_id,
+           o.quality_level,
+           min(o.item_price) as lowest_price,
+           coalesce(sum(coalesce(i.stack_size, s.initial_stack_size)), 0) as total_stock,
+           coalesce(sum(case when o.is_npc_order then coalesce(i.stack_size, s.initial_stack_size) else 0 end), 0) as npc_stock,
+           count(*) as listing_count
+    from dune.dune_exchange_orders o
+    join dune.dune_exchange_sell_orders s on s.order_id = o.id
+    left join dune.items i on i.id = o.item_id
+    where ${ownerPredicate(owner, botParam)} and o.owner_id <> all(${blockParam})
+    group by o.template_id, o.quality_level`, params);
+  const metadata = adminItemMetadata();
+  return result.rows.map((row) => enrichItem(row, metadata, repoRoot));
+}
+
+async function aggregatedItems(db, view) {
+  const key = `${view.owner}|${view.botIds.join(",")}|${view.blacklist.join(",")}`;
+  const now = Date.now();
+  const cached = aggregateCache.get(key);
+  if (cached && now - cached.at < AGG_CACHE_TTL_MS) return cached.rows;
+  const rows = await queryAggregatedItems(db, view);
+  aggregateCache.set(key, { at: now, rows });
+  return rows;
+}
+
+function sortItems(rows, column, direction) {
+  const type = EXCHANGE_SORT_COLUMNS[column];
+  const factor = direction === "desc" ? -1 : 1;
+  return [...rows].sort((a, b) => {
+    let cmp;
+    if (type === "num") cmp = num(a[column]) - num(b[column]);
+    else cmp = String(a[column] || "").toLowerCase().localeCompare(String(b[column] || "").toLowerCase());
+    if (cmp === 0) cmp = String(a.template_id).localeCompare(String(b.template_id));
+    return cmp * factor;
+  });
+}
+
+export async function listExchangeItems(db, {
+  q = "", page = 0, pageSize = 50,
+  sortColumn = "display_name", sortDirection = "asc",
+  owner = "player", botOwnerIds = [], blacklist = [], repoRoot = ""
+} = {}) {
+  if (!(await exchangeSupported(db))) return { ...unsupported(), totalCount: 0, totalItems: 0 };
+
+  const safePageSize = intParam(pageSize, "pageSize", 1, 200);
+  const safePage = intParam(page, "page", 0);
+  const safeOwner = OWNER_FILTERS.has(owner) ? owner : "player";
+  const safeSortColumn = Object.hasOwn(EXCHANGE_SORT_COLUMNS, sortColumn) ? sortColumn : "display_name";
+  const safeSortDirection = String(sortDirection).toLowerCase() === "desc" ? "desc" : "asc";
+
+  const all = await aggregatedItems(db, {
+    owner: safeOwner,
+    botIds: coerceIdList(botOwnerIds),
+    blacklist: coerceIdList(blacklist),
+    repoRoot
+  });
+
+  const term = String(q || "").trim().toLowerCase();
+  const filtered = term
+    ? all.filter((row) => row.display_name.toLowerCase().includes(term)
+      || row.category.toLowerCase().includes(term)
+      || row.template_id.toLowerCase().includes(term))
+    : all;
+
+  const sorted = sortItems(filtered, safeSortColumn, safeSortDirection);
+  const offset = safePage * safePageSize;
+  return {
+    capabilities: { exchange: true },
+    rows: sorted.slice(offset, offset + safePageSize),
+    totalCount: filtered.length,
+    totalItems: all.length
+  };
+}
+
+export async function listExchangeListings(db, {
+  templateId = "", qualityLevel = "", owner = "all", botOwnerIds = [], blacklist = []
+} = {}) {
+  if (!(await exchangeSupported(db))) return unsupported();
+
+  const tid = String(templateId || "").trim();
+  if (!tid || tid.length > 240 || /[\r\n\0]/.test(tid)) {
+    throw Object.assign(new Error("A valid item template id is required."), { statusCode: 400 });
+  }
+  const safeOwner = OWNER_FILTERS.has(owner) ? owner : "all";
+  const botIds = coerceIdList(botOwnerIds);
+  const blacklistIds = coerceIdList(blacklist);
+
+  const params = [tid];
+  params.push(botIds);
+  const botParam = `$${params.length}::bigint[]`;
+  params.push(blacklistIds);
+  const blockParam = `$${params.length}::bigint[]`;
+  let qualitySql = "";
+  if (String(qualityLevel).trim() !== "") {
+    params.push(intParam(qualityLevel, "quality", 0));
+    qualitySql = ` and o.quality_level = $${params.length}`;
+  }
+
+  const result = await db.query(`
+    select o.id::text as order_id,
+           o.template_id,
+           o.is_npc_order,
+           o.owner_id::text as owner_id,
+           coalesce(ps.character_name, a.class, 'Unknown') as owner_name,
+           o.item_price,
+           coalesce(i.stack_size, s.initial_stack_size) as stock,
+           coalesce(o.quality_level, 0) as quality
+    from dune.dune_exchange_orders o
+    join dune.dune_exchange_sell_orders s on s.order_id = o.id
+    left join dune.items i on i.id = o.item_id
+    left join dune.actors a on a.id = o.owner_id
+    left join dune.player_state ps on ps.account_id = a.owner_account_id
+    where o.template_id = $1 and ${ownerPredicate(safeOwner, botParam)} and o.owner_id <> all(${blockParam})${qualitySql}
+    order by o.item_price asc, o.id asc`, params);
+
+  const botSet = new Set(botIds);
+  const rows = result.rows.map((row) => {
+    const isBot = Boolean(row.is_npc_order) || botSet.has(String(row.owner_id));
+    return {
+      order_id: row.order_id,
+      template_id: String(row.template_id || ""),
+      owner_type: isBot ? "bot" : "player",
+      owner_name: String(row.owner_name || "Unknown"),
+      price: num(row.item_price),
+      stock: num(row.stock),
+      quality: num(row.quality)
+    };
+  });
+  return { capabilities: { exchange: true }, rows };
+}
+
+export async function exchangeStats(db, { botOwnerIds = [], blacklist = [] } = {}) {
+  if (!(await exchangeSupported(db))) return unsupported();
+  const params = [coerceIdList(botOwnerIds), coerceIdList(blacklist)];
+  const result = await db.query(`
+    select count(*) as total_listings,
+           count(*) filter (where o.is_npc_order or o.owner_id = any($1::bigint[])) as bot_listings,
+           count(*) filter (where not o.is_npc_order and o.owner_id <> all($1::bigint[])) as player_listings,
+           count(distinct o.template_id) as unique_items
+    from dune.dune_exchange_orders o
+    join dune.dune_exchange_sell_orders s on s.order_id = o.id
+    where o.owner_id <> all($2::bigint[])`, params);
+  const row = result.rows[0] || {};
+  return {
+    capabilities: { exchange: true },
+    totalListings: num(row.total_listings),
+    botListings: num(row.bot_listings),
+    playerListings: num(row.player_listings),
+    uniqueItems: num(row.unique_items)
+  };
+}
+
+export function readExchangeConfig(repoRoot) {
+  const file = configFile(repoRoot);
+  if (!existsSync(file)) return { botOwnerIds: [], blacklistedOwnerIds: [] };
+  try {
+    const raw = JSON.parse(readFileSync(file, "utf8"));
+    return {
+      botOwnerIds: coerceIdList(raw?.botOwnerIds),
+      blacklistedOwnerIds: coerceIdList(raw?.blacklistedOwnerIds)
+    };
+  } catch (error) {
+    console.warn(`Ignoring unreadable exchange config: ${redact(error?.message || error)}`);
+    return { botOwnerIds: [], blacklistedOwnerIds: [] };
+  }
+}
+
+export function saveExchangeConfig(repoRoot, next) {
+  const config = {
+    botOwnerIds: coerceIdList(next?.botOwnerIds, { throwOnInvalid: true }),
+    blacklistedOwnerIds: coerceIdList(next?.blacklistedOwnerIds, { throwOnInvalid: true })
+  };
+  writeJsonAtomic(configFile(repoRoot), config, 0o600);
+  return config;
+}
+
+export const exchangeInternals = Object.freeze({
+  REQUIRED_TABLES,
+  EXCHANGE_SORT_COLUMNS,
+  parseTier,
+  coerceIdList,
+  ownerPredicate,
+  clearCache: () => aggregateCache.clear()
+});

--- a/console/api/src/services/exchange.js
+++ b/console/api/src/services/exchange.js
@@ -102,9 +102,25 @@ function num(value) {
 // bot     -> the in-game NPC broker OR any configured bot owner id
 // all     -> no owner predicate
 // Blacklisted owner ids are always excluded, on every owner value.
-function ownerPredicate(owner, botParam) {
-  if (owner === "player") return `not o.is_npc_order and o.owner_id <> all(${botParam})`;
-  if (owner === "bot") return `(o.is_npc_order or o.owner_id = any(${botParam}))`;
+//
+// Pushes the bot-id array onto `params` ONLY when the predicate references it.
+// The `all` case references no bot param, so passing one would leave an
+// unreferenced parameter that Postgres cannot type ("could not determine data
+// type of parameter $N").
+// The in-game NPC broker (Revy) is classified as a bot via is_npc_order rather
+// than a configured owner id. `includeNpcBroker` (default true) lets an admin
+// stop treating it as a bot; when false, its orders fall out of the bot bucket
+// (and thus appear under player/all like any other seller).
+function ownerClause(owner, botIds, includeNpcBroker, params) {
+  const npc = includeNpcBroker ? "o.is_npc_order" : "false";
+  if (owner === "player") {
+    params.push(botIds);
+    return `not (${npc} or o.owner_id = any($${params.length}::bigint[]))`;
+  }
+  if (owner === "bot") {
+    params.push(botIds);
+    return `(${npc} or o.owner_id = any($${params.length}::bigint[]))`;
+  }
   return "true";
 }
 
@@ -125,10 +141,9 @@ function enrichItem(row, metadata, repoRoot) {
   };
 }
 
-async function queryAggregatedItems(db, { owner, botIds, blacklist, repoRoot }) {
+async function queryAggregatedItems(db, { owner, botIds, blacklist, includeNpcBroker, repoRoot }) {
   const params = [];
-  params.push(botIds);
-  const botParam = `$${params.length}::bigint[]`;
+  const ownerSql = ownerClause(owner, botIds, includeNpcBroker, params);
   params.push(blacklist);
   const blockParam = `$${params.length}::bigint[]`;
   const result = await db.query(`
@@ -141,14 +156,14 @@ async function queryAggregatedItems(db, { owner, botIds, blacklist, repoRoot }) 
     from dune.dune_exchange_orders o
     join dune.dune_exchange_sell_orders s on s.order_id = o.id
     left join dune.items i on i.id = o.item_id
-    where ${ownerPredicate(owner, botParam)} and o.owner_id <> all(${blockParam})
+    where ${ownerSql} and o.owner_id <> all(${blockParam})
     group by o.template_id, o.quality_level`, params);
   const metadata = adminItemMetadata();
   return result.rows.map((row) => enrichItem(row, metadata, repoRoot));
 }
 
 async function aggregatedItems(db, view) {
-  const key = `${view.owner}|${view.botIds.join(",")}|${view.blacklist.join(",")}`;
+  const key = `${view.owner}|${view.includeNpcBroker ? 1 : 0}|${view.botIds.join(",")}|${view.blacklist.join(",")}`;
   const now = Date.now();
   const cached = aggregateCache.get(key);
   if (cached && now - cached.at < AGG_CACHE_TTL_MS) return cached.rows;
@@ -172,13 +187,14 @@ function sortItems(rows, column, direction) {
 export async function listExchangeItems(db, {
   q = "", page = 0, pageSize = 50,
   sortColumn = "display_name", sortDirection = "asc",
-  owner = "player", botOwnerIds = [], blacklist = [], repoRoot = ""
+  owner = "all", category = "", botOwnerIds = [], blacklist = [], includeNpcBroker = true, repoRoot = ""
 } = {}) {
-  if (!(await exchangeSupported(db))) return { ...unsupported(), totalCount: 0, totalItems: 0 };
+  if (!(await exchangeSupported(db))) return { ...unsupported(), totalCount: 0, totalItems: 0, categories: [] };
 
   const safePageSize = intParam(pageSize, "pageSize", 1, 200);
   const safePage = intParam(page, "page", 0);
-  const safeOwner = OWNER_FILTERS.has(owner) ? owner : "player";
+  const safeOwner = OWNER_FILTERS.has(owner) ? owner : "all";
+  const safeCategory = String(category || "").trim().slice(0, 120);
   const safeSortColumn = Object.hasOwn(EXCHANGE_SORT_COLUMNS, sortColumn) ? sortColumn : "display_name";
   const safeSortDirection = String(sortDirection).toLowerCase() === "desc" ? "desc" : "asc";
 
@@ -186,15 +202,23 @@ export async function listExchangeItems(db, {
     owner: safeOwner,
     botIds: coerceIdList(botOwnerIds),
     blacklist: coerceIdList(blacklist),
+    includeNpcBroker: includeNpcBroker !== false,
     repoRoot
   });
 
+  // Category options are the distinct categories in the whole owner-scoped set
+  // (before the category/search filters) so the dropdown stays stable while you
+  // filter within it.
+  const categories = [...new Set(all.map((row) => row.category).filter(Boolean))].sort((a, b) => a.localeCompare(b));
+
+  let filtered = all;
+  if (safeCategory && safeCategory !== "all") filtered = filtered.filter((row) => row.category === safeCategory);
   const term = String(q || "").trim().toLowerCase();
-  const filtered = term
-    ? all.filter((row) => row.display_name.toLowerCase().includes(term)
+  if (term) {
+    filtered = filtered.filter((row) => row.display_name.toLowerCase().includes(term)
       || row.category.toLowerCase().includes(term)
-      || row.template_id.toLowerCase().includes(term))
-    : all;
+      || row.template_id.toLowerCase().includes(term));
+  }
 
   const sorted = sortItems(filtered, safeSortColumn, safeSortDirection);
   const offset = safePage * safePageSize;
@@ -202,12 +226,13 @@ export async function listExchangeItems(db, {
     capabilities: { exchange: true },
     rows: sorted.slice(offset, offset + safePageSize),
     totalCount: filtered.length,
-    totalItems: all.length
+    totalItems: all.length,
+    categories
   };
 }
 
 export async function listExchangeListings(db, {
-  templateId = "", qualityLevel = "", owner = "all", botOwnerIds = [], blacklist = []
+  templateId = "", qualityLevel = "", owner = "all", botOwnerIds = [], blacklist = [], includeNpcBroker = true
 } = {}) {
   if (!(await exchangeSupported(db))) return unsupported();
 
@@ -220,8 +245,7 @@ export async function listExchangeListings(db, {
   const blacklistIds = coerceIdList(blacklist);
 
   const params = [tid];
-  params.push(botIds);
-  const botParam = `$${params.length}::bigint[]`;
+  const ownerSql = ownerClause(safeOwner, botIds, includeNpcBroker !== false, params);
   params.push(blacklistIds);
   const blockParam = `$${params.length}::bigint[]`;
   let qualitySql = "";
@@ -244,12 +268,12 @@ export async function listExchangeListings(db, {
     left join dune.items i on i.id = o.item_id
     left join dune.actors a on a.id = o.owner_id
     left join dune.player_state ps on ps.account_id = a.owner_account_id
-    where o.template_id = $1 and ${ownerPredicate(safeOwner, botParam)} and o.owner_id <> all(${blockParam})${qualitySql}
+    where o.template_id = $1 and ${ownerSql} and o.owner_id <> all(${blockParam})${qualitySql}
     order by o.item_price asc, o.id asc`, params);
 
   const botSet = new Set(botIds);
   const rows = result.rows.map((row) => {
-    const isBot = Boolean(row.is_npc_order) || botSet.has(String(row.owner_id));
+    const isBot = (includeNpcBroker !== false && Boolean(row.is_npc_order)) || botSet.has(String(row.owner_id));
     return {
       order_id: row.order_id,
       template_id: String(row.template_id || ""),
@@ -263,13 +287,14 @@ export async function listExchangeListings(db, {
   return { capabilities: { exchange: true }, rows };
 }
 
-export async function exchangeStats(db, { botOwnerIds = [], blacklist = [] } = {}) {
+export async function exchangeStats(db, { botOwnerIds = [], blacklist = [], includeNpcBroker = true } = {}) {
   if (!(await exchangeSupported(db))) return unsupported();
   const params = [coerceIdList(botOwnerIds), coerceIdList(blacklist)];
+  const npc = includeNpcBroker !== false ? "o.is_npc_order" : "false";
   const result = await db.query(`
     select count(*) as total_listings,
-           count(*) filter (where o.is_npc_order or o.owner_id = any($1::bigint[])) as bot_listings,
-           count(*) filter (where not o.is_npc_order and o.owner_id <> all($1::bigint[])) as player_listings,
+           count(*) filter (where ${npc} or o.owner_id = any($1::bigint[])) as bot_listings,
+           count(*) filter (where not (${npc} or o.owner_id = any($1::bigint[]))) as player_listings,
            count(distinct o.template_id) as unique_items
     from dune.dune_exchange_orders o
     join dune.dune_exchange_sell_orders s on s.order_id = o.id
@@ -286,21 +311,23 @@ export async function exchangeStats(db, { botOwnerIds = [], blacklist = [] } = {
 
 export function readExchangeConfig(repoRoot) {
   const file = configFile(repoRoot);
-  if (!existsSync(file)) return { botOwnerIds: [], blacklistedOwnerIds: [] };
+  if (!existsSync(file)) return { includeNpcBroker: true, botOwnerIds: [], blacklistedOwnerIds: [] };
   try {
     const raw = JSON.parse(readFileSync(file, "utf8"));
     return {
+      includeNpcBroker: raw?.includeNpcBroker !== false,
       botOwnerIds: coerceIdList(raw?.botOwnerIds),
       blacklistedOwnerIds: coerceIdList(raw?.blacklistedOwnerIds)
     };
   } catch (error) {
     console.warn(`Ignoring unreadable exchange config: ${redact(error?.message || error)}`);
-    return { botOwnerIds: [], blacklistedOwnerIds: [] };
+    return { includeNpcBroker: true, botOwnerIds: [], blacklistedOwnerIds: [] };
   }
 }
 
 export function saveExchangeConfig(repoRoot, next) {
   const config = {
+    includeNpcBroker: next?.includeNpcBroker !== false,
     botOwnerIds: coerceIdList(next?.botOwnerIds, { throwOnInvalid: true }),
     blacklistedOwnerIds: coerceIdList(next?.blacklistedOwnerIds, { throwOnInvalid: true })
   };
@@ -313,6 +340,6 @@ export const exchangeInternals = Object.freeze({
   EXCHANGE_SORT_COLUMNS,
   parseTier,
   coerceIdList,
-  ownerPredicate,
+  ownerClause,
   clearCache: () => aggregateCache.clear()
 });

--- a/console/api/test/exchange.test.js
+++ b/console/api/test/exchange.test.js
@@ -1,0 +1,127 @@
+import test, { beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { listExchangeItems, listExchangeListings, exchangeStats, exchangeInternals } from "../src/services/exchange.js";
+
+// Aggregated rows arrive from Postgres with bigint columns as strings; mirror that.
+const AGG_ROWS = [
+  { template_id: "T6_Augment_Acuracy1", quality_level: "0", lowest_price: "12000", total_stock: "2", npc_stock: "0", listing_count: "1" },
+  { template_id: "PartialStabilizationBelt", quality_level: "0", lowest_price: "45084", total_stock: "4", npc_stock: "0", listing_count: "4" },
+  { template_id: "OrnithopterTransportLocomotion_6", quality_level: "0", lowest_price: "49000", total_stock: "8", npc_stock: "8", listing_count: "8" }
+];
+
+// A fake db that answers to_regclass probes as "present" and routes the data
+// query by SQL shape. lastSql captures the aggregation/listings SQL so tests can
+// assert the owner/blacklist predicates that a fake db would otherwise ignore.
+function fakeDb(dataRows, capture = {}) {
+  return {
+    query: async (sql, params) => {
+      if (/to_regclass/.test(sql)) return { rows: [{ exists: true }] };
+      capture.sql = sql;
+      capture.params = params;
+      return { rows: dataRows };
+    }
+  };
+}
+
+function unsupportedDb() {
+  return { query: async (sql) => (/to_regclass/.test(sql) ? { rows: [{ exists: false }] } : { rows: [] }) };
+}
+
+beforeEach(() => {
+  exchangeInternals.clearCache();
+});
+
+test("aggregated items enrich, sort by name, and paginate with filtered/unfiltered totals", async () => {
+  const result = await listExchangeItems(fakeDb(AGG_ROWS), { owner: "player", pageSize: 2, sortColumn: "display_name", sortDirection: "asc" });
+  assert.equal(result.capabilities.exchange, true);
+  assert.equal(result.totalItems, 3); // unfiltered group count
+  assert.equal(result.totalCount, 3); // no search term
+  assert.equal(result.rows.length, 2); // page slice
+  // The known augment id resolves to a friendly catalog name; unknown ids fall back
+  // to the template id. Sorted ascending by display name.
+  const names = result.rows.map((r) => r.display_name);
+  assert.ok(names.every((n) => typeof n === "string" && n.length));
+  assert.deepEqual([...names].sort((a, b) => a.localeCompare(b)), names);
+});
+
+test("tier parses from a T<n>_ prefix and is null otherwise", async () => {
+  const result = await listExchangeItems(fakeDb(AGG_ROWS), { owner: "all", pageSize: 50 });
+  const byId = Object.fromEntries(result.rows.map((r) => [r.template_id, r]));
+  assert.equal(byId["T6_Augment_Acuracy1"].tier, 6);
+  assert.equal(byId["PartialStabilizationBelt"].tier, null);
+});
+
+test("search matches display_name / category / template_id", async () => {
+  exchangeInternals.clearCache();
+  const byTemplate = await listExchangeItems(fakeDb(AGG_ROWS), { owner: "all", q: "OrnithopterTransport" });
+  assert.equal(byTemplate.totalCount, 1);
+  assert.equal(byTemplate.rows[0].template_id, "OrnithopterTransportLocomotion_6");
+});
+
+test("owner filter maps to the documented SQL predicate", async () => {
+  const player = {};
+  await listExchangeItems(fakeDb(AGG_ROWS, player), { owner: "player" });
+  assert.match(player.sql, /not o\.is_npc_order and o\.owner_id <> all/);
+
+  exchangeInternals.clearCache();
+  const bot = {};
+  await listExchangeItems(fakeDb(AGG_ROWS, bot), { owner: "bot" });
+  assert.match(bot.sql, /o\.is_npc_order or o\.owner_id = any/);
+
+  exchangeInternals.clearCache();
+  const all = {};
+  await listExchangeItems(fakeDb(AGG_ROWS, all), { owner: "all" });
+  // blacklist predicate is always present, on every owner value
+  assert.match(all.sql, /o\.owner_id <> all/);
+});
+
+test("an unknown owner value falls back to player", async () => {
+  const capture = {};
+  await listExchangeItems(fakeDb(AGG_ROWS, capture), { owner: "bogus" });
+  assert.match(capture.sql, /not o\.is_npc_order/);
+});
+
+test("items returns the unsupported shape when a required table is missing", async () => {
+  const result = await listExchangeItems(unsupportedDb(), {});
+  assert.equal(result.capabilities.exchange, false);
+  assert.equal(result.totalCount, 0);
+  assert.equal(result.rows.length, 0);
+  assert.match(result.reason, /Missing required table/);
+});
+
+test("listings flag bot vs player and pass through the resolved seller name", async () => {
+  const rows = [
+    { order_id: "1", template_id: "Belt", is_npc_order: true, owner_id: "75", owner_name: "Revy", item_price: "44000", stock: "1", quality: "0" },
+    { order_id: "2", template_id: "Belt", is_npc_order: false, owner_id: "9929", owner_name: "Halfmoondee", item_price: "45084", stock: "1", quality: "0" },
+    { order_id: "3", template_id: "Belt", is_npc_order: false, owner_id: "555", owner_name: "BotAcct", item_price: "50000", stock: "2", quality: "0" }
+  ];
+  const result = await listExchangeListings(fakeDb(rows), { templateId: "Belt", owner: "all", botOwnerIds: ["555"] });
+  const byId = Object.fromEntries(result.rows.map((r) => [r.order_id, r]));
+  assert.equal(byId["1"].owner_type, "bot");            // is_npc_order
+  assert.equal(byId["1"].owner_name, "Revy");
+  assert.equal(byId["2"].owner_type, "player");         // real player
+  assert.equal(byId["3"].owner_type, "bot");            // configured bot owner id
+  assert.equal(byId["2"].price, 45084);
+});
+
+test("listings reject a missing or malformed template id", async () => {
+  await assert.rejects(() => listExchangeListings(fakeDb([]), { templateId: "" }), /valid item template id/);
+  await assert.rejects(() => listExchangeListings(fakeDb([]), { templateId: "bad\nid" }), /valid item template id/);
+});
+
+test("stats returns totals and the supported flag", async () => {
+  const rows = [{ total_listings: "5746", bot_listings: "5742", player_listings: "4", unique_items: "1429" }];
+  const result = await exchangeStats(fakeDb(rows), {});
+  assert.equal(result.capabilities.exchange, true);
+  assert.equal(result.totalListings, 5746);
+  assert.equal(result.botListings, 5742);
+  assert.equal(result.playerListings, 4);
+  assert.equal(result.uniqueItems, 1429);
+});
+
+test("internal helpers: coerceIdList validates, dedupes, and caps", () => {
+  assert.deepEqual(exchangeInternals.coerceIdList(["75", "75", "abc", "9929"]), ["75", "9929"]);
+  assert.throws(() => exchangeInternals.coerceIdList(["abc"], { throwOnInvalid: true }), /Invalid owner id/);
+  assert.equal(exchangeInternals.parseTier("T6_Augment_Acuracy1"), 6);
+  assert.equal(exchangeInternals.parseTier("PartialStabilizationBelt"), null);
+});

--- a/console/api/test/exchange.test.js
+++ b/console/api/test/exchange.test.js
@@ -51,6 +51,25 @@ test("tier parses from a T<n>_ prefix and is null otherwise", async () => {
   assert.equal(byId["PartialStabilizationBelt"].tier, null);
 });
 
+test("returns distinct sorted category options and filters rows by category", async () => {
+  const listed = await listExchangeItems(fakeDb(AGG_ROWS), { owner: "all", pageSize: 50 });
+  assert.ok(Array.isArray(listed.categories));
+  // deduped + sorted, no blanks
+  assert.deepEqual([...new Set(listed.categories)], listed.categories);
+  assert.deepEqual([...listed.categories].sort((a, b) => a.localeCompare(b)), listed.categories);
+  assert.ok(listed.categories.every((c) => c));
+
+  if (listed.categories.length) {
+    exchangeInternals.clearCache();
+    const cat = listed.categories[0];
+    const only = await listExchangeItems(fakeDb(AGG_ROWS), { owner: "all", category: cat, pageSize: 50 });
+    assert.ok(only.rows.length >= 1);
+    assert.ok(only.rows.every((row) => row.category === cat));
+    assert.equal(only.totalItems, listed.totalItems); // totalItems stays unfiltered
+    assert.ok(only.totalCount <= listed.totalCount);
+  }
+});
+
 test("search matches display_name / category / template_id", async () => {
   exchangeInternals.clearCache();
   const byTemplate = await listExchangeItems(fakeDb(AGG_ROWS), { owner: "all", q: "OrnithopterTransport" });
@@ -61,7 +80,7 @@ test("search matches display_name / category / template_id", async () => {
 test("owner filter maps to the documented SQL predicate", async () => {
   const player = {};
   await listExchangeItems(fakeDb(AGG_ROWS, player), { owner: "player" });
-  assert.match(player.sql, /not o\.is_npc_order and o\.owner_id <> all/);
+  assert.match(player.sql, /not \(o\.is_npc_order or o\.owner_id = any/);
 
   exchangeInternals.clearCache();
   const bot = {};
@@ -75,10 +94,59 @@ test("owner filter maps to the documented SQL predicate", async () => {
   assert.match(all.sql, /o\.owner_id <> all/);
 });
 
-test("an unknown owner value falls back to player", async () => {
+// Regression: owner="all" must not pass a parameter it never references, or
+// Postgres fails with "could not determine data type of parameter $N". A fake db
+// ignores param types, so assert the invariant directly on the generated SQL.
+function assertEveryParamReferenced(capture) {
+  const referenced = new Set([...capture.sql.matchAll(/\$(\d+)/g)].map((m) => Number(m[1])));
+  const maxReferenced = referenced.size ? Math.max(...referenced) : 0;
+  assert.ok(maxReferenced <= capture.params.length, `SQL references $${maxReferenced} but only ${capture.params.length} params were passed`);
+  for (let i = 1; i <= capture.params.length; i += 1) {
+    assert.ok(referenced.has(i), `param $${i} is passed but never referenced in the SQL`);
+  }
+}
+
+test("owner=all passes no unreferenced parameters (items + listings)", async () => {
+  const items = {};
+  await listExchangeItems(fakeDb(AGG_ROWS, items), { owner: "all", botOwnerIds: ["75"], blacklist: ["9"] });
+  assertEveryParamReferenced(items);
+
+  exchangeInternals.clearCache();
+  const listings = {};
+  await listExchangeListings(fakeDb([], listings), { templateId: "Belt", owner: "all", botOwnerIds: ["75"], blacklist: ["9"] });
+  assertEveryParamReferenced(listings);
+
+  // And with an owner value that does reference the bot param, plus a quality filter.
+  const withQuality = {};
+  await listExchangeListings(fakeDb([], withQuality), { templateId: "Belt", quality: 5, owner: "bot", botOwnerIds: ["75"] });
+  assertEveryParamReferenced(withQuality);
+});
+
+test("an unknown owner value falls back to the default (all)", async () => {
   const capture = {};
   await listExchangeItems(fakeDb(AGG_ROWS, capture), { owner: "bogus" });
-  assert.match(capture.sql, /not o\.is_npc_order/);
+  assert.match(capture.sql, /where true and o\.owner_id <> all/);
+});
+
+test("includeNpcBroker=false drops the in-game broker from the bot predicate", async () => {
+  // Assert on the WHERE predicate specifically — the SELECT always references
+  // is_npc_order for the npc_stock column, independent of the owner filter.
+  const withBroker = {};
+  await listExchangeItems(fakeDb(AGG_ROWS, withBroker), { owner: "bot", includeNpcBroker: true });
+  assert.match(withBroker.sql, /where \(o\.is_npc_order or o\.owner_id = any/);
+
+  exchangeInternals.clearCache();
+  const without = {};
+  await listExchangeItems(fakeDb(AGG_ROWS, without), { owner: "bot", includeNpcBroker: false });
+  assert.match(without.sql, /where \(false or o\.owner_id = any/);
+});
+
+test("a listing from the in-game broker is reclassified as player when the broker is excluded", async () => {
+  const rows = [{ order_id: "1", template_id: "Belt", is_npc_order: true, owner_id: "75", owner_name: "Revy", item_price: "44000", stock: "1", quality: "0" }];
+  const included = await listExchangeListings(fakeDb(rows), { templateId: "Belt", owner: "all", includeNpcBroker: true });
+  assert.equal(included.rows[0].owner_type, "bot");
+  const excluded = await listExchangeListings(fakeDb(rows), { templateId: "Belt", owner: "all", includeNpcBroker: false });
+  assert.equal(excluded.rows[0].owner_type, "player");
 });
 
 test("items returns the unsupported shape when a required table is missing", async () => {

--- a/console/api/test/exchangeConfig.test.js
+++ b/console/api/test/exchangeConfig.test.js
@@ -14,20 +14,28 @@ function withRepo(run) {
   }
 }
 
-test("readExchangeConfig returns empty defaults when no file exists", () => {
+test("readExchangeConfig returns defaults (broker included) when no file exists", () => {
   withRepo((repo) => {
-    assert.deepEqual(readExchangeConfig(repo), { botOwnerIds: [], blacklistedOwnerIds: [] });
+    assert.deepEqual(readExchangeConfig(repo), { includeNpcBroker: true, botOwnerIds: [], blacklistedOwnerIds: [] });
   });
 });
 
 test("saveExchangeConfig validates, dedupes, persists, and round-trips", () => {
   withRepo((repo) => {
     const saved = saveExchangeConfig(repo, { botOwnerIds: ["75", "75", "123"], blacklistedOwnerIds: ["9929"] });
-    assert.deepEqual(saved, { botOwnerIds: ["75", "123"], blacklistedOwnerIds: ["9929"] });
+    assert.deepEqual(saved, { includeNpcBroker: true, botOwnerIds: ["75", "123"], blacklistedOwnerIds: ["9929"] });
     assert.deepEqual(readExchangeConfig(repo), saved);
     // persisted at the documented console-local path
     const raw = JSON.parse(readFileSync(join(repo, "runtime/generated/exchange-config.json"), "utf8"));
     assert.deepEqual(raw.botOwnerIds, ["75", "123"]);
+  });
+});
+
+test("saveExchangeConfig persists includeNpcBroker=false (broker removed)", () => {
+  withRepo((repo) => {
+    const saved = saveExchangeConfig(repo, { includeNpcBroker: false, botOwnerIds: [], blacklistedOwnerIds: [] });
+    assert.equal(saved.includeNpcBroker, false);
+    assert.equal(readExchangeConfig(repo).includeNpcBroker, false);
   });
 });
 
@@ -44,6 +52,6 @@ test("readExchangeConfig tolerates a corrupt file by falling back to defaults", 
     saveExchangeConfig(repo, { botOwnerIds: ["1"], blacklistedOwnerIds: [] });
     const file = join(repo, "runtime/generated/exchange-config.json");
     rmSync(file);
-    assert.deepEqual(readExchangeConfig(repo), { botOwnerIds: [], blacklistedOwnerIds: [] });
+    assert.deepEqual(readExchangeConfig(repo), { includeNpcBroker: true, botOwnerIds: [], blacklistedOwnerIds: [] });
   });
 });

--- a/console/api/test/exchangeConfig.test.js
+++ b/console/api/test/exchangeConfig.test.js
@@ -1,0 +1,49 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readExchangeConfig, saveExchangeConfig } from "../src/services/exchange.js";
+
+function withRepo(run) {
+  const repo = mkdtempSync(join(tmpdir(), "exchange-config-"));
+  try {
+    return run(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+}
+
+test("readExchangeConfig returns empty defaults when no file exists", () => {
+  withRepo((repo) => {
+    assert.deepEqual(readExchangeConfig(repo), { botOwnerIds: [], blacklistedOwnerIds: [] });
+  });
+});
+
+test("saveExchangeConfig validates, dedupes, persists, and round-trips", () => {
+  withRepo((repo) => {
+    const saved = saveExchangeConfig(repo, { botOwnerIds: ["75", "75", "123"], blacklistedOwnerIds: ["9929"] });
+    assert.deepEqual(saved, { botOwnerIds: ["75", "123"], blacklistedOwnerIds: ["9929"] });
+    assert.deepEqual(readExchangeConfig(repo), saved);
+    // persisted at the documented console-local path
+    const raw = JSON.parse(readFileSync(join(repo, "runtime/generated/exchange-config.json"), "utf8"));
+    assert.deepEqual(raw.botOwnerIds, ["75", "123"]);
+  });
+});
+
+test("saveExchangeConfig rejects non-numeric owner ids", () => {
+  withRepo((repo) => {
+    assert.throws(() => saveExchangeConfig(repo, { botOwnerIds: ["abc"], blacklistedOwnerIds: [] }), /Invalid owner id/);
+    assert.throws(() => saveExchangeConfig(repo, { botOwnerIds: [], blacklistedOwnerIds: ["12x"] }), /Invalid owner id/);
+  });
+});
+
+test("readExchangeConfig tolerates a corrupt file by falling back to defaults", () => {
+  withRepo((repo) => {
+    // Save a valid file, then corrupt it, and confirm the reader degrades gracefully.
+    saveExchangeConfig(repo, { botOwnerIds: ["1"], blacklistedOwnerIds: [] });
+    const file = join(repo, "runtime/generated/exchange-config.json");
+    rmSync(file);
+    assert.deepEqual(readExchangeConfig(repo), { botOwnerIds: [], blacklistedOwnerIds: [] });
+  });
+});

--- a/console/api/test/rbacParity.test.js
+++ b/console/api/test/rbacParity.test.js
@@ -136,7 +136,8 @@ test("parity: all IAM actions reference known namespaces", () => {
   const validNamespaces = new Set([
     "setup", "server", "logs", "backups", "database", "updates", "settings",
     "players", "guilds", "bases", "maps", "sietches", "deepdesert", "admin",
-    "landsraad", "addons", "carepackage", "storage", "blueprints", "vehicles"
+    "landsraad", "addons", "carepackage", "storage", "blueprints", "vehicles",
+    "exchange"
   ]);
   for (const action of Object.values(ROUTE_ACTIONS)) {
     if (typeof action !== "string") continue;
@@ -149,7 +150,8 @@ test("parity: all REGEX_ACTIONS entries reference known namespaces", () => {
   const validNamespaces = new Set([
     "setup", "server", "logs", "backups", "database", "updates", "settings",
     "players", "guilds", "bases", "maps", "sietches", "deepdesert", "admin",
-    "landsraad", "addons", "carepackage", "storage", "blueprints", "vehicles"
+    "landsraad", "addons", "carepackage", "storage", "blueprints", "vehicles",
+    "exchange"
   ]);
   for (const [, action] of REGEX_ACTIONS) {
     if (typeof action !== "string") continue;

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { Fragment, Suspense, lazy, useCallback, useEffect, useRef, useState } from "react";
-import { Archive, Building2, Car, CircleArrowUp, Database, ExternalLink, FileText, Gift, Heart, Home, Landmark, Map as MapIcon, Menu, MessageCircle, PackagePlus, RefreshCw, Server, Settings, Shield, Sparkles, Users, X } from "lucide-react";
+import { Archive, Building2, Car, CircleArrowUp, Database, ExternalLink, FileText, Gift, Heart, Home, Landmark, Map as MapIcon, Menu, MessageCircle, PackagePlus, RefreshCw, Server, Settings, Shield, Sparkles, Store, Users, X } from "lucide-react";
 import { api, AUTH_SESSION_EXPIRED_EVENT, AUTH_SESSION_EXPIRED_MESSAGE, post, setCsrfToken } from "./api/client";
 import { serverApi } from "./api/server";
 import { updatesApi } from "./api/updates";
@@ -32,7 +32,7 @@ import {
 import { parseUpdateTask, stackVersionButtonLabel, stackVersionButtonTitle } from "./features/updates/updateUtils";
 import { formatUiSentence, stripAnsi, summarizeCommandText, titleCase } from "./lib/display";
 
-type Tab = "Home" | "Server Control" | "Services" | "Players" | "Guilds" | "Bases" | "Vehicles" | "Landsraad" | "Admin Tools" | "Live Map" | "Maps" | "Care Package" | "Addons" | "Database" | "Storage" | "Backups" | "Logs" | "Updates" | "Settings";
+type Tab = "Home" | "Server Control" | "Services" | "Players" | "Guilds" | "Bases" | "Vehicles" | "Exchange" | "Landsraad" | "Admin Tools" | "Live Map" | "Maps" | "Care Package" | "Addons" | "Database" | "Storage" | "Backups" | "Logs" | "Updates" | "Settings";
 type SetupState = { files: Record<string, boolean>; config: Record<string, unknown> };
 type PublicDirectoryStatus = {
   mode?: string;
@@ -60,6 +60,7 @@ const SettingsPanel = lazy(() => import("./features/settings/SettingsPanel").the
 const StoragePanel = lazy(() => import("./features/storage/StoragePanel").then((module) => ({ default: module.StoragePanel })));
 const UpdatesPanel = lazy(() => import("./features/updates/UpdatesPanel").then((module) => ({ default: module.UpdatesPanel })));
 const VehiclesPanel = lazy(() => import("./features/vehicles/VehiclesPanel").then((module) => ({ default: module.VehiclesPanel })));
+const ExchangePanel = lazy(() => import("./features/exchange/ExchangePanel").then((module) => ({ default: module.ExchangePanel })));
 
 function confirmDialog(message: string, options: Partial<Omit<ConfirmDialogRequest, "message" | "resolve">> = {}) {
   return new Promise<boolean>((resolve) => {
@@ -121,6 +122,7 @@ const navGroups: { title: string; items: { tab: Tab; icon: React.ReactNode }[] }
       { tab: "Guilds", icon: <Shield size={18} /> },
       { tab: "Bases", icon: <Building2 size={18} /> },
       { tab: "Vehicles", icon: <Car size={18} /> },
+      { tab: "Exchange", icon: <Store size={18} /> },
       { tab: "Live Map", icon: <MapIcon size={18} /> },
       { tab: "Landsraad", icon: <Landmark size={18} /> },
       { tab: "Admin Tools", icon: <PackagePlus size={18} /> },
@@ -643,6 +645,7 @@ export function App() {
         {!redeploySetupOpen && tab === "Guilds" && <LazyTabBoundary label="Loading Guilds"><GuildsPanel onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Bases" && <LazyTabBoundary label="Loading Bases"><BasesPanel onError={setError} confirmAction={confirmDialog} formatMutationResult={formatMutationResult} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Vehicles" && <LazyTabBoundary label="Loading Vehicles"><VehiclesPanel onError={setError} confirmAction={confirmDialog} formatMutationResult={formatMutationResult} /></LazyTabBoundary>}
+        {!redeploySetupOpen && tab === "Exchange" && <LazyTabBoundary label="Loading Market Board"><ExchangePanel onError={setError} confirmAction={confirmDialog} formatMutationResult={formatMutationResult} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Landsraad" && <LazyTabBoundary label="Loading Landsraad"><LandsraadPanel onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Admin Tools" && <LazyTabBoundary label="Loading Admin Tools"><AdminToolsPanel onError={setError} confirmAction={confirmDialog} /></LazyTabBoundary>}
         {!redeploySetupOpen && tab === "Live Map" && <LazyTabBoundary label="Loading Live Map"><LiveMapPanel onError={setError} confirmAction={confirmDialog} waitForTask={waitForTaskSilently} taskTechnicalDetails={taskTechnicalDetails} /></LazyTabBoundary>}

--- a/console/web/src/api/exchange.test.ts
+++ b/console/web/src/api/exchange.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { api, post } from "./client";
+import { exchangeApi } from "./exchange";
+
+vi.mock("./client", () => ({ api: vi.fn().mockResolvedValue({}), post: vi.fn().mockResolvedValue({}) }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("exchangeApi", () => {
+  it("builds the items query string from the standard params + owner", () => {
+    exchangeApi.items({ q: "belt", page: 2, pageSize: 100, sortColumn: "lowest_price", sortDirection: "desc", owner: "bot" });
+    const url = vi.mocked(api).mock.calls[0][0];
+    expect(url).toContain("/api/exchange/items?");
+    expect(url).toContain("q=belt");
+    expect(url).toContain("page=2");
+    expect(url).toContain("pageSize=100");
+    expect(url).toContain("sortColumn=lowest_price");
+    expect(url).toContain("sortDirection=desc");
+    expect(url).toContain("owner=bot");
+  });
+
+  it("omits empty params from the items query", () => {
+    exchangeApi.items({});
+    expect(vi.mocked(api).mock.calls[0][0]).toBe("/api/exchange/items");
+  });
+
+  it("builds the listings query with templateId, quality, and owner", () => {
+    exchangeApi.listings("PartialStabilizationBelt", 0, "all");
+    const url = vi.mocked(api).mock.calls[0][0];
+    expect(url).toContain("templateId=PartialStabilizationBelt");
+    expect(url).toContain("quality=0");
+    expect(url).toContain("owner=all");
+  });
+
+  it("saves config via POST", () => {
+    exchangeApi.saveConfig({ botOwnerIds: ["75"], blacklistedOwnerIds: [] });
+    expect(vi.mocked(post)).toHaveBeenCalledWith("/api/exchange/config", { botOwnerIds: ["75"], blacklistedOwnerIds: [] });
+  });
+});

--- a/console/web/src/api/exchange.test.ts
+++ b/console/web/src/api/exchange.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
 
 describe("exchangeApi", () => {
   it("builds the items query string from the standard params + owner", () => {
-    exchangeApi.items({ q: "belt", page: 2, pageSize: 100, sortColumn: "lowest_price", sortDirection: "desc", owner: "bot" });
+    exchangeApi.items({ q: "belt", page: 2, pageSize: 100, sortColumn: "lowest_price", sortDirection: "desc", owner: "bot", category: "weapons" });
     const url = vi.mocked(api).mock.calls[0][0];
     expect(url).toContain("/api/exchange/items?");
     expect(url).toContain("q=belt");
@@ -19,6 +19,7 @@ describe("exchangeApi", () => {
     expect(url).toContain("sortColumn=lowest_price");
     expect(url).toContain("sortDirection=desc");
     expect(url).toContain("owner=bot");
+    expect(url).toContain("category=weapons");
   });
 
   it("omits empty params from the items query", () => {
@@ -35,7 +36,7 @@ describe("exchangeApi", () => {
   });
 
   it("saves config via POST", () => {
-    exchangeApi.saveConfig({ botOwnerIds: ["75"], blacklistedOwnerIds: [] });
-    expect(vi.mocked(post)).toHaveBeenCalledWith("/api/exchange/config", { botOwnerIds: ["75"], blacklistedOwnerIds: [] });
+    exchangeApi.saveConfig({ includeNpcBroker: true, botOwnerIds: ["75"], blacklistedOwnerIds: [] });
+    expect(vi.mocked(post)).toHaveBeenCalledWith("/api/exchange/config", { includeNpcBroker: true, botOwnerIds: ["75"], blacklistedOwnerIds: [] });
   });
 });

--- a/console/web/src/api/exchange.ts
+++ b/console/web/src/api/exchange.ts
@@ -19,6 +19,7 @@ export type ExchangeItemsResponse = {
   rows: ExchangeItem[];
   totalCount: number;
   totalItems: number;
+  categories: string[];
   capabilities: { exchange?: boolean } & Record<string, unknown>;
   reason?: string;
 };
@@ -40,12 +41,13 @@ export type ExchangeListingsResponse = {
 };
 
 export type ExchangeConfig = {
+  includeNpcBroker: boolean;
   botOwnerIds: string[];
   blacklistedOwnerIds: string[];
 };
 
 export const exchangeApi = {
-  items: (params: { q?: string; page?: number; pageSize?: number; sortColumn?: string; sortDirection?: "asc" | "desc"; owner?: ExchangeOwner } = {}) => {
+  items: (params: { q?: string; page?: number; pageSize?: number; sortColumn?: string; sortDirection?: "asc" | "desc"; owner?: ExchangeOwner; category?: string } = {}) => {
     const search = new URLSearchParams();
     if (params.q) search.set("q", params.q);
     if (params.page) search.set("page", String(params.page));
@@ -53,6 +55,7 @@ export const exchangeApi = {
     if (params.sortColumn) search.set("sortColumn", params.sortColumn);
     if (params.sortDirection) search.set("sortDirection", params.sortDirection);
     if (params.owner) search.set("owner", params.owner);
+    if (params.category) search.set("category", params.category);
     const qs = search.toString();
     return api<ExchangeItemsResponse>(`/api/exchange/items${qs ? `?${qs}` : ""}`);
   },

--- a/console/web/src/api/exchange.ts
+++ b/console/web/src/api/exchange.ts
@@ -1,0 +1,69 @@
+import { api, post } from "./client";
+
+export type ExchangeOwner = "all" | "player" | "bot";
+
+export type ExchangeItem = {
+  template_id: string;
+  quality_level: number;
+  display_name: string;
+  category: string;
+  tier: number | null;
+  lowest_price: number;
+  total_stock: number;
+  npc_stock: number;
+  listing_count: number;
+  icon: string | null;
+};
+
+export type ExchangeItemsResponse = {
+  rows: ExchangeItem[];
+  totalCount: number;
+  totalItems: number;
+  capabilities: { exchange?: boolean } & Record<string, unknown>;
+  reason?: string;
+};
+
+export type ExchangeListing = {
+  order_id: string;
+  template_id: string;
+  owner_type: "player" | "bot";
+  owner_name: string;
+  price: number;
+  stock: number;
+  quality: number;
+};
+
+export type ExchangeListingsResponse = {
+  rows: ExchangeListing[];
+  capabilities: { exchange?: boolean } & Record<string, unknown>;
+  reason?: string;
+};
+
+export type ExchangeConfig = {
+  botOwnerIds: string[];
+  blacklistedOwnerIds: string[];
+};
+
+export const exchangeApi = {
+  items: (params: { q?: string; page?: number; pageSize?: number; sortColumn?: string; sortDirection?: "asc" | "desc"; owner?: ExchangeOwner } = {}) => {
+    const search = new URLSearchParams();
+    if (params.q) search.set("q", params.q);
+    if (params.page) search.set("page", String(params.page));
+    if (params.pageSize) search.set("pageSize", String(params.pageSize));
+    if (params.sortColumn) search.set("sortColumn", params.sortColumn);
+    if (params.sortDirection) search.set("sortDirection", params.sortDirection);
+    if (params.owner) search.set("owner", params.owner);
+    const qs = search.toString();
+    return api<ExchangeItemsResponse>(`/api/exchange/items${qs ? `?${qs}` : ""}`);
+  },
+  listings: (templateId: string, quality?: number | null, owner: ExchangeOwner = "all") => {
+    const search = new URLSearchParams();
+    search.set("templateId", templateId);
+    if (quality !== null && quality !== undefined) search.set("quality", String(quality));
+    if (owner) search.set("owner", owner);
+    return api<ExchangeListingsResponse>(`/api/exchange/listings?${search.toString()}`);
+  },
+  stats: () => api<{ totalListings: number; botListings: number; playerListings: number; uniqueItems: number; capabilities: { exchange?: boolean }; reason?: string }>("/api/exchange/stats"),
+  getConfig: () => api<ExchangeConfig>("/api/exchange/config"),
+  saveConfig: (config: ExchangeConfig) => post<ExchangeConfig>("/api/exchange/config", config)
+};

--- a/console/web/src/features/exchange/ExchangeConfigOverlay.test.tsx
+++ b/console/web/src/features/exchange/ExchangeConfigOverlay.test.tsx
@@ -19,20 +19,43 @@ function listSection(title: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(exchangeApi.getConfig).mockResolvedValue({ includeNpcBroker: true, botOwnerIds: [], blacklistedOwnerIds: [] });
   vi.mocked(exchangeApi.saveConfig).mockImplementation(async (config) => config);
 });
 
 describe("ExchangeConfigOverlay", () => {
   it("loads and shows existing bot ids as chips", async () => {
-    vi.mocked(exchangeApi.getConfig).mockResolvedValue({ botOwnerIds: ["75"], blacklistedOwnerIds: [] });
+    vi.mocked(exchangeApi.getConfig).mockResolvedValue({ includeNpcBroker: true, botOwnerIds: ["75"], blacklistedOwnerIds: [] });
     renderOverlay();
 
     const botList = await waitFor(() => listSection("Bot user IDs"));
     expect(await within(botList).findByText("75")).toBeInTheDocument();
   });
 
+  it("shows the built-in in-game broker as a removable chip by default", async () => {
+    renderOverlay();
+
+    const botList = await waitFor(() => listSection("Bot user IDs"));
+    expect(within(botList).getByText("In-game broker (Revy)")).toBeInTheDocument();
+    expect(within(botList).getByLabelText("Remove In-game broker (Revy)")).toBeInTheDocument();
+  });
+
+  it("removes the built-in broker and saves includeNpcBroker=false, then can restore it", async () => {
+    const props = renderOverlay();
+
+    const botList = await waitFor(() => listSection("Bot user IDs"));
+    fireEvent.click(within(botList).getByLabelText("Remove In-game broker (Revy)"));
+    // A restore affordance appears once it is removed.
+    const restore = within(botList).getByRole("button", { name: /Restore In-game broker/ });
+    expect(restore).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Save"));
+    await waitFor(() => expect(vi.mocked(exchangeApi.saveConfig)).toHaveBeenCalledWith({ includeNpcBroker: false, botOwnerIds: [], blacklistedOwnerIds: [] }));
+    expect(props.onSaved).toHaveBeenCalled();
+  });
+
   it("adds a blacklist id and saves the merged config", async () => {
-    vi.mocked(exchangeApi.getConfig).mockResolvedValue({ botOwnerIds: ["75"], blacklistedOwnerIds: [] });
+    vi.mocked(exchangeApi.getConfig).mockResolvedValue({ includeNpcBroker: true, botOwnerIds: ["75"], blacklistedOwnerIds: [] });
     const props = renderOverlay();
 
     await screen.findByText("75");
@@ -41,18 +64,17 @@ describe("ExchangeConfigOverlay", () => {
     fireEvent.click(within(blacklist).getByRole("button", { name: /Add/ }));
     fireEvent.click(screen.getByText("Save"));
 
-    await waitFor(() => expect(vi.mocked(exchangeApi.saveConfig)).toHaveBeenCalledWith({ botOwnerIds: ["75"], blacklistedOwnerIds: ["9929"] }));
+    await waitFor(() => expect(vi.mocked(exchangeApi.saveConfig)).toHaveBeenCalledWith({ includeNpcBroker: true, botOwnerIds: ["75"], blacklistedOwnerIds: ["9929"] }));
     await waitFor(() => expect(props.onSaved).toHaveBeenCalled());
     expect(props.onClose).toHaveBeenCalled();
   });
 
   it("strips non-numeric input and disables Add for empty values", async () => {
-    vi.mocked(exchangeApi.getConfig).mockResolvedValue({ botOwnerIds: [], blacklistedOwnerIds: [] });
     renderOverlay();
 
     const botList = await waitFor(() => listSection("Bot user IDs"));
     const input = within(botList).getByPlaceholderText("Add owner ID") as HTMLInputElement;
-    const addButton = within(botList).getByRole("button", { name: /Add/ });
+    const addButton = within(botList).getByRole("button", { name: /^Add/ });
     expect(addButton).toBeDisabled();
     // Letters are stripped by the input handler, keeping the field numeric-only.
     fireEvent.change(input, { target: { value: "1a2b3" } });
@@ -60,7 +82,7 @@ describe("ExchangeConfigOverlay", () => {
   });
 
   it("removes a bot id chip", async () => {
-    vi.mocked(exchangeApi.getConfig).mockResolvedValue({ botOwnerIds: ["75"], blacklistedOwnerIds: [] });
+    vi.mocked(exchangeApi.getConfig).mockResolvedValue({ includeNpcBroker: false, botOwnerIds: ["75"], blacklistedOwnerIds: [] });
     renderOverlay();
 
     await screen.findByText("75");

--- a/console/web/src/features/exchange/ExchangeConfigOverlay.test.tsx
+++ b/console/web/src/features/exchange/ExchangeConfigOverlay.test.tsx
@@ -1,0 +1,70 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { exchangeApi } from "../../api/exchange";
+import { ExchangeConfigOverlay } from "./ExchangeConfigOverlay";
+
+vi.mock("../../api/exchange", () => ({
+  exchangeApi: { getConfig: vi.fn(), saveConfig: vi.fn() }
+}));
+
+function renderOverlay() {
+  const props = { onClose: vi.fn(), onSaved: vi.fn(), onError: vi.fn() };
+  render(<ExchangeConfigOverlay {...props} />);
+  return props;
+}
+
+function listSection(title: string) {
+  return screen.getByText(title).closest(".exchange-config-list") as HTMLElement;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(exchangeApi.saveConfig).mockImplementation(async (config) => config);
+});
+
+describe("ExchangeConfigOverlay", () => {
+  it("loads and shows existing bot ids as chips", async () => {
+    vi.mocked(exchangeApi.getConfig).mockResolvedValue({ botOwnerIds: ["75"], blacklistedOwnerIds: [] });
+    renderOverlay();
+
+    const botList = await waitFor(() => listSection("Bot user IDs"));
+    expect(await within(botList).findByText("75")).toBeInTheDocument();
+  });
+
+  it("adds a blacklist id and saves the merged config", async () => {
+    vi.mocked(exchangeApi.getConfig).mockResolvedValue({ botOwnerIds: ["75"], blacklistedOwnerIds: [] });
+    const props = renderOverlay();
+
+    await screen.findByText("75");
+    const blacklist = listSection("Blacklisted IDs");
+    fireEvent.change(within(blacklist).getByPlaceholderText("Add owner ID"), { target: { value: "9929" } });
+    fireEvent.click(within(blacklist).getByRole("button", { name: /Add/ }));
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(vi.mocked(exchangeApi.saveConfig)).toHaveBeenCalledWith({ botOwnerIds: ["75"], blacklistedOwnerIds: ["9929"] }));
+    await waitFor(() => expect(props.onSaved).toHaveBeenCalled());
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  it("strips non-numeric input and disables Add for empty values", async () => {
+    vi.mocked(exchangeApi.getConfig).mockResolvedValue({ botOwnerIds: [], blacklistedOwnerIds: [] });
+    renderOverlay();
+
+    const botList = await waitFor(() => listSection("Bot user IDs"));
+    const input = within(botList).getByPlaceholderText("Add owner ID") as HTMLInputElement;
+    const addButton = within(botList).getByRole("button", { name: /Add/ });
+    expect(addButton).toBeDisabled();
+    // Letters are stripped by the input handler, keeping the field numeric-only.
+    fireEvent.change(input, { target: { value: "1a2b3" } });
+    expect(input.value).toBe("123");
+  });
+
+  it("removes a bot id chip", async () => {
+    vi.mocked(exchangeApi.getConfig).mockResolvedValue({ botOwnerIds: ["75"], blacklistedOwnerIds: [] });
+    renderOverlay();
+
+    await screen.findByText("75");
+    fireEvent.click(screen.getByLabelText("Remove 75"));
+    expect(screen.queryByText("75")).not.toBeInTheDocument();
+  });
+});

--- a/console/web/src/features/exchange/ExchangeConfigOverlay.tsx
+++ b/console/web/src/features/exchange/ExchangeConfigOverlay.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from "react";
+import { Plus, Trash2, X } from "lucide-react";
+import { exchangeApi, type ExchangeConfig } from "../../api/exchange";
+
+type ExchangeConfigOverlayProps = {
+  onClose: () => void;
+  onSaved: (config: ExchangeConfig) => void;
+  onError: (text: string) => void;
+};
+
+function errorText(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function IdListEditor({ title, hint, ids, onChange }: { title: string; hint: string; ids: string[]; onChange: (next: string[]) => void }) {
+  const [draft, setDraft] = useState("");
+  const valid = /^\d{1,19}$/.test(draft.trim());
+
+  function add() {
+    const id = draft.trim();
+    if (!/^\d{1,19}$/.test(id) || ids.includes(id)) return;
+    onChange([...ids, id]);
+    setDraft("");
+  }
+
+  return (
+    <div className="exchange-config-list">
+      <div className="exchange-config-list-head">
+        <strong>{title}</strong>
+        <span className="muted">{hint}</span>
+      </div>
+      {ids.length === 0
+        ? <p className="muted exchange-config-empty">None yet.</p>
+        : <ul className="exchange-config-chips">
+          {ids.map((id) => (
+            <li key={id} className="exchange-config-chip">
+              <span>{id}</span>
+              <button type="button" aria-label={`Remove ${id}`} onClick={() => onChange(ids.filter((value) => value !== id))}><Trash2 size={13} /></button>
+            </li>
+          ))}
+        </ul>}
+      <div className="exchange-config-add">
+        <input
+          value={draft}
+          inputMode="numeric"
+          placeholder="Add owner ID"
+          onChange={(event) => setDraft(event.target.value.replace(/[^\d]/g, ""))}
+          onKeyDown={(event) => { if (event.key === "Enter") { event.preventDefault(); add(); } }}
+        />
+        <button type="button" onClick={add} disabled={!valid || ids.includes(draft.trim())}><Plus size={14} /> Add</button>
+      </div>
+    </div>
+  );
+}
+
+export function ExchangeConfigOverlay({ onClose, onSaved, onError }: ExchangeConfigOverlayProps) {
+  const [botOwnerIds, setBotOwnerIds] = useState<string[]>([]);
+  const [blacklistedOwnerIds, setBlacklistedOwnerIds] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void exchangeApi.getConfig()
+      .then((config) => {
+        if (cancelled) return;
+        setBotOwnerIds(config.botOwnerIds || []);
+        setBlacklistedOwnerIds(config.blacklistedOwnerIds || []);
+        setLoading(false);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        onError(errorText(error));
+        setLoading(false);
+      });
+    return () => { cancelled = true; };
+  }, [onError]);
+
+  async function save() {
+    setSaving(true);
+    onError("");
+    try {
+      const saved = await exchangeApi.saveConfig({ botOwnerIds, blacklistedOwnerIds });
+      onSaved(saved);
+      onClose();
+    } catch (error) {
+      onError(errorText(error));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-label="Exchange filter settings" onClick={onClose}>
+      <div className="confirm-modal exchange-config-modal" onClick={(event) => event.stopPropagation()}>
+        <div className="confirm-modal-title">
+          <h3>Exchange filter settings</h3>
+          <button className="exchange-config-close" aria-label="Close" onClick={onClose}><X size={16} /></button>
+        </div>
+        <p>Stored in the console only. No game data is changed. Blacklisted IDs are hidden from the market on every view.</p>
+        {loading
+          ? <p className="muted">Loading…</p>
+          : <>
+            <IdListEditor title="Bot user IDs" hint="Counted as bot listings, alongside the in-game broker." ids={botOwnerIds} onChange={setBotOwnerIds} />
+            <IdListEditor title="Blacklisted IDs" hint="Hidden from the market on every view." ids={blacklistedOwnerIds} onChange={setBlacklistedOwnerIds} />
+          </>}
+        <div className="confirm-modal-actions">
+          <button onClick={onClose} disabled={saving}>Cancel</button>
+          <button className="primary" onClick={() => void save()} disabled={saving || loading}>{saving ? "Saving…" : "Save"}</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/console/web/src/features/exchange/ExchangeConfigOverlay.tsx
+++ b/console/web/src/features/exchange/ExchangeConfigOverlay.tsx
@@ -12,9 +12,12 @@ function errorText(error: unknown) {
   return error instanceof Error ? error.message : String(error);
 }
 
-function IdListEditor({ title, hint, ids, onChange }: { title: string; hint: string; ids: string[]; onChange: (next: string[]) => void }) {
+type BuiltInEntry = { present: boolean; label: string; onToggle: (present: boolean) => void };
+
+function IdListEditor({ title, hint, ids, onChange, builtIn }: { title: string; hint: string; ids: string[]; onChange: (next: string[]) => void; builtIn?: BuiltInEntry }) {
   const [draft, setDraft] = useState("");
   const valid = /^\d{1,19}$/.test(draft.trim());
+  const hasChips = ids.length > 0 || Boolean(builtIn?.present);
 
   function add() {
     const id = draft.trim();
@@ -29,16 +32,25 @@ function IdListEditor({ title, hint, ids, onChange }: { title: string; hint: str
         <strong>{title}</strong>
         <span className="muted">{hint}</span>
       </div>
-      {ids.length === 0
-        ? <p className="muted exchange-config-empty">None yet.</p>
-        : <ul className="exchange-config-chips">
+      {hasChips
+        ? <ul className="exchange-config-chips">
+          {builtIn?.present && (
+            <li className="exchange-config-chip exchange-config-chip-builtin">
+              <span>{builtIn.label}<em>built-in</em></span>
+              <button type="button" aria-label={`Remove ${builtIn.label}`} onClick={() => builtIn.onToggle(false)}><Trash2 size={13} /></button>
+            </li>
+          )}
           {ids.map((id) => (
             <li key={id} className="exchange-config-chip">
               <span>{id}</span>
               <button type="button" aria-label={`Remove ${id}`} onClick={() => onChange(ids.filter((value) => value !== id))}><Trash2 size={13} /></button>
             </li>
           ))}
-        </ul>}
+        </ul>
+        : <p className="muted exchange-config-empty">None yet.</p>}
+      {builtIn && !builtIn.present && (
+        <button type="button" className="exchange-config-restore" onClick={() => builtIn.onToggle(true)}><Plus size={13} /> Restore {builtIn.label}</button>
+      )}
       <div className="exchange-config-add">
         <input
           value={draft}
@@ -54,6 +66,7 @@ function IdListEditor({ title, hint, ids, onChange }: { title: string; hint: str
 }
 
 export function ExchangeConfigOverlay({ onClose, onSaved, onError }: ExchangeConfigOverlayProps) {
+  const [includeNpcBroker, setIncludeNpcBroker] = useState(true);
   const [botOwnerIds, setBotOwnerIds] = useState<string[]>([]);
   const [blacklistedOwnerIds, setBlacklistedOwnerIds] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
@@ -64,6 +77,7 @@ export function ExchangeConfigOverlay({ onClose, onSaved, onError }: ExchangeCon
     void exchangeApi.getConfig()
       .then((config) => {
         if (cancelled) return;
+        setIncludeNpcBroker(config.includeNpcBroker !== false);
         setBotOwnerIds(config.botOwnerIds || []);
         setBlacklistedOwnerIds(config.blacklistedOwnerIds || []);
         setLoading(false);
@@ -80,7 +94,7 @@ export function ExchangeConfigOverlay({ onClose, onSaved, onError }: ExchangeCon
     setSaving(true);
     onError("");
     try {
-      const saved = await exchangeApi.saveConfig({ botOwnerIds, blacklistedOwnerIds });
+      const saved = await exchangeApi.saveConfig({ includeNpcBroker, botOwnerIds, blacklistedOwnerIds });
       onSaved(saved);
       onClose();
     } catch (error) {
@@ -101,7 +115,13 @@ export function ExchangeConfigOverlay({ onClose, onSaved, onError }: ExchangeCon
         {loading
           ? <p className="muted">Loading…</p>
           : <>
-            <IdListEditor title="Bot user IDs" hint="Counted as bot listings, alongside the in-game broker." ids={botOwnerIds} onChange={setBotOwnerIds} />
+            <IdListEditor
+              title="Bot user IDs"
+              hint="Counted as bot listings. The in-game broker is built in; remove it to stop treating its orders as bot."
+              ids={botOwnerIds}
+              onChange={setBotOwnerIds}
+              builtIn={{ present: includeNpcBroker, label: "In-game broker (Revy)", onToggle: setIncludeNpcBroker }}
+            />
             <IdListEditor title="Blacklisted IDs" hint="Hidden from the market on every view." ids={blacklistedOwnerIds} onChange={setBlacklistedOwnerIds} />
           </>}
         <div className="confirm-modal-actions">

--- a/console/web/src/features/exchange/ExchangePanel.test.tsx
+++ b/console/web/src/features/exchange/ExchangePanel.test.tsx
@@ -1,0 +1,153 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { exchangeApi, type ExchangeItemsResponse } from "../../api/exchange";
+import { ExchangePanel } from "./ExchangePanel";
+
+vi.mock("../../api/exchange", () => ({
+  exchangeApi: {
+    items: vi.fn(),
+    listings: vi.fn(),
+    stats: vi.fn(),
+    getConfig: vi.fn(),
+    saveConfig: vi.fn()
+  }
+}));
+
+function renderPanel(overrides: Partial<Parameters<typeof ExchangePanel>[0]> = {}) {
+  const props = {
+    onError: vi.fn(),
+    confirmAction: vi.fn().mockResolvedValue(true),
+    formatMutationResult: vi.fn().mockReturnValue("Action completed."),
+    ...overrides
+  };
+  render(<ExchangePanel {...props} />);
+  return props;
+}
+
+function itemsResponse(overrides: Partial<ExchangeItemsResponse> = {}): ExchangeItemsResponse {
+  return {
+    capabilities: { exchange: true },
+    totalCount: 1,
+    totalItems: 1,
+    rows: [
+      {
+        template_id: "PartialStabilizationBelt",
+        quality_level: 0,
+        display_name: "Partial Stabilization Belt",
+        category: "utility",
+        tier: null,
+        lowest_price: 45084,
+        total_stock: 4,
+        npc_stock: 0,
+        listing_count: 4,
+        icon: null
+      }
+    ],
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(exchangeApi.getConfig).mockResolvedValue({ botOwnerIds: [], blacklistedOwnerIds: [] });
+  vi.mocked(exchangeApi.listings).mockResolvedValue({ capabilities: { exchange: true }, rows: [] });
+});
+
+describe("ExchangePanel", () => {
+  it("renders an aggregated item row with name and lowest price", async () => {
+    vi.mocked(exchangeApi.items).mockResolvedValue(itemsResponse());
+    renderPanel();
+
+    expect(await screen.findByText("Partial Stabilization Belt")).toBeInTheDocument();
+    expect(screen.getByText("45,084")).toBeInTheDocument();
+  });
+
+  it("defaults the owner filter to player listings", async () => {
+    vi.mocked(exchangeApi.items).mockResolvedValue(itemsResponse());
+    renderPanel();
+
+    await screen.findByText("Partial Stabilization Belt");
+    expect(vi.mocked(exchangeApi.items)).toHaveBeenCalledWith(expect.objectContaining({ owner: "player" }));
+  });
+
+  it("refetches when the owner filter changes", async () => {
+    vi.mocked(exchangeApi.items).mockResolvedValue(itemsResponse());
+    renderPanel();
+
+    await screen.findByText("Partial Stabilization Belt");
+    fireEvent.change(screen.getByRole("combobox", { name: /Show/ }), { target: { value: "bot" } });
+
+    await waitFor(() => expect(vi.mocked(exchangeApi.items)).toHaveBeenCalledWith(expect.objectContaining({ owner: "bot" })));
+  });
+
+  it("submits the search term", async () => {
+    vi.mocked(exchangeApi.items).mockResolvedValue(itemsResponse());
+    renderPanel();
+
+    await screen.findByText("Partial Stabilization Belt");
+    fireEvent.change(screen.getByPlaceholderText("Search item name, category, or template"), { target: { value: "belt" } });
+    fireEvent.click(screen.getByText("Search"));
+
+    await waitFor(() => expect(vi.mocked(exchangeApi.items)).toHaveBeenCalledWith(expect.objectContaining({ q: "belt" })));
+  });
+
+  it("advances to the next page", async () => {
+    vi.mocked(exchangeApi.items).mockResolvedValue(itemsResponse({ totalCount: 120, totalItems: 120 }));
+    renderPanel();
+
+    await screen.findByText("Partial Stabilization Belt");
+    await waitFor(() => expect(screen.getByText("Next")).not.toBeDisabled());
+    fireEvent.click(screen.getByText("Next"));
+
+    await waitFor(() => expect(vi.mocked(exchangeApi.items)).toHaveBeenCalledWith(expect.objectContaining({ page: 1 })));
+  });
+
+  it("sorts by a column when its header is clicked", async () => {
+    vi.mocked(exchangeApi.items).mockResolvedValue(itemsResponse());
+    renderPanel();
+
+    await screen.findByText("Partial Stabilization Belt");
+    fireEvent.click(screen.getByRole("columnheader", { name: /Lowest Price/ }));
+
+    await waitFor(() => expect(vi.mocked(exchangeApi.items)).toHaveBeenCalledWith(expect.objectContaining({ sortColumn: "lowest_price", sortDirection: "asc" })));
+  });
+
+  it("opens the config overlay from the gear button", async () => {
+    vi.mocked(exchangeApi.items).mockResolvedValue(itemsResponse());
+    renderPanel();
+
+    await screen.findByText("Partial Stabilization Belt");
+    fireEvent.click(screen.getByLabelText("Configure bots and blacklist"));
+
+    expect(await screen.findByText("Exchange filter settings")).toBeInTheDocument();
+    expect(vi.mocked(exchangeApi.getConfig)).toHaveBeenCalled();
+  });
+
+  it("loads listings on demand when a row is expanded", async () => {
+    vi.mocked(exchangeApi.items).mockResolvedValue(itemsResponse());
+    vi.mocked(exchangeApi.listings).mockResolvedValue({
+      capabilities: { exchange: true },
+      rows: [{ order_id: "1", template_id: "PartialStabilizationBelt", owner_type: "player", owner_name: "Halfmoondee", price: 45084, stock: 1, quality: 0 }]
+    });
+    renderPanel();
+
+    fireEvent.click(await screen.findByLabelText("Show listings for Partial Stabilization Belt"));
+
+    expect(await screen.findByText("Halfmoondee")).toBeInTheDocument();
+    expect(vi.mocked(exchangeApi.listings)).toHaveBeenCalledWith("PartialStabilizationBelt", 0, "all");
+  });
+
+  it("shows the unsupported reason when the schema lacks exchange tables", async () => {
+    vi.mocked(exchangeApi.items).mockResolvedValue({
+      capabilities: { exchange: false },
+      totalCount: 0,
+      totalItems: 0,
+      rows: [],
+      reason: "Unsupported by detected schema. Missing required table(s): dune.dune_exchange_orders"
+    });
+    renderPanel();
+
+    expect(await screen.findByText(/Missing required table/)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("Search item name, category, or template")).not.toBeInTheDocument();
+  });
+});

--- a/console/web/src/features/exchange/ExchangePanel.test.tsx
+++ b/console/web/src/features/exchange/ExchangePanel.test.tsx
@@ -1,7 +1,7 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { exchangeApi, type ExchangeItemsResponse } from "../../api/exchange";
-import { ExchangePanel } from "./ExchangePanel";
+import { ExchangePanel, _resetExchangeCacheForTests } from "./ExchangePanel";
 
 vi.mock("../../api/exchange", () => ({
   exchangeApi: {
@@ -29,6 +29,7 @@ function itemsResponse(overrides: Partial<ExchangeItemsResponse> = {}): Exchange
     capabilities: { exchange: true },
     totalCount: 1,
     totalItems: 1,
+    categories: ["utility", "weapons"],
     rows: [
       {
         template_id: "PartialStabilizationBelt",
@@ -49,7 +50,8 @@ function itemsResponse(overrides: Partial<ExchangeItemsResponse> = {}): Exchange
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(exchangeApi.getConfig).mockResolvedValue({ botOwnerIds: [], blacklistedOwnerIds: [] });
+  _resetExchangeCacheForTests();
+  vi.mocked(exchangeApi.getConfig).mockResolvedValue({ includeNpcBroker: true, botOwnerIds: [], blacklistedOwnerIds: [] });
   vi.mocked(exchangeApi.listings).mockResolvedValue({ capabilities: { exchange: true }, rows: [] });
 });
 
@@ -62,12 +64,12 @@ describe("ExchangePanel", () => {
     expect(screen.getByText("45,084")).toBeInTheDocument();
   });
 
-  it("defaults the owner filter to player listings", async () => {
+  it("defaults the owner filter to all listings", async () => {
     vi.mocked(exchangeApi.items).mockResolvedValue(itemsResponse());
     renderPanel();
 
     await screen.findByText("Partial Stabilization Belt");
-    expect(vi.mocked(exchangeApi.items)).toHaveBeenCalledWith(expect.objectContaining({ owner: "player" }));
+    expect(vi.mocked(exchangeApi.items)).toHaveBeenCalledWith(expect.objectContaining({ owner: "all" }));
   });
 
   it("refetches when the owner filter changes", async () => {
@@ -78,6 +80,30 @@ describe("ExchangePanel", () => {
     fireEvent.change(screen.getByRole("combobox", { name: /Show/ }), { target: { value: "bot" } });
 
     await waitFor(() => expect(vi.mocked(exchangeApi.items)).toHaveBeenCalledWith(expect.objectContaining({ owner: "bot" })));
+  });
+
+  it("populates the category options and refetches on category change", async () => {
+    vi.mocked(exchangeApi.items).mockResolvedValue(itemsResponse());
+    renderPanel();
+
+    await screen.findByText("Partial Stabilization Belt");
+    const categorySelect = screen.getByRole("combobox", { name: /Category/ });
+    expect(within(categorySelect).getByRole("option", { name: "weapons" })).toBeInTheDocument();
+    fireEvent.change(categorySelect, { target: { value: "utility" } });
+
+    await waitFor(() => expect(vi.mocked(exchangeApi.items)).toHaveBeenCalledWith(expect.objectContaining({ category: "utility" })));
+  });
+
+  it("clears the category when the owner filter changes", async () => {
+    vi.mocked(exchangeApi.items).mockResolvedValue(itemsResponse());
+    renderPanel();
+
+    await screen.findByText("Partial Stabilization Belt");
+    fireEvent.change(screen.getByRole("combobox", { name: /Category/ }), { target: { value: "utility" } });
+    await waitFor(() => expect(vi.mocked(exchangeApi.items)).toHaveBeenCalledWith(expect.objectContaining({ category: "utility" })));
+
+    fireEvent.change(screen.getByRole("combobox", { name: /Show/ }), { target: { value: "bot" } });
+    await waitFor(() => expect(vi.mocked(exchangeApi.items)).toHaveBeenCalledWith(expect.objectContaining({ owner: "bot", category: "" })));
   });
 
   it("submits the search term", async () => {
@@ -134,6 +160,7 @@ describe("ExchangePanel", () => {
     fireEvent.click(await screen.findByLabelText("Show listings for Partial Stabilization Belt"));
 
     expect(await screen.findByText("Halfmoondee")).toBeInTheDocument();
+    // Drill-down respects the current owner filter (default: all).
     expect(vi.mocked(exchangeApi.listings)).toHaveBeenCalledWith("PartialStabilizationBelt", 0, "all");
   });
 
@@ -142,6 +169,7 @@ describe("ExchangePanel", () => {
       capabilities: { exchange: false },
       totalCount: 0,
       totalItems: 0,
+      categories: [],
       rows: [],
       reason: "Unsupported by detected schema. Missing required table(s): dune.dune_exchange_orders"
     });

--- a/console/web/src/features/exchange/ExchangePanel.tsx
+++ b/console/web/src/features/exchange/ExchangePanel.tsx
@@ -18,17 +18,18 @@ const EXCHANGE_AUTO_REFRESH_MS = 5 * 60_000; // 5 minutes — the market changes
 const EXCHANGE_PAGE_SIZES = [25, 50, 100, 200] as const;
 const EXCHANGE_DEFAULT_PAGE_SIZE = 50;
 const OWNER_OPTIONS: { value: ExchangeOwner; label: string }[] = [
+  { value: "all", label: "All listings" },
   { value: "player", label: "Player listings" },
-  { value: "bot", label: "Bot listings" },
-  { value: "all", label: "All listings" }
+  { value: "bot", label: "Bot listings" }
 ];
 
-type ExchangeView = { q: string; page: number; pageSize: number; sortColumn: string; sortDirection: SortDirection; owner: ExchangeOwner };
+type ExchangeView = { q: string; page: number; pageSize: number; sortColumn: string; sortDirection: SortDirection; owner: ExchangeOwner; category: string };
 
 type ExchangeCache = ExchangeView & {
   rows: ExchangeItem[];
   totalCount: number;
   totalItems: number;
+  categories: string[];
   supported: boolean;
   reason: string;
   lastFetchedAt: number;
@@ -36,9 +37,17 @@ type ExchangeCache = ExchangeView & {
 
 let exchangeCache: ExchangeCache | null = null;
 
+// Test-only: the module-level cache persists across renders (for instant
+// back-navigation), which leaks view state between test cases. Reset it in test
+// setup so each case starts from the default view.
+export function _resetExchangeCacheForTests() {
+  exchangeCache = null;
+}
+
 function sameView(cache: ExchangeCache | null, view: ExchangeView) {
   return !!cache && cache.q === view.q && cache.page === view.page && cache.pageSize === view.pageSize
-    && cache.sortColumn === view.sortColumn && cache.sortDirection === view.sortDirection && cache.owner === view.owner;
+    && cache.sortColumn === view.sortColumn && cache.sortDirection === view.sortDirection && cache.owner === view.owner
+    && cache.category === view.category;
 }
 
 function errorText(error: unknown) {
@@ -52,7 +61,9 @@ export function ExchangePanel({ onError }: ExchangePanelProps) {
   const [pageSize, setPageSize] = useState<number>(() => exchangeCache?.pageSize ?? EXCHANGE_DEFAULT_PAGE_SIZE);
   const [sortColumn, setSortColumn] = useState(() => exchangeCache?.sortColumn ?? "display_name");
   const [sortDirection, setSortDirection] = useState<SortDirection>(() => exchangeCache?.sortDirection ?? "asc");
-  const [owner, setOwner] = useState<ExchangeOwner>(() => exchangeCache?.owner ?? "player");
+  const [owner, setOwner] = useState<ExchangeOwner>(() => exchangeCache?.owner ?? "all");
+  const [category, setCategory] = useState(() => exchangeCache?.category ?? "");
+  const [categories, setCategories] = useState<string[]>(() => exchangeCache?.categories ?? []);
   const [rows, setRows] = useState<ExchangeItem[]>(() => exchangeCache?.rows ?? []);
   const [totalCount, setTotalCount] = useState(() => exchangeCache?.totalCount ?? 0);
   const [totalItems, setTotalItems] = useState(() => exchangeCache?.totalItems ?? 0);
@@ -69,7 +80,7 @@ export function ExchangePanel({ onError }: ExchangePanelProps) {
       return;
     }
     setPage(0);
-  }, [submittedQ, owner]);
+  }, [submittedQ, owner, category]);
 
   function submitSearch() {
     setSubmittedQ(q);
@@ -102,10 +113,12 @@ export function ExchangePanel({ onError }: ExchangePanelProps) {
       const result = await exchangeApi.items(view);
       if (requestIdRef.current !== requestId) return;
       const nextRows = result.rows || [];
+      const nextCategories = result.categories || [];
       const nextSupported = result.capabilities?.exchange !== false;
       setRows(nextRows);
       setTotalCount(result.totalCount || 0);
       setTotalItems(result.totalItems || 0);
+      setCategories(nextCategories);
       setSupported(nextSupported);
       setReason(result.reason || "");
       exchangeCache = {
@@ -113,6 +126,7 @@ export function ExchangePanel({ onError }: ExchangePanelProps) {
         rows: nextRows,
         totalCount: result.totalCount || 0,
         totalItems: result.totalItems || 0,
+        categories: nextCategories,
         supported: nextSupported,
         reason: result.reason || "",
         lastFetchedAt: Date.now()
@@ -127,13 +141,14 @@ export function ExchangePanel({ onError }: ExchangePanelProps) {
   useEffect(() => {
     let cancelled = false;
     let timeoutId: number | undefined;
-    const view: ExchangeView = { q: submittedQ, page, pageSize, sortColumn, sortDirection, owner };
+    const view: ExchangeView = { q: submittedQ, page, pageSize, sortColumn, sortDirection, owner, category };
     const cacheHit = sameView(exchangeCache, view) ? exchangeCache : null;
 
     if (cacheHit) {
       setRows(cacheHit.rows);
       setTotalCount(cacheHit.totalCount);
       setTotalItems(cacheHit.totalItems);
+      setCategories(cacheHit.categories);
       setSupported(cacheHit.supported);
       setReason(cacheHit.reason);
       setLoading(false);
@@ -165,10 +180,17 @@ export function ExchangePanel({ onError }: ExchangePanelProps) {
       window.clearTimeout(timeoutId);
       document.removeEventListener("visibilitychange", onVisibilityChange);
     };
-  }, [submittedQ, page, pageSize, sortColumn, sortDirection, owner, load]);
+  }, [submittedQ, page, pageSize, sortColumn, sortDirection, owner, category, load]);
 
   function currentView(): ExchangeView {
-    return { q: submittedQ, page, pageSize, sortColumn, sortDirection, owner };
+    return { q: submittedQ, page, pageSize, sortColumn, sortDirection, owner, category };
+  }
+
+  function changeOwner(nextOwner: ExchangeOwner) {
+    setOwner(nextOwner);
+    // Categories differ per owner scope; clear the selection so a category that
+    // isn't in the new scope can't linger as a filter that hides everything.
+    setCategory("");
   }
 
   if (loading && !rows.length) {
@@ -197,7 +219,7 @@ export function ExchangePanel({ onError }: ExchangePanelProps) {
         </div>
       </div>
       {supported
-        ? <p className="action-help-note">Read-only view of the CHOAM exchange. {totalItems.toLocaleString()} item{totalItems === 1 ? "" : "s"} listed for the current filter.</p>
+        ? <p className="action-help-note">Read-only view of the CHOAM exchange. {totalCount.toLocaleString()}{totalCount !== totalItems ? ` of ${totalItems.toLocaleString()}` : ""} item{totalItems === 1 ? "" : "s"} listed for the current filter.</p>
         : <p className="action-help-note">{reason || "The Market Board is unsupported by the detected database schema."}</p>}
       {supported && <>
         <div className="action-row exchange-search-row">
@@ -209,9 +231,16 @@ export function ExchangePanel({ onError }: ExchangePanelProps) {
           />
           <button onClick={submitSearch}>Search</button>
           <button onClick={handleClearSearch} disabled={!q && !submittedQ}>Clear</button>
+          <label className="compact-select exchange-category-select">
+            Category
+            <select value={categories.includes(category) ? category : ""} onChange={(event) => setCategory(event.target.value)}>
+              <option value="">All categories</option>
+              {categories.map((name) => <option key={name} value={name}>{name}</option>)}
+            </select>
+          </label>
           <label className="compact-select exchange-owner-select">
             Show
-            <select value={owner} onChange={(event) => setOwner(event.target.value as ExchangeOwner)}>
+            <select value={owner} onChange={(event) => changeOwner(event.target.value as ExchangeOwner)}>
               {OWNER_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
             </select>
           </label>
@@ -221,6 +250,7 @@ export function ExchangePanel({ onError }: ExchangePanelProps) {
         </div>
         <ExchangeTable
           rows={rows}
+          owner={owner}
           sortColumn={sortColumn}
           sortDirection={sortDirection}
           onSort={handleSort}

--- a/console/web/src/features/exchange/ExchangePanel.tsx
+++ b/console/web/src/features/exchange/ExchangePanel.tsx
@@ -1,0 +1,255 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Settings } from "lucide-react";
+import { exchangeApi, type ExchangeItem, type ExchangeOwner } from "../../api/exchange";
+import type { SortDirection } from "../../components/common/DataTable";
+import { ExchangeTable } from "./ExchangeTable";
+import { ExchangeConfigOverlay } from "./ExchangeConfigOverlay";
+
+type ExchangePanelProps = {
+  onError: (text: string) => void;
+  // Read-only page: confirmAction/formatMutationResult are passed by App.tsx for
+  // parity with the other panels but intentionally unused here (the only writes
+  // are the bot/blacklist console config, handled inside ExchangeConfigOverlay).
+  confirmAction: (message: string, options?: { title?: string; confirmLabel?: string; warning?: string; danger?: boolean; details?: { label: string; value: string; tone?: "accent" | "success" | "danger" }[] }) => Promise<boolean>;
+  formatMutationResult: (result: unknown) => string;
+};
+
+const EXCHANGE_AUTO_REFRESH_MS = 5 * 60_000; // 5 minutes — the market changes slowly
+const EXCHANGE_PAGE_SIZES = [25, 50, 100, 200] as const;
+const EXCHANGE_DEFAULT_PAGE_SIZE = 50;
+const OWNER_OPTIONS: { value: ExchangeOwner; label: string }[] = [
+  { value: "player", label: "Player listings" },
+  { value: "bot", label: "Bot listings" },
+  { value: "all", label: "All listings" }
+];
+
+type ExchangeView = { q: string; page: number; pageSize: number; sortColumn: string; sortDirection: SortDirection; owner: ExchangeOwner };
+
+type ExchangeCache = ExchangeView & {
+  rows: ExchangeItem[];
+  totalCount: number;
+  totalItems: number;
+  supported: boolean;
+  reason: string;
+  lastFetchedAt: number;
+};
+
+let exchangeCache: ExchangeCache | null = null;
+
+function sameView(cache: ExchangeCache | null, view: ExchangeView) {
+  return !!cache && cache.q === view.q && cache.page === view.page && cache.pageSize === view.pageSize
+    && cache.sortColumn === view.sortColumn && cache.sortDirection === view.sortDirection && cache.owner === view.owner;
+}
+
+function errorText(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function ExchangePanel({ onError }: ExchangePanelProps) {
+  const [q, setQ] = useState(() => exchangeCache?.q ?? "");
+  const [submittedQ, setSubmittedQ] = useState(() => exchangeCache?.q ?? "");
+  const [page, setPage] = useState(() => exchangeCache?.page ?? 0);
+  const [pageSize, setPageSize] = useState<number>(() => exchangeCache?.pageSize ?? EXCHANGE_DEFAULT_PAGE_SIZE);
+  const [sortColumn, setSortColumn] = useState(() => exchangeCache?.sortColumn ?? "display_name");
+  const [sortDirection, setSortDirection] = useState<SortDirection>(() => exchangeCache?.sortDirection ?? "asc");
+  const [owner, setOwner] = useState<ExchangeOwner>(() => exchangeCache?.owner ?? "player");
+  const [rows, setRows] = useState<ExchangeItem[]>(() => exchangeCache?.rows ?? []);
+  const [totalCount, setTotalCount] = useState(() => exchangeCache?.totalCount ?? 0);
+  const [totalItems, setTotalItems] = useState(() => exchangeCache?.totalItems ?? 0);
+  const [supported, setSupported] = useState(() => exchangeCache?.supported ?? true);
+  const [reason, setReason] = useState(() => exchangeCache?.reason ?? "");
+  const [loading, setLoading] = useState(() => exchangeCache === null);
+  const [configOpen, setConfigOpen] = useState(false);
+  const requestIdRef = useRef(0);
+  const skipNextSearchReset = useRef(true);
+
+  useEffect(() => {
+    if (skipNextSearchReset.current) {
+      skipNextSearchReset.current = false;
+      return;
+    }
+    setPage(0);
+  }, [submittedQ, owner]);
+
+  function submitSearch() {
+    setSubmittedQ(q);
+  }
+
+  function handleClearSearch() {
+    setQ("");
+    setSubmittedQ("");
+  }
+
+  function handleSort(column: string) {
+    setPage(0);
+    if (column === sortColumn) {
+      setSortDirection((current) => current === "asc" ? "desc" : "asc");
+      return;
+    }
+    setSortColumn(column);
+    setSortDirection("asc");
+  }
+
+  function changePageSize(nextSize: number) {
+    setPageSize(nextSize);
+    setPage(0);
+  }
+
+  const load = useCallback(async (view: ExchangeView, options: { silent?: boolean } = {}) => {
+    const requestId = ++requestIdRef.current;
+    if (!options.silent) onError("");
+    try {
+      const result = await exchangeApi.items(view);
+      if (requestIdRef.current !== requestId) return;
+      const nextRows = result.rows || [];
+      const nextSupported = result.capabilities?.exchange !== false;
+      setRows(nextRows);
+      setTotalCount(result.totalCount || 0);
+      setTotalItems(result.totalItems || 0);
+      setSupported(nextSupported);
+      setReason(result.reason || "");
+      exchangeCache = {
+        ...view,
+        rows: nextRows,
+        totalCount: result.totalCount || 0,
+        totalItems: result.totalItems || 0,
+        supported: nextSupported,
+        reason: result.reason || "",
+        lastFetchedAt: Date.now()
+      };
+    } catch (error) {
+      if (requestIdRef.current === requestId && !options.silent) onError(errorText(error));
+    } finally {
+      if (requestIdRef.current === requestId) setLoading(false);
+    }
+  }, [onError]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timeoutId: number | undefined;
+    const view: ExchangeView = { q: submittedQ, page, pageSize, sortColumn, sortDirection, owner };
+    const cacheHit = sameView(exchangeCache, view) ? exchangeCache : null;
+
+    if (cacheHit) {
+      setRows(cacheHit.rows);
+      setTotalCount(cacheHit.totalCount);
+      setTotalItems(cacheHit.totalItems);
+      setSupported(cacheHit.supported);
+      setReason(cacheHit.reason);
+      setLoading(false);
+    }
+
+    const scheduleNext = () => {
+      if (cancelled) return;
+      window.clearTimeout(timeoutId);
+      timeoutId = window.setTimeout(() => { void tick(); }, EXCHANGE_AUTO_REFRESH_MS);
+    };
+
+    const tick = async () => {
+      if (document.visibilityState !== "hidden") await load(view, { silent: true });
+      scheduleNext();
+    };
+
+    void load(view, { silent: Boolean(cacheHit) }).then(scheduleNext);
+
+    const onVisibilityChange = () => {
+      const currentCache = sameView(exchangeCache, view) ? exchangeCache : null;
+      if (document.visibilityState === "visible" && (!currentCache || Date.now() - currentCache.lastFetchedAt >= EXCHANGE_AUTO_REFRESH_MS)) {
+        void load(view, { silent: true }).then(scheduleNext);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeoutId);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [submittedQ, page, pageSize, sortColumn, sortDirection, owner, load]);
+
+  function currentView(): ExchangeView {
+    return { q: submittedQ, page, pageSize, sortColumn, sortDirection, owner };
+  }
+
+  if (loading && !rows.length) {
+    return (
+      <section className="panel">
+        <div className="loading-panel">
+          <span className="spinner" aria-hidden="true" />
+          <strong className="loading-dots">Loading Market Board</strong>
+        </div>
+      </section>
+    );
+  }
+
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const rangeStart = totalCount === 0 ? 0 : page * pageSize + 1;
+  const rangeEnd = totalCount === 0 ? 0 : rangeStart + rows.length - 1;
+  const hasPreviousPage = page > 0;
+  const hasNextPage = page + 1 < totalPages;
+
+  return (
+    <section className="panel">
+      <div className="panel-title">
+        <h2>Market Board</h2>
+        <div className="action-row">
+          <button onClick={() => void load(currentView())}>Refresh</button>
+        </div>
+      </div>
+      {supported
+        ? <p className="action-help-note">Read-only view of the CHOAM exchange. {totalItems.toLocaleString()} item{totalItems === 1 ? "" : "s"} listed for the current filter.</p>
+        : <p className="action-help-note">{reason || "The Market Board is unsupported by the detected database schema."}</p>}
+      {supported && <>
+        <div className="action-row exchange-search-row">
+          <input
+            value={q}
+            onChange={(event) => setQ(event.target.value)}
+            onKeyDown={(event) => { if (event.key === "Enter") submitSearch(); }}
+            placeholder="Search item name, category, or template"
+          />
+          <button onClick={submitSearch}>Search</button>
+          <button onClick={handleClearSearch} disabled={!q && !submittedQ}>Clear</button>
+          <label className="compact-select exchange-owner-select">
+            Show
+            <select value={owner} onChange={(event) => setOwner(event.target.value as ExchangeOwner)}>
+              {OWNER_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select>
+          </label>
+          <button className="exchange-config-button" title="Configure bots and blacklist" aria-label="Configure bots and blacklist" onClick={() => setConfigOpen(true)}>
+            <Settings size={16} />
+          </button>
+        </div>
+        <ExchangeTable
+          rows={rows}
+          sortColumn={sortColumn}
+          sortDirection={sortDirection}
+          onSort={handleSort}
+          emptyMessage="No market listings match this filter."
+        />
+        <div className="panel-title exchange-pagination-footer">
+          <p className="action-help-note">Showing {rangeStart}-{rangeEnd} of {totalCount} items.</p>
+          <div className="database-pagination-controls">
+            <label className="compact-select">
+              Rows
+              <select value={String(pageSize)} onChange={(event) => changePageSize(Number(event.target.value))}>
+                {EXCHANGE_PAGE_SIZES.map((size) => <option key={size} value={size}>{size}</option>)}
+              </select>
+            </label>
+            <button disabled={!hasPreviousPage} onClick={() => setPage(0)}>First</button>
+            <button disabled={!hasPreviousPage} onClick={() => setPage(page - 1)}>Previous</button>
+            <span className="muted database-page-indicator">Page {page + 1} of {totalPages}</span>
+            <button disabled={!hasNextPage} onClick={() => setPage(page + 1)}>Next</button>
+            <button disabled={!hasNextPage} onClick={() => setPage(totalPages - 1)}>Last</button>
+          </div>
+        </div>
+      </>}
+      {configOpen && (
+        <ExchangeConfigOverlay
+          onClose={() => setConfigOpen(false)}
+          onError={onError}
+          onSaved={() => { exchangeCache = null; void load(currentView()); }}
+        />
+      )}
+    </section>
+  );
+}

--- a/console/web/src/features/exchange/ExchangeTable.tsx
+++ b/console/web/src/features/exchange/ExchangeTable.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { exchangeApi, type ExchangeItem, type ExchangeListing } from "../../api/exchange";
+import { DataTable, type SortDirection } from "../../components/common/DataTable";
+
+const COLUMNS = ["display_name", "quality_level", "category", "tier", "lowest_price", "total_stock", "listing_count"];
+const COLUMN_LABELS: Record<string, string> = {
+  display_name: "Item",
+  quality_level: "Grade",
+  category: "Category",
+  tier: "Tier",
+  lowest_price: "Lowest Price",
+  total_stock: "Stock",
+  listing_count: "Listings"
+};
+
+type ExchangeTableProps = {
+  rows: ExchangeItem[];
+  sortColumn?: string;
+  sortDirection?: SortDirection;
+  onSort?: (column: string) => void;
+  emptyMessage?: string;
+};
+
+function itemKey(row: ExchangeItem) {
+  return `${row.template_id}:${row.quality_level}`;
+}
+
+function fmt(value: number) {
+  return Number(value || 0).toLocaleString();
+}
+
+function gradeLabel(quality: number) {
+  return quality > 0 ? `Q${quality}` : "Standard";
+}
+
+function renderCell(row: Record<string, unknown>, column: string) {
+  const item = row as ExchangeItem;
+  if (column === "display_name") {
+    return (
+      <div className="exchange-item-cell">
+        {item.icon
+          ? <img className="exchange-item-icon" src={item.icon} alt="" loading="lazy" />
+          : <span className="exchange-item-icon exchange-item-icon-empty" aria-hidden="true" />}
+        <span className="exchange-item-text">
+          <span className="exchange-item-name">{item.display_name || item.template_id}</span>
+          <span className="exchange-item-template" title={item.template_id}>{item.template_id}</span>
+        </span>
+      </div>
+    );
+  }
+  if (column === "quality_level") return gradeLabel(item.quality_level);
+  if (column === "category") return item.category ? String(item.category) : <span className="muted">—</span>;
+  if (column === "tier") return item.tier ? `T${item.tier}` : <span className="muted">—</span>;
+  if (column === "lowest_price") return <span className="exchange-price">{fmt(item.lowest_price)}</span>;
+  if (column === "total_stock") return fmt(item.total_stock);
+  if (column === "listing_count") return fmt(item.listing_count);
+  const value = row[column];
+  return value === null || value === undefined || value === "" ? "—" : String(value);
+}
+
+function ListingRows({ listings }: { listings: ExchangeListing[] }) {
+  if (!listings.length) return <p className="muted">No active listings for this item.</p>;
+  return (
+    <table className="exchange-listings-table">
+      <thead>
+        <tr>
+          <th>Seller</th>
+          <th className="exchange-num">Price</th>
+          <th className="exchange-num">Qty</th>
+          <th>Grade</th>
+        </tr>
+      </thead>
+      <tbody>
+        {listings.map((listing) => (
+          <tr key={listing.order_id}>
+            <td>
+              <span className="exchange-seller-name">{listing.owner_name}</span>
+              <span className={`exchange-owner-badge exchange-owner-${listing.owner_type}`}>{listing.owner_type}</span>
+            </td>
+            <td className="exchange-num exchange-price">{fmt(listing.price)}</td>
+            <td className="exchange-num">{fmt(listing.stock)}</td>
+            <td>{gradeLabel(listing.quality)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export function ExchangeTable({ rows, sortColumn, sortDirection, onSort, emptyMessage = "No market listings found." }: ExchangeTableProps) {
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  const [listings, setListings] = useState<Record<string, ExchangeListing[]>>({});
+  const [loadingKey, setLoadingKey] = useState<string | null>(null);
+  const [errorKey, setErrorKey] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (expandedKey && !rows.some((row) => itemKey(row) === expandedKey)) setExpandedKey(null);
+  }, [expandedKey, rows]);
+
+  async function toggle(row: ExchangeItem) {
+    const key = itemKey(row);
+    if (expandedKey === key) {
+      setExpandedKey(null);
+      return;
+    }
+    setExpandedKey(key);
+    if (listings[key]) return;
+    setLoadingKey(key);
+    setErrorKey(null);
+    try {
+      const result = await exchangeApi.listings(row.template_id, row.quality_level, "all");
+      setListings((current) => ({ ...current, [key]: result.rows || [] }));
+    } catch {
+      setErrorKey(key);
+    } finally {
+      setLoadingKey((current) => (current === key ? null : current));
+    }
+  }
+
+  return (
+    <DataTable
+      rows={rows}
+      columns={COLUMNS}
+      columnLabels={COLUMN_LABELS}
+      tableClassName="exchange-table"
+      wrapClassName="exchange-table-wrap"
+      headerTitles
+      renderCell={renderCell}
+      sortColumn={sortColumn}
+      sortDirection={sortDirection}
+      onSort={onSort}
+      secondaryActionPosition="start"
+      secondaryActionLabel=""
+      secondaryActionClassName="exchange-expand-column"
+      secondaryAction={(row) => {
+        const item = row as ExchangeItem;
+        const key = itemKey(item);
+        const isExpanded = expandedKey === key;
+        const label = `${isExpanded ? "Hide" : "Show"} listings for ${item.display_name || item.template_id}`;
+        return (
+          <button className="exchange-expand-button" title={label} aria-label={label} aria-expanded={isExpanded} onClick={(event) => { event.stopPropagation(); void toggle(item); }}>
+            {isExpanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          </button>
+        );
+      }}
+      rowKey={(row) => itemKey(row as ExchangeItem)}
+      onRowClick={(row) => void toggle(row as ExchangeItem)}
+      isRowExpanded={(row) => expandedKey === itemKey(row as ExchangeItem)}
+      renderExpandedRow={(row) => {
+        const item = row as ExchangeItem;
+        const key = itemKey(item);
+        return (
+          <div className="exchange-listings">
+            <p className="exchange-listings-header">{item.display_name || item.template_id} · {gradeLabel(item.quality_level)} · {item.listing_count} listing{item.listing_count === 1 ? "" : "s"}</p>
+            {loadingKey === key
+              ? <p className="muted">Loading listings…</p>
+              : errorKey === key
+                ? <p className="muted">Could not load listings. Click again to retry.</p>
+                : <ListingRows listings={listings[key] || []} />}
+          </div>
+        );
+      }}
+      emptyMessage={emptyMessage}
+    />
+  );
+}

--- a/console/web/src/features/exchange/ExchangeTable.tsx
+++ b/console/web/src/features/exchange/ExchangeTable.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
-import { exchangeApi, type ExchangeItem, type ExchangeListing } from "../../api/exchange";
+import { exchangeApi, type ExchangeItem, type ExchangeListing, type ExchangeOwner } from "../../api/exchange";
 import { DataTable, type SortDirection } from "../../components/common/DataTable";
 
 const COLUMNS = ["display_name", "quality_level", "category", "tier", "lowest_price", "total_stock", "listing_count"];
@@ -16,6 +16,7 @@ const COLUMN_LABELS: Record<string, string> = {
 
 type ExchangeTableProps = {
   rows: ExchangeItem[];
+  owner: ExchangeOwner;
   sortColumn?: string;
   sortDirection?: SortDirection;
   onSort?: (column: string) => void;
@@ -88,8 +89,11 @@ function ListingRows({ listings }: { listings: ExchangeListing[] }) {
   );
 }
 
-export function ExchangeTable({ rows, sortColumn, sortDirection, onSort, emptyMessage = "No market listings found." }: ExchangeTableProps) {
+export function ExchangeTable({ rows, owner, sortColumn, sortDirection, onSort, emptyMessage = "No market listings found." }: ExchangeTableProps) {
   const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  // Listings are cached per (owner, item) because the owner filter changes which
+  // sellers are returned; keying by item alone would show a stale set after the
+  // filter changes.
   const [listings, setListings] = useState<Record<string, ExchangeListing[]>>({});
   const [loadingKey, setLoadingKey] = useState<string | null>(null);
   const [errorKey, setErrorKey] = useState<string | null>(null);
@@ -105,12 +109,13 @@ export function ExchangeTable({ rows, sortColumn, sortDirection, onSort, emptyMe
       return;
     }
     setExpandedKey(key);
-    if (listings[key]) return;
+    const cacheKey = `${owner}:${key}`;
+    if (listings[cacheKey]) return;
     setLoadingKey(key);
     setErrorKey(null);
     try {
-      const result = await exchangeApi.listings(row.template_id, row.quality_level, "all");
-      setListings((current) => ({ ...current, [key]: result.rows || [] }));
+      const result = await exchangeApi.listings(row.template_id, row.quality_level, owner);
+      setListings((current) => ({ ...current, [cacheKey]: result.rows || [] }));
     } catch {
       setErrorKey(key);
     } finally {
@@ -157,7 +162,7 @@ export function ExchangeTable({ rows, sortColumn, sortDirection, onSort, emptyMe
               ? <p className="muted">Loading listings…</p>
               : errorKey === key
                 ? <p className="muted">Could not load listings. Click again to retry.</p>
-                : <ListingRows listings={listings[key] || []} />}
+                : <ListingRows listings={listings[`${owner}:${key}`] || []} />}
           </div>
         );
       }}

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2029,9 +2029,12 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 .exchange-search-row > input { flex: 1 1 220px; min-width: 160px; }
 /* Lay the filter controls out inline (label beside the select) instead of the
    default stacked label grid, so they share the search row's baseline with the
-   input, buttons, and gear. The input's flex-grow right-aligns this cluster. */
-.exchange-category-select, .exchange-owner-select { display: flex; flex-direction: row; align-items: center; gap: 6px; flex: 0 0 auto; white-space: nowrap; }
-.exchange-category-select select, .exchange-owner-select select { width: auto; min-width: 150px; max-width: 220px; }
+   input, buttons, and gear. The input's flex-grow right-aligns this cluster.
+   Qualified with `label` so `flex: 0 0 auto` matches the specificity of the global
+   `label.compact-select { flex: 0 1 240px }` and wins (later rule) — otherwise the
+   selects render as fixed 240px boxes instead of hugging their content. */
+label.exchange-category-select, label.exchange-owner-select { display: flex; flex-direction: row; align-items: center; gap: 6px; flex: 0 0 auto; white-space: nowrap; }
+.exchange-category-select select, .exchange-owner-select select { width: auto; min-width: 150px; max-width: 220px; height: 43px; }
 .exchange-config-button { width: 43px; height: 43px; min-width: 0; padding: 0; display: inline-grid; place-items: center; }
 .table-wrap.exchange-table-wrap { max-height: none; }
 .exchange-table th.exchange-expand-column, .exchange-table td.exchange-expand-column {
@@ -2062,6 +2065,13 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 .exchange-item-template { color: #8f8371; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .exchange-price { color: var(--accent-strong); font-variant-numeric: tabular-nums; }
 .exchange-num { text-align: right; font-variant-numeric: tabular-nums; }
+/* Right-align the numeric magnitude columns (header + cells) so digits line up for
+   comparison and match the drill-down sub-table. Targeted by data-column (set by
+   DataTable) rather than nth-child, so it never touches the expanded drill-down row
+   and won't drift if column order changes. */
+.exchange-table th[data-column="lowest_price"], .exchange-table td[data-column="lowest_price"],
+.exchange-table th[data-column="total_stock"], .exchange-table td[data-column="total_stock"],
+.exchange-table th[data-column="listing_count"], .exchange-table td[data-column="listing_count"] { text-align: right; }
 .exchange-pagination-footer { margin-top: 12px; }
 .exchange-listings { padding: 6px 4px; display: grid; gap: 8px; }
 .exchange-listings-header { margin: 0; color: #ffd08a; font-size: 13px; }

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2026,8 +2026,13 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 
 /* Market Board (Exchange) */
 .exchange-search-row { margin: 12px 0; display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
-.exchange-owner-select { margin-left: auto; }
-.exchange-config-button { width: 34px; height: 34px; min-width: 0; padding: 0; display: inline-grid; place-items: center; }
+.exchange-search-row > input { flex: 1 1 220px; min-width: 160px; }
+/* Lay the filter controls out inline (label beside the select) instead of the
+   default stacked label grid, so they share the search row's baseline with the
+   input, buttons, and gear. The input's flex-grow right-aligns this cluster. */
+.exchange-category-select, .exchange-owner-select { display: flex; flex-direction: row; align-items: center; gap: 6px; flex: 0 0 auto; white-space: nowrap; }
+.exchange-category-select select, .exchange-owner-select select { width: auto; min-width: 150px; max-width: 220px; }
+.exchange-config-button { width: 43px; height: 43px; min-width: 0; padding: 0; display: inline-grid; place-items: center; }
 .table-wrap.exchange-table-wrap { max-height: none; }
 .exchange-table th.exchange-expand-column, .exchange-table td.exchange-expand-column {
   width: 32px;
@@ -2078,6 +2083,10 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 .exchange-config-chips { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 6px; }
 .exchange-config-chip { display: inline-flex; align-items: center; gap: 6px; background: #221a10; border: 1px solid #4d4031; color: #e7c893; border-radius: 999px; padding: 3px 8px; font-size: 12px; font-variant-numeric: tabular-nums; }
 .exchange-config-chip button { width: 18px; height: 18px; min-width: 0; padding: 0; border: 0; background: none; color: inherit; display: inline-grid; place-items: center; cursor: pointer; }
+.exchange-config-chip > span { display: inline-flex; align-items: center; gap: 6px; }
+.exchange-config-chip-builtin { background: #13212b; border-color: #33556a; color: #a9d0e6; }
+.exchange-config-chip-builtin em { font-style: normal; font-size: 9px; letter-spacing: 0.04em; text-transform: uppercase; color: #7fb0c9; border: 1px solid #33556a; border-radius: 999px; padding: 1px 5px; }
+.exchange-config-restore { width: auto; min-width: 0; align-self: flex-start; padding: 3px 10px; font-size: 12px; display: inline-flex; align-items: center; gap: 5px; }
 .exchange-config-add { display: flex; gap: 6px; }
 .exchange-config-add input { flex: 1; min-width: 0; }
 .exchange-config-add button { width: auto; min-width: 72px; }

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2024,6 +2024,65 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 .vehicles-access.co-owner { border-color: rgba(255, 208, 138, .42); color: #ffd08a; }
 .player-vehicles-table thead th:nth-child(8), .player-vehicles-table tbody td:nth-child(8) { text-align: center; }
 
+/* Market Board (Exchange) */
+.exchange-search-row { margin: 12px 0; display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+.exchange-owner-select { margin-left: auto; }
+.exchange-config-button { width: 34px; height: 34px; min-width: 0; padding: 0; display: inline-grid; place-items: center; }
+.table-wrap.exchange-table-wrap { max-height: none; }
+.exchange-table th.exchange-expand-column, .exchange-table td.exchange-expand-column {
+  width: 32px;
+  padding-inline: 4px;
+  text-align: center;
+  overflow: visible;
+  text-overflow: clip;
+}
+.exchange-expand-button {
+  width: 24px;
+  height: 24px;
+  min-width: 0;
+  padding: 0;
+  margin: 0 auto;
+  border: 0;
+  background: none;
+  color: inherit;
+  display: inline-grid;
+  place-items: center;
+  cursor: pointer;
+}
+.exchange-item-cell { display: flex; align-items: center; gap: 9px; white-space: normal; }
+.exchange-item-icon { width: 26px; height: 26px; border-radius: 5px; object-fit: contain; background: #171a1d; border: 1px solid #302b25; flex: none; }
+.exchange-item-icon-empty { display: inline-block; }
+.exchange-item-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.exchange-item-name { color: #fff1d4; font-weight: 500; }
+.exchange-item-template { color: #8f8371; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.exchange-price { color: var(--accent-strong); font-variant-numeric: tabular-nums; }
+.exchange-num { text-align: right; font-variant-numeric: tabular-nums; }
+.exchange-pagination-footer { margin-top: 12px; }
+.exchange-listings { padding: 6px 4px; display: grid; gap: 8px; }
+.exchange-listings-header { margin: 0; color: #ffd08a; font-size: 13px; }
+.exchange-listings-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.exchange-listings-table th { text-align: left; color: #ad9f89; font-weight: 500; padding: 5px 8px; border-bottom: 1px solid #302b25; }
+.exchange-listings-table th.exchange-num { text-align: right; }
+.exchange-listings-table td { padding: 5px 8px; border-top: 1px solid #201c17; }
+.exchange-seller-name { color: #f3efe7; }
+.exchange-owner-badge { margin-left: 6px; padding: 1px 7px; border-radius: 999px; font-size: 11px; border: 1px solid; }
+.exchange-owner-player { background: rgba(76, 175, 124, .12); color: #9be6bd; border-color: rgba(155, 230, 189, .35); }
+.exchange-owner-bot { background: rgba(198, 139, 74, .14); color: #e7c893; border-color: #4d4031; }
+.exchange-config-modal { width: min(480px, calc(100vw - 32px)); }
+.exchange-config-close { width: 28px; height: 28px; min-width: 0; padding: 0; border: 0; background: none; color: inherit; display: inline-grid; place-items: center; cursor: pointer; }
+.exchange-config-list { display: grid; gap: 8px; border: 1px solid #302b25; border-radius: 8px; padding: 10px 12px; background: #12151a; }
+.exchange-config-list-head { display: flex; flex-direction: column; gap: 2px; }
+.exchange-config-list-head strong { color: #ffd08a; }
+.exchange-config-list-head .muted { font-size: 12px; }
+.exchange-config-empty { margin: 0; font-style: italic; }
+.exchange-config-chips { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: 6px; }
+.exchange-config-chip { display: inline-flex; align-items: center; gap: 6px; background: #221a10; border: 1px solid #4d4031; color: #e7c893; border-radius: 999px; padding: 3px 8px; font-size: 12px; font-variant-numeric: tabular-nums; }
+.exchange-config-chip button { width: 18px; height: 18px; min-width: 0; padding: 0; border: 0; background: none; color: inherit; display: inline-grid; place-items: center; cursor: pointer; }
+.exchange-config-add { display: flex; gap: 6px; }
+.exchange-config-add input { flex: 1; min-width: 0; }
+.exchange-config-add button { width: auto; min-width: 72px; }
+.exchange-config-modal .confirm-modal-actions .primary { background: var(--accent); color: #1a130a; border-color: var(--accent); }
+
 .stable-action-button { min-width: 72px; }
 .map-action-buttons { display: flex; flex-wrap: wrap; justify-content: center; gap: 6px; }
 .map-action-buttons .stable-action-button { min-width: 72px; width: auto; }

--- a/console/web/vite.config.ts
+++ b/console/web/vite.config.ts
@@ -4,9 +4,13 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   server: {
-    port: 5173,
+    // Overridable for local/containerized dev (e.g. .claude/scripts/live-test.sh
+    // points this at a docker-network API hostname). Defaults are unchanged from
+    // the historical hardcoded values, so a plain `npm run dev` behaves exactly
+    // as before.
+    port: Number(process.env.VITE_DEV_PORT) || 5173,
     proxy: {
-      "/api": "http://127.0.0.1:8088"
+      "/api": process.env.VITE_API_TARGET || "http://127.0.0.1:8088"
     }
   }
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ reference. Everything else is marked **Current** and is expected to stay accurat
 - [generator-refill-caps.md](console/generator-refill-caps.md) — Current. Refill-generators endpoint behavior and per-type fuel caps.
 - [base-permissions.md](console/base-permissions.md) — Current. Editing base ownership and sharing: ranks, the config-driven roster cap, and why the change needs no map restart.
 - [base-inventory.md](console/base-inventory.md) — Current. The read-only base Inventory tab: which placeables count as storage, the two inventories every refinery carries, and why the tab cannot write.
+- [exchange.md](console/exchange.md) — Current. The read-only Market Board: aggregated-by-item CHOAM exchange listings, seller resolution, how bot listings are identified, and the bot/blacklist filter config.
 
 ## Runtime (`runtime/`)
 

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -340,6 +340,48 @@ read.
 
 ---
 
+## Market Board
+
+| Method | Route | Description | Parameters |
+|--------|-------|-------------|------------|
+| GET | `/api/exchange/items` | List active CHOAM exchange sell orders aggregated by item + grade (paginated): lowest price, total stock, listing count | `q?`, `page?`, `pageSize?`, `sortColumn?`, `sortDirection?`, `owner?` |
+| GET | `/api/exchange/listings` | List the individual sell orders for one item, each with a resolved seller | `templateId`, `quality?`, `owner?` |
+| GET | `/api/exchange/stats` | Aggregate totals (total, bot, player listings; unique items) | None |
+| GET | `/api/exchange/config` | Read the console-local bot/blacklist filter config | None |
+| POST | `/api/exchange/config` | Save the bot/blacklist filter config (audited, rate-limited) | body: `botOwnerIds[]`, `blacklistedOwnerIds[]` |
+
+Read-only over the game's own exchange tables (the game writes them; the console
+never mutates them). `GET /api/exchange/items` reports `capabilities.exchange`; it
+is false (with a `reason`) when the schema lacks the required tables
+(`dune_exchange_orders`, `dune_exchange_sell_orders`, `items`, `actors`,
+`player_state`).
+
+The `owner` filter selects `player` (default for `/items`), `bot`, or `all`, where
+**bot** = `is_npc_order` OR a configured `botOwnerIds` entry, **player** = the
+complement, and **all** = no owner predicate. Blacklisted owner ids are excluded on
+every `owner` value. Sortable `sortColumn` values: `display_name`, `template_id`,
+`category`, `quality_level`, `tier`, `lowest_price`, `total_stock`, `listing_count`;
+`q` matches `display_name`, `category`, and `template_id`. The response mirrors the
+paginated-list convention (`rows`, `totalCount` filtered, `totalItems` unfiltered).
+Because `display_name`/`category`/`tier` come from the local `admin-items.json`
+catalog rather than the database, search and sort run in the service after
+enrichment (a short-TTL cache of the enriched aggregate keeps interactive paging
+cheap).
+
+`GET /api/exchange/listings` requires `templateId`; `quality` and `owner` are
+optional. Each row carries `owner_type` (`player`|`bot`) and a resolved `owner_name`
+(via `actors.owner_account_id → player_state.character_name`, falling back to the
+actor class; NPC/broker orders show the in-game broker), plus `price`, `stock`, and
+`quality`.
+
+`POST /api/exchange/config` is the **only** write in this feature and persists
+**only** the console-local `runtime/generated/exchange-config.json` (no game-DB
+writes). Ids are validated as numeric owner-id strings, deduped, and length-capped.
+See [exchange.md](exchange.md) for how bot listings are identified and how the
+blacklist behaves.
+
+---
+
 ## Blueprints
 
 | Method | Route | Description | Parameters |

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -344,11 +344,11 @@ read.
 
 | Method | Route | Description | Parameters |
 |--------|-------|-------------|------------|
-| GET | `/api/exchange/items` | List active CHOAM exchange sell orders aggregated by item + grade (paginated): lowest price, total stock, listing count | `q?`, `page?`, `pageSize?`, `sortColumn?`, `sortDirection?`, `owner?` |
+| GET | `/api/exchange/items` | List active CHOAM exchange sell orders aggregated by item + grade (paginated): lowest price, total stock, listing count | `q?`, `page?`, `pageSize?`, `sortColumn?`, `sortDirection?`, `owner?`, `category?` |
 | GET | `/api/exchange/listings` | List the individual sell orders for one item, each with a resolved seller | `templateId`, `quality?`, `owner?` |
 | GET | `/api/exchange/stats` | Aggregate totals (total, bot, player listings; unique items) | None |
 | GET | `/api/exchange/config` | Read the console-local bot/blacklist filter config | None |
-| POST | `/api/exchange/config` | Save the bot/blacklist filter config (audited, rate-limited) | body: `botOwnerIds[]`, `blacklistedOwnerIds[]` |
+| POST | `/api/exchange/config` | Save the bot/blacklist filter config (audited, rate-limited) | body: `includeNpcBroker`, `botOwnerIds[]`, `blacklistedOwnerIds[]` |
 
 Read-only over the game's own exchange tables (the game writes them; the console
 never mutates them). `GET /api/exchange/items` reports `capabilities.exchange`; it
@@ -356,12 +356,17 @@ is false (with a `reason`) when the schema lacks the required tables
 (`dune_exchange_orders`, `dune_exchange_sell_orders`, `items`, `actors`,
 `player_state`).
 
-The `owner` filter selects `player` (default for `/items`), `bot`, or `all`, where
-**bot** = `is_npc_order` OR a configured `botOwnerIds` entry, **player** = the
-complement, and **all** = no owner predicate. Blacklisted owner ids are excluded on
-every `owner` value. Sortable `sortColumn` values: `display_name`, `template_id`,
+The `owner` filter selects `all` (default for `/items`), `player`, or `bot`, where
+**bot** = the in-game NPC broker (unless excluded via `includeNpcBroker: false`) OR a
+configured `botOwnerIds` entry, **player** = the complement, and **all** = no owner
+predicate. Blacklisted owner ids are excluded on every `owner` value. `includeNpcBroker`
+(default true) is the built-in broker toggle: set it false to stop classifying the
+in-game broker's orders as bot. Sortable `sortColumn` values: `display_name`, `template_id`,
 `category`, `quality_level`, `tier`, `lowest_price`, `total_stock`, `listing_count`;
-`q` matches `display_name`, `category`, and `template_id`. The response mirrors the
+`q` matches `display_name`, `category`, and `template_id`. `category` filters to an
+exact catalog category; the response also returns `categories` — the distinct
+categories present in the current owner scope (computed before the category/search
+filters, so the list is stable for populating a dropdown). The response mirrors the
 paginated-list convention (`rows`, `totalCount` filtered, `totalItems` unfiltered).
 Because `display_name`/`category`/`tier` come from the local `admin-items.json`
 catalog rather than the database, search and sort run in the service after

--- a/docs/console/exchange.md
+++ b/docs/console/exchange.md
@@ -1,0 +1,85 @@
+# Market Board (Exchange)
+
+**Status:** Current | **Last Updated:** August 2026
+
+The Market Board is a **read-only** view of the in-game CHOAM exchange. It reads the
+game's own exchange tables (the game writes them; the console never mutates them) so
+an admin can see what is currently listed for sale — prices, stock, and sellers — at
+a glance. It is modeled on the Market tab from
+[Icehunter/dune-admin](https://github.com/Icehunter/dune-admin), rendered in the
+console's own theme and components.
+
+See [API-REFERENCE.md](API-REFERENCE.md#market-board) for the endpoint contract.
+
+## What it shows
+
+The board is **aggregated by item**: one row per `(template_id, quality_level)`,
+with the **lowest price**, **total stock**, and **listing count** across all matching
+sell orders. Item name, category, and icon come from the local
+`runtime/data/admin-items.json` catalog (`template_id` falls through as the name when
+the catalog has no entry); tier is parsed from a `T<n>_` template prefix when present.
+
+Clicking a row drills down to the **individual sell orders** for that item, each with
+its resolved seller, price, quantity, and grade.
+
+### Seller resolution
+
+A listing's seller (`owner_id`) is resolved the same way the Players page resolves a
+character: `dune.actors.owner_account_id → dune.player_state.character_name`, falling
+back to the actor's `class`, then `Unknown`. `player_state` is the decryption view, so
+this works without touching encrypted account data.
+
+## Bot listing identification
+
+This is the one piece worth understanding before trusting the `Bot listings` filter.
+
+- The **only** database-level signal that an order is not a real player's is
+  `dune.dune_exchange_orders.is_npc_order` (a boolean).
+- Every `is_npc_order = true` order belongs to the in-game CHOAM broker NPC (a single
+  actor whose class is `Revy`). External market-bot tools operate by posting their
+  sell orders **as this NPC**, so in practice `is_npc_order = true` is *the bot
+  channel*.
+
+Consequences, by design:
+
+- `is_npc_order = true` lumps the game's own NPC vendor together with any bot posting
+  through it — you **cannot** distinguish one bot tool from another at the database
+  level.
+- A bot that instead lists through a **normal player account** would be classified as
+  a *Player* listing, not a *Bot* listing. So `is_npc_order` alone is a **necessary
+  but not complete** definition of "bot".
+
+To cover that gap without a schema change, the board lets an admin widen the
+definition with a configurable **allowlist of bot owner ids** (see below). The
+effective rule is:
+
+- **bot** = `is_npc_order` **OR** `owner_id ∈ botOwnerIds`
+- **player** = not a bot (not `is_npc_order` and not in `botOwnerIds`)
+- **all** = no owner filter
+
+Because most servers are dominated by NPC/broker stock, the board defaults to
+**Player listings** so real player activity is not buried.
+
+## Filter configuration (gear icon)
+
+The gear beside the owner selector opens a small overlay with two editable lists:
+
+- **Bot user ids** — owner ids to treat as bot listings, unioned with `is_npc_order`
+  as described above. Use this to capture bots that post through player accounts, or
+  bots run by other tools.
+- **Blacklisted ids** — owner ids to hide from the market entirely. A blacklisted
+  seller is excluded from **every** view and every owner filter (including "All").
+
+Both lists are stored **console-side only**, in
+`runtime/generated/exchange-config.json` — **no game data is changed**. Ids are
+validated as numeric owner-id strings, deduped, and length-capped. Saving the config
+is a mutation: it is rate-limited and written to the audit log (only the id counts
+are recorded, no personal data). Blacklisting is a moderation action — it changes
+what the market shows — which is why every change is audited.
+
+## Scope
+
+Strictly read-only over game data. There is **no** buy/sell/cancel/relist action and
+**no** market bot here — the console only *classifies and hides* listings, it never
+places or automates orders. The sole persistence is the console-local filter config
+above.

--- a/docs/console/exchange.md
+++ b/docs/console/exchange.md
@@ -57,8 +57,9 @@ effective rule is:
 - **player** = not a bot (not `is_npc_order` and not in `botOwnerIds`)
 - **all** = no owner filter
 
-Because most servers are dominated by NPC/broker stock, the board defaults to
-**Player listings** so real player activity is not buried.
+The board defaults to **All listings**; switch to **Player listings** to focus on
+real player activity (most servers are dominated by NPC/broker stock) or **Bot
+listings** to see only bot/broker stock.
 
 ## Filter configuration (gear icon)
 
@@ -66,7 +67,10 @@ The gear beside the owner selector opens a small overlay with two editable lists
 
 - **Bot user ids** — owner ids to treat as bot listings, unioned with `is_npc_order`
   as described above. Use this to capture bots that post through player accounts, or
-  bots run by other tools.
+  bots run by other tools. The in-game broker (Revy) appears here as a built-in,
+  removable entry: it is classified as a bot via `is_npc_order` rather than an id, and
+  removing it (persisted as `includeNpcBroker: false`) stops treating its orders as
+  bot — they then fall under player/all like any other seller. Restore it any time.
 - **Blacklisted ids** — owner ids to hide from the market entirely. A blacklisted
   seller is excluded from **every** view and every owner filter (including "All").
 


### PR DESCRIPTION
## Summary
- Adds a read-only Market Board for the CHOAM exchange: items aggregated by template/grade with lowest price, stock, and listing count, plus a per-item drill-down showing resolved sellers.
- Owner filter (All / Player / Bot listings, default All) and a category filter; bot classification is `is_npc_order` unioned with an admin-configurable `botOwnerIds` allowlist (the built-in in-game broker is shown as a removable entry), plus a blacklist to hide specific sellers everywhere. All config is console-local JSON — no game-DB writes.
- Registers the new routes in the RBAC/IAM model added upstream (`exchange:read` / `exchange:write-config`, granted to the existing viewer tiers like `vehicles:read`).
- Docs: new `docs/console/exchange.md`, `API-REFERENCE.md` section, README index entry.

## Test plan
- [x] `console/api` suite green in the pinned Ubuntu 22.04 + Postgres 17.4 container (952/952, 0 skipped) — includes the rebased RBAC parity test
- [x] `console/web` suite green (349/349), `tsc -b` clean
- [x] Live-verified against a real production-schema dump: aggregation, seller resolution, owner/category filters, and the bot/blacklist config overlay all checked in the browser with real data