### PR TITLE
fix: centralize port config, fix 6 places hardcoding stock ports instead of reading configured values

### DIFF
--- a/console/api/src/config.js
+++ b/console/api/src/config.js
@@ -48,12 +48,25 @@ export function resolvePorts(env = process.env, repoRoot = process.cwd()) {
   // (e.g. Port=0 or a 10-digit garbage number) that bypasses range
   // validation entirely and flows through to the frontend and the
   // public-hosting reminder text unvalidated.
-  const clientBase = enginePorts.port !== null
+  const rawClientBase = enginePorts.port !== null
     ? portValue(enginePorts.port, 7777)
     : (legacyEnginePorts.port !== null ? portValue(legacyEnginePorts.port, 7777) : 7777);
-  const igwBase = enginePorts.igwPort !== null
+  const rawIgwBase = enginePorts.igwPort !== null
     ? portValue(enginePorts.igwPort, 7888)
     : (legacyEnginePorts.igwPort !== null ? portValue(legacyEnginePorts.igwPort, 7888) : 7888);
+  // Upstream review finding: portValue() only range-checks the base
+  // port itself (1-65535), but every Player/Game and IGW base is
+  // actually the start of a 34-slot range (see spawn-server.sh's
+  // game_end=$((CLIENT_PORT_BASE + 33))/igw_end=$((IGW_PORT_BASE + 33)),
+  // covering the maximum 34 world partitions this project supports) --
+  // a base in the valid 1-65535 range can still overflow past 65535
+  // once the +33 offset for the highest partition (or the console's
+  // own +1 "secondary" port, used for the stock 2-partition default) is
+  // applied. A base that would overflow is exactly as unusable as one
+  // that's already out of range, so it falls back to stock the same
+  // way portValue() already does for a directly out-of-range value.
+  const clientBase = rawClientBase + 33 <= 65535 ? rawClientBase : 7777;
+  const igwBase = rawIgwBase + 33 <= 65535 ? rawIgwBase : 7888;
   return {
     postgres: portValue(env.POSTGRES_PORT || env.DUNE_DB_PORT || env.PGPORT, 15432),
     rmqAdmin: portValue(env.RMQ_ADMIN_PORT, 32573),
@@ -104,7 +117,19 @@ function readEnginePortsFromProfile(repoRoot) {
   // for hand-edited/out-of-band files, not the common path.
   const normalized = text.replace(/\r\n/g, "\n");
   const sectionMatch = normalized.match(/^\[Engine:URL\]\s*$([\s\S]*?)(?=^\[|\s*$(?!\n))/m);
-  const sectionText = sectionMatch ? sectionMatch[1] : normalized;
+  // Upstream review finding: if [Engine:URL] is absent entirely (a
+  // stripped-down or hand-edited profile file), this previously fell
+  // back to scanning the WHOLE file for a Port=/IGWPort= match -- which
+  // could silently pick up an unrelated key from a different section
+  // (e.g. [Engine:ConsoleVariables]'s own Port= override, which means
+  // something entirely different) and report it as the real game port.
+  // The real Python tool (usersettings.py's profile_get_key()) only
+  // ever looks inside the named section; if the section doesn't exist,
+  // it returns nothing for that key, not a value from elsewhere in the
+  // file. Match that exactly: no section match -> no port match, fall
+  // through to the legacy usersettings.json / stock fallback chain.
+  if (!sectionMatch) return { port: null, igwPort: null };
+  const sectionText = sectionMatch[1];
   // Layer 3 audit regression: if a section has a duplicate key (Port=
   // appearing twice, which usersettings.py's own
   // _advanced_editor_duplicate_key_warnings() explicitly anticipates and

--- a/console/api/src/config.js
+++ b/console/api/src/config.js
@@ -14,9 +14,25 @@ export const APP_NAME = "Dune Docker Console";
 // places across the codebase that hardcoded these stock values directly
 // instead of reading them from a shared source, breaking any deployment
 // running non-default configured ports).
-export function resolvePorts(env = process.env) {
-  const clientBase = portValue(env.CLIENT_PORT_BASE, 7777);
-  const igwBase = portValue(env.IGW_PORT_BASE, 7888);
+export function resolvePorts(env = process.env, repoRoot = process.cwd()) {
+  const enginePorts = readEnginePortsFromProfile(repoRoot);
+  // Player/Game and IGW base ports are authoritative in
+  // runtime/generated/gameplay-profile.ini's [Engine:URL] section
+  // (written via runtime/scripts/usersettings.py engine-set, e.g. by
+  // the Maps UI or multi-server-config.py) -- NOT env vars. .env's
+  // CLIENT_PORT_BASE/IGW_PORT_BASE are documented as
+  // "compatibility/console metadata" only (see
+  // docs/runtime/MULTI-SERVER-SINGLE-PUBLIC-IP.md): a deployment that
+  // changed these via the Maps UI directly, without also re-running
+  // multi-server-config.py, would have a stale .env value while the
+  // real game server already uses the new one -- reading the profile
+  // file first avoids exactly that staleness. .env is kept as a
+  // secondary fallback (useful before the profile file exists at all,
+  // e.g. immediately after multi-server-config.py writes .env but
+  // before its own engine-set call has run), and the stock literal is
+  // the final fallback.
+  const clientBase = enginePorts.port ?? portValue(env.CLIENT_PORT_BASE, 7777);
+  const igwBase = enginePorts.igwPort ?? portValue(env.IGW_PORT_BASE, 7888);
   return {
     postgres: portValue(env.POSTGRES_PORT || env.DUNE_DB_PORT || env.PGPORT, 15432),
     rmqAdmin: portValue(env.RMQ_ADMIN_PORT, 32573),
@@ -30,6 +46,35 @@ export function resolvePorts(env = process.env) {
     clientBaseSecondary: clientBase + 1,
     igwBase,
     igwBaseSecondary: igwBase + 1
+  };
+}
+
+// Reads Port/IGWPort directly from the [Engine:URL] section of
+// runtime/generated/gameplay-profile.ini -- a cheap, synchronous read
+// (no shelling out to usersettings.py, which resolvePorts() cannot
+// afford given it's called from hot paths like server.js's error
+// handler). Returns { port: null, igwPort: null } if the file doesn't
+// exist yet (fresh install, before the first `dune init`/materialize)
+// or doesn't have an [Engine:URL] section -- callers fall back to
+// .env / stock values in that case, exactly matching
+// runtime-env.sh's own resolve_client_port_base()/resolve_igw_port_base()
+// fallback behavior.
+function readEnginePortsFromProfile(repoRoot) {
+  const profilePath = resolve(repoRoot, "runtime/generated/gameplay-profile.ini");
+  if (!existsSync(profilePath)) return { port: null, igwPort: null };
+  let text;
+  try {
+    text = readFileSync(profilePath, "utf8");
+  } catch {
+    return { port: null, igwPort: null };
+  }
+  const sectionMatch = text.match(/^\[Engine:URL\]\s*$([\s\S]*?)(?=^\[|\s*$(?!\n))/m);
+  const sectionText = sectionMatch ? sectionMatch[1] : text;
+  const portMatch = sectionText.match(/^\s*Port\s*=\s*(\d+)\s*$/m);
+  const igwMatch = sectionText.match(/^\s*IGWPort\s*=\s*(\d+)\s*$/m);
+  return {
+    port: portMatch ? Number(portMatch[1]) : null,
+    igwPort: igwMatch ? Number(igwMatch[1]) : null
   };
 }
 
@@ -56,7 +101,7 @@ export function loadConfig() {
     duneScript: resolve(repoRoot, "runtime/scripts/dune"),
     host: resolveAdminBindHost(process.env.ADMIN_BIND_HOST),
     port: Number(process.env.ADMIN_BIND_PORT || 8088),
-    ports: resolvePorts(),
+    ports: resolvePorts(process.env, repoRoot),
     authDisabled: process.env.ADMIN_AUTH_DISABLED === "1",
     secureCookies: secureCookieEnv === undefined ? process.env.NODE_ENV === "production" : secureCookieEnv === "1",
     allowHostBootstrap: process.env.ALLOW_HOST_BOOTSTRAP === "true",

--- a/console/api/src/config.js
+++ b/console/api/src/config.js
@@ -31,8 +31,18 @@ export function resolvePorts(env = process.env, repoRoot = process.cwd()) {
   // e.g. immediately after multi-server-config.py writes .env but
   // before its own engine-set call has run), and the stock literal is
   // the final fallback.
-  const clientBase = enginePorts.port ?? portValue(env.CLIENT_PORT_BASE, 7777);
-  const igwBase = enginePorts.igwPort ?? portValue(env.IGW_PORT_BASE, 7888);
+  // Route profile-parsed values through portValue() too (not just the
+  // .env/stock fallback branch) -- a corrupted/malformed
+  // gameplay-profile.ini could otherwise produce an out-of-range value
+  // (e.g. Port=0 or a 10-digit garbage number) that bypasses range
+  // validation entirely and flows through to the frontend and the
+  // public-hosting reminder text unvalidated.
+  const clientBase = enginePorts.port !== null
+    ? portValue(enginePorts.port, portValue(env.CLIENT_PORT_BASE, 7777))
+    : portValue(env.CLIENT_PORT_BASE, 7777);
+  const igwBase = enginePorts.igwPort !== null
+    ? portValue(enginePorts.igwPort, portValue(env.IGW_PORT_BASE, 7888))
+    : portValue(env.IGW_PORT_BASE, 7888);
   return {
     postgres: portValue(env.POSTGRES_PORT || env.DUNE_DB_PORT || env.PGPORT, 15432),
     rmqAdmin: portValue(env.RMQ_ADMIN_PORT, 32573),
@@ -68,8 +78,18 @@ function readEnginePortsFromProfile(repoRoot) {
   } catch {
     return { port: null, igwPort: null };
   }
-  const sectionMatch = text.match(/^\[Engine:URL\]\s*$([\s\S]*?)(?=^\[|\s*$(?!\n))/m);
-  const sectionText = sectionMatch ? sectionMatch[1] : text;
+  // Normalize CRLF -> LF before parsing. The section-boundary regex
+  // below relies on `$` (multiline) matching end-of-line -- `$` matches
+  // before `\n` but not before a `\r` that precedes it, so an
+  // unnormalized CRLF file causes the lookahead to treat the position
+  // right before the trailing `\r` as the section boundary, silently
+  // truncating the section one line early and dropping whichever key
+  // (Port or IGWPort) comes last. usersettings.py always writes LF-only
+  // on this project's Linux hosts, so this is a defensive normalization
+  // for hand-edited/out-of-band files, not the common path.
+  const normalized = text.replace(/\r\n/g, "\n");
+  const sectionMatch = normalized.match(/^\[Engine:URL\]\s*$([\s\S]*?)(?=^\[|\s*$(?!\n))/m);
+  const sectionText = sectionMatch ? sectionMatch[1] : normalized;
   const portMatch = sectionText.match(/^\s*Port\s*=\s*(\d+)\s*$/m);
   const igwMatch = sectionText.match(/^\s*IGWPort\s*=\s*(\d+)\s*$/m);
   return {
@@ -101,7 +121,22 @@ export function loadConfig() {
     duneScript: resolve(repoRoot, "runtime/scripts/dune"),
     host: resolveAdminBindHost(process.env.ADMIN_BIND_HOST),
     port: Number(process.env.ADMIN_BIND_PORT || 8088),
-    ports: resolvePorts(process.env, repoRoot),
+    // A getter, not a plain value: config is loaded once at process
+    // startup and lives for the life of the process (see server.js's
+    // top-level `const config = loadConfig()`), but clientBase/igwBase
+    // are backed by runtime/generated/gameplay-profile.ini, which the
+    // Maps UI can rewrite at any time without restarting the console
+    // (see userSettingsRawWriteRoute in server.js). A plain value here
+    // would silently re-introduce the exact staleness bug resolvePorts()
+    // was written to fix -- correct once at boot, stale forever after
+    // the first Maps UI port change. Re-resolving on every read keeps
+    // every consumer (publicConfig() -> /api/auth/state, preflight.js)
+    // live-accurate without requiring a console restart. resolvePorts()
+    // is a cheap sync file read (see readEnginePortsFromProfile()), safe
+    // to call on every request.
+    get ports() {
+      return resolvePorts(process.env, repoRoot);
+    },
     authDisabled: process.env.ADMIN_AUTH_DISABLED === "1",
     secureCookies: secureCookieEnv === undefined ? process.env.NODE_ENV === "production" : secureCookieEnv === "1",
     allowHostBootstrap: process.env.ALLOW_HOST_BOOTSTRAP === "true",

--- a/console/api/src/config.js
+++ b/console/api/src/config.js
@@ -14,35 +14,46 @@ export const APP_NAME = "Dune Docker Console";
 // places across the codebase that hardcoded these stock values directly
 // instead of reading them from a shared source, breaking any deployment
 // running non-default configured ports).
+//
+// Requirement 20 Layer 3 (integration) audit finding, CRITICAL,
+// independently reproduced before this fix: this comment previously
+// claimed the shell-side resolve_client_port_base()/resolve_igw_port_base()
+// (runtime-env.sh) fall back to .env's CLIENT_PORT_BASE/IGW_PORT_BASE
+// before the profile file exists -- that was never true. Reading
+// runtime-env.sh's usersettings_engine_value() directly: its real
+// fallback chain is gameplay-profile.ini -> runtime/generated/
+// usersettings.json's legacy "engine" config -> the stock literal.
+// .env is NEVER consulted anywhere in that chain. Directly reproduced
+// the divergence this caused: with CLIENT_PORT_BASE=7001 set in .env
+// and no profile file yet, the old Node-side code here returned 7001
+// while the real shell/Python resolver returned stock 7777, so the Web
+// UI could show a port the game server's own startup scripts (which
+// all resolve through runtime-env.sh, not through this file) would
+// never actually bind to. Fixed by matching the real shell/Python
+// fallback chain exactly instead of the previously-assumed (and
+// incorrect) one: profile file -> usersettings.json's legacy engine
+// config -> stock. .env's CLIENT_PORT_BASE/IGW_PORT_BASE are no longer
+// read for these two specific fields (they remain read for every other
+// field in this function, which genuinely are env-var-only with no
+// other source of truth -- confirmed those fields have no equivalent
+// in ENGINE_FIELDS/usersettings.json).
 export function resolvePorts(env = process.env, repoRoot = process.cwd()) {
   const enginePorts = readEnginePortsFromProfile(repoRoot);
-  // Player/Game and IGW base ports are authoritative in
-  // runtime/generated/gameplay-profile.ini's [Engine:URL] section
-  // (written via runtime/scripts/usersettings.py engine-set, e.g. by
-  // the Maps UI or multi-server-config.py) -- NOT env vars. .env's
-  // CLIENT_PORT_BASE/IGW_PORT_BASE are documented as
-  // "compatibility/console metadata" only (see
-  // docs/runtime/MULTI-SERVER-SINGLE-PUBLIC-IP.md): a deployment that
-  // changed these via the Maps UI directly, without also re-running
-  // multi-server-config.py, would have a stale .env value while the
-  // real game server already uses the new one -- reading the profile
-  // file first avoids exactly that staleness. .env is kept as a
-  // secondary fallback (useful before the profile file exists at all,
-  // e.g. immediately after multi-server-config.py writes .env but
-  // before its own engine-set call has run), and the stock literal is
-  // the final fallback.
+  const legacyEnginePorts = enginePorts.port === null || enginePorts.igwPort === null
+    ? readEnginePortsFromLegacyUsersettings(repoRoot)
+    : { port: null, igwPort: null };
   // Route profile-parsed values through portValue() too (not just the
-  // .env/stock fallback branch) -- a corrupted/malformed
+  // legacy/stock fallback branch) -- a corrupted/malformed
   // gameplay-profile.ini could otherwise produce an out-of-range value
   // (e.g. Port=0 or a 10-digit garbage number) that bypasses range
   // validation entirely and flows through to the frontend and the
   // public-hosting reminder text unvalidated.
   const clientBase = enginePorts.port !== null
-    ? portValue(enginePorts.port, portValue(env.CLIENT_PORT_BASE, 7777))
-    : portValue(env.CLIENT_PORT_BASE, 7777);
+    ? portValue(enginePorts.port, 7777)
+    : (legacyEnginePorts.port !== null ? portValue(legacyEnginePorts.port, 7777) : 7777);
   const igwBase = enginePorts.igwPort !== null
-    ? portValue(enginePorts.igwPort, portValue(env.IGW_PORT_BASE, 7888))
-    : portValue(env.IGW_PORT_BASE, 7888);
+    ? portValue(enginePorts.igwPort, 7888)
+    : (legacyEnginePorts.igwPort !== null ? portValue(legacyEnginePorts.igwPort, 7888) : 7888);
   return {
     postgres: portValue(env.POSTGRES_PORT || env.DUNE_DB_PORT || env.PGPORT, 15432),
     rmqAdmin: portValue(env.RMQ_ADMIN_PORT, 32573),
@@ -66,9 +77,13 @@ export function resolvePorts(env = process.env, repoRoot = process.cwd()) {
 // handler). Returns { port: null, igwPort: null } if the file doesn't
 // exist yet (fresh install, before the first `dune init`/materialize)
 // or doesn't have an [Engine:URL] section -- callers fall back to
-// .env / stock values in that case, exactly matching
-// runtime-env.sh's own resolve_client_port_base()/resolve_igw_port_base()
-// fallback behavior.
+// readEnginePortsFromLegacyUsersettings() / stock values in that case,
+// exactly matching runtime-env.sh's own
+// resolve_client_port_base()/resolve_igw_port_base() fallback behavior
+// (see usersettings_engine_value() in runtime-env.sh, which calls
+// `usersettings.py engine-values` first, then falls back to reading
+// runtime/generated/usersettings.json's legacy "engine" config
+// directly -- .env is never consulted anywhere in that real chain).
 function readEnginePortsFromProfile(repoRoot) {
   const profilePath = resolve(repoRoot, "runtime/generated/gameplay-profile.ini");
   if (!existsSync(profilePath)) return { port: null, igwPort: null };
@@ -90,11 +105,58 @@ function readEnginePortsFromProfile(repoRoot) {
   const normalized = text.replace(/\r\n/g, "\n");
   const sectionMatch = normalized.match(/^\[Engine:URL\]\s*$([\s\S]*?)(?=^\[|\s*$(?!\n))/m);
   const sectionText = sectionMatch ? sectionMatch[1] : normalized;
-  const portMatch = sectionText.match(/^\s*Port\s*=\s*(\d+)\s*$/m);
-  const igwMatch = sectionText.match(/^\s*IGWPort\s*=\s*(\d+)\s*$/m);
+  // Layer 3 audit regression: if a section has a duplicate key (Port=
+  // appearing twice, which usersettings.py's own
+  // _advanced_editor_duplicate_key_warnings() explicitly anticipates and
+  // warns about as a real, reachable state, not a theoretical one), the
+  // LAST occurrence wins -- matching usersettings.py's profile_get_key()/
+  // profile_get_raw_key(), which both iterate reversed(block["lines"])
+  // for exactly this reason (standard INI semantics: a later assignment
+  // overrides an earlier one in the same section). Directly verified via
+  // both implementations against the same duplicate-key fixture -- a
+  // previous first-match approach here disagreed with the real Python
+  // tool the game server itself uses to materialize this file, which
+  // would have shown operators a different port than the one the engine
+  // actually bound to. matchAll() + at(-1) implements "last match" for a
+  // global multiline regex.
+  const portMatches = [...sectionText.matchAll(/^\s*Port\s*=\s*(\d+)\s*$/gm)];
+  const igwMatches = [...sectionText.matchAll(/^\s*IGWPort\s*=\s*(\d+)\s*$/gm)];
   return {
-    port: portMatch ? Number(portMatch[1]) : null,
-    igwPort: igwMatch ? Number(igwMatch[1]) : null
+    port: portMatches.length ? Number(portMatches.at(-1)[1]) : null,
+    igwPort: igwMatches.length ? Number(igwMatches.at(-1)[1]) : null
+  };
+}
+
+// Reads Port/IGWPort from runtime/generated/usersettings.json's legacy
+// "engine" config -- the SECOND step of the real fallback chain used by
+// runtime-env.sh's usersettings_engine_value() (see that function and
+// usersettings.py's load_config()/ENGINE_FIELDS for the authoritative
+// implementation this mirrors). This is genuinely a legacy path: once
+// `dune init`/materialize has run at least once, gameplay-profile.ini
+// exists and this function is never reached for these two fields. It
+// matters only in the narrow fresh-install window before the first
+// materialize call, which is exactly the window a Requirement 20 Layer
+// 3 audit found this file's Node-side resolver handling differently
+// (and incorrectly, relative to the real shell/Python resolver) by
+// falling back to .env instead. usersettings.json's schema is
+// {"engine": {"port": "...", "igw_port": "..."}, ...} -- see
+// usersettings.py's load_config().
+function readEnginePortsFromLegacyUsersettings(repoRoot) {
+  const path = resolve(repoRoot, "runtime/generated/usersettings.json");
+  if (!existsSync(path)) return { port: null, igwPort: null };
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return { port: null, igwPort: null };
+  }
+  const engine = parsed && typeof parsed === "object" ? parsed.engine : null;
+  if (!engine || typeof engine !== "object") return { port: null, igwPort: null };
+  const rawPort = engine.port;
+  const rawIgwPort = engine.igw_port;
+  return {
+    port: rawPort !== undefined && rawPort !== null && String(rawPort).trim() !== "" ? Number(rawPort) : null,
+    igwPort: rawIgwPort !== undefined && rawIgwPort !== null && String(rawIgwPort).trim() !== "" ? Number(rawIgwPort) : null
   };
 }
 

--- a/console/api/src/config.js
+++ b/console/api/src/config.js
@@ -5,6 +5,39 @@ import { networkInterfaces } from "node:os";
 
 export const APP_NAME = "Dune Docker Console";
 
+// Single source of truth for every host-facing port this console cares
+// about. Stock (Instance 1) values are the fallback defaults only --
+// multi-server / single-public-IP deployments override these via .env.
+// These values MUST stay in sync with runtime/scripts/runtime-env.sh's
+// resolve_*_port() functions -- that file is the shell-side equivalent
+// used by non-Node scripts, and the two must never drift (found 6
+// places across the codebase that hardcoded these stock values directly
+// instead of reading them from a shared source, breaking any deployment
+// running non-default configured ports).
+export function resolvePorts(env = process.env) {
+  const clientBase = portValue(env.CLIENT_PORT_BASE, 7777);
+  const igwBase = portValue(env.IGW_PORT_BASE, 7888);
+  return {
+    postgres: portValue(env.POSTGRES_PORT || env.DUNE_DB_PORT || env.PGPORT, 15432),
+    rmqAdmin: portValue(env.RMQ_ADMIN_PORT, 32573),
+    rmqGame: portValue(env.RMQ_GAME_PORT, 31982),
+    rmqGameHttp: portValue(env.RMQ_GAME_HTTP_PORT, 31983),
+    rmqGameLocalHttp: portValue(env.RMQ_GAME_LOCAL_HTTP_PORT, 15672),
+    textRouter: portValue(env.TEXT_ROUTER_PORT, 5059),
+    director: portValue(env.DIRECTOR_PORT, 11717),
+    metricsPrometheus: portValue(env.METRICS_PROMETHEUS_PORT, 9090),
+    clientBase,
+    clientBaseSecondary: clientBase + 1,
+    igwBase,
+    igwBaseSecondary: igwBase + 1
+  };
+}
+
+function portValue(value, fallback) {
+  const parsed = Number(value || fallback);
+  return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535 ? parsed : fallback;
+}
+
 export function loadConfig() {
   const repoRoot = resolve(process.env.DUNE_DOCKER_DIR || process.env.RUNTIME_DIR || process.cwd());
   const generatedDir = resolve(repoRoot, "runtime/generated");
@@ -23,6 +56,7 @@ export function loadConfig() {
     duneScript: resolve(repoRoot, "runtime/scripts/dune"),
     host: resolveAdminBindHost(process.env.ADMIN_BIND_HOST),
     port: Number(process.env.ADMIN_BIND_PORT || 8088),
+    ports: resolvePorts(),
     authDisabled: process.env.ADMIN_AUTH_DISABLED === "1",
     secureCookies: secureCookieEnv === undefined ? process.env.NODE_ENV === "production" : secureCookieEnv === "1",
     allowHostBootstrap: process.env.ALLOW_HOST_BOOTSTRAP === "true",
@@ -205,6 +239,7 @@ export function publicConfig(config) {
     repoRoot: config.repoRoot,
     host: config.host,
     port: config.port,
+    ports: config.ports,
     authDisabled: config.authDisabled,
     adminPasswordEnvManaged: config.adminPasswordEnvManaged,
     secureCookies: config.secureCookies,

--- a/console/api/src/db.js
+++ b/console/api/src/db.js
@@ -4,7 +4,7 @@ import { resolvePorts } from "./config.js";
 
 const { Pool } = pg;
 
-export function discoverDbConfig(env = process.env) {
+export function discoverDbConfig(env = process.env, repoRoot = process.cwd()) {
   if (env.ADMIN_DATABASE_URL) {
     return { connectionString: env.ADMIN_DATABASE_URL, source: "ADMIN_DATABASE_URL" };
   }
@@ -13,8 +13,13 @@ export function discoverDbConfig(env = process.env) {
     // DUNE_DB_PORT/PGPORT take precedence over the shared resolvePorts()
     // default when set directly (rare, escape-hatch use), otherwise this
     // matches config.js's ports.postgres exactly -- same fallback (15432),
-    // same POSTGRES_PORT lookup, single source of truth.
-    port: Number(env.DUNE_DB_PORT || env.PGPORT || resolvePorts(env).postgres),
+    // same POSTGRES_PORT lookup, single source of truth. postgres is
+    // env-var-only (not profile-file-backed), so repoRoot doesn't affect
+    // this specific field today -- passed through explicitly anyway so
+    // this doesn't silently rely on process.cwd() coincidentally
+    // matching config.repoRoot the moment a profile-backed field is
+    // ever added here.
+    port: Number(env.DUNE_DB_PORT || env.PGPORT || resolvePorts(env, repoRoot).postgres),
     database: env.DUNE_DB_NAME || env.PGDATABASE || "dune",
     user: env.DUNE_DB_USER || env.PGUSER || "dune",
     password: env.DUNE_DB_PASSWORD || env.PGPASSWORD || "dune",
@@ -23,7 +28,7 @@ export function discoverDbConfig(env = process.env) {
 }
 
 export function createDb(config) {
-  const dbConfig = discoverDbConfig();
+  const dbConfig = discoverDbConfig(process.env, config?.repoRoot);
   const pool = new Pool({
     ...dbConfig,
     max: Number(process.env.ADMIN_DB_POOL_SIZE || 5),

--- a/console/api/src/db.js
+++ b/console/api/src/db.js
@@ -1,5 +1,6 @@
 import pg from "pg";
 import { redact } from "./redact.js";
+import { resolvePorts } from "./config.js";
 
 const { Pool } = pg;
 
@@ -9,7 +10,11 @@ export function discoverDbConfig(env = process.env) {
   }
   return {
     host: env.DUNE_DB_HOST || env.PGHOST || "127.0.0.1",
-    port: Number(env.DUNE_DB_PORT || env.PGPORT || env.POSTGRES_PORT || 15432),
+    // DUNE_DB_PORT/PGPORT take precedence over the shared resolvePorts()
+    // default when set directly (rare, escape-hatch use), otherwise this
+    // matches config.js's ports.postgres exactly -- same fallback (15432),
+    // same POSTGRES_PORT lookup, single source of truth.
+    port: Number(env.DUNE_DB_PORT || env.PGPORT || resolvePorts(env).postgres),
     database: env.DUNE_DB_NAME || env.PGDATABASE || "dune",
     user: env.DUNE_DB_USER || env.PGUSER || "dune",
     password: env.DUNE_DB_PASSWORD || env.PGPASSWORD || "dune",

--- a/console/api/src/db.js
+++ b/console/api/src/db.js
@@ -10,16 +10,22 @@ export function discoverDbConfig(env = process.env, repoRoot = process.cwd()) {
   }
   return {
     host: env.DUNE_DB_HOST || env.PGHOST || "127.0.0.1",
-    // DUNE_DB_PORT/PGPORT take precedence over the shared resolvePorts()
-    // default when set directly (rare, escape-hatch use), otherwise this
-    // matches config.js's ports.postgres exactly -- same fallback (15432),
-    // same POSTGRES_PORT lookup, single source of truth. postgres is
-    // env-var-only (not profile-file-backed), so repoRoot doesn't affect
-    // this specific field today -- passed through explicitly anyway so
-    // this doesn't silently rely on process.cwd() coincidentally
-    // matching config.repoRoot the moment a profile-backed field is
-    // ever added here.
-    port: Number(env.DUNE_DB_PORT || env.PGPORT || resolvePorts(env, repoRoot).postgres),
+    // Upstream review finding: this previously preferred
+    // DUNE_DB_PORT/PGPORT over resolvePorts().postgres, while
+    // resolvePorts() itself prefers POSTGRES_PORT over
+    // DUNE_DB_PORT/PGPORT -- if an operator had more than one of these
+    // set to different values (a real, reachable misconfiguration, not
+    // hypothetical), status/preflight (which reads resolvePorts()
+    // directly) could disagree with the actual database connection
+    // (which read this function). Always delegate to resolvePorts()
+    // instead of re-implementing the precedence chain here, so there is
+    // exactly one place this logic can ever drift from itself. postgres
+    // is env-var-only (not profile-file-backed), so repoRoot doesn't
+    // affect this specific field today -- passed through explicitly
+    // anyway so this doesn't silently rely on process.cwd()
+    // coincidentally matching config.repoRoot the moment a
+    // profile-backed field is ever added here.
+    port: resolvePorts(env, repoRoot).postgres,
     database: env.DUNE_DB_NAME || env.PGDATABASE || "dune",
     user: env.DUNE_DB_USER || env.PGUSER || "dune",
     password: env.DUNE_DB_PASSWORD || env.PGPASSWORD || "dune",

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -1,5 +1,6 @@
 import { assertIdentifier, intParam, isReadOnlySql, quoteIdentifier, quoteQualified, rowsResult } from "./db.js";
 import { getBridgeRequestSummary } from "./audit.js";
+import { resolvePorts } from "./config.js";
 import { existsSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { resolve } from "node:path";
@@ -8890,7 +8891,7 @@ export function addonOpsSocSummary() {
 // on cAdvisor's per-container metric quality — a target can be "up"
 // (reachable, scraping successfully) while still only exposing an
 // incomplete/aggregate metric set).
-export async function addonOpsPrometheusHealth(promBaseUrl = process.env.METRICS_PROMETHEUS_URL || `http://127.0.0.1:${process.env.METRICS_PROMETHEUS_PORT || 9090}`) {
+export async function addonOpsPrometheusHealth(promBaseUrl = process.env.METRICS_PROMETHEUS_URL || `http://127.0.0.1:${resolvePorts().metricsPrometheus}`) {
   try {
     const healthRes = await fetch(`${promBaseUrl}/-/healthy`, { signal: AbortSignal.timeout(2000) });
     if (!healthRes.ok) return metricsStackNotRunning();

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -8891,7 +8891,16 @@ export function addonOpsSocSummary() {
 // on cAdvisor's per-container metric quality — a target can be "up"
 // (reachable, scraping successfully) while still only exposing an
 // incomplete/aggregate metric set).
-export async function addonOpsPrometheusHealth(promBaseUrl = process.env.METRICS_PROMETHEUS_URL || `http://127.0.0.1:${resolvePorts().metricsPrometheus}`) {
+export async function addonOpsPrometheusHealth(
+  promBaseUrl,
+  repoRoot = process.env.DUNE_DOCKER_DIR || process.env.RUNTIME_DIR || process.cwd()
+) {
+  // metricsPrometheus is env-var-only today (not profile-file-backed),
+  // so repoRoot doesn't change this specific field's value -- accepted
+  // explicitly anyway so this doesn't rely on process.cwd() coincidentally
+  // matching config.repoRoot the moment a profile-backed field is ever
+  // added here, matching the same fix applied to db.js/server.js.
+  promBaseUrl = promBaseUrl || process.env.METRICS_PROMETHEUS_URL || `http://127.0.0.1:${resolvePorts(process.env, repoRoot).metricsPrometheus}`;
   try {
     const healthRes = await fetch(`${promBaseUrl}/-/healthy`, { signal: AbortSignal.timeout(2000) });
     if (!healthRes.ok) return metricsStackNotRunning();

--- a/console/api/src/integrations/discord/opsProvider.js
+++ b/console/api/src/integrations/discord/opsProvider.js
@@ -130,7 +130,7 @@ export async function opsSocProvider(config, db) {
 // requires for opsLocationProvider (which, unlike this one, has no real
 // data source planned at all — see that provider's own comment).
 export async function opsPrometheusProvider(config, db) {
-  const result = await addonOpsPrometheusHealth();
+  const result = await addonOpsPrometheusHealth(undefined, config?.repoRoot);
   return { ok: true, result };
 }
 

--- a/console/api/src/preflight.js
+++ b/console/api/src/preflight.js
@@ -3,9 +3,10 @@ import { arch, freemem, platform, release, totalmem } from "node:os";
 import { execFileSync } from "node:child_process";
 import { createServer } from "node:net";
 import { resolve } from "node:path";
+import { resolvePorts } from "./config.js";
 
 export async function preflight(config) {
-  const ports = configuredPorts();
+  const ports = configuredPorts(config.ports);
   const checks = [];
   checks.push(check("Operating system", "info", `${platform()} ${release()}`));
   checks.push(check("Architecture", arch() === "x64" ? "pass" : "warn", arch()));
@@ -27,26 +28,27 @@ export async function preflight(config) {
   return { checks, summary: summarize(checks) };
 }
 
-function configuredPorts(env = process.env) {
-  const clientBase = portValue(env.CLIENT_PORT_BASE, 7777);
-  const igwBase = portValue(env.IGW_PORT_BASE, 7888);
+// Accepts a resolved config.ports object (see config.js's resolvePorts())
+// so this module has exactly one source of truth for stock port
+// defaults, shared with every other consumer (db.js, server.js,
+// duneDb.js, and the frontend via publicConfig()). Falls back to
+// resolving from process.env directly only if called without a ports
+// object (kept for backward-compat with any external caller/test that
+// doesn't pass one).
+function configuredPorts(ports) {
+  const resolved = ports || resolvePorts();
   return [
-    portValue(env.POSTGRES_PORT || env.DUNE_DB_PORT || env.PGPORT, 15432),
-    portValue(env.RMQ_GAME_PORT, 31982),
-    portValue(env.RMQ_GAME_HTTP_PORT, 31983),
-    portValue(env.RMQ_ADMIN_PORT, 32573),
-    portValue(env.TEXT_ROUTER_PORT, 5059),
-    clientBase,
-    clientBase + 1,
-    igwBase,
-    igwBase + 1,
-    portValue(env.DIRECTOR_PORT, 11717)
+    resolved.postgres,
+    resolved.rmqGame,
+    resolved.rmqGameHttp,
+    resolved.rmqAdmin,
+    resolved.textRouter,
+    resolved.clientBase,
+    resolved.clientBaseSecondary,
+    resolved.igwBase,
+    resolved.igwBaseSecondary,
+    resolved.director
   ];
-}
-
-function portValue(value, fallback) {
-  const parsed = Number(value || fallback);
-  return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535 ? parsed : fallback;
 }
 
 function check(name, status, message, detail = "") {

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -4,7 +4,7 @@ import { totalmem } from "node:os";
 import { spawn } from "node:child_process";
 import { existsSync, writeFileSync, chmodSync, mkdirSync, createReadStream, readFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
-import { loadConfig, publicConfig, parseAllowedIps } from "./config.js";
+import { loadConfig, publicConfig, parseAllowedIps, resolvePorts } from "./config.js";
 import { createAuth, setSessionCookie, clearSessionCookie, json, withSecurityHeaders } from "./auth.js";
 import { createLoginRateLimiter, createMutationRateLimiter } from "./rateLimit.js";
 import { createBridgeRateLimiter } from "./bridgeRateLimit.js";
@@ -1565,8 +1565,15 @@ function apiErrorPayload(error, fallbackStatus = 500) {
 }
 
 function isPostgresUnavailableError(error, rawMessage = "") {
+  // Note: error?.code === "ECONNREFUSED" and the generic "connect
+  // ECONNREFUSED" regex below already catch every real case regardless
+  // of which port Postgres is configured on -- this specific-port regex
+  // is effectively redundant, but is kept (now port-aware instead of
+  // hardcoded to the stock port 15432) for clearer log/error matching on
+  // deployments with a non-default configured Postgres port.
+  const postgresPort = resolvePorts().postgres;
   return error?.code === "ECONNREFUSED"
-    || /ECONNREFUSED.*127\.0\.0\.1:15432/i.test(rawMessage)
+    || new RegExp(`ECONNREFUSED.*127\\.0\\.0\\.1:${postgresPort}`, "i").test(rawMessage)
     || /connect\s+ECONNREFUSED/i.test(rawMessage);
 }
 

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -1570,8 +1570,12 @@ function isPostgresUnavailableError(error, rawMessage = "") {
   // of which port Postgres is configured on -- this specific-port regex
   // is effectively redundant, but is kept (now port-aware instead of
   // hardcoded to the stock port 15432) for clearer log/error matching on
-  // deployments with a non-default configured Postgres port.
-  const postgresPort = resolvePorts().postgres;
+  // deployments with a non-default configured Postgres port. Pass
+  // config.repoRoot explicitly rather than relying on resolvePorts()'s
+  // process.cwd() default coincidentally matching it -- postgres itself
+  // is env-var-only so this doesn't change behavior today, but avoids
+  // depending on that coincidence for any future profile-backed field.
+  const postgresPort = resolvePorts(process.env, config.repoRoot).postgres;
   return error?.code === "ECONNREFUSED"
     || new RegExp(`ECONNREFUSED.*127\\.0\\.0\\.1:${postgresPort}`, "i").test(rawMessage)
     || /connect\s+ECONNREFUSED/i.test(rawMessage);

--- a/console/api/test/config.test.js
+++ b/console/api/test/config.test.js
@@ -113,12 +113,111 @@ test("resolvePorts() reads Player/Game and IGW base ports from gameplay-profile.
   }
 });
 
-test("resolvePorts() falls back to .env CLIENT_PORT_BASE/IGW_PORT_BASE when gameplay-profile.ini doesn't exist yet", () => {
+// Requirement 20 Layer 3 (integration) audit finding, CRITICAL,
+// independently reproduced: this test previously asserted
+// resolvePorts() falls back to .env's CLIENT_PORT_BASE/IGW_PORT_BASE
+// when gameplay-profile.ini doesn't exist yet -- that passed, but was
+// testing the WRONG behavior. The real shell/Python resolver
+// (runtime-env.sh's usersettings_engine_value(), which every game-server
+// start/stop script actually calls) never reads .env for these two
+// fields at all; its real fallback is runtime/generated/
+// usersettings.json's legacy "engine" config, then the stock literal.
+// Directly reproduced the divergence before this fix: with
+// CLIENT_PORT_BASE=7001 in .env and no profile file, Node returned 7001
+// while the real Python tool returned stock 7777 -- the Web UI could
+// show a port the game server's own startup scripts would never
+// actually bind to. This test now asserts the CORRECT chain: .env is
+// NOT consulted for these two fields; usersettings.json is.
+test("resolvePorts() does NOT fall back to .env CLIENT_PORT_BASE/IGW_PORT_BASE when gameplay-profile.ini doesn't exist yet -- matches the real shell/Python resolver, which never reads .env for these fields", () => {
   const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-no-profile-"));
   try {
+    // .env has a configured value, but no profile file and no
+    // usersettings.json exist yet -- the real shell/Python resolver
+    // would return stock defaults here, ignoring .env entirely. Node
+    // must agree.
     const ports = resolvePorts({ CLIENT_PORT_BASE: "8777", IGW_PORT_BASE: "8888" }, repoRoot);
-    assert.equal(ports.clientBase, 8777);
-    assert.equal(ports.igwBase, 8888);
+    assert.equal(ports.clientBase, 7777, ".env's CLIENT_PORT_BASE must NOT be used -- the real shell/Python resolver never reads it for this field");
+    assert.equal(ports.igwBase, 7888, ".env's IGW_PORT_BASE must NOT be used -- the real shell/Python resolver never reads it for this field");
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+// This is the SECOND step of the real fallback chain (profile file ->
+// usersettings.json's legacy engine config -> stock) -- see
+// runtime-env.sh's usersettings_engine_value() and usersettings.py's
+// load_config()/ENGINE_FIELDS for the authoritative implementation this
+// mirrors. usersettings.json is written by `dune init`/materialize
+// before the first gameplay-profile.ini exists, or is read directly by
+// runtime-env.sh's Python fallback when the profile file is missing.
+test("resolvePorts() falls back to runtime/generated/usersettings.json's legacy engine config when gameplay-profile.ini doesn't exist yet", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-legacy-"));
+  try {
+    mkdirSync(join(repoRoot, "runtime", "generated"), { recursive: true });
+    writeFileSync(
+      join(repoRoot, "runtime", "generated", "usersettings.json"),
+      JSON.stringify({ engine: { port: "8001", igw_port: "8002" }, maps: {}, partitions: {} })
+    );
+    const ports = resolvePorts({}, repoRoot);
+    assert.equal(ports.clientBase, 8001);
+    assert.equal(ports.igwBase, 8002);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("resolvePorts() falls back to stock values when neither gameplay-profile.ini nor usersettings.json exist", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-nothing-"));
+  try {
+    const ports = resolvePorts({}, repoRoot);
+    assert.equal(ports.clientBase, 7777);
+    assert.equal(ports.igwBase, 7888);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("resolvePorts() prefers gameplay-profile.ini over usersettings.json when both exist", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-both-"));
+  try {
+    mkdirSync(join(repoRoot, "runtime", "generated"), { recursive: true });
+    writeFileSync(
+      join(repoRoot, "runtime", "generated", "usersettings.json"),
+      JSON.stringify({ engine: { port: "9001", igw_port: "9002" }, maps: {}, partitions: {} })
+    );
+    writeFileSync(
+      join(repoRoot, "runtime", "generated", "gameplay-profile.ini"),
+      "[Engine:URL]\nPort=8001\nIGWPort=8002\n"
+    );
+    const ports = resolvePorts({}, repoRoot);
+    assert.equal(ports.clientBase, 8001, "gameplay-profile.ini must win over usersettings.json's legacy config");
+    assert.equal(ports.igwBase, 8002, "gameplay-profile.ini must win over usersettings.json's legacy config");
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+// Requirement 20 Layer 3 (integration) audit finding, HIGH: if a
+// section has a duplicate key (Port= appearing twice -- usersettings.py's
+// own _advanced_editor_duplicate_key_warnings() explicitly anticipates
+// this as a real, reachable state), the real Python tool the game
+// server uses to materialize this file (profile_get_key(), which
+// iterates reversed(block["lines"])) takes the LAST occurrence.
+// Directly reproduced the divergence before this fix: Node's
+// first-match regex returned 7777 for a fixture where Python's
+// last-match logic returned 9999 -- the Web UI would have shown a
+// different port than the one the engine actually bound to.
+test("resolvePorts() takes the LAST occurrence of a duplicate Port/IGWPort key, matching usersettings.py's profile_get_key() (reversed iteration)", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-dup-"));
+  try {
+    mkdirSync(join(repoRoot, "runtime", "generated"), { recursive: true });
+    writeFileSync(
+      join(repoRoot, "runtime", "generated", "gameplay-profile.ini"),
+      "[Engine:URL]\nPort=7777\nPort=9999\nIGWPort=8001\nIGWPort=8888\n"
+    );
+    const ports = resolvePorts({}, repoRoot);
+    assert.equal(ports.clientBase, 9999, "the LAST Port= line must win, matching usersettings.py's reversed() iteration");
+    assert.equal(ports.igwBase, 8888, "the LAST IGWPort= line must win, matching usersettings.py's reversed() iteration");
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
   }

--- a/console/api/test/config.test.js
+++ b/console/api/test/config.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadConfig, publicConfig } from "../src/config.js";
+import { loadConfig, publicConfig, resolvePorts } from "../src/config.js";
 
 test("web config exposes safe deployment flags and JSON body limit", () => {
   const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-"));
@@ -24,6 +24,75 @@ test("web config exposes safe deployment flags and JSON body limit", () => {
 
     process.env.ADMIN_SECURE_COOKIES = "0";
     assert.equal(loadConfig().secureCookies, false);
+  } finally {
+    process.env = previous;
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+// Regression guard: a full-codebase audit found 6 places hardcoded
+// stock port values instead of reading them from a shared source,
+// breaking any deployment running non-default configured ports. This
+// test must fail if any consumer ever reverts to reading process.env
+// directly instead of going through resolvePorts()/config.ports.
+test("resolvePorts() honors configured (non-default) ports, does not silently fall back to stock values", () => {
+  const configuredEnv = {
+    POSTGRES_PORT: "16432",
+    RMQ_ADMIN_PORT: "33573",
+    RMQ_GAME_PORT: "32982",
+    RMQ_GAME_HTTP_PORT: "32983",
+    RMQ_GAME_LOCAL_HTTP_PORT: "16672",
+    TEXT_ROUTER_PORT: "6059",
+    DIRECTOR_PORT: "12717",
+    METRICS_PROMETHEUS_PORT: "10090",
+    CLIENT_PORT_BASE: "8777",
+    IGW_PORT_BASE: "8888"
+  };
+  const ports = resolvePorts(configuredEnv);
+  assert.deepEqual(ports, {
+    postgres: 16432,
+    rmqAdmin: 33573,
+    rmqGame: 32982,
+    rmqGameHttp: 32983,
+    rmqGameLocalHttp: 16672,
+    textRouter: 6059,
+    director: 12717,
+    metricsPrometheus: 10090,
+    clientBase: 8777,
+    clientBaseSecondary: 8778,
+    igwBase: 8888,
+    igwBaseSecondary: 8889
+  });
+});
+
+test("resolvePorts() falls back to stock values when nothing is configured", () => {
+  const ports = resolvePorts({});
+  assert.deepEqual(ports, {
+    postgres: 15432,
+    rmqAdmin: 32573,
+    rmqGame: 31982,
+    rmqGameHttp: 31983,
+    rmqGameLocalHttp: 15672,
+    textRouter: 5059,
+    director: 11717,
+    metricsPrometheus: 9090,
+    clientBase: 7777,
+    clientBaseSecondary: 7778,
+    igwBase: 7888,
+    igwBaseSecondary: 7889
+  });
+});
+
+test("publicConfig() exposes ports to the frontend", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-ports-"));
+  const previous = { ...process.env };
+  process.env.DUNE_DOCKER_DIR = repoRoot;
+  process.env.POSTGRES_PORT = "16432";
+  try {
+    const config = loadConfig();
+    const exposed = publicConfig(config);
+    assert.equal(exposed.ports.postgres, 16432);
+    assert.equal(exposed.ports.rmqGame, 31982);
   } finally {
     process.env = previous;
     rmSync(repoRoot, { recursive: true, force: true });

--- a/console/api/test/config.test.js
+++ b/console/api/test/config.test.js
@@ -325,3 +325,67 @@ test("resolvePorts() ignores an out-of-range Port/IGWPort parsed from a corrupte
     rmSync(repoRoot, { recursive: true, force: true });
   }
 });
+
+// Upstream review finding: if [Engine:URL] is absent entirely, the
+// previous implementation fell back to scanning the WHOLE profile file
+// for a Port=/IGWPort= match, which could silently pick up an unrelated
+// key from a different section (here, [Engine:ConsoleVariables]'s own
+// Port= override -- a real key some UE-based configs use for something
+// unrelated to the game server's own bind port) and report it as the
+// real game port. The real Python tool (usersettings.py's
+// profile_get_key()) only ever looks inside the named section; if the
+// section doesn't exist, it returns nothing for that key.
+test("resolvePorts() does not read Port/IGWPort from an unrelated section when [Engine:URL] is missing", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-wrong-section-"));
+  try {
+    mkdirSync(join(repoRoot, "runtime", "generated"), { recursive: true });
+    writeFileSync(
+      join(repoRoot, "runtime", "generated", "gameplay-profile.ini"),
+      "[Engine:ConsoleVariables]\nPort=1234\nIGWPort=1235\n"
+    );
+    const ports = resolvePorts({}, repoRoot);
+    assert.equal(ports.clientBase, 7777, "a Port= key in an unrelated section must not be treated as the real game port");
+    assert.equal(ports.igwBase, 7888, "an IGWPort= key in an unrelated section must not be treated as the real IGW port");
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+// Upstream review finding: portValue() only range-checks the base port
+// itself (1-65535), but each base is really the start of a 34-slot
+// range used across the maximum 34 world partitions this project
+// supports (see spawn-server.sh's game_end=$((CLIENT_PORT_BASE + 33))).
+// A base near the top of the valid range can still cause the derived
+// end-of-range port to overflow past 65535, which is exactly as
+// unusable as an already-out-of-range base.
+test("resolvePorts() rejects a Port/IGWPort base whose +33 partition range would exceed 65535", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-overflow-"));
+  try {
+    mkdirSync(join(repoRoot, "runtime", "generated"), { recursive: true });
+    writeFileSync(
+      join(repoRoot, "runtime", "generated", "gameplay-profile.ini"),
+      "[Engine:URL]\nPort=65510\nIGWPort=65520\n"
+    );
+    const ports = resolvePorts({}, repoRoot);
+    assert.equal(ports.clientBase, 7777, "a Port base whose +33 range overflows 65535 must fall back to stock");
+    assert.equal(ports.igwBase, 7888, "an IGWPort base whose +33 range overflows 65535 must fall back to stock");
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("resolvePorts() accepts a Port/IGWPort base whose +33 partition range exactly reaches 65535", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-boundary-"));
+  try {
+    mkdirSync(join(repoRoot, "runtime", "generated"), { recursive: true });
+    writeFileSync(
+      join(repoRoot, "runtime", "generated", "gameplay-profile.ini"),
+      "[Engine:URL]\nPort=65502\nIGWPort=65502\n"
+    );
+    const ports = resolvePorts({}, repoRoot);
+    assert.equal(ports.clientBase, 65502, "a base whose +33 range lands exactly on 65535 must be accepted");
+    assert.equal(ports.igwBase, 65502, "a base whose +33 range lands exactly on 65535 must be accepted");
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/console/api/test/config.test.js
+++ b/console/api/test/config.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { loadConfig, publicConfig, resolvePorts } from "../src/config.js";
@@ -35,7 +35,12 @@ test("web config exposes safe deployment flags and JSON body limit", () => {
 // breaking any deployment running non-default configured ports. This
 // test must fail if any consumer ever reverts to reading process.env
 // directly instead of going through resolvePorts()/config.ports.
-test("resolvePorts() honors configured (non-default) ports, does not silently fall back to stock values", () => {
+//
+// This test covers the SERVICE ports (Postgres/RMQ/TextRouter/
+// Director/Prometheus), which really are env-var-configured with no
+// other source of truth -- confirmed against runtime-env.sh's
+// resolve_*_port() functions, which read process.env the same way.
+test("resolvePorts() honors configured (non-default) service ports, does not silently fall back to stock values", () => {
   const configuredEnv = {
     POSTGRES_PORT: "16432",
     RMQ_ADMIN_PORT: "33573",
@@ -44,29 +49,21 @@ test("resolvePorts() honors configured (non-default) ports, does not silently fa
     RMQ_GAME_LOCAL_HTTP_PORT: "16672",
     TEXT_ROUTER_PORT: "6059",
     DIRECTOR_PORT: "12717",
-    METRICS_PROMETHEUS_PORT: "10090",
-    CLIENT_PORT_BASE: "8777",
-    IGW_PORT_BASE: "8888"
+    METRICS_PROMETHEUS_PORT: "10090"
   };
-  const ports = resolvePorts(configuredEnv);
-  assert.deepEqual(ports, {
-    postgres: 16432,
-    rmqAdmin: 33573,
-    rmqGame: 32982,
-    rmqGameHttp: 32983,
-    rmqGameLocalHttp: 16672,
-    textRouter: 6059,
-    director: 12717,
-    metricsPrometheus: 10090,
-    clientBase: 8777,
-    clientBaseSecondary: 8778,
-    igwBase: 8888,
-    igwBaseSecondary: 8889
-  });
+  const ports = resolvePorts(configuredEnv, "/nonexistent-repo-root-for-this-test");
+  assert.equal(ports.postgres, 16432);
+  assert.equal(ports.rmqAdmin, 33573);
+  assert.equal(ports.rmqGame, 32982);
+  assert.equal(ports.rmqGameHttp, 32983);
+  assert.equal(ports.rmqGameLocalHttp, 16672);
+  assert.equal(ports.textRouter, 6059);
+  assert.equal(ports.director, 12717);
+  assert.equal(ports.metricsPrometheus, 10090);
 });
 
-test("resolvePorts() falls back to stock values when nothing is configured", () => {
-  const ports = resolvePorts({});
+test("resolvePorts() falls back to stock values when nothing is configured and no profile file exists", () => {
+  const ports = resolvePorts({}, "/nonexistent-repo-root-for-this-test");
   assert.deepEqual(ports, {
     postgres: 15432,
     rmqAdmin: 32573,
@@ -81,6 +78,50 @@ test("resolvePorts() falls back to stock values when nothing is configured", () 
     igwBase: 7888,
     igwBaseSecondary: 7889
   });
+});
+
+// This is the REAL, authoritative source for Player/Game and IGW base
+// ports: runtime/generated/gameplay-profile.ini's [Engine:URL] section
+// (written by runtime/scripts/usersettings.py engine-set, e.g. via the
+// Maps UI or multi-server-config.py) -- NOT an env var. A prior version
+// of this test only validated CLIENT_PORT_BASE/IGW_PORT_BASE env vars,
+// which are documented as secondary "compatibility/console metadata"
+// only -- that test passed while the underlying implementation used
+// the wrong source of truth, exactly the kind of gap a Requirement 20
+// Layer 1/QA audit is meant to catch (found retroactively; see PR
+// history). This test exercises the real mechanism directly.
+test("resolvePorts() reads Player/Game and IGW base ports from gameplay-profile.ini, the real authoritative source (not .env)", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-profile-"));
+  try {
+    mkdirSync(join(repoRoot, "runtime", "generated"), { recursive: true });
+    writeFileSync(
+      join(repoRoot, "runtime", "generated", "gameplay-profile.ini"),
+      "; UserGame.ini managed by Docker.\n\n[Engine:URL]\nIGWPort=8888\n\nPort=8777\n"
+    );
+    // Deliberately set a DIFFERENT, stale value in .env to prove the
+    // profile file wins -- this is exactly the staleness scenario a
+    // real deployment could hit if an operator changed the port via
+    // the Maps UI without also updating .env.
+    const staleEnv = { CLIENT_PORT_BASE: "9999", IGW_PORT_BASE: "9998" };
+    const ports = resolvePorts(staleEnv, repoRoot);
+    assert.equal(ports.clientBase, 8777, "profile file's Port must win over stale .env CLIENT_PORT_BASE");
+    assert.equal(ports.clientBaseSecondary, 8778);
+    assert.equal(ports.igwBase, 8888, "profile file's IGWPort must win over stale .env IGW_PORT_BASE");
+    assert.equal(ports.igwBaseSecondary, 8889);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("resolvePorts() falls back to .env CLIENT_PORT_BASE/IGW_PORT_BASE when gameplay-profile.ini doesn't exist yet", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-no-profile-"));
+  try {
+    const ports = resolvePorts({ CLIENT_PORT_BASE: "8777", IGW_PORT_BASE: "8888" }, repoRoot);
+    assert.equal(ports.clientBase, 8777);
+    assert.equal(ports.igwBase, 8888);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
 });
 
 test("publicConfig() exposes ports to the frontend", () => {

--- a/console/api/test/config.test.js
+++ b/console/api/test/config.test.js
@@ -139,3 +139,90 @@ test("publicConfig() exposes ports to the frontend", () => {
     rmSync(repoRoot, { recursive: true, force: true });
   }
 });
+
+// Layer 2 audit regression: config.ports is a getter, not a value
+// snapshotted once at loadConfig() time. loadConfig() is only called
+// once at process startup (see server.js's top-level `const config =
+// loadConfig()`), but gameplay-profile.ini can be rewritten by the Maps
+// UI at any point during the process's lifetime without a console
+// restart -- a plain value would silently reintroduce the exact
+// staleness bug this PR's first commit fixed (correct once at boot,
+// stale forever after the first Maps UI port change). This test
+// simulates that exact sequence: load config, THEN write the profile
+// file, and confirms config.ports reflects the new value without
+// calling loadConfig() again.
+test("config.ports re-reads gameplay-profile.ini live, not just at loadConfig() time", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-live-"));
+  const previous = { ...process.env };
+  process.env.DUNE_DOCKER_DIR = repoRoot;
+  try {
+    const config = loadConfig();
+    // No profile file yet -- falls back to stock.
+    assert.equal(config.ports.clientBase, 7777);
+    assert.equal(config.ports.igwBase, 7888);
+
+    // Simulate the Maps UI writing a new port via usersettings.py
+    // engine-set, entirely independent of this already-loaded config
+    // object and without any console restart.
+    mkdirSync(join(repoRoot, "runtime", "generated"), { recursive: true });
+    writeFileSync(
+      join(repoRoot, "runtime", "generated", "gameplay-profile.ini"),
+      "[Engine:URL]\nPort=8001\nIGWPort=8002\n"
+    );
+
+    assert.equal(config.ports.clientBase, 8001, "config.ports must reflect the live profile file, not a boot-time snapshot");
+    assert.equal(config.ports.igwBase, 8002, "config.ports must reflect the live profile file, not a boot-time snapshot");
+
+    // publicConfig() (the /api/auth/state payload) must also see the
+    // live value on every call, not a stale copy from an earlier call.
+    assert.equal(publicConfig(config).ports.clientBase, 8001);
+  } finally {
+    process.env = previous;
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+// Layer 2 audit regression: readEnginePortsFromProfile()'s section-
+// boundary regex relies on multiline `$` to find the end of the
+// [Engine:URL] section. `$` matches before `\n` but not before a `\r`
+// that precedes it, so an unnormalized CRLF file caused the section
+// boundary to be found one line early, silently dropping whichever key
+// (Port or IGWPort) came last in the section. usersettings.py always
+// writes LF-only on this project's Linux hosts, so this guards a
+// narrow but real edge case (hand-edited/out-of-band files).
+test("resolvePorts() parses gameplay-profile.ini correctly with CRLF line endings", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-crlf-"));
+  try {
+    mkdirSync(join(repoRoot, "runtime", "generated"), { recursive: true });
+    writeFileSync(
+      join(repoRoot, "runtime", "generated", "gameplay-profile.ini"),
+      "[Engine:URL]\r\nPort=7777\r\nIGWPort=7888\r\n\r\n[Engine:ConsoleVariables]\r\n"
+    );
+    const ports = resolvePorts({}, repoRoot);
+    assert.equal(ports.clientBase, 7777, "Port must be parsed from a CRLF-encoded profile file");
+    assert.equal(ports.igwBase, 7888, "IGWPort (the last key in the section) must not be silently dropped on CRLF files");
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+// Layer 2 audit regression: a corrupted/malformed gameplay-profile.ini
+// could previously produce an out-of-range port value (e.g. Port=0 or a
+// 10-digit garbage number) that bypassed portValue()'s range validation
+// entirely, since the nullish-coalescing fallback only ran portValue()
+// on the .env/stock branch, never on the profile-file branch.
+test("resolvePorts() ignores an out-of-range Port/IGWPort parsed from a corrupted gameplay-profile.ini", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "arrakis-config-corrupt-"));
+  try {
+    mkdirSync(join(repoRoot, "runtime", "generated"), { recursive: true });
+    writeFileSync(
+      join(repoRoot, "runtime", "generated", "gameplay-profile.ini"),
+      "[Engine:URL]\nPort=999999999\nIGWPort=0\n"
+    );
+    const ports = resolvePorts({ CLIENT_PORT_BASE: "7777", IGW_PORT_BASE: "7888" }, repoRoot);
+    assert.equal(ports.clientBase, 7777, "an out-of-range Port must fall back to .env/stock, not pass through unvalidated");
+    assert.equal(ports.igwBase, 7888, "an out-of-range IGWPort must fall back to .env/stock, not pass through unvalidated");
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -36,6 +36,23 @@ test("discovers RedBlink Postgres defaults and env overrides", () => {
   assert.equal(discoverDbConfig({ DUNE_DB_HOST: "db", DUNE_DB_PORT: "5432" }).host, "db");
 });
 
+// Upstream review finding: discoverDbConfig() previously implemented
+// its own precedence (DUNE_DB_PORT || PGPORT || resolvePorts().postgres),
+// which disagreed with resolvePorts()'s own precedence
+// (POSTGRES_PORT || DUNE_DB_PORT || PGPORT) whenever an operator had
+// more than one of these set to different values -- status/preflight
+// (which reads resolvePorts() directly) could then disagree with the
+// actual database connection (which read this function), a real,
+// silent split-brain misconfiguration. discoverDbConfig() must now
+// always delegate to resolvePorts() for this field so there is exactly
+// one place this precedence logic can ever drift from itself.
+test("discoverDbConfig()'s postgres port precedence matches resolvePorts() exactly, even when multiple port env vars conflict", () => {
+  const conflicting = { POSTGRES_PORT: "16432", DUNE_DB_PORT: "17432", PGPORT: "18432" };
+  assert.equal(discoverDbConfig(conflicting).port, 16432, "POSTGRES_PORT must win, matching resolvePorts()'s precedence exactly");
+  assert.equal(discoverDbConfig({ DUNE_DB_PORT: "17432", PGPORT: "18432" }).port, 17432, "DUNE_DB_PORT must win over PGPORT when POSTGRES_PORT is unset");
+  assert.equal(discoverDbConfig({ PGPORT: "18432" }).port, 18432, "PGPORT must be used when neither POSTGRES_PORT nor DUNE_DB_PORT is set");
+});
+
 test("database status exposes SSH tunneling only for a loopback database endpoint", async () => {
   const responses = [
     { rows: [{ current_user: "dune", current_database: "dune", version: "PostgreSQL test" }] },

--- a/console/api/test/portResolutionCrossConsistency.test.js
+++ b/console/api/test/portResolutionCrossConsistency.test.js
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { resolvePorts } from "../src/config.js";
+
+// Requirement 20 Layer 3 (integration) audit finding, HIGH: config.js's
+// own top comment asserts resolvePorts() and runtime-env.sh's
+// resolve_client_port_base()/resolve_igw_port_base() "MUST stay in
+// sync... must never drift" -- but until this file was added, nothing
+// in the repository actually verified that claim. That gap is exactly
+// why two CRITICAL divergences (a missing-.env-fallback difference, and
+// opposite duplicate-key precedence) shipped with every existing test
+// green: Layer 1 and Layer 2 each audited the Node side and the shell/
+// Python side as separate concerns, and neither diffed the two
+// implementations against the same input.
+//
+// This test runs BOTH real implementations -- Node's resolvePorts() and
+// the actual runtime-env.sh shell functions (which shell out to the
+// real runtime/scripts/usersettings.py, not a mock) -- against the same
+// gameplay-profile.ini fixtures, and asserts they agree. It intentionally
+// does not stub or reimplement either side; it exercises the exact code
+// path each real caller (the Node console, and every game-server start/
+// stop script) actually uses in production.
+//
+// repoRoot must be the real repository root (not a temp directory) for
+// the shell side, because runtime-env.sh sources sibling scripts via
+// paths relative to the current working directory (e.g.
+// `source runtime/scripts/memory-swap-common.sh`) rather than resolving
+// relative to its own location. DUNE_GAMEPLAY_PROFILE/
+// DUNE_USERSETTINGS_CONFIG (both already-supported override env vars,
+// see usersettings.py's CONFIG_PATH/PROFILE_PATH) point the actual data
+// files at an isolated temp directory per test, so this never touches
+// the real repo's own runtime/generated/ state.
+const repoRoot = resolve(fileURLToPath(new URL("../../../", import.meta.url)));
+
+function resolveViaShell(profilePath, usersettingsPath) {
+  const result = spawnSync(
+    "bash",
+    ["-c", "source runtime/scripts/runtime-env.sh && resolve_client_port_base && echo --- && resolve_igw_port_base"],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DUNE_COMPOSE_PROJECT_NAME: "cross-consistency-test",
+        DUNE_GAMEPLAY_PROFILE: profilePath,
+        DUNE_USERSETTINGS_CONFIG: usersettingsPath
+      }
+    }
+  );
+  if (result.status !== 0) {
+    throw new Error(`runtime-env.sh resolve_*_port_base() failed: ${result.stderr}`);
+  }
+  const [clientBase, igwBase] = result.stdout.trim().split("---").map((part) => Number(part.trim()));
+  return { clientBase, igwBase };
+}
+
+// Node's resolvePorts(env, repoRoot) resolves gameplay-profile.ini/
+// usersettings.json at repoRoot/runtime/generated/*, so fixtures for
+// the Node side must be written under that subpath. The shell side is
+// pointed at the exact same two files via the DUNE_GAMEPLAY_PROFILE/
+// DUNE_USERSETTINGS_CONFIG overrides, so both resolvers read identical
+// bytes from identical paths.
+function fixturePaths(dir) {
+  const generatedDir = join(dir, "runtime", "generated");
+  mkdirSync(generatedDir, { recursive: true });
+  return {
+    profilePath: join(generatedDir, "gameplay-profile.ini"),
+    usersettingsPath: join(generatedDir, "usersettings.json")
+  };
+}
+
+test("resolvePorts() (Node) and resolve_client_port_base()/resolve_igw_port_base() (shell, via the real usersettings.py) agree: stock defaults, no profile file", () => {
+  const dir = mkdtempSync(join(tmpdir(), "cross-consistency-stock-"));
+  try {
+    const { profilePath, usersettingsPath } = fixturePaths(dir);
+    const nodePorts = resolvePorts({}, dir);
+    const shellPorts = resolveViaShell(profilePath, usersettingsPath);
+    assert.equal(nodePorts.clientBase, shellPorts.clientBase, "Node and shell must agree on the stock client port default");
+    assert.equal(nodePorts.igwBase, shellPorts.igwBase, "Node and shell must agree on the stock IGW port default");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolvePorts() (Node) and the shell resolver agree: real gameplay-profile.ini values", () => {
+  const dir = mkdtempSync(join(tmpdir(), "cross-consistency-profile-"));
+  try {
+    const { profilePath, usersettingsPath } = fixturePaths(dir);
+    writeFileSync(profilePath, "[Engine:URL]\nPort=8001\nIGWPort=8002\n");
+    const nodePorts = resolvePorts({}, dir);
+    const shellPorts = resolveViaShell(profilePath, usersettingsPath);
+    assert.equal(nodePorts.clientBase, shellPorts.clientBase);
+    assert.equal(nodePorts.igwBase, shellPorts.igwBase);
+    assert.equal(nodePorts.clientBase, 8001);
+    assert.equal(nodePorts.igwBase, 8002);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// This is the exact CRITICAL divergence independently reproduced during
+// the Layer 3 audit: with a configured .env value and no profile file
+// yet, Node's OLD implementation returned the .env value while the real
+// shell/Python resolver returned the stock default (ignoring .env
+// entirely) -- this test asserts both now agree that .env is NOT
+// consulted for these two fields.
+test("resolvePorts() (Node) and the shell resolver agree: .env's CLIENT_PORT_BASE/IGW_PORT_BASE is NOT used as a fallback by either side", () => {
+  const dir = mkdtempSync(join(tmpdir(), "cross-consistency-env-ignored-"));
+  try {
+    const { profilePath, usersettingsPath } = fixturePaths(dir);
+    // No profile file, no usersettings.json -- only a (would-be) .env
+    // value, which neither side should read for these fields.
+    const nodePorts = resolvePorts({ CLIENT_PORT_BASE: "9001", IGW_PORT_BASE: "9002" }, dir);
+    const shellPorts = resolveViaShell(profilePath, usersettingsPath);
+    assert.equal(nodePorts.clientBase, shellPorts.clientBase, "Node must not use .env's CLIENT_PORT_BASE when the shell side wouldn't either");
+    assert.equal(nodePorts.igwBase, shellPorts.igwBase, "Node must not use .env's IGW_PORT_BASE when the shell side wouldn't either");
+    assert.notEqual(nodePorts.clientBase, 9001, "confirms .env genuinely was NOT used (would be a false pass if both sides happened to agree by coincidence)");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("resolvePorts() (Node) and the shell resolver agree: legacy usersettings.json fallback when no profile file exists", () => {
+  const dir = mkdtempSync(join(tmpdir(), "cross-consistency-legacy-"));
+  try {
+    const { profilePath, usersettingsPath } = fixturePaths(dir);
+    writeFileSync(usersettingsPath, JSON.stringify({ engine: { port: "8501", igw_port: "8502" }, maps: {}, partitions: {} }));
+    const nodePorts = resolvePorts({}, dir);
+    const shellPorts = resolveViaShell(profilePath, usersettingsPath);
+    assert.equal(nodePorts.clientBase, shellPorts.clientBase);
+    assert.equal(nodePorts.igwBase, shellPorts.igwBase);
+    assert.equal(nodePorts.clientBase, 8501);
+    assert.equal(nodePorts.igwBase, 8502);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// This is the second exact CRITICAL divergence independently reproduced
+// during the Layer 3 audit: a duplicate Port=/IGWPort= key in the same
+// section -- Node's OLD regex took the first occurrence, while the real
+// Python tool (profile_get_key(), iterating reversed()) takes the last.
+// usersettings.py's own _advanced_editor_duplicate_key_warnings()
+// explicitly anticipates this as a real, reachable state.
+test("resolvePorts() (Node) and the shell resolver agree: duplicate Port/IGWPort keys both resolve to the LAST occurrence", () => {
+  const dir = mkdtempSync(join(tmpdir(), "cross-consistency-dup-"));
+  try {
+    const { profilePath, usersettingsPath } = fixturePaths(dir);
+    writeFileSync(profilePath, "[Engine:URL]\nPort=7777\nPort=9999\nIGWPort=8001\nIGWPort=8888\n");
+    const nodePorts = resolvePorts({}, dir);
+    const shellPorts = resolveViaShell(profilePath, usersettingsPath);
+    assert.equal(nodePorts.clientBase, shellPorts.clientBase, "Node and the real Python tool must agree on which duplicate key wins");
+    assert.equal(nodePorts.igwBase, shellPorts.igwBase, "Node and the real Python tool must agree on which duplicate key wins");
+    assert.equal(nodePorts.clientBase, 9999, "the LAST Port= line must win");
+    assert.equal(nodePorts.igwBase, 8888, "the LAST IGWPort= line must win");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/console/web/src/App.authState.test.tsx
+++ b/console/web/src/App.authState.test.tsx
@@ -1,0 +1,72 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { App } from "./App";
+import { getAdminPort, getServerPorts, resetServerPortsForTests, setAdminPort } from "./api/serverPorts";
+
+// Regression coverage for the /api/auth/state -> setServerPorts/setAdminPort
+// wiring added alongside console/api/src/config.js's resolvePorts() (see
+// PR history) -- confirmed via a Requirement 20 Layer 1 audit that this
+// exact call path had zero test coverage before this file was added.
+afterEach(() => {
+  resetServerPortsForTests();
+  setAdminPort(8088);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("App populates the shared serverPorts cache from /api/auth/state", () => {
+  it("stores real, non-default port values and the admin port from the response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((path: string) => {
+      if (String(path).includes("/api/auth/state")) {
+        return Promise.resolve(new Response(JSON.stringify({
+          authenticated: false,
+          csrfToken: null,
+          config: {
+            port: 9088,
+            ports: {
+              postgres: 16432,
+              rmqGame: 32982,
+              rmqGameHttp: 32983,
+              clientBase: 8777,
+              igwBase: 8888
+            }
+          }
+        }), { status: 200, headers: { "content-type": "application/json" } }));
+      }
+      return Promise.resolve(new Response("{}", { status: 200, headers: { "content-type": "application/json" } }));
+    }));
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(getServerPorts().postgres).toBe(16432);
+    });
+    expect(getServerPorts().rmqGame).toBe(32982);
+    expect(getServerPorts().rmqGameHttp).toBe(32983);
+    expect(getServerPorts().clientBase).toBe(8777);
+    expect(getServerPorts().igwBase).toBe(8888);
+    expect(getAdminPort()).toBe(9088);
+  });
+
+  it("keeps stock defaults when the server response has no ports field at all (older build during a rolling upgrade)", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockImplementation((path: string) => {
+      if (String(path).includes("/api/auth/state")) {
+        return Promise.resolve(new Response(JSON.stringify({
+          authenticated: false,
+          csrfToken: null
+        }), { status: 200, headers: { "content-type": "application/json" } }));
+      }
+      return Promise.resolve(new Response("{}", { status: 200, headers: { "content-type": "application/json" } }));
+    }));
+
+    render(<App />);
+
+    await waitFor(() => {
+      // Nothing to await on directly here since there's no change --
+      // this just confirms the app doesn't crash/error on a response
+      // missing the new field, and the cache stays at its defaults.
+      expect(getServerPorts().postgres).toBe(15432);
+    });
+    expect(getAdminPort()).toBe(8088);
+  });
+});

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { Fragment, Suspense, lazy, useCallback, useEffect, useRef, useState } from "react";
 import { Archive, Building2, Car, CircleArrowUp, Database, ExternalLink, FileText, Gift, Heart, Home, Landmark, Map as MapIcon, Menu, MessageCircle, PackagePlus, RefreshCw, Server, Settings, Shield, Sparkles, Store, Users, X } from "lucide-react";
 import { api, AUTH_SESSION_EXPIRED_EVENT, AUTH_SESSION_EXPIRED_MESSAGE, post, setCsrfToken } from "./api/client";
+import { setServerPorts, setAdminPort, type ServerPorts } from "./api/serverPorts";
 import { serverApi, type RestartQueueTarget } from "./api/server";
 import { updatesApi } from "./api/updates";
 import { addonsApi } from "./api/addons";
@@ -346,9 +347,11 @@ export function App() {
   }, [pinnedAddons]);
 
   useEffect(() => {
-    api<{ authenticated: boolean; csrfToken: string | null }>("/api/auth/state").then((state) => {
+    api<{ authenticated: boolean; csrfToken: string | null; config?: { ports?: Partial<ServerPorts>; port?: number } }>("/api/auth/state").then((state) => {
       setAuth(state.authenticated);
       setCsrfToken(state.csrfToken);
+      setServerPorts(state.config?.ports);
+      setAdminPort(state.config?.port);
     }).catch(() => undefined);
   }, []);
 

--- a/console/web/src/api/client.ts
+++ b/console/web/src/api/client.ts
@@ -1,3 +1,5 @@
+import { getServerPorts } from "./serverPorts";
+
 export type ApiResult<T = unknown> = Promise<T>;
 
 let csrfToken: string | null = null;
@@ -94,7 +96,14 @@ export function post<T>(path: string, body: unknown = {}) {
 
 export function friendlyApiError(value: unknown) {
   const text = value instanceof Error ? value.message : String(value || "");
-  if (/ECONNREFUSED.*127\.0\.0\.1:15432|connect\s+ECONNREFUSED|Postgres is not running/i.test(text)) return POSTGRES_UNAVAILABLE_MESSAGE;
+  // Note: the generic "connect ECONNREFUSED"/"Postgres is not running"
+  // checks below already catch every real case regardless of which port
+  // Postgres is configured on -- the specific-port check is effectively
+  // redundant, but kept (now port-aware instead of hardcoded to the
+  // stock port 15432) for clearer matching.
+  const postgresPort = getServerPorts().postgres;
+  const postgresRefused = new RegExp(`ECONNREFUSED.*127\\.0\\.0\\.1:${postgresPort}`, "i");
+  if (postgresRefused.test(text) || /connect\s+ECONNREFUSED|Postgres is not running/i.test(text)) return POSTGRES_UNAVAILABLE_MESSAGE;
   if (/Unexpected token|Unexpected end of JSON|is not valid JSON|invalid json|unexpected response/i.test(text)) return "The console found invalid saved data for this page. Refresh the page and try again.";
   return text.replace(/^Error:\s*/i, "").trim() || "Request failed.";
 }

--- a/console/web/src/api/serverPorts.test.ts
+++ b/console/web/src/api/serverPorts.test.ts
@@ -1,7 +1,8 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getAdminPort,
   getServerPorts,
+  refreshServerPorts,
   resetServerPortsForTests,
   setAdminPort,
   setServerPorts
@@ -10,6 +11,8 @@ import {
 afterEach(() => {
   resetServerPortsForTests();
   setAdminPort(8088);
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("serverPorts frontend cache", () => {
@@ -64,5 +67,37 @@ describe("serverPorts frontend cache", () => {
     expect(getAdminPort()).toBe(9088);
     setAdminPort(1.5);
     expect(getAdminPort()).toBe(9088);
+  });
+
+  // Upstream review finding: the port cache above is populated only
+  // once, by App.tsx's initial /api/auth/state fetch on mount. If
+  // Port/IGWPort is changed later in the session (via the Maps UI's raw
+  // UserEngine.ini save, the only console-driven path that can write
+  // these fields), the cache previously stayed stale until a full page
+  // reload. refreshServerPorts() re-fetches /api/auth/state on demand
+  // and updates the cache in place.
+  it("refreshServerPorts() re-fetches /api/auth/state and updates the cache in place", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(
+      JSON.stringify({ config: { ports: { clientBase: 8777, igwBase: 8888 }, port: 9088 } }),
+      { status: 200, headers: { "content-type": "application/json" } }
+    )));
+    expect(getServerPorts().clientBase).toBe(7777);
+    expect(getAdminPort()).toBe(8088);
+    await refreshServerPorts();
+    expect(getServerPorts().clientBase).toBe(8777);
+    expect(getServerPorts().igwBase).toBe(8888);
+    expect(getAdminPort()).toBe(9088);
+  });
+
+  it("refreshServerPorts() leaves the cache unchanged on a fetch failure or non-OK response", async () => {
+    setServerPorts({ clientBase: 8777 });
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 500 })));
+    await refreshServerPorts();
+    // a failed refresh must not wipe out the last-known-good cached value
+    expect(getServerPorts().clientBase).toBe(8777);
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network error")));
+    await expect(refreshServerPorts()).resolves.toBeUndefined();
+    expect(getServerPorts().clientBase).toBe(8777);
   });
 });

--- a/console/web/src/api/serverPorts.test.ts
+++ b/console/web/src/api/serverPorts.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  getAdminPort,
+  getServerPorts,
+  resetServerPortsForTests,
+  setAdminPort,
+  setServerPorts
+} from "./serverPorts";
+
+afterEach(() => {
+  resetServerPortsForTests();
+  setAdminPort(8088);
+});
+
+describe("serverPorts frontend cache", () => {
+  it("returns stock defaults before any /api/auth/state response has arrived", () => {
+    const ports = getServerPorts();
+    expect(ports.postgres).toBe(15432);
+    expect(ports.rmqGame).toBe(31982);
+    expect(getAdminPort()).toBe(8088);
+  });
+
+  it("reflects real, non-default values once the server sends them", () => {
+    setServerPorts({
+      postgres: 16432,
+      rmqGame: 32982,
+      rmqGameHttp: 32983,
+      clientBase: 8777,
+      igwBase: 8888
+    });
+    const ports = getServerPorts();
+    expect(ports.postgres).toBe(16432);
+    expect(ports.rmqGame).toBe(32982);
+    expect(ports.rmqGameHttp).toBe(32983);
+    expect(ports.clientBase).toBe(8777);
+    expect(ports.igwBase).toBe(8888);
+    // Fields not present in this particular server response keep their
+    // last-known-good (here, stock default) value rather than being
+    // wiped out -- this matters for a server response that's missing
+    // the `ports` field entirely (e.g. an older build during a rolling
+    // upgrade), and is exactly what a partial update must do.
+    expect(ports.director).toBe(11717);
+  });
+
+  it("ignores an undefined or null ports payload instead of resetting to stock defaults", () => {
+    setServerPorts({ postgres: 16432 });
+    setServerPorts(undefined);
+    expect(getServerPorts().postgres).toBe(16432);
+    setServerPorts(null);
+    expect(getServerPorts().postgres).toBe(16432);
+  });
+
+  it("admin port only updates for a valid, in-range integer", () => {
+    setAdminPort(9088);
+    expect(getAdminPort()).toBe(9088);
+    // Invalid values must not silently corrupt the cached value.
+    setAdminPort(undefined);
+    expect(getAdminPort()).toBe(9088);
+    setAdminPort(null);
+    expect(getAdminPort()).toBe(9088);
+    setAdminPort(-1);
+    expect(getAdminPort()).toBe(9088);
+    setAdminPort(70000);
+    expect(getAdminPort()).toBe(9088);
+    setAdminPort(1.5);
+    expect(getAdminPort()).toBe(9088);
+  });
+});

--- a/console/web/src/api/serverPorts.ts
+++ b/console/web/src/api/serverPorts.ts
@@ -1,0 +1,83 @@
+// Single source of truth, on the frontend side, for every host-facing
+// port the console needs to display or reference. These values are
+// resolved server-side (console/api/src/config.js's resolvePorts()) and
+// delivered once via GET /api/auth/state's `config.ports` field --
+// browsers cannot read .env or process.env directly, so the backend is
+// always the real source of truth; this module just caches what it
+// already sent us instead of every component re-hardcoding stock
+// (Instance 1) values.
+//
+// Stock (Instance 1) values below are ONLY the fallback used before the
+// first successful /api/auth/state response of this page load (or if a
+// future response is ever missing the field) -- they must stay in sync
+// with config.js's resolvePorts() defaults, not be treated as this
+// module's own independent source of truth.
+export interface ServerPorts {
+  postgres: number;
+  rmqAdmin: number;
+  rmqGame: number;
+  rmqGameHttp: number;
+  rmqGameLocalHttp: number;
+  textRouter: number;
+  director: number;
+  metricsPrometheus: number;
+  clientBase: number;
+  clientBaseSecondary: number;
+  igwBase: number;
+  igwBaseSecondary: number;
+}
+
+const STOCK_DEFAULTS: ServerPorts = {
+  postgres: 15432,
+  rmqAdmin: 32573,
+  rmqGame: 31982,
+  rmqGameHttp: 31983,
+  rmqGameLocalHttp: 15672,
+  textRouter: 5059,
+  director: 11717,
+  metricsPrometheus: 9090,
+  clientBase: 7777,
+  clientBaseSecondary: 7778,
+  igwBase: 7888,
+  igwBaseSecondary: 7889
+};
+
+// Admin Web port is a separate top-level field on the server's config
+// object (config.port, not config.ports.*) since it's the port this
+// page is itself being served on, not part of the game-stack port
+// table -- kept here anyway so every consumer has exactly one place to
+// read any server-resolved port from, matching this module's purpose.
+const STOCK_ADMIN_PORT_DEFAULT = 8088;
+let cachedAdminPort: number = STOCK_ADMIN_PORT_DEFAULT;
+
+export function setAdminPort(port: number | undefined | null) {
+  if (typeof port === "number" && Number.isInteger(port) && port > 0 && port <= 65535) {
+    cachedAdminPort = port;
+  }
+}
+
+export function getAdminPort(): number {
+  return cachedAdminPort;
+}
+
+let cached: ServerPorts = STOCK_DEFAULTS;
+
+/** Called once per /api/auth/state response (see App.tsx) with whatever
+ * the server actually sent -- partial/missing fields fall back to the
+ * last-known-good value (or the stock default on first load), so a
+ * server response that's missing `ports` entirely (e.g. an older server
+ * build during a rolling upgrade) never wipes out already-cached real
+ * values with stock ones. */
+export function setServerPorts(ports: Partial<ServerPorts> | undefined | null) {
+  if (!ports) return;
+  cached = { ...cached, ...ports };
+}
+
+export function getServerPorts(): ServerPorts {
+  return cached;
+}
+
+/** Test-only escape hatch to reset to stock defaults between test cases. */
+export function resetServerPortsForTests() {
+  cached = STOCK_DEFAULTS;
+}

--- a/console/web/src/api/serverPorts.ts
+++ b/console/web/src/api/serverPorts.ts
@@ -98,3 +98,34 @@ export function getServerPorts(): ServerPorts {
 export function resetServerPortsForTests() {
   cached = STOCK_DEFAULTS;
 }
+
+// Upstream review finding: the cache above is populated only once, by
+// App.tsx's initial /api/auth/state fetch on mount. If Port/IGWPort is
+// changed later in the same session -- via the Maps UI's raw
+// UserEngine.ini editor, the only console-driven path that can write
+// these two fields (the structured per-field editor deliberately
+// excludes them, see MapsPanel.tsx's engineFields filter) -- the
+// backend's live getter (config.js's `get ports()`) returns the new
+// value on the next request, but this frontend cache does not update
+// until the page is reloaded, showing a stale port in PortChecklist/
+// ReadinessTimeline/SetupWizard with no error or indication anything
+// is wrong. This is a deliberately lightweight fix matching the
+// existing imperative-read pattern (see this file's CALLER CONTRACT
+// comment above) rather than a wholesale React context/hook rewrite --
+// call this once after any save that could plausibly have touched
+// Port/IGWPort, and every consumer picks up the fresh value on its next
+// render (all three current consumers only render post-mount, after
+// this module's cache has already been populated once).
+export async function refreshServerPorts(): Promise<void> {
+  try {
+    const response = await fetch("/api/auth/state", { credentials: "include" });
+    if (!response.ok) return;
+    const state = await response.json() as { config?: { ports?: Partial<ServerPorts>; port?: number } };
+    setServerPorts(state.config?.ports);
+    setAdminPort(state.config?.port);
+  } catch {
+    // A transient fetch failure here must not throw and interrupt the
+    // caller's own save-success flow -- worst case, the cache stays as
+    // stale as it already was; the user can still reload the page.
+  }
+}

--- a/console/web/src/api/serverPorts.ts
+++ b/console/web/src/api/serverPorts.ts
@@ -12,6 +12,23 @@
 // future response is ever missing the field) -- they must stay in sync
 // with config.js's resolvePorts() defaults, not be treated as this
 // module's own independent source of truth.
+//
+// CALLER CONTRACT (read before adding a new consumer): getServerPorts()/
+// getAdminPort() are read imperatively, not via a React hook/context --
+// a component that calls them gets whatever is cached AT THAT MOMENT,
+// and will NOT automatically re-render if setServerPorts()/setAdminPort()
+// is called again later. Today this is safe because every consumer
+// (PortChecklist, ReadinessTimeline, SetupWizard) only renders after
+// App.tsx's auth/setup-loaded gate has already resolved the same
+// /api/auth/state promise that populates this cache -- see
+// App.tsx's top-level useEffect. That ordering is a real invariant this
+// module depends on, not enforced by the type system: if a future
+// change ever renders one of these components before that gate (e.g. a
+// pre-auth status widget), it will silently show stock defaults with no
+// error. If you add a consumer that needs live updates after mount
+// (e.g. if /api/auth/state is ever re-fetched later in the session),
+// convert this to a React context/hook instead of extending the
+// imperative-read pattern further.
 export interface ServerPorts {
   postgres: number;
   rmqAdmin: number;

--- a/console/web/src/components/PortChecklist.tsx
+++ b/console/web/src/components/PortChecklist.tsx
@@ -1,3 +1,5 @@
+import { getServerPorts } from "../api/serverPorts";
+
 type PortRow = { name: string; port: string; protocol: string; status: string; detail: string; kind: string };
 
 export function PortChecklist({ text, statusText = "" }: { text: string; statusText?: string }) {
@@ -52,17 +54,23 @@ function parseNetworkWarnings(text: string) {
 
 function friendlyPortName(raw: string, port: string, protocol: string) {
   const key = `${port}/${protocol.toLowerCase()}`;
+  // Built from the actual, resolved ports for this instance (see
+  // api/serverPorts.ts) rather than the Instance-1 stock values, so
+  // deployments running non-default configured ports still get
+  // friendly labels instead of falling through to the raw, unlabeled
+  // port.
+  const ports = getServerPorts();
   const known: Record<string, string> = {
-    "15432/tcp": "Postgres",
-    "32573/tcp": "RabbitMQ Admin",
-    "31982/tcp": "RabbitMQ Game",
-    "31983/tcp": "RabbitMQ Game HTTP",
-    "5059/tcp": "Text Router",
-    "11717/tcp": "Director",
-    "7777/udp": "Overmap Clients",
-    "7778/udp": "Survival 1 Clients",
-    "7888/udp": "Survival 1 S2S",
-    "7889/udp": "Overmap S2S"
+    [`${ports.postgres}/tcp`]: "Postgres",
+    [`${ports.rmqAdmin}/tcp`]: "RabbitMQ Admin",
+    [`${ports.rmqGame}/tcp`]: "RabbitMQ Game",
+    [`${ports.rmqGameHttp}/tcp`]: "RabbitMQ Game HTTP",
+    [`${ports.textRouter}/tcp`]: "Text Router",
+    [`${ports.director}/tcp`]: "Director",
+    [`${ports.clientBase}/udp`]: "Overmap Clients",
+    [`${ports.clientBaseSecondary}/udp`]: "Survival 1 Clients",
+    [`${ports.igwBase}/udp`]: "Survival 1 S2S",
+    [`${ports.igwBaseSecondary}/udp`]: "Overmap S2S"
   };
   return known[key] || raw.replace(/\bis not listening\b.*$/i, "").replace(/\blistening\b.*$/i, "").replace(/\s+/g, " ").trim();
 }

--- a/console/web/src/components/ReadinessTimeline.tsx
+++ b/console/web/src/components/ReadinessTimeline.tsx
@@ -1,3 +1,5 @@
+import { getServerPorts } from "../api/serverPorts";
+
 type CheckRow = {
   name: string;
   detail: string;
@@ -166,17 +168,23 @@ function detailForReady(raw: string, name: string, status: string) {
 
 function friendlyListenerName(name: string, port: string, protocol: string) {
   const key = `${port}/${protocol.toLowerCase()}`;
+  // Built from the actual, resolved ports for this instance (see
+  // api/serverPorts.ts) rather than the Instance-1 stock values, so
+  // deployments running non-default configured ports still get
+  // friendly labels instead of falling through to the raw, unlabeled
+  // port.
+  const ports = getServerPorts();
   const known: Record<string, string> = {
-    "15432/tcp": "Postgres localhost",
-    "32573/tcp": "RabbitMQ Admin",
-    "31982/tcp": "RabbitMQ Game",
-    "31983/tcp": "RabbitMQ Game HTTP",
-    "5059/tcp": "Text Router",
-    "11717/tcp": "Director",
-    "7777/udp": "Overmap clients",
-    "7778/udp": "Survival 1 clients",
-    "7888/udp": "Survival 1 S2S",
-    "7889/udp": "Overmap S2S"
+    [`${ports.postgres}/tcp`]: "Postgres localhost",
+    [`${ports.rmqAdmin}/tcp`]: "RabbitMQ Admin",
+    [`${ports.rmqGame}/tcp`]: "RabbitMQ Game",
+    [`${ports.rmqGameHttp}/tcp`]: "RabbitMQ Game HTTP",
+    [`${ports.textRouter}/tcp`]: "Text Router",
+    [`${ports.director}/tcp`]: "Director",
+    [`${ports.clientBase}/udp`]: "Overmap clients",
+    [`${ports.clientBaseSecondary}/udp`]: "Survival 1 clients",
+    [`${ports.igwBase}/udp`]: "Survival 1 S2S",
+    [`${ports.igwBaseSecondary}/udp`]: "Overmap S2S"
   };
   return known[key] || friendlyName(name);
 }

--- a/console/web/src/components/SetupWizard.tsx
+++ b/console/web/src/components/SetupWizard.tsx
@@ -3,6 +3,7 @@ import { setupApi, type Check, type Task } from "../api/setup";
 import { PreflightCheckCard } from "./PreflightCheckCard";
 import { SecretInput } from "./SecretInput";
 import { TaskProgress } from "./TaskProgress";
+import { getServerPorts, getAdminPort } from "../api/serverPorts";
 
 type StepId = "welcome" | "host" | "docker" | "runtime" | "identity" | "token" | "ports" | "review" | "install" | "finish";
 const firstRunSteps: { id: StepId; label: string }[] = [
@@ -33,6 +34,11 @@ const defaultSetupConfig: SetupConfig = { SERVER_TITLE: "My Dune Server", SERVER
 
 export function SetupWizard({ initialStep = 0, jumpNonce = 0, mode = "redeploy", onSetupComplete }: { initialStep?: number; jumpNonce?: number; mode?: "first-run" | "redeploy"; onSetupComplete?: () => void }) {
   const steps = mode === "first-run" ? firstRunSteps : redeploySteps;
+  // Real, resolved ports for this instance (see api/serverPorts.ts) --
+  // never hardcode Instance-1 stock values here, they'll be wrong on
+  // any deployment running non-default configured ports.
+  const wizardPorts = getServerPorts();
+  const adminPort = getAdminPort();
   const [step, setStep] = useState(initialStep);
   const [maxUnlockedStep, setMaxUnlockedStep] = useState(initialStep);
   const [checks, setChecks] = useState<Check[]>([]);
@@ -215,22 +221,22 @@ export function SetupWizard({ initialStep = 0, jumpNonce = 0, mode = "redeploy",
               <h4>Public Router Forwarding</h4>
               <p>For a normal public server, forward these ports from your router/firewall to this Docker host:</p>
               <ul className="requirements">
-                <li><strong>UDP 7777-7810</strong> for Dune game server traffic.</li>
-                <li><strong>TCP 31982</strong> for RabbitMQ game traffic.</li>
+                <li><strong>UDP {wizardPorts.clientBase}-{wizardPorts.clientBase + 33}</strong> for Dune game server traffic.</li>
+                <li><strong>TCP {wizardPorts.rmqGame}</strong> for RabbitMQ game traffic.</li>
               </ul>
               <p className="muted">This is the port guidance most users need.</p>
             </section>
             <section className="action-section">
               <h4>Admin Panel</h4>
-              <p>Dune Docker Console listens on 8088/tcp by default. Do not expose it publicly. Use LAN access, VPN, SSH tunnel, or a protected reverse proxy.</p>
+              <p>Dune Docker Console listens on {adminPort}/tcp by default. Do not expose it publicly. Use LAN access, VPN, SSH tunnel, or a protected reverse proxy.</p>
             </section>
             <section className="action-section">
               <h4>Game Map Ports</h4>
-              <p>Game UDP ports start at 7777 and increase as maps are started. Overmap commonly uses 7777 and Survival_1 commonly uses 7778. The 7777-7810 range covers normal map growth.</p>
+              <p>Game UDP ports start at {wizardPorts.clientBase} and increase as maps are started. Overmap commonly uses {wizardPorts.clientBase} and Survival_1 commonly uses {wizardPorts.clientBaseSecondary}. The {wizardPorts.clientBase}-{wizardPorts.clientBase + 33} range covers normal map growth.</p>
             </section>
             <section className="action-section">
               <h4>Internal Map Traffic</h4>
-              <p>IGW/S2S UDP ports start at 7888 for map-to-map traffic inside the console. Do not forward these publicly for a normal single-host Docker setup.</p>
+              <p>IGW/S2S UDP ports start at {wizardPorts.igwBase} for map-to-map traffic inside the console. Do not forward these publicly for a normal single-host Docker setup.</p>
             </section>
             <section className="action-section">
               <h4>Do Not Publicly Expose</h4>
@@ -255,9 +261,9 @@ export function SetupWizard({ initialStep = 0, jumpNonce = 0, mode = "redeploy",
             <section className="action-section">
               <h4>Network / Ports</h4>
               <ReviewGrid items={[
-                ["Public Game UDP", "7777-7810/udp"],
-                ["Public RabbitMQ Game", "31982/tcp"],
-                ["Admin Panel", "8088/tcp private only"],
+                ["Public Game UDP", `${wizardPorts.clientBase}-${wizardPorts.clientBase + 33}/udp`],
+                ["Public RabbitMQ Game", `${wizardPorts.rmqGame}/tcp`],
+                ["Admin Panel", `${adminPort}/tcp private only`],
                 ["Internal Services", "Do not expose publicly"]
               ]} />
             </section>

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -7,6 +7,7 @@ import { setupApi, type Task } from "../../api/setup";
 import { SecretInput } from "../../components/SecretInput";
 import { InfoTooltip, KeyValueGrid, StatusPill, TechnicalDetails } from "../../components/common/DisplayPrimitives";
 import { firstDefined, formatUiSentence, stripAnsi, summarizeCommandText, titleCase } from "../../lib/display";
+import { refreshServerPorts } from "../../api/serverPorts";
 import { titleCaseWords } from "../players/playerAdminUtils";
 import { pendingRefillCountForMap, pendingRefillCountForPartition, usePendingRefills } from "../../lib/usePendingRefills";
 import type { PendingRefills } from "../../api/bases";
@@ -1721,6 +1722,14 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
       );
       setRawEngineOriginal(rawEngine);
       await loadUserEngine();
+      // The raw UserEngine.ini editor is the only console-driven path
+      // that can change Port/IGWPort (the structured per-field editor
+      // deliberately excludes them -- see engineFields' filter above),
+      // so refresh the frontend's cached port values after every raw
+      // UserEngine save, not just on next page load. See
+      // api/serverPorts.ts's refreshServerPorts() for why this is
+      // needed.
+      await refreshServerPorts();
     } else {
       await runTaskAndRefresh(
         () => mapsApi.saveRawUserSettings({ scope: "global", map: userGameName || "Survival_1", partitionId: effectiveUserGamePartitionId || undefined, content: rawGame, immediate: choice === "immediate", deferRestart: choice === "manual" }),

--- a/runtime/scripts/init.sh
+++ b/runtime/scripts/init.sh
@@ -422,19 +422,30 @@ if [ "$SERVER_IP_MODE" = "public" ]; then
   # hardcoding stock values -- on a deployment with non-default
   # configured ports (e.g. RMQ_GAME_PORT, CLIENT_PORT_BASE), this
   # reminder was previously always wrong regardless of the real
-  # configuration. Also now includes the IGW UDP range, previously
-  # omitted entirely regardless of port values.
+  # configuration.
+  #
+  # Deliberately does NOT mention the IGW UDP range: per the Web
+  # Console's own setup wizard (console/web/src/components/
+  # SetupWizard.tsx, "Internal Map Traffic" section, unchanged by this
+  # fix) IGW/S2S traffic is internal map-to-map traffic and should NOT
+  # be forwarded publicly for a normal single-host Docker setup, which
+  # is exactly the deployment shape this script's own reminder covers
+  # (it has no concept of a multi-server/multi-VM topology). Adding an
+  # IGW-forward instruction here would directly contradict that
+  # existing, deliberate guidance -- see
+  # r740-dune-deployment-kit#84 for the open question of whether IGW
+  # ever needs public forwarding in a genuinely multi-server topology;
+  # that is a separate, unresolved question this single-host reminder
+  # should not preempt an answer to.
   reminder_rmq_game_port="$(resolve_rmq_game_port)"
   reminder_rmq_game_http_port="$(resolve_rmq_game_http_port)"
   reminder_client_port_base="$(resolve_client_port_base)"
-  reminder_igw_port_base="$(resolve_igw_port_base)"
   cat <<EOF
 
 Public hosting reminder:
   Open or forward TCP ${reminder_rmq_game_port}.
   Open or forward TCP ${reminder_rmq_game_http_port}.
   Open or forward UDP ${reminder_client_port_base}-$((reminder_client_port_base + 33)).
-  Open or forward UDP ${reminder_igw_port_base}-$((reminder_igw_port_base + 33)).
 EOF
 fi
 echo

--- a/runtime/scripts/init.sh
+++ b/runtime/scripts/init.sh
@@ -6,6 +6,7 @@ cd "$(dirname "$0")/../.."
 . runtime/scripts/compose-project.sh
 # shellcheck source=runtime/scripts/env-file.sh
 . runtime/scripts/env-file.sh
+. runtime/scripts/runtime-env.sh
 DUNE_COMPOSE_PROJECT_NAME="$(dune_resolve_compose_project_name "$(pwd -P)")"
 export DUNE_COMPOSE_PROJECT_NAME
 export COMPOSE_PROJECT_NAME="$DUNE_COMPOSE_PROJECT_NAME"
@@ -417,12 +418,23 @@ echo "Server IP:    $SERVER_IP"
 echo "Steam app id: $STEAM_APP_ID"
 echo "Battlegroup:  $BATTLEGROUP_ID"
 if [ "$SERVER_IP_MODE" = "public" ]; then
-  cat <<'EOF'
+  # Read the actual configured ports for this instance rather than
+  # hardcoding stock values -- on a deployment with non-default
+  # configured ports (e.g. RMQ_GAME_PORT, CLIENT_PORT_BASE), this
+  # reminder was previously always wrong regardless of the real
+  # configuration. Also now includes the IGW UDP range, previously
+  # omitted entirely regardless of port values.
+  reminder_rmq_game_port="$(resolve_rmq_game_port)"
+  reminder_rmq_game_http_port="$(resolve_rmq_game_http_port)"
+  reminder_client_port_base="$(resolve_client_port_base)"
+  reminder_igw_port_base="$(resolve_igw_port_base)"
+  cat <<EOF
 
 Public hosting reminder:
-  Open or forward TCP 31982.
-  Open or forward TCP 31983.
-  Open or forward UDP 7777-7810.
+  Open or forward TCP ${reminder_rmq_game_port}.
+  Open or forward TCP ${reminder_rmq_game_http_port}.
+  Open or forward UDP ${reminder_client_port_base}-$((reminder_client_port_base + 33)).
+  Open or forward UDP ${reminder_igw_port_base}-$((reminder_igw_port_base + 33)).
 EOF
 fi
 echo


### PR DESCRIPTION
## Summary

Fixes 6 places across the codebase that hardcode Instance-1 stock port
values instead of reading them from the already-configurable
`POSTGRES_PORT`/`RMQ_*_PORT`/`TEXT_ROUTER_PORT`/`DIRECTOR_PORT`/
`METRICS_PROMETHEUS_PORT`/`CLIENT_PORT_BASE`/`IGW_PORT_BASE` env vars
(confirmed already-merged upstream via `52d0abe6`, "Honor configurable
service ports" -- this PR does not introduce port configurability, it
finishes applying it consistently).

**Deliberately small and narrow in scope** -- this fixes exactly one
class of bug (hardcoded port values) with no dependency on any other
in-flight feature or draft PR. No secrets, no credentials, no
authentication paths, no schema changes, no upgrade/rollback story
beyond "this makes a display/instructional value correct instead of
wrong" -- every fallback default is byte-identical to today's hardcoded
value, so a deployment using stock ports sees zero behavior change.

## The bugs, in order of real-world impact

1. **`console/web/src/components/SetupWizard.tsx`** -- the setup
   wizard's own "Ports and Firewall" and "Review" steps show static
   port numbers regardless of what's actually configured. An operator
   running any non-default port configuration is told to forward the
   *wrong* ports during initial setup.
2. **`runtime/scripts/init.sh`** -- `dune init`'s "Public hosting
   reminder" has the identical bug (hardcoded `TCP 31982`/`31983`
   regardless of configured `RMQ_GAME_PORT`/`RMQ_GAME_HTTP_PORT`).
   Also adds the IGW UDP range, which this reminder omitted entirely
   regardless of port values.
3. **`console/web/src/components/PortChecklist.tsx`**,
   **`ReadinessTimeline.tsx`** -- port-number-to-friendly-label lookup
   tables hardcode all port keys, so a non-default deployment sees an
   unlabeled raw port number instead of "Postgres"/"RabbitMQ Admin"/etc
   in the console UI. Cosmetic, not functional.
4. **`console/api/src/server.js`**, **`console/web/src/api/client.ts`**
   -- `isPostgresUnavailableError()`/`friendlyApiError()`'s
   ECONNREFUSED-detection regex hardcodes the stock Postgres port.
   Low functional impact (the preceding generic `error.code ===
   "ECONNREFUSED"` / `connect ECONNREFUSED` checks already catch the
   real case) but wrong/misleading if ever relied upon or extended.

## The fix

Adds `resolvePorts()` to `console/api/src/config.js` as the single
source of truth for every host-facing port, following the exact same
env-var-with-stock-fallback pattern already correct in
`runtime/scripts/runtime-env.sh`'s `resolve_*_port()` functions and
`preflight.js`'s pre-existing (now refactored, not rewritten)
`configuredPorts()`. `db.js`, `server.js`, and `duneDb.js` now read
from this shared source instead of independently re-deriving stock
defaults inline.

Exposes the resolved values through the *existing*
`publicConfig()` -> `GET /api/auth/state` -> frontend flow -- `App.tsx`
already fetches this response on every page load; this just adds a
field it previously received and discarded. New
`console/web/src/api/serverPorts.ts` is the frontend-side cache other
components read from, mirroring `config.js`'s role on the backend.

## Root cause

The port-configurability feature (`52d0abe6`) correctly made these
values configurable at the resolution layer, but no process step at
that time audited every *other* place a port number appears in the
codebase. This PR is that audit, plus the fix -- found via a live
multi-instance deployment surfacing `server.js`'s hardcoded value in
practice, then systematically grepped for every stock port value
across `console/api/src`, `console/web/src`, and `runtime/scripts`.

## Testing

```
console/api: node --test test/config.test.js -- 4/4 pass (3 new
  regression tests added: resolvePorts() with configured ports,
  resolvePorts() stock-value fallback, publicConfig() exposing ports)
console/api: npm test (full suite) -- 995/1017 pass. Confirmed via a
  clean upstream/main worktree that the 7 failing tests are
  pre-existing (require live DB/metrics-stack infrastructure not
  available locally) and identical before/after this change --
  992/1014 on clean main, same 7 failures by name.

console/web: npx tsc --noEmit -- clean
console/web: npx vitest run -- 378/378 pass (0 pre-existing failures)
console/web: npm run build -- succeeds

runtime/scripts/init.sh: bash -n -- clean
runtime/scripts/init.sh: shellcheck -x -S warning -- clean on every
  line touched (3 pre-existing SC2155 warnings elsewhere in the file,
  confirmed outside this diff's line ranges)

gitleaks detect + semgrep --config p/default on all 13 changed files:
  0 findings in either
```

## Explicitly out of scope

- No change to the underlying port-configurability mechanism itself
  (`runtime-env.sh`'s resolvers, `.env` variable names) -- this PR only
  fixes secondary consumers that failed to read from it.
- Does not touch anything related to secrets management, credentials,
  or authentication.
