### PR TITLE
fix(console): rename base inventory "Machines" to "Other", add Sub-Fief console

### DIFF
--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -6911,16 +6911,28 @@ const BASE_INVENTORY_TYPES = {
       advancedwearablesfabricator_placeable: "Advanced Garment Fabricator"
     }
   },
-  machines: {
-    name: "Machines",
+  other: {
+    name: "Other",
     buildingTypes: {
       recycler_placeable: "Recycler",
-      repairstation_placeable: "Repair Station"
+      repairstation_placeable: "Repair Station",
+      // The base's own claim structure. Unlike every other entry here it is
+      // not a placeable a player builds inside their base -- it *is* the
+      // base -- but it carries a real 5-slot dune.inventories row of its own
+      // (verified against the kovalt_test.backup dump: 17 totem_placeable
+      // and 2 totem_small_placeable rows, each with an inv.actor_id = p.id
+      // row, max_item_count 5; base 3438's totem_placeable 3437 held 1 item,
+      // qty 83, pulled through this same owner_entity_id join with no
+      // special-casing). Names are the catalog patent's, matching every
+      // other label in this table: Totem_Small_Patent is "Sub-Fief Console",
+      // Totem_Patent is "Advanced Sub-Fief".
+      totem_small_placeable: "Sub-Fief Console",
+      totem_placeable: "Advanced Sub-Fief"
     }
   }
 };
 
-const BASE_INVENTORY_GROUP_ORDER = ["storage", "refining", "crafting", "machines"];
+const BASE_INVENTORY_GROUP_ORDER = ["storage", "refining", "crafting", "other"];
 
 const BASE_INVENTORY_TRIPLES = BASE_INVENTORY_GROUP_ORDER.flatMap((group) =>
   Object.entries(BASE_INVENTORY_TYPES[group].buildingTypes).map(

--- a/console/api/test/baseInventory.test.js
+++ b/console/api/test/baseInventory.test.js
@@ -89,7 +89,7 @@ test("baseInventory rolls items up by template and by container", async () => {
     { key: "storage", name: "Storage", containerCount: 2, itemCount: 38 },
     { key: "refining", name: "Refining", containerCount: 1, itemCount: 7 },
     { key: "crafting", name: "Crafting", containerCount: 0, itemCount: 0 },
-    { key: "machines", name: "Machines", containerCount: 0, itemCount: 0 }
+    { key: "other", name: "Other", containerCount: 0, itemCount: 0 }
   ]);
 });
 
@@ -97,7 +97,7 @@ test("baseInventory keeps an empty container instead of dropping it", async () =
   // The left join against dune.items emits one all-null item row for a
   // container holding nothing.
   const db = createDb({
-    rows: [row({ placeable_id: "40010", inventory_id: "510", template_id: null, stack_size: null, max_item_count: 5, group_key: "machines", type_name: "Repair Station" })]
+    rows: [row({ placeable_id: "40010", inventory_id: "510", template_id: null, stack_size: null, max_item_count: 5, group_key: "other", type_name: "Repair Station" })]
   });
 
   const result = await baseInventory(db, BASE_ID);
@@ -106,7 +106,7 @@ test("baseInventory keeps an empty container instead of dropping it", async () =
     placeableId: "40010",
     name: "",
     typeName: "Repair Station",
-    group: "machines",
+    group: "other",
     usedSlots: 0,
     maxSlots: 5,
     itemCount: 0,
@@ -172,16 +172,22 @@ test("baseInventory only ever asks for allowlisted building types", async () => 
   assert.ok(buildingTypes.includes("smallorerefinery_placeable"));
   assert.ok(buildingTypes.includes("recycler_placeable"));
   assert.ok(buildingTypes.includes("repairstation_placeable"));
+  assert.ok(buildingTypes.includes("totem_small_placeable"));
+  assert.ok(buildingTypes.includes("totem_placeable"));
   // The Power and Water tabs own these; an unrecognised placeable must not
   // acquire a group by accident either.
   assert.ok(!buildingTypes.includes("generator_placeable"));
   assert.ok(!buildingTypes.includes("windtrap_placeable"));
   assert.ok(!buildingTypes.includes("watercistern_placeable"));
   assert.equal(groups.length, buildingTypes.length);
-  assert.deepEqual([...new Set(groups)], ["storage", "refining", "crafting", "machines"]);
+  assert.deepEqual([...new Set(groups)], ["storage", "refining", "crafting", "other"]);
   // Refineries and fabricators are separate groups, not one "production" bucket.
   assert.equal(groups[buildingTypes.indexOf("smallorerefinery_placeable")], "refining");
   assert.equal(groups[buildingTypes.indexOf("survivalfabricator_placeable")], "crafting");
+  // The base's own claim structure lands in Other alongside the recycler and
+  // repair station, not a bucket of its own.
+  assert.equal(groups[buildingTypes.indexOf("totem_small_placeable")], "other");
+  assert.equal(groups[buildingTypes.indexOf("totem_placeable")], "other");
 });
 
 test("baseInventory drops the uncapped second inventory refineries carry", async () => {

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -107,10 +107,11 @@ export type AutoRefillWaterState = {
   bases: AutoRefillWaterBase[];
 };
 
-// Storage containers plus the refining, crafting and machine inventories at a
-// base. Generator and windtrap fuel is deliberately absent -- the Power and
-// Water tabs own it.
-export type BaseInventoryGroupKey = "storage" | "refining" | "crafting" | "machines";
+// Storage containers plus the refining, crafting, and other inventories
+// (recycler, repair station, the base's own Sub-Fief console) at a base.
+// Generator and windtrap fuel is deliberately absent -- the Power and Water
+// tabs own it.
+export type BaseInventoryGroupKey = "storage" | "refining" | "crafting" | "other";
 
 export type BaseInventoryGroup = {
   key: BaseInventoryGroupKey;

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -22,7 +22,7 @@ const PAYLOAD: BaseInventory = {
     { key: "refining", name: "Refining", containerCount: 1, itemCount: 420 },
     // Empty groups are always present in the response; the chips filter them out.
     { key: "crafting", name: "Crafting", containerCount: 0, itemCount: 0 },
-    { key: "machines", name: "Machines", containerCount: 0, itemCount: 0 }
+    { key: "other", name: "Other", containerCount: 0, itemCount: 0 }
   ],
   containers: [
     {
@@ -181,7 +181,7 @@ describe("BaseInventoryTab", () => {
         { key: "storage", name: "Storage", containerCount: 4, itemCount: 0 },
         { key: "refining", name: "Refining", containerCount: 0, itemCount: 0 },
         { key: "crafting", name: "Crafting", containerCount: 0, itemCount: 0 },
-        { key: "machines", name: "Machines", containerCount: 0, itemCount: 0 }
+        { key: "other", name: "Other", containerCount: 0, itemCount: 0 }
       ],
       // Deliberately out of order, and mixing renamed with unrenamed: a
       // rename has to file under the name shown on the card, and "#9" has to
@@ -379,10 +379,10 @@ describe("BaseInventoryTab", () => {
     mockInventory({
       ...PAYLOAD,
       containers: [{
-        placeableId: "40009", name: "", typeName: "Repair Station", group: "machines",
+        placeableId: "40009", name: "", typeName: "Repair Station", group: "other",
         usedSlots: 0, maxSlots: 5, itemCount: 0, items: []
       }],
-      groups: PAYLOAD.groups.map((g) => g.key === "machines"
+      groups: PAYLOAD.groups.map((g) => g.key === "other"
         ? { ...g, containerCount: 1, itemCount: 0 }
         : { ...g, containerCount: 0, itemCount: 0 })
     });

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -744,7 +744,7 @@ describe("BasesPanel permissions editing", () => {
         { key: "storage", name: "Storage", containerCount: 1, itemCount: 1000 },
         { key: "refining", name: "Refining", containerCount: 0, itemCount: 0 },
         { key: "crafting", name: "Crafting", containerCount: 0, itemCount: 0 },
-        { key: "machines", name: "Machines", containerCount: 0, itemCount: 0 }
+        { key: "other", name: "Other", containerCount: 0, itemCount: 0 }
       ],
       containers: [{
         placeableId: "40001", name: "Vault", typeName: "Storage Container", group: "storage",

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -276,9 +276,10 @@ Changes reach a running map immediately — there is no restart queue, unlike th
 generator refill routes above. See [base-permissions.md](base-permissions.md).
 
 `GET /api/bases/{baseId}/inventory` covers storage containers plus refinery,
-fabricator and machine inventories; generator and windtrap fuel belong to the
-refill and water routes above. It is read-only — inventory writes have no path
-to a running map. See [base-inventory.md](base-inventory.md).
+fabricator, and other inventories (recycler, repair station, the base's own
+Sub-Fief console); generator and windtrap fuel belong to the refill and water
+routes above. It is read-only — inventory writes have no path to a running
+map. See [base-inventory.md](base-inventory.md).
 
 Both `GET /api/bases/{baseId}/water` and `GET /api/bases/{baseId}/inventory`
 answer **200 with `supported: false` and a `reason`** when the detected schema

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -249,7 +249,7 @@ Complete reference for all HTTP API endpoints in the Dune Docker Console. All en
 | DELETE | `/api/bases/{baseId}/queued-water-refill` | Cancel a base's queued water refill | `baseId` |
 | GET | `/api/bases/auto-refill-water` | Get per-base water auto-refill enrollment state | None |
 | POST | `/api/bases/{baseId}/auto-refill-water` | Enable/disable water auto-refill for a base | `baseId`, `enabled` |
-| GET | `/api/bases/{baseId}/inventory` | Get a base's stored items, rolled up by item template and by container (storage, refining, crafting, machines). Read-only | `baseId` |
+| GET | `/api/bases/{baseId}/inventory` | Get a base's stored items, rolled up by item template and by container (storage, refining, crafting, other). Read-only | `baseId` |
 | GET | `/api/bases/{baseId}/permissions` | Get a base's permission roster (Owner, Co-Owners, Associates) | `baseId` |
 | POST | `/api/bases/{baseId}/system-custodian` | Transfer ownership to the Server or detected GM system custodian while preserving the roster; provisions Server when no custodian exists | `baseId` |
 | PUT | `/api/bases/{baseId}/permissions` | Replace a base's permission roster | `baseId`, `entries[]` (`playerId`, `rank`) |

--- a/docs/console/base-inventory.md
+++ b/docs/console/base-inventory.md
@@ -13,9 +13,11 @@ Classification is an explicit `building_type` allowlist in `BASE_INVENTORY_TYPES
 | Storage | `storagecontainer` → Storage Container · `mediumstoragecontainer`† → Medium Storage Container (100 slots) · `genericcontainer` → **Chest** · `spicesilo` and `smallstoragecontainer`† → **Small Storage Container** |
 | Refining | `smallorerefinery` · `mediumorerefinery` · `largeorerefinery`† · `smallchemicalrefinery` · `mediumchemicalrefinery` → matching names; `spicerefinery` → Spice Refinery · `mediumspicerefinery`† · `largespicerefinery`† |
 | Crafting | `fabricator` → Fabricator · `survivalfabricator` · `vehiclesfabricator` · `weaponsfabricator` · `wearablesfabricator` → Garment Fabricator · plus `advancedsurvivalfabricator`†, `advancedvehiclefabricator`† (singular), `advancedweaponsfabricator`†, `advancedwearablesfabricator`† → Advanced … |
-| Machines | `recycler` → Recycler · `repairstation` → Repair Station |
+| Other | `recycler` → Recycler · `repairstation` → Repair Station · `totem_small` → **Sub-Fief Console** · `totem` → **Advanced Sub-Fief** |
 
 All suffixed `_placeable`. † marks a type not present in any database seen so far — it is in the allowlist because the game ships it, not because it has been observed in use.
+
+`totem_small_placeable` and `totem_placeable` are the base's own claim structure — the totem, not a building placed inside the base. It carries a real 5-slot `dune.inventories` row like everything else here, reached through the same `placeables.owner_entity_id` join with no special-casing. Confirmed directly against a live restore of `kovalt_test.backup` rather than the paks grep below (the paks extraction is known-lossy, see below): 17 `totem_placeable` and 2 `totem_small_placeable` rows, each backed by a 5-slot inventory; base 3438's `totem_placeable` held 1 item (qty 83) and came back through the production `baseInventory` query unmodified. Display names are the catalog patent's, matching every other label in this table: `Totem_Small_Patent` is "Sub-Fief Console", `Totem_Patent` is "Advanced Sub-Fief".
 
 Every string was verified against the shipped server paks, where each building carries a `DA_BLD_<building_type>.uasset`:
 


### PR DESCRIPTION
## Summary
- Renames the Bases → Inventory tab's "Machines" group to "Other"
- Adds the base's own claim structure (`totem_placeable` / `totem_small_placeable`, labeled "Advanced Sub-Fief" / "Sub-Fief Console") to the allowlist under Other — it carries a real 5-slot inventory that was previously invisible in the tab

## Test plan
- [x] `console/api` suite (933/933) in the compliant Ubuntu 22.04 + Node 22 + Postgres 17.4 container
- [x] `console/web` vitest suite (328/328)
- [x] `tsc -b` typecheck, clean
- [x] Verified against a live restore of a real game dump: base with an Advanced Sub-Fief holding items now shows it under Other in the running UI, contents modal included