### PR TITLE
fix(console): set correct cache-control on static console assets

### DIFF
--- a/console/api/src/http/staticFiles.js
+++ b/console/api/src/http/staticFiles.js
@@ -16,6 +16,18 @@ export function contentTypeForPath(target) {
   return mime.get(extname(target)) || "application/octet-stream";
 }
 
+// Vite fingerprints every file under its default assetsDir ("/assets") with a
+// content hash, so those can be cached forever -- a rebuild that changes their
+// content always produces a new filename. Everything else, above all
+// index.html (the SPA shell every navigation and every unrecognized route
+// falls back to via safeStaticTarget), must never be cached without
+// revalidation: without this, a browser holding a stale index.html keeps
+// requesting hashed asset filenames a later image rebuild already replaced,
+// which looks like "the page doesn't update until I hard refresh."
+export function cacheControlForPath(path) {
+  return path.startsWith("/assets/") ? "public, max-age=31536000, immutable" : "no-cache";
+}
+
 export function serveStatic(config, req, res) {
   const path = new URL(req.url || "/", "http://localhost").pathname;
   const target = safeStaticTarget(config.staticDir, path);
@@ -23,6 +35,6 @@ export function serveStatic(config, req, res) {
     json(res, 200, { app: config.appName, message: "Frontend is not built yet. Run npm install && npm run build in console/web/." });
     return;
   }
-  res.writeHead(200, withSecurityHeaders({ "content-type": contentTypeForPath(target) }));
+  res.writeHead(200, withSecurityHeaders({ "content-type": contentTypeForPath(target), "cache-control": cacheControlForPath(path) }));
   createReadStream(target).pipe(res);
 }

--- a/console/api/test/staticFiles.test.js
+++ b/console/api/test/staticFiles.test.js
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Writable } from "node:stream";
+import { once } from "node:events";
+import { cacheControlForPath, contentTypeForPath, serveStatic } from "../src/http/staticFiles.js";
+
+test("cacheControlForPath caches Vite's hashed /assets files forever, everything else must revalidate", () => {
+  assert.equal(cacheControlForPath("/assets/index-a1b2c3.js"), "public, max-age=31536000, immutable");
+  assert.equal(cacheControlForPath("/assets/index-a1b2c3.css"), "public, max-age=31536000, immutable");
+  // index.html is the SPA shell every navigation and unrecognized route falls
+  // back to (safeStaticTarget) -- it must never be cached without
+  // revalidation, or a stale copy keeps referencing hashed filenames a later
+  // rebuild already replaced.
+  assert.equal(cacheControlForPath("/index.html"), "no-cache");
+  assert.equal(cacheControlForPath("/"), "no-cache");
+  // An unrecognized client-side route also falls back to index.html.
+  assert.equal(cacheControlForPath("/some/client/route"), "no-cache");
+  // A non-hashed top-level file (e.g. a public/ asset copied verbatim) is not
+  // safe to cache aggressively either, since its filename never changes.
+  assert.equal(cacheControlForPath("/favicon.svg"), "no-cache");
+});
+
+test("contentTypeForPath is unaffected by the cache-control change", () => {
+  assert.equal(contentTypeForPath("/app/dist/index.html"), "text/html; charset=utf-8");
+  assert.equal(contentTypeForPath("/app/dist/assets/index-abc.js"), "text/javascript; charset=utf-8");
+});
+
+// A real Writable so createReadStream(...).pipe(res) works as it does against
+// an actual http.ServerResponse, while still capturing writeHead's arguments.
+function fakeResponse() {
+  const res = new Writable({ write(_chunk, _encoding, callback) { callback(); } });
+  res.status = null;
+  res.headers = null;
+  res.writeHead = (status, headers) => {
+    res.status = status;
+    res.headers = headers;
+  };
+  return res;
+}
+
+test("serveStatic sends cache-control: no-cache for index.html and immutable for hashed assets", async () => {
+  const dist = mkdtempSync(join(tmpdir(), "static-files-test-"));
+  try {
+    mkdirSync(join(dist, "assets"));
+    writeFileSync(join(dist, "index.html"), "<html></html>");
+    writeFileSync(join(dist, "assets", "index-deadbeef.js"), "console.log(1);");
+    const config = { staticDir: dist, appName: "Test" };
+
+    const htmlRes = fakeResponse();
+    serveStatic(config, { url: "/" }, htmlRes);
+    await once(htmlRes, "finish");
+    assert.equal(htmlRes.status, 200);
+    assert.equal(htmlRes.headers["cache-control"], "no-cache");
+    assert.equal(htmlRes.headers["content-type"], "text/html; charset=utf-8");
+
+    const assetRes = fakeResponse();
+    serveStatic(config, { url: "/assets/index-deadbeef.js" }, assetRes);
+    await once(assetRes, "finish");
+    assert.equal(assetRes.status, 200);
+    assert.equal(assetRes.headers["cache-control"], "public, max-age=31536000, immutable");
+  } finally {
+    rmSync(dist, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
`serveStatic` sent no `Cache-Control` on any static file, including `index.html`. Vite fingerprints JS/CSS filenames on every build, but `index.html` keeps a stable name and is the fallback for every navigation and unrecognized client route. Without a revalidation directive, a browser holding a stale cached `index.html` keeps requesting hashed asset filenames a later image rebuild already replaced, so the console appears to need a hard refresh after every deploy.

Split the policy: `assets/*` (content-hashed) get a long immutable cache; everything else, `index.html` above all, gets `no-cache` so it's always revalidated.

## Test plan
- [x] Unit tests for `cacheControlForPath` and `serveStatic` (`console/api/test/staticFiles.test.js`)
- [x] Built the real web dist (`npm run build`) and served it from a Linux container matching production: confirmed `index.html` and unknown SPA routes report `no-cache`, and a hashed `assets/*.js` file reports `public, max-age=31536000, immutable` with its real JS body
- [x] Confirmed via stash-compare that pre-existing host-suite failures are unaffected by this change