### PR TITLE
fix(bases): resolve Deep Desert PvP/PvE labels from config, not position

### DIFF
--- a/console/api/src/services/mapCombatState.js
+++ b/console/api/src/services/mapCombatState.js
@@ -119,6 +119,30 @@ export async function resolvePartitionCombatStatesFromRuntime(config, mapName, p
 }
 
 /**
+ * Resolve the effective, merged `Bgd.ServerDisplayName` for several
+ * partitions with one `usersettings.py` process. This already reflects
+ * partition -> map -> global UserEngine.ini precedence, including any
+ * per-partition name set via `sietches set-display` (which writes into the
+ * same field — see runtime/scripts/sietches.sh `set-display`). Failures are
+ * swallowed to an empty map so a missing/errored name never blocks combat
+ * state resolution; callers fall back to a synthesized name.
+ */
+export async function resolvePartitionDisplayNamesFromRuntime(config, mapName, partitionIds) {
+  const map = validateMapNameForCombatState(mapName);
+  const ids = [...new Set((Array.isArray(partitionIds) ? partitionIds : [])
+    .map((partitionId) => validatePartitionIdForCombatState(partitionId)))];
+  if (!ids.length) return new Map();
+  const result = await runDune(config, ["usersettings", "partition-engine-values-many", map, ...ids], { timeoutMs: 8000, env: config.env });
+  const parsed = JSON.parse(result.stdout || "{}");
+  const byPartition = new Map();
+  for (const id of ids) {
+    const name = String(parsed?.[id]?.server_display_name || "").trim();
+    if (name) byPartition.set(id, name);
+  }
+  return byPartition;
+}
+
+/**
  * Aggregate independently-resolved partition combat states into a single
  * map-level combat state. Mirrors the Python `aggregate_map_combat_state`
  * implementation exactly (both must be kept in sync).
@@ -167,10 +191,18 @@ export async function resolveMapCombatState(config, mapName, partitionRows) {
   const ids = rows.map((row) => String(row.partitionId ?? "").trim()).filter(Boolean);
   let resolvedByPartition = new Map();
   let resolverError = null;
-  try {
-    resolvedByPartition = await resolvePartitionCombatStatesFromRuntime(config, map, ids);
-  } catch (error) {
-    resolverError = error;
+  let displayNameByPartition = new Map();
+  const [combatResult, displayNameResult] = await Promise.allSettled([
+    resolvePartitionCombatStatesFromRuntime(config, map, ids),
+    resolvePartitionDisplayNamesFromRuntime(config, map, ids),
+  ]);
+  if (combatResult.status === "fulfilled") {
+    resolvedByPartition = combatResult.value;
+  } else {
+    resolverError = combatResult.reason;
+  }
+  if (displayNameResult.status === "fulfilled") {
+    displayNameByPartition = displayNameResult.value;
   }
 
   const partitions = rows.map((row) => {
@@ -182,6 +214,7 @@ export async function resolveMapCombatState(config, mapName, partitionRows) {
       dimensionIndex: row.dimensionIndex ?? null,
       databaseLabel: row.databaseLabel ?? null,
       runtimeStatus,
+      serverDisplayName: displayNameByPartition.get(partitionId) || null,
     };
 
     if (!partitionId) {

--- a/console/api/test/mapCombatState.test.js
+++ b/console/api/test/mapCombatState.test.js
@@ -9,6 +9,7 @@ import {
   resolveRuntimeStatus,
   resolvePartitionCombatStateFromRuntime,
   resolvePartitionCombatStatesFromRuntime,
+  resolvePartitionDisplayNamesFromRuntime,
   resolveMapCombatState,
   PARTITION_COMBAT_STATES,
   MAP_COMBAT_STATES
@@ -316,4 +317,61 @@ test("resolveMapCombatState treats a partition with no partition id as UNKNOWN w
   ]);
   assert.equal(result.partitions[0].configuredState, "UNKNOWN");
   assert.equal(result.mapState, "UNKNOWN");
+});
+
+// ─── Effective Bgd.ServerDisplayName resolution ────────────────────────────
+//
+// server_display_name has no per-map override tier (see usersettings.py
+// SCOPED_ENGINE_FIELDS / MAP_ENGINE_FIELDS / PARTITION_ENGINE_FIELDS) -- only
+// global (every Sietch in the battlegroup) and per-partition (the
+// battlegroup editor / "sietches set-display", which writes into this same
+// field -- see runtime/scripts/sietches.sh `set-display`).
+
+test("resolvePartitionDisplayNamesFromRuntime: a partition override wins over the global battlegroup name", async () => {
+  const { config, env } = buildSandbox();
+  writeProfile(env, [
+    "[Engine:ConsoleVariables]",
+    'Bgd.ServerDisplayName="Battlegroup Wide Name"',
+    "[PartitionEngine:DeepDesert_1:8:ConsoleVariables]",
+    'Bgd.ServerDisplayName="Named Sietch"'
+  ]);
+
+  const result = await resolvePartitionDisplayNamesFromRuntime({ ...config, env }, "DeepDesert_1", ["8", "9"]);
+  assert.equal(result.get("8"), "Named Sietch");
+  assert.equal(result.get("9"), "Battlegroup Wide Name");
+});
+
+test("resolvePartitionDisplayNamesFromRuntime: no configured name anywhere resolves to an empty map", async () => {
+  const { config, env } = buildSandbox();
+  writeProfile(env, []);
+
+  const result = await resolvePartitionDisplayNamesFromRuntime({ ...config, env }, "DeepDesert_1", ["8"]);
+  assert.equal(result.has("8"), false);
+});
+
+test("resolveMapCombatState surfaces serverDisplayName per partition alongside combat state", async () => {
+  const { config, env } = buildSandbox();
+  writeProfile(env, [
+    "[Partition:DeepDesert_1:8:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PveEnabledPartitions=8",
+    "[Partition:DeepDesert_1:9:/Script/DuneSandbox.PvpPveSettings]",
+    "+m_PvpEnabledPartitions=9",
+    "[PartitionEngine:DeepDesert_1:8:ConsoleVariables]",
+    'Bgd.ServerDisplayName="My Arrakis"'
+  ]);
+
+  const result = await resolveMapCombatState({ ...config, env }, "DeepDesert_1", [
+    { partitionId: "8", dimensionIndex: 0, databaseLabel: "PvP" },
+    { partitionId: "9", dimensionIndex: 1, databaseLabel: "PvE" }
+  ]);
+
+  const partitionEight = result.partitions.find((p) => p.partitionId === "8");
+  const partitionNine = result.partitions.find((p) => p.partitionId === "9");
+  // The configured display name takes precedence regardless of the (here
+  // deliberately stale/swapped) databaseLabel -- combat state and display
+  // name are resolved independently, neither one from the other.
+  assert.equal(partitionEight.serverDisplayName, "My Arrakis");
+  assert.equal(partitionEight.configuredState, "PVE");
+  assert.equal(partitionNine.serverDisplayName, null);
+  assert.equal(partitionNine.configuredState, "PVP");
 });

--- a/console/web/src/api/maps.ts
+++ b/console/web/src/api/maps.ts
@@ -95,6 +95,7 @@ export type PartitionCombatStateRow = {
   dimensionIndex: number | null;
   databaseLabel: string | null;
   runtimeStatus: PartitionRuntimeStatus;
+  serverDisplayName: string | null;
   configuredState: PartitionCombatState;
   materializedState: PartitionCombatState | null;
   source: string;

--- a/console/web/src/features/maps/MapsPanel.combatState.test.ts
+++ b/console/web/src/features/maps/MapsPanel.combatState.test.ts
@@ -15,6 +15,7 @@ function combatRow(overrides: Partial<PartitionCombatStateRow> = {}): PartitionC
     dimensionIndex: 0,
     databaseLabel: "DeepDesert_0",
     runtimeStatus: "RUNNING",
+    serverDisplayName: null,
     configuredState: "PVE",
     materializedState: "PVE",
     source: "legacy-flags",
@@ -103,6 +104,34 @@ describe("deepDesertPartitionName", () => {
     const name = deepDesertPartitionName(
       { label: "DeepDesert_0", dimension: 0 },
       combatRow({ partitionId: "8", dimensionIndex: 0, configuredState: "PVP" })
+    );
+    expect(name).toBe("Deep Desert 1 (PvP)");
+  });
+
+  // Regression coverage for surfacing the operator-configured Bgd.ServerDisplayName
+  // (effective partition -> map -> global UserEngine.ini value) ahead of the
+  // synthesized "Deep Desert N (PvP/PvE)" text. Previously this name was resolved
+  // by neither the Bases page nor the Maps page.
+  it("prefers a configured server display name over the synthesized PvP/PvE text", () => {
+    const name = deepDesertPartitionName(
+      { label: "", dimension: 0 },
+      combatRow({ configuredState: "PVE", serverDisplayName: "My Arrakis" })
+    );
+    expect(name).toBe("My Arrakis");
+  });
+
+  it("falls back to the synthesized name when no display name is configured", () => {
+    const name = deepDesertPartitionName(
+      { label: "", dimension: 0 },
+      combatRow({ configuredState: "PVE", serverDisplayName: null })
+    );
+    expect(name).toBe("Deep Desert 1 (PvE)");
+  });
+
+  it("ignores a blank/whitespace-only configured display name", () => {
+    const name = deepDesertPartitionName(
+      { label: "", dimension: 0 },
+      combatRow({ configuredState: "PVP", serverDisplayName: "   " })
     );
     expect(name).toBe("Deep Desert 1 (PvP)");
   });

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -2632,7 +2632,14 @@ function partitionMemoryValue(memoryText: string, partitionId: string, fallback:
 // This function must NOT infer PvP/PvE from `row.dimension` — dimension
 // index is positional metadata only and does not determine combat state
 // (see the "Dual Deep Desert" resolver contract).
+//
+// `combatRow.serverDisplayName`, when present, is the effective, merged
+// Bgd.ServerDisplayName (partition -> map -> global UserEngine.ini) — the
+// name a player actually sees in-game. It takes precedence over the
+// synthesized "Deep Desert N (PvP/PvE)" text below.
 export function deepDesertPartitionName(row: Record<string, unknown>, combatRow?: PartitionCombatStateRow | null) {
+  const configuredName = String(combatRow?.serverDisplayName || "").trim();
+  if (configuredName) return configuredName;
   const dimension = Number(row.dimension);
   const suffix = Number.isFinite(dimension) ? ` ${dimension + 1}` : "";
   if (combatRow) {

--- a/runtime/scripts/sietches.sh
+++ b/runtime/scripts/sietches.sh
@@ -764,6 +764,34 @@ def default_display_name(row):
         return "(unset)"
     return label if label.lower().startswith("sietch ") else f"Sietch {label}"
 
+# The effective Bgd.ServerDisplayName (partition -> map -> global UserEngine.ini,
+# via usersettings.py) is the name a player actually sees in-game, and it already
+# includes any per-partition name set through "sietches set-display" (which writes
+# into this same field). It must win over the legacy sietch-config.json mirror and
+# the DB-label-derived generic name below.
+import subprocess
+server_display_names = {}
+partition_ids = [str(row.get("id")) for row in rows]
+if partition_ids:
+    try:
+        proc = subprocess.run(
+            ["python3", "runtime/scripts/usersettings.py", "partition-engine-values-many", rows[0].get("map"), *partition_ids],
+            capture_output=True, text=True, timeout=10,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            for pid, values in json.loads(proc.stdout).items():
+                name = str((values or {}).get("server_display_name") or "").strip()
+                if name:
+                    server_display_names[pid] = name
+    except Exception:
+        pass
+
+def resolved_display_name(row, cfg):
+    configured = server_display_names.get(str(row.get("id")))
+    if configured:
+        return configured
+    return cfg.get("display_name") or default_display_name(row)
+
 if mode == "--ids":
     for row in rows:
         print(row.get("id"))
@@ -776,7 +804,7 @@ elif mode == "--numbered":
     for idx, row in enumerate(rows, 1):
         pid = str(row.get("id"))
         cfg = partition_config.get(pid, {})
-        display = cfg.get("display_name") or default_display_name(row)
+        display = resolved_display_name(row, cfg)
         password = "(set)" if cfg.get("password") else "(unset)"
         print(f"{idx}) {row.get('map')} Dimension {row.get('dimension', 0)}")
         print(f"   Display Name: {display}")
@@ -785,7 +813,7 @@ elif mode == "--labels":
     for row in rows:
         pid = str(row.get("id"))
         cfg = partition_config.get(pid, {})
-        display = cfg.get("display_name") or default_display_name(row)
+        display = resolved_display_name(row, cfg)
         password = "(set)" if cfg.get("password") else "(unset)"
         print(f"{row.get('map')} Dimension {row.get('dimension', 0)}  Display Name: {display}  Password: {password}")
 else:
@@ -793,7 +821,7 @@ else:
     for row in rows:
         pid = str(row.get("id"))
         cfg = partition_config.get(pid, {})
-        display = cfg.get("display_name") or default_display_name(row)
+        display = resolved_display_name(row, cfg)
         password = "(set)" if cfg.get("password") else "(unset)"
         print(f"{str(row.get('dimension', 0)):<10} {display:<32} {password}")
 PY
@@ -917,16 +945,56 @@ normalize_deepdesert_labels() {
     return 0
   fi
 
+  local dim0_id dim1_id
+  dim0_id="$(psql_value "
+    select partition_id from dune.world_partition
+    where map = 'DeepDesert_1' and dimension_index = 0
+    order by partition_id limit 1;
+  " | tr -d '[:space:]')"
+  dim1_id="$(psql_value "
+    select partition_id from dune.world_partition
+    where map = 'DeepDesert_1' and dimension_index = 1
+    order by partition_id limit 1;
+  " | tr -d '[:space:]')"
+  [ -n "$dim0_id" ] && [ -n "$dim1_id" ] || return 0
+
+  # Resolve each dimension's label from its actual configured UserGame.ini
+  # combat state -- never from dimension_index position, which is positional
+  # metadata only and does not determine which dimension is PvP vs PvE.
+  local states_json
+  states_json="$(python3 runtime/scripts/usersettings.py partition-combat-states DeepDesert_1 "$dim0_id" "$dim1_id" 2>/dev/null || true)"
+  [ -n "$states_json" ] || return 0
+
+  local resolved
+  resolved="$(printf '%s' "$states_json" | python3 -c '
+import json, sys
+data = json.load(sys.stdin)
+label = {"PVP": "PvP", "PVE": "PvE"}
+for partition in data.get("partitions", []):
+    state = partition.get("configuredState")
+    if state in label:
+        print(f"{partition[\"partitionId\"]}|{label[state]}")
+' 2>/dev/null || true)"
+  [ -n "$resolved" ] || return 0
+
+  # Labels are globally unique. Move both rows through partition-specific temporary labels so
+  # reversing an existing PvP/PvE pair cannot hit a transient duplicate-key violation.
   docker exec dune-postgres psql -U postgres -d dune -v ON_ERROR_STOP=1 -c "
 update dune.world_partition
-set label = case
-  when dimension_index = 0 then 'PvP'
-  when dimension_index = 1 then 'PvE'
-  else label
-end
+set label = 'DualDeepDesert_' || partition_id::text
 where map = 'DeepDesert_1'
   and dimension_index in (0, 1);
 " >/dev/null
+
+  local partition_id label_value
+  while IFS='|' read -r partition_id label_value; do
+    [ -n "$partition_id" ] && [ -n "$label_value" ] || continue
+    docker exec dune-postgres psql -U postgres -d dune -v ON_ERROR_STOP=1 -c "
+update dune.world_partition
+set label = '${label_value}'
+where partition_id = ${partition_id};
+" >/dev/null
+  done <<< "$resolved"
 }
 
 refresh_survival_browser_state() {
@@ -1833,8 +1901,28 @@ def default_display_name(partition_row):
         return ""
     return label if label.lower().startswith("sietch ") else f"Sietch {label}"
 
+def effective_display_name(map_name, pid):
+    # The merged Bgd.ServerDisplayName (partition -> map -> global UserEngine.ini)
+    # already reflects any per-partition name set via "sietches set-display", so it
+    # must win over the legacy sietch-config.json mirror and the DB-label fallback.
+    import subprocess
+    try:
+        proc = subprocess.run(
+            ["python3", "runtime/scripts/usersettings.py", "partition-engine-values", map_name, pid],
+            capture_output=True, text=True, timeout=10,
+        )
+        if proc.returncode != 0:
+            return ""
+        for line in proc.stdout.splitlines():
+            key, _, value = line.partition("\t")
+            if key == "server_display_name":
+                return value.strip()
+    except Exception:
+        pass
+    return ""
+
 args = []
-display_name = entry.get("display_name") or default_display_name(row)
+display_name = effective_display_name(sys.argv[4], partition_id) or entry.get("display_name") or default_display_name(row)
 if display_name:
     args.append(f"-ServerDisplayName={ini_quote(display_name)}")
 if entry.get("password"):

--- a/runtime/scripts/sietches.sh
+++ b/runtime/scripts/sietches.sh
@@ -965,37 +965,49 @@ normalize_deepdesert_labels() {
   states_json="$(python3 runtime/scripts/usersettings.py partition-combat-states DeepDesert_1 "$dim0_id" "$dim1_id" 2>/dev/null || true)"
   [ -n "$states_json" ] || return 0
 
-  local resolved
+  local resolved dim0_label dim1_label
   resolved="$(printf '%s' "$states_json" | python3 -c '
 import json, sys
-data = json.load(sys.stdin)
-label = {"PVP": "PvP", "PVE": "PvE"}
-for partition in data.get("partitions", []):
-    state = partition.get("configuredState")
-    if state in label:
-        pid = partition.get("partitionId")
-        print(f"{pid}|{label[state]}")
-' 2>/dev/null || true)"
-  [ -n "$resolved" ] || return 0
 
-  # Labels are globally unique. Move both rows through partition-specific temporary labels so
-  # reversing an existing PvP/PvE pair cannot hit a transient duplicate-key violation.
+data = json.load(sys.stdin)
+expected = sys.argv[1:]
+states = {
+    str(partition.get("partitionId")): partition.get("configuredState")
+    for partition in data.get("partitions", [])
+}
+
+# The canonical short labels are globally unique in world_partition. Only
+# swap them when both requested partitions resolved and form the expected
+# one-PvP/one-PvE pair. UNKNOWN/CONFLICT or duplicate modes must leave the
+# existing labels untouched instead of producing temporary or duplicate
+# labels.
+if set(states) != set(expected):
+    raise SystemExit(1)
+if {states[partition_id] for partition_id in expected} != {"PVP", "PVE"}:
+    raise SystemExit(1)
+
+label = {"PVP": "PvP", "PVE": "PvE"}
+print("|".join(label[states[partition_id]] for partition_id in expected))
+' "$dim0_id" "$dim1_id" 2>/dev/null || true)"
+  IFS='|' read -r dim0_label dim1_label <<< "$resolved"
+  [ -n "$dim0_label" ] && [ -n "$dim1_label" ] || return 0
+
+  # Labels are globally unique. Swap both rows atomically through temporary
+  # partition-specific labels so a failure cannot strand either row with an
+  # internal DualDeepDesert_* label.
   docker exec dune-postgres psql -U postgres -d dune -v ON_ERROR_STOP=1 -c "
+begin;
 update dune.world_partition
 set label = 'DualDeepDesert_' || partition_id::text
-where map = 'DeepDesert_1'
-  and dimension_index in (0, 1);
-" >/dev/null
-
-  local partition_id label_value
-  while IFS='|' read -r partition_id label_value; do
-    [ -n "$partition_id" ] && [ -n "$label_value" ] || continue
-    docker exec dune-postgres psql -U postgres -d dune -v ON_ERROR_STOP=1 -c "
+where partition_id in ($dim0_id, $dim1_id);
 update dune.world_partition
-set label = '${label_value}'
-where partition_id = ${partition_id};
+set label = case partition_id
+  when $dim0_id then '$dim0_label'
+  when $dim1_id then '$dim1_label'
+end
+where partition_id in ($dim0_id, $dim1_id);
+commit;
 " >/dev/null
-  done <<< "$resolved"
 }
 
 refresh_survival_browser_state() {

--- a/runtime/scripts/sietches.sh
+++ b/runtime/scripts/sietches.sh
@@ -973,7 +973,8 @@ label = {"PVP": "PvP", "PVE": "PvE"}
 for partition in data.get("partitions", []):
     state = partition.get("configuredState")
     if state in label:
-        print(f"{partition[\"partitionId\"]}|{label[state]}")
+        pid = partition.get("partitionId")
+        print(f"{pid}|{label[state]}")
 ' 2>/dev/null || true)"
   [ -n "$resolved" ] || return 0
 

--- a/runtime/scripts/test_profile_override_precedence.py
+++ b/runtime/scripts/test_profile_override_precedence.py
@@ -26,8 +26,11 @@ Or via unittest discovery:
 """
 from __future__ import annotations
 
+import io
+import json
 import sys
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -248,6 +251,84 @@ class EngineFieldOverridePrecedenceTests(ProfilePathTestCase):
         self.assertEqual(usersettings.profile_engine_values(reloaded)[self.FIELD_ID], "2.0")
         self.assertEqual(usersettings.profile_map_engine_values(reloaded, MAP_NAME)[self.FIELD_ID], "3.0")
         self.assertEqual(usersettings.profile_partition_engine_values(reloaded, MAP_NAME, PARTITION_ID)[self.FIELD_ID], "4.0")
+
+
+class PartitionEngineValuesManyCommandTests(ProfilePathTestCase):
+    """`partition-engine-values-many` backs both sietches.sh's display-name
+    resolution (dimensions()/runtime_args()) and the console API's
+    resolvePartitionDisplayNamesFromRuntime -- one profile read resolving
+    server_display_name (Bgd.ServerDisplayName) for several partitions at
+    once. It must apply the exact same partition -> map -> global precedence
+    as the singular partition-engine-values command, not a simplified or
+    stale copy of it."""
+
+    FIELD_ID = "server_display_name"
+
+    def _spec(self):
+        return usersettings.ENGINE_FIELDS[self.FIELD_ID]
+
+    def _run_command(self, map_name, partition_ids):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            usersettings.partition_engine_values_many_command(map_name, partition_ids)
+        return json.loads(buffer.getvalue())
+
+    def test_resolves_distinct_partitions_in_one_call(self):
+        # server_display_name is deliberately excluded from SCOPED_ENGINE_FIELDS
+        # (see usersettings.py:516-519), so unlike most engine fields it has no
+        # per-map override tier -- only global (every Sietch in the battlegroup)
+        # and per-partition (the battlegroup editor / "sietches set-display"),
+        # matching the UserEngine.ini comment ("Set the name of every Sietch in
+        # the battlegroup ... use the battlegroup editor instead" for per-Sietch
+        # names). This asserts partition vs. global, not partition vs. map.
+        section, key, _default = self._spec()
+        profile = usersettings.empty_profile()
+        usersettings.profile_set_key(profile, "engine", section, key, "Battlegroup Wide Name")
+        usersettings.profile_set_key(profile, "partition_engine", section, key, "Named Sietch", MAP_NAME, PARTITION_ID)
+        usersettings.write_profile(profile)
+
+        result = self._run_command(MAP_NAME, [PARTITION_ID, OTHER_PARTITION_ID])
+
+        # The partition with its own override wins over the battlegroup-wide name...
+        self.assertEqual(result[PARTITION_ID][self.FIELD_ID], "Named Sietch")
+        # ...while its sibling, with no override of its own, still falls
+        # through to the global name rather than coming back empty.
+        self.assertEqual(result[OTHER_PARTITION_ID][self.FIELD_ID], "Battlegroup Wide Name")
+
+    def test_matches_the_singular_command_for_the_same_partition(self):
+        section, key, _default = self._spec()
+        profile = usersettings.empty_profile()
+        usersettings.profile_set_key(profile, "engine", section, key, "Global Name")
+        usersettings.profile_set_key(profile, "partition_engine", section, key, "Partition Name", MAP_NAME, PARTITION_ID)
+        usersettings.write_profile(profile)
+
+        result = self._run_command(MAP_NAME, [PARTITION_ID, OTHER_PARTITION_ID])
+        reloaded = usersettings.read_profile()
+
+        self.assertEqual(
+            result[PARTITION_ID][self.FIELD_ID],
+            usersettings.profile_partition_engine_values(reloaded, MAP_NAME, PARTITION_ID)[self.FIELD_ID],
+        )
+        self.assertEqual(
+            result[OTHER_PARTITION_ID][self.FIELD_ID],
+            usersettings.profile_partition_engine_values(reloaded, MAP_NAME, OTHER_PARTITION_ID)[self.FIELD_ID],
+        )
+        # Sanity: the sibling with no partition override actually fell through
+        # to the global name, so this isn't trivially true for both sides.
+        self.assertEqual(result[OTHER_PARTITION_ID][self.FIELD_ID], "Global Name")
+
+    def test_a_name_set_via_sietches_set_display_is_visible_in_bulk(self):
+        # `sietches set-display` writes into this exact field via
+        # `usersettings.py partition-engine-set ... server_display_name`
+        # (see runtime/scripts/sietches.sh) -- simulate that write directly
+        # through the same profile API rather than shelling out.
+        section, key, _default = self._spec()
+        profile = usersettings.empty_profile()
+        usersettings.profile_set_key(profile, "partition_engine", section, key, "The Kulon Show", MAP_NAME, PARTITION_ID)
+        usersettings.write_profile(profile)
+
+        result = self._run_command(MAP_NAME, [PARTITION_ID])
+        self.assertEqual(result[PARTITION_ID][self.FIELD_ID], "The Kulon Show")
 
 
 if __name__ == "__main__":

--- a/runtime/scripts/test_sietches_embedded_python.py
+++ b/runtime/scripts/test_sietches_embedded_python.py
@@ -34,6 +34,8 @@ Or via unittest discovery:
 from __future__ import annotations
 
 import unittest
+import subprocess
+import sys
 from pathlib import Path
 
 SIETCHES_SH = Path(__file__).resolve().parent / "sietches.sh"
@@ -106,6 +108,46 @@ class EmbeddedPythonSyntaxTests(unittest.TestCase):
             except SyntaxError as exc:
                 failures.append(f"sietches.sh:{line_no}: {exc}")
         self.assertEqual(failures, [], "Syntax errors in embedded Python:\n" + "\n".join(failures))
+
+    def test_deep_desert_label_resolver_requires_a_complete_pvp_pve_pair(self):
+        text = SIETCHES_SH.read_text(encoding="utf-8")
+        source = next(
+            source for _, source in extract_python_blocks(text)
+            if "The canonical short labels are globally unique" in source
+        )
+
+        def resolve(payload: str):
+            return subprocess.run(
+                [sys.executable, "-c", source, "10", "20"],
+                input=payload,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+        valid = resolve('{"partitions":[{"partitionId":"10","configuredState":"PVP"},{"partitionId":"20","configuredState":"PVE"}]}')
+        self.assertEqual(valid.returncode, 0)
+        self.assertEqual(valid.stdout.strip(), "PvP|PvE")
+
+        reversed_pair = resolve('{"partitions":[{"partitionId":"10","configuredState":"PVE"},{"partitionId":"20","configuredState":"PVP"}]}')
+        self.assertEqual(reversed_pair.returncode, 0)
+        self.assertEqual(reversed_pair.stdout.strip(), "PvE|PvP")
+
+        for unsafe_payload in (
+            '{"partitions":[{"partitionId":"10","configuredState":"PVP"}]}',
+            '{"partitions":[{"partitionId":"10","configuredState":"UNKNOWN"},{"partitionId":"20","configuredState":"PVE"}]}',
+            '{"partitions":[{"partitionId":"10","configuredState":"PVP"},{"partitionId":"20","configuredState":"PVP"}]}',
+        ):
+            result = resolve(unsafe_payload)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(result.stdout, "")
+
+    def test_deep_desert_label_swap_is_one_atomic_database_command(self):
+        text = SIETCHES_SH.read_text(encoding="utf-8")
+        function_body = text.split("normalize_deepdesert_labels() {", 1)[1].split("\n}\n\nrefresh_survival_browser_state()", 1)[0]
+        self.assertEqual(function_body.count("docker exec dune-postgres psql"), 1)
+        self.assertIn("begin;", function_body)
+        self.assertIn("commit;", function_body)
 
 
 if __name__ == "__main__":

--- a/runtime/scripts/test_sietches_embedded_python.py
+++ b/runtime/scripts/test_sietches_embedded_python.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Compile-check every Python block embedded in sietches.sh.
+
+`bash -n sietches.sh` only validates the surrounding shell -- the body of a
+`python3 -c '...'` or `<<'PY' ... PY` heredoc is just a string literal to
+bash, so a syntax error inside one is invisible to bash's own syntax check
+and to any test that only exercises the underlying usersettings.py commands
+the heredoc shells out to (those pass even when the heredoc calling them is
+broken). This is exactly how normalize_deepdesert_labels() shipped with an
+f-string SyntaxError (`f"{partition[\"partitionId\"]}..."`, invalid because
+the escaped quote isn't valid inside an f-string expression) that made every
+reconcile silently no-op via its own `2>/dev/null || true` guard -- caught
+only by running the real command against a real deployment.
+
+The `python3 -c '...'` form has a second, sharper hazard the naive fix
+walked straight into: bash single quotes have NO escape mechanism, so a
+literal `'` anywhere inside the block -- even to close a Python dict-key
+string -- ends the bash string right there. Everything after becomes literal
+bash, and python3 only ever sees the truncated prefix. That prefix can still
+be syntactically broken (unterminated string/bracket), so the extractor
+below finds the closing quote the same way bash's own single-quote scanner
+does -- first literal `'`, full stop, no line-anchoring, no escaping -- and
+compiles exactly what bash would actually hand to python3. A block that
+looks fine at the source-text level but truncates early is exactly the
+`partition['partitionId']` case that shipped: valid Python if you squint at
+the full source, but bash never gets that far.
+
+Run directly:
+    python3 runtime/scripts/test_sietches_embedded_python.py
+
+Or via unittest discovery:
+    python3 -m unittest discover -s runtime/scripts -p "test_*.py"
+"""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+SIETCHES_SH = Path(__file__).resolve().parent / "sietches.sh"
+
+
+def extract_python_blocks(text: str) -> list[tuple[int, str]]:
+    """Return (starting_line_number, source) for each embedded Python block.
+
+    Handles the two forms used throughout sietches.sh:
+      - `<<'PY'` ... a line that is exactly `PY` (quoted heredoc delimiter --
+        content is literal, no character-level quote parsing needed)
+      - `python3 -c '...'` -- content ends at the first literal `'`
+        character bash finds, scanning byte by byte across lines exactly
+        like bash's own single-quote parser (no escaping exists inside
+        single quotes, so line position is irrelevant).
+    """
+    lines = text.splitlines()
+    blocks: list[tuple[int, str]] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if "<<'PY'" in line or '<<"PY"' in line:
+            start = i + 1
+            body: list[str] = []
+            i += 1
+            while i < len(lines) and lines[i] != "PY":
+                body.append(lines[i])
+                i += 1
+            if i >= len(lines):
+                raise AssertionError(f"Unterminated <<'PY' heredoc starting at line {start}")
+            blocks.append((start, "\n".join(body)))
+            i += 1
+            continue
+        marker = "python3 -c '"
+        if marker in line:
+            start = i + 1
+            remainder = "\n".join(lines[i:])
+            offset = remainder.index(marker) + len(marker)
+            close = remainder.find("'", offset)
+            if close == -1:
+                raise AssertionError(f"Unterminated python3 -c '...' block starting at line {start}")
+            blocks.append((start, remainder[offset:close]))
+            # Resume scanning after the closing quote, which may be on a
+            # later line than it started -- recompute how many lines that
+            # consumed rather than assuming single-line blocks.
+            consumed_lines = remainder[:close].count("\n")
+            i += consumed_lines + 1
+            continue
+        i += 1
+    return blocks
+
+
+class EmbeddedPythonSyntaxTests(unittest.TestCase):
+    def test_every_embedded_python_block_compiles(self):
+        text = SIETCHES_SH.read_text(encoding="utf-8")
+        blocks = extract_python_blocks(text)
+        # A minimum count pins the extractor itself to the file's known
+        # shape -- if sietches.sh stops matching either pattern entirely
+        # (e.g. a refactor), silently checking zero blocks must not pass.
+        self.assertGreaterEqual(
+            len(blocks), 15,
+            "Expected at least 15 embedded Python blocks in sietches.sh -- "
+            "the extractor may no longer be matching this file's heredoc/"
+            "python3 -c patterns.",
+        )
+        failures = []
+        for line_no, source in blocks:
+            try:
+                compile(source, f"sietches.sh:{line_no}", "exec")
+            except SyntaxError as exc:
+                failures.append(f"sietches.sh:{line_no}: {exc}")
+        self.assertEqual(failures, [], "Syntax errors in embedded Python:\n" + "\n".join(failures))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/runtime/scripts/usersettings.py
+++ b/runtime/scripts/usersettings.py
@@ -3443,6 +3443,19 @@ def partition_combat_states_command(map_name: str, partition_ids: list[str]) -> 
     return 0
 
 
+def partition_engine_values_many_command(map_name: str, partition_ids: list[str]) -> int:
+    """Resolve effective per-partition engine values (e.g. server_display_name) for
+    several partitions in one process and one profile read path."""
+    profile = read_profile()
+    target_map = canonical_map(map_name)
+    result = {
+        str(partition_id): profile_partition_engine_values(profile, target_map, partition_id)
+        for partition_id in partition_ids
+    }
+    print(json.dumps(result, separators=(",", ":")))
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if len(argv) < 2:
         return 2
@@ -3503,6 +3516,8 @@ def main(argv: list[str]) -> int:
         return partition_combat_states_command(argv[2], argv[3:])
     if command == "partition-engine-values" and len(argv) == 4:
         return print_rows(merged_partition_engine_values(config, canonical_map(argv[2]), argv[3]), PARTITION_ENGINE_FIELDS)
+    if command == "partition-engine-values-many" and len(argv) >= 4:
+        return partition_engine_values_many_command(argv[2], argv[3:])
     if command == "engine-set" and len(argv) == 4:
         return set_field("engine", None, argv[2], argv[3])
     if command == "map-set" and len(argv) == 5:


### PR DESCRIPTION
## Summary
- `normalize_deepdesert_labels()` hardcoded `dimension_index 0 -> PvP`, `1 -> PvE` on every reconcile, overwriting the correct label whenever the real configured combat state disagreed with that assumption. It now resolves each dimension's label from `usersettings.py partition-combat-states`.
- The Bases and Maps pages never surfaced an operator-configured `Bgd.ServerDisplayName`, always falling back to a generic synthesized name. Both now prefer the effective, merged display name (already including per-partition names set via `sietches set-display`) ahead of the combat-state-derived label.
- Second commit fixes a Python `SyntaxError` in the label-resolver's embedded heredoc that made the reconcile write silently no-op (caught by testing against a real deployment), plus a follow-up bash single-quote-nesting bug in the first attempted fix. Adds `test_sietches_embedded_python.py`, which compile-checks every embedded Python block in `sietches.sh` using the same character-level quote scanning bash itself uses.

## Test plan
- [x] Full `console/api` suite via `.claude/scripts/test-api.sh`: 990/990 pass, 0 skipped
- [x] `runtime/scripts` Python suite (`python3 -m unittest discover`): 68/68 pass
- [x] `MapsPanel.combatState.test.ts`, `mapCombatState.test.js`: new precedence/display-name cases pass
- [x] Live-verified against a real production dump and a real deployment (dune2): reproduced the exact stale-label bug, confirmed the fixed `reconcile DeepDesert_1` writes the correct PvP/PvE label, confirmed `Bgd.ServerDisplayName` surfaces correctly through `/api/maps/combat-state`