### PR TITLE
fix(installer): preserve .env mode/ownership on Alpine without GNU-only chmod flag

### DIFF
--- a/runtime/scripts/compose-project.sh
+++ b/runtime/scripts/compose-project.sh
@@ -203,8 +203,16 @@ dune_persist_compose_project_name() {
     # Scheduled systemd helpers can run as root. Preserve both mode and
     # ownership before the atomic replacement so a root-created temporary file
     # cannot turn the operator's .env into root-owned state.
-    if ! chmod --reference="$dune_compose_env_file" "$dune_compose_tmp_file" \
-      || ! chown --reference="$dune_compose_env_file" "$dune_compose_tmp_file"; then
+    # The GNU-coreutils "reference file" chmod/chown flag fails on BusyBox
+    # (Alpine), so derive the mode/owner via `stat` instead.
+    dune_compose_ref_mode="$(stat -c '%a' "$dune_compose_env_file" 2>/dev/null || true)"
+    dune_compose_ref_owner="$(stat -c '%u:%g' "$dune_compose_env_file" 2>/dev/null || true)"
+    if [ -z "$dune_compose_ref_mode" ] || [ -z "$dune_compose_ref_owner" ]; then
+      rm -f "$dune_compose_tmp_file"
+      return 1
+    fi
+    if ! chmod "$dune_compose_ref_mode" "$dune_compose_tmp_file" \
+      || ! chown "$dune_compose_ref_owner" "$dune_compose_tmp_file"; then
       rm -f "$dune_compose_tmp_file"
       return 1
     fi

--- a/runtime/tests/test-compose-project-resolution.sh
+++ b/runtime/tests/test-compose-project-resolution.sh
@@ -161,9 +161,12 @@ sh -c '. "$1/runtime/scripts/compose-project.sh"; dune_persist_compose_project_n
 [ "$(stat -c '%Y' "$persist_root/.env")" = "$persist_mtime_before" ] \
   || fail "persisting an unchanged project name touched .env"
 
-grep -q 'chown --reference="\$dune_compose_env_file" "\$dune_compose_tmp_file"' \
+grep -q 'chown "\$dune_compose_ref_owner" "\$dune_compose_tmp_file"' \
   "$repo_root/runtime/scripts/compose-project.sh" \
   || fail "atomic .env replacement does not explicitly preserve ownership"
+if grep -q -- '--reference=' "$repo_root/runtime/scripts/compose-project.sh"; then
+  fail "atomic .env replacement uses a GNU-coreutils-only chmod/chown flag BusyBox does not support"
+fi
 
 compose_json="$(cd "$repo_root" && \
   DUNE_COMPOSE_PROJECT_NAME=legacy-main \


### PR DESCRIPTION
## Summary
- `dune_persist_compose_project_name()` used `chmod --reference=` / `chown --reference=` to preserve `.env`'s mode/ownership before the atomic replace. `--reference=` is GNU-coreutils-only; BusyBox `chmod`/`chown` on Alpine don't support it and abort with a usage error.
- `choose_web_port()` already creates `.env` earlier in the same install run, so this hit on every fresh Alpine install (not just upgrades), crashing the installer right after "Starting the Web UI." — before Docker Compose ever ran.
- Replaced with a portable `stat -c '%a'` / `stat -c '%u:%g'` capture plus plain `chmod`/`chown`, which works on both GNU coreutils and BusyBox.

## Test plan
- [x] Reproduced the exact crash on a clean Alpine 3.22 container using real BusyBox `chmod`/`chown`
- [x] Applied the fix and reran the same install end-to-end — completes fully, console starts, admin password issued
- [x] Confirmed `.env` mode/ownership are still correctly preserved after the fix
- [x] `runtime/tests/test-compose-project-resolution.sh` passes with the new implementation (updated its stale assertion + added a regression check for `--reference=`)
- [x] `shellcheck` / `dash -n` clean on both changed files