### PR TITLE
Add base deletion, and console awareness of the game's base-backup tool

### DIFF
--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -376,6 +376,26 @@ export const REGEX_ACTIONS_BY_METHOD = {
   "PATCH /api/database/tables/": "database:mutate",
 };
 
+// ---- Parameterized route actions (regex, not prefix) ----
+//
+// REGEX_ACTIONS_BY_METHOD only tests a startsWith prefix, which cannot tell
+// "/api/bases/{id}" (the base itself) apart from "/api/bases/{id}/queued-
+// delete" (a sub-resource under it) — both start with the same
+// "/api/bases/" prefix, since the variable segment comes before, not after,
+// the part that would distinguish them. Routes that need that distinction
+// go here instead, tested as a real regex before the prefix fallback.
+export const REGEX_ACTIONS_BY_METHOD_PATTERN = [
+  // DELETE /api/bases/{baseId} — the actual, irreversible base delete.
+  // Deliberately its own action rather than the shared bases:mutate bucket
+  // every other base mutation uses (refills, permission edits, cancelling
+  // a queued refill/delete) — those are all reversible; this is not, so an
+  // operator's policy should be able to grant one without the other. Every
+  // other bases DELETE route (queued-refill, queued-water-refill, queued-
+  // delete — all cancellations) still falls through to the
+  // "DELETE /api/bases/" prefix rule above, unaffected.
+  { method: "DELETE", pattern: /^\/api\/bases\/[^/]+$/, action: "bases:delete" }
+];
+
 // ---- Action resolution ----
 //
 // Returns the action string for a given route path and HTTP method.
@@ -388,6 +408,13 @@ export function actionForRoute(path, method) {
 
   // Exact match
   if (ROUTE_ACTIONS.hasOwnProperty(exactKey)) return ROUTE_ACTIONS[exactKey];
+
+  // Parameterized pattern match (checked before the prefix fallback below,
+  // so a route needing a real regex to distinguish itself from a sibling
+  // sub-resource wins over the coarser startsWith bucket).
+  for (const { method: m, pattern, action } of REGEX_ACTIONS_BY_METHOD_PATTERN) {
+    if (routeMethod === m && pattern.test(path)) return action;
+  }
 
   // Method-aware regex match (ordered first — more specific)
   for (const [key, action] of Object.entries(REGEX_ACTIONS_BY_METHOD)) {

--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -182,6 +182,7 @@ export const ROUTE_ACTIONS = {
   "GET /api/bases/pending-water-refills":      "bases:read",
   "GET /api/bases/auto-refill-water":          "bases:read",
   "GET /api/bases/permission-candidates":      "bases:read",
+  "GET /api/bases/pending-deletes":            "bases:read",
 
   // --- Storage (read) ---
   "GET /api/storage":                          "storage:read",

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3609,13 +3609,28 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
   const requiredTables = ["buildings", "building_instances", "actor_fgl_entities", "actors"];
   // One round-trip each and none of them depends on another, so probe them
   // together rather than five times in series before any real work starts.
-  const [required, hasWorldPartition] = await Promise.all([
+  const [required, hasWorldPartition, hasBaseBackups] = await Promise.all([
     Promise.all(requiredTables.map((table) => tableExists(db, table))),
-    tableExists(db, "world_partition")
+    tableExists(db, "world_partition"),
+    tableExists(db, "base_backup_linked_actors")
   ]);
   if (required.some((exists) => !exists)) {
     return { ...unsupported("bases", requiredTables.map((t) => `dune.${t}`)), totalCount: 0, totalBases: 0, totalPieces: 0, totalPlaceables: 0 };
   }
+  // The base-backup tool ("pick up base") does not move or delete any of a
+  // base's rows -- it only deletes permission_actor/permission_actor_rank
+  // (unclaiming it) and registers its actor ids in base_backup_linked_actors
+  // so it can be redeployed later. Left un-filtered, a picked-up base still
+  // has every buildings/building_instances/placeables row intact and would
+  // show up here as an ordinary, ownerless base. Both signals are required
+  // -- unclaimed AND backup-linked -- rather than either alone: "unclaimed"
+  // by itself would also hide a base that legitimately has no owner for some
+  // other reason, and "backup-linked" by itself would hide a base again once
+  // redeployed if the game doesn't clean up old linked-actor rows on redeploy
+  // (unconfirmed either way). A base satisfying both is unambiguous.
+  const backupExclusion = hasBaseBackups
+    ? "and not (pa.actor_id is null and exists (select 1 from dune.base_backup_linked_actors bbla where bbla.actor_id = a.id))"
+    : "";
   // A base's own a.map is the game's map name ("HaggaBasin"), which cannot tell
   // two instances of it apart. world_partition resolves the partition to the
   // name the rest of the console uses ("Survival_1") plus its dimension --
@@ -3708,6 +3723,7 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
         left join dune.permission_actor pa on pa.actor_id = a.id
         ${matchedOwnerJoin}
         where a.transform is not null
+        ${backupExclusion}
         group by a.id, a.class, pa.actor_name, ${matchedGroupByOwner}a.map, a.partition_id, a.transform
         ${having}
       ),
@@ -3754,7 +3770,9 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
         join dune.building_instances bi on bi.building_id = b.id
         join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
         join dune.actors a on a.id = afe.actor_id
+        left join dune.permission_actor pa on pa.actor_id = a.id
         where a.transform is not null
+        ${backupExclusion}
       )
       select (select count(*) from valid_claims)::int as total_bases,
              (select count(*) from dune.building_instances bi join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id join valid_claims vc on vc.actor_id = afe.actor_id)::int as total_pieces,

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3221,6 +3221,31 @@ export async function basePermissionActor(db, baseId) {
   };
 }
 
+// The base-backup tool ("pick up base") only deletes permission_actor/
+// permission_actor_rank and registers the base's actor ids in
+// base_backup_linked_actors -- see listBases' matching exclusion. That keeps
+// a picked-up base out of the panel, but a caller hitting a route directly
+// (or a stale bookmarked base id) would otherwise still be able to mutate
+// it. Every mutation route checks this before writing, the same way each
+// already checks the pending-delete lock.
+export async function baseIsBackedUp(db, baseId) {
+  const target = intParam(baseId, "base id", 1);
+  if (!(await tableExists(db, "base_backup_linked_actors"))) return false;
+  const result = await db.query(`
+    select exists (
+      select 1
+      from dune.buildings b
+      join dune.building_instances bi on bi.building_id = b.id
+      join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+      join dune.actors a on a.id = afe.actor_id
+      left join dune.permission_actor pa on pa.actor_id = a.id
+      where b.id = $1
+        and pa.actor_id is null
+        and exists (select 1 from dune.base_backup_linked_actors bbla where bbla.actor_id = a.id)
+    ) as backed_up`, [target]);
+  return Boolean(result.rows[0]?.backed_up);
+}
+
 // permission_actor_rank.player_id is a player's player_controller_id, not just
 // any actors row belonging to their account -- one account holds several. The
 // shipped permission_actor_create_or_update_base_marker joins

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3789,22 +3789,24 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
     // columns the generator capability check requires, so reusing that check
     // would wrongly hide Refill Water on a schema that has everything water
     // actually needs.
-    const [generatorRefill, basePermissions, waterRefill] = await Promise.all([
+    const [generatorRefill, basePermissions, waterRefill, baseDelete] = await Promise.all([
       supportsGeneratorRefill(db).catch(() => false),
       supportsBasePermissionEditing(db).catch(() => false),
-      supportsWaterRefill(db).catch(() => false)
+      supportsWaterRefill(db).catch(() => false),
+      supportsBaseDelete(db).catch(() => false)
     ]);
     // Without world_partition the console cannot tell a running map from a
-    // stopped one, so the panel hides the queue entirely and refills stay
-    // immediate. Each check reuses the flag just computed above instead of
-    // re-deriving it, and both run concurrently for the same reason as above.
-    const [generatorRefillQueue, waterRefillQueue] = await Promise.all([
+    // stopped one, so the panel hides the queue entirely and refills/deletes
+    // stay immediate. Each check reuses the flag just computed above instead
+    // of re-deriving it, and all run concurrently for the same reason as above.
+    const [generatorRefillQueue, waterRefillQueue, baseDeleteQueue] = await Promise.all([
       generatorRefill ? supportsGeneratorRefillQueue(db, { generatorRefill }).catch(() => false) : Promise.resolve(false),
-      waterRefill ? supportsWaterRefillQueue(db, { waterRefill }).catch(() => false) : Promise.resolve(false)
+      waterRefill ? supportsWaterRefillQueue(db, { waterRefill }).catch(() => false) : Promise.resolve(false),
+      baseDelete ? supportsBaseDeleteQueue(db, { baseDelete }).catch(() => false) : Promise.resolve(false)
     ]);
 
     return {
-      capabilities: { bases: true, generatorRefill, generatorRefillQueue, basePermissions, waterRefill, waterRefillQueue },
+      capabilities: { bases: true, generatorRefill, generatorRefillQueue, basePermissions, waterRefill, waterRefillQueue, baseDelete, baseDeleteQueue },
       totalCount: result.rows[0] ? Number(result.rows[0].total_count) : 0,
       totalBases: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_bases) : 0,
       totalPieces: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_pieces) : 0,
@@ -3843,6 +3845,108 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
 
 function quaternionYawDegrees(qz, qw) {
   return (2 * Math.atan2(Number(qz) || 0, Number(qw) || 0)) * (180 / Math.PI);
+}
+
+// Gates base deletion the same way supportsBasePermissionEditing gates
+// permission edits. This repo has no migrations directory and never issues
+// CREATE FUNCTION anywhere (every write path composes the game's own shipped
+// procedures), so a self-hosted server missing these tables/functions cannot
+// have a delete proc added for it -- it is simply unsupported.
+async function supportsBaseDelete(db) {
+  for (const table of ["buildings", "building_instances", "actor_fgl_entities", "placeables", "actors"]) {
+    if (!(await tableExists(db, table))) return false;
+  }
+  return await functionExists(db, "dune.permission_actor_destroy(bigint)")
+    && await functionExists(db, "dune.delete_actors(bigint[])");
+}
+
+// Mirrors supportsGeneratorRefillQueue: without dune.world_partition there is
+// no way to tell a running map from a stopped one, so the panel hides the
+// queue and deletes stay immediate rather than offering a control that
+// silently risks a live server resurrecting the deleted rows.
+export async function supportsBaseDeleteQueue(db, { baseDelete } = {}) {
+  const supported = baseDelete !== undefined ? baseDelete : await supportsBaseDelete(db);
+  if (!supported) return false;
+  return tableExists(db, "world_partition");
+}
+
+// Every dune.actors row a full base delete must remove: the claim actor
+// itself, every building's actor id (dune.buildings.id IS an actors.id, the
+// same fact exportBaseAsBlueprint's piece query below relies on), and every
+// placeable's actor id via its own owner_entity_id chain -- a separate FK
+// path from building_instances', so it needs its own query. Deleting this
+// full set is what lets the declared ON DELETE CASCADE foreign keys clean up
+// buildings/building_instances/placeables/inventories/items on their own.
+async function baseDeletionActorIds(db, baseId) {
+  const actor = await basePermissionActor(db, baseId);
+  const buildingRows = await db.query(`
+    select distinct bi.building_id
+    from dune.building_instances bi
+    join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+    where afe.actor_id = $1::bigint`, [actor.actorId]);
+  const placeableRows = await db.query(`
+    select distinct p.id
+    from dune.placeables p
+    join dune.actor_fgl_entities afe on afe.entity_id = p.owner_entity_id
+    where afe.actor_id = $1::bigint`, [actor.actorId]);
+  const ids = new Set([
+    actor.actorId,
+    ...buildingRows.rows.map((row) => String(row.building_id)),
+    ...placeableRows.rows.map((row) => String(row.id))
+  ]);
+  return {
+    actor,
+    actorIds: [...ids],
+    buildingCount: buildingRows.rowCount,
+    placeableCount: placeableRows.rowCount
+  };
+}
+
+// Permanently deletes a base and everything on it. A destructive, irreversible
+// operation, so every statement here must succeed together or not at all --
+// db.transaction already rolls back on any thrown error (see db.js), so this
+// is a straightforward wrap rather than new plumbing, made an explicit,
+// tested guarantee here because unlike most callers of db.transaction, a
+// partial failure of this one cannot be retried against player-recoverable
+// state. The caller (server.js) is responsible for the mandatory pre-delete
+// safety backup -- kept out of this file, which never shells out to the
+// `dune` CLI the way runner.js's backupCreate does.
+export async function deleteBaseCompletely(db, baseId) {
+  await requireCapability(await supportsBaseDelete(db),
+    "Base deletion requires dune.buildings, building_instances, actor_fgl_entities, placeables, actors, and the dune.permission_actor_destroy(bigint)/delete_actors(bigint[]) functions.");
+  const target = intParam(baseId, "base id", 1);
+  return db.transaction(async (tx) => {
+    await tx.query("set local search_path to dune, public");
+    // Re-enumerated inside the transaction, not reused from an earlier
+    // read: never trust a snapshot from when the confirm dialog opened or
+    // the delete was queued, the same discipline the refill queue already
+    // applies to amounts.
+    const { actor, actorIds, buildingCount, placeableCount } = await baseDeletionActorIds(tx, target);
+    // Lock the claim actor row, not a maybe-empty child row -- same reasoning
+    // as mutateBasePermissions: it is guaranteed to exist, and `for update`
+    // over zero rows would serialize nothing.
+    const locked = await tx.query("select id from dune.actors where id = $1::bigint for update", [actor.actorId]);
+    if (!locked.rowCount) throw new Error("That base was not found.");
+    // permission_actor_destroy first: it is the only thing that clears
+    // markers/player_markers, which are keyed on the claim actor id but not
+    // FK-cascaded from actors (only from map_names). Its permission_actor/
+    // permission_actor_rank deletes are redundant with the cascade that
+    // follows, but a DELETE matching zero rows is a harmless no-op.
+    await tx.query("select dune.permission_actor_destroy($1::bigint)", [actor.actorId]);
+    // Cascades away buildings, building_instances, placeables, inventories,
+    // and items via their declared ON DELETE CASCADE foreign keys.
+    await tx.query("select dune.delete_actors($1::bigint[])", [actorIds]);
+    return {
+      ok: true,
+      baseId: target,
+      actorId: actor.actorId,
+      map: actor.map,
+      partitionId: actor.partitionId,
+      deletedActorCount: actorIds.length,
+      deletedBuildingCount: buildingCount,
+      deletedPlaceableCount: placeableCount
+    };
+  });
 }
 
 export async function exportBaseAsBlueprint(db, id) {
@@ -6694,6 +6798,187 @@ function reconcileQueuedGeneratorRefills(repoRoot, outcomes) {
     if (outcome.keep) next.push({ ...entry, attempts: outcome.attempts, nextRetryAt: outcome.nextRetryAt, lastError: outcome.lastError });
   }
   writeQueuedGeneratorRefills(repoRoot, next);
+  return next;
+}
+
+// ---------------------------------------------------------------------------
+// Base deletion
+//
+// Permanently removes a base and everything on it. Like a refill, a delete
+// aimed at a live map's rows can be silently overwritten the next time that
+// map flushes its own state back to Postgres, so this reuses the exact same
+// pending-queue/write-safety machinery as the generator refill queue above --
+// see baseRefillTarget, observeRefillPartitions, partitionWriteSafe,
+// isTransientFlushError. It diverges from that queue in two ways, both noted
+// where they happen: a vanished base is success, not a retryable failure, and
+// the mandatory pre-delete safety backup is the caller's responsibility (kept
+// out of this file -- it shells out to the `dune` CLI, which duneDb.js never
+// does; see flushBaseDeletes's onBeforeApply and server.js's baseDeleteRoute).
+
+const PENDING_BASE_DELETE_PATH = "runtime/generated/pending-base-deletes.json";
+// Lower than MAX_PENDING_REFILLS: a large backlog of pending deletes is
+// itself a signal worth surfacing early, not silently absorbing.
+const MAX_PENDING_BASE_DELETES = 200;
+const MAX_DELETE_FLUSH_ATTEMPTS = 3;
+
+function pendingBaseDeleteMaxAgeMs() {
+  return clampInt(process.env.ADMIN_BASE_DELETE_MAX_AGE_MS, 7 * 24 * 60 * 60 * 1000, 1, Number.MAX_SAFE_INTEGER);
+}
+function pendingBaseDeleteRetryDelayMs() {
+  return clampInt(process.env.ADMIN_BASE_DELETE_RETRY_DELAY_MS, 60000, 1, Number.MAX_SAFE_INTEGER);
+}
+
+function pendingBaseDeleteFile(repoRoot) {
+  return resolve(repoRoot || "", PENDING_BASE_DELETE_PATH);
+}
+
+// Intent only, like normalizePendingRefill -- no captured actor-id list, so
+// flushBaseDeletes re-enumerates fresh at flush time rather than trusting
+// what existed when the delete was requested.
+function normalizePendingBaseDelete(entry) {
+  const baseId = Math.floor(Number(entry?.baseId));
+  if (!Number.isInteger(baseId) || baseId < 1) return null;
+  const partitionId = Math.floor(Number(entry?.partitionId));
+  return {
+    baseId,
+    map: String(entry?.map ?? "").slice(0, 120),
+    partitionId: Number.isInteger(partitionId) && partitionId > 0 ? partitionId : 0,
+    queuedAt: typeof entry?.queuedAt === "string" ? entry.queuedAt.slice(0, 40) : "",
+    attempts: clampInt(entry?.attempts, 0, 0, MAX_DELETE_FLUSH_ATTEMPTS),
+    nextRetryAt: Number.isFinite(Number(entry?.nextRetryAt)) ? Number(entry.nextRetryAt) : 0,
+    lastError: String(entry?.lastError ?? "").slice(0, 300)
+  };
+}
+
+export function listQueuedBaseDeletes(repoRoot) {
+  const file = pendingBaseDeleteFile(repoRoot);
+  if (!existsSync(file)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    if (!Array.isArray(parsed)) return [];
+    // One entry per base, so a double-clicked button cannot queue it twice.
+    const seen = new Set();
+    return parsed.map(normalizePendingBaseDelete).filter((entry) => {
+      if (!entry || seen.has(entry.baseId)) return false;
+      seen.add(entry.baseId);
+      return true;
+    });
+  } catch (error) {
+    console.warn(`Ignoring unreadable pending base delete queue: ${redact(error?.message || "Unexpected error.")}`);
+    return [];
+  }
+}
+
+// Deliberately synchronous read-modify-write, matching writeQueuedGeneratorRefills.
+function writeQueuedBaseDeletes(repoRoot, entries) {
+  writeJsonAtomic(pendingBaseDeleteFile(repoRoot), entries);
+  return entries;
+}
+
+export function queueBaseDelete(repoRoot, { baseId, map = "", partitionId = 0, now = () => new Date() } = {}) {
+  const entry = normalizePendingBaseDelete({ baseId, map, partitionId, queuedAt: now().toISOString() });
+  if (!entry) throw new Error("Invalid base id");
+  const others = listQueuedBaseDeletes(repoRoot).filter((row) => row.baseId !== entry.baseId);
+  if (others.length >= MAX_PENDING_BASE_DELETES) {
+    throw new Error(`The pending delete queue already holds ${MAX_PENDING_BASE_DELETES} bases. Restart the affected maps to apply them first.`);
+  }
+  writeQueuedBaseDeletes(repoRoot, [...others, entry]);
+  return entry;
+}
+
+export function cancelQueuedBaseDelete(repoRoot, baseId) {
+  const target = intParam(baseId, "base id", 1);
+  const entries = listQueuedBaseDeletes(repoRoot);
+  const remaining = entries.filter((entry) => entry.baseId !== target);
+  if (remaining.length === entries.length) throw new Error("That base has no queued delete.");
+  writeQueuedBaseDeletes(repoRoot, remaining);
+  return { ok: true, baseId: target, pending: remaining.length };
+}
+
+// basePermissionActor and baseMapLocation both throw one of these two
+// messages for a base that was demolished or never existed, so a flush
+// hitting either has already achieved what the queued delete wanted.
+// Retrying would either spam a false failure or, worse, wait out the attempt
+// limit before dropping an entry that was already done.
+function baseDeleteAlreadyGone(message) {
+  return /was not found|no resolvable owner entity/i.test(message);
+}
+
+// Mirrors flushGeneratorRefills, with two divergences:
+//   - deleteBaseCompletely replaces refillBaseGenerators, since there is
+//     nothing to recompute an "amount" for -- one delete, not a top-up;
+//   - onBeforeApply runs at most once per pass, immediately before the first
+//     entry that is actually about to be deleted (not merely queued): a full
+//     database backup is not cheap, and several bases can flush in the same
+//     pass (e.g. a whole battlegroup restart), so one backup covers the whole
+//     batch instead of one per base. If it throws, the entire pass aborts --
+//     a failed safety backup is not about any one base, and deleting others
+//     without it would defeat the point just the same. Every entry stays
+//     queued and is retried, backup included, on the next tick.
+export async function flushBaseDeletes(db, repoRoot, { now = Date.now, onBeforeApply } = {}) {
+  const pending = listQueuedBaseDeletes(repoRoot);
+  if (!pending.length) return { flushed: [], pending: 0 };
+  const observed = await observeRefillPartitions(db, { now });
+  if (!observed) return { flushed: [], pending: pending.length, unsupported: true };
+
+  const flushed = [];
+  const outcomes = new Map();
+  const timestamp = now();
+  let backedUp = false;
+  for (const entry of pending) {
+    // Age is checked before write-safety: an expired entry should be cleared
+    // even for a map that never comes down again.
+    const queuedMs = Date.parse(entry.queuedAt);
+    if (Number.isFinite(queuedMs) && timestamp - queuedMs >= pendingBaseDeleteMaxAgeMs()) {
+      const message = `Queued for longer than the ${Math.round(pendingBaseDeleteMaxAgeMs() / 3600000)}h limit without being applied.`;
+      outcomes.set(entry.baseId, { queuedAt: entry.queuedAt, keep: false });
+      flushed.push({ baseId: entry.baseId, map: entry.map, partitionId: entry.partitionId, ok: false, expired: true, dropped: true, error: message });
+      continue;
+    }
+    if (!partitionWriteSafe(observed, entry.partitionId)) continue;
+    if (entry.nextRetryAt && timestamp < entry.nextRetryAt) continue;
+    if (!backedUp && onBeforeApply) {
+      try {
+        await onBeforeApply();
+        backedUp = true;
+      } catch (error) {
+        return { flushed: [], pending: pending.length, backupFailed: true, error: String(error?.message || "Unexpected error.").slice(0, 300) };
+      }
+    }
+    try {
+      const result = await deleteBaseCompletely(db, entry.baseId);
+      outcomes.set(entry.baseId, { queuedAt: entry.queuedAt, keep: false });
+      flushed.push({ baseId: entry.baseId, map: entry.map, partitionId: entry.partitionId, ok: true, ...result });
+    } catch (error) {
+      const message = String(error?.message || "Unexpected error.").slice(0, 300);
+      if (baseDeleteAlreadyGone(message)) {
+        outcomes.set(entry.baseId, { queuedAt: entry.queuedAt, keep: false });
+        flushed.push({ baseId: entry.baseId, map: entry.map, partitionId: entry.partitionId, ok: true, alreadyGone: true });
+        continue;
+      }
+      const attempts = isTransientFlushError(message) ? entry.attempts : entry.attempts + 1;
+      const dropped = attempts >= MAX_DELETE_FLUSH_ATTEMPTS;
+      const nextRetryAt = timestamp + pendingBaseDeleteRetryDelayMs();
+      outcomes.set(entry.baseId, { queuedAt: entry.queuedAt, keep: !dropped, attempts, nextRetryAt, lastError: message });
+      flushed.push({ baseId: entry.baseId, map: entry.map, partitionId: entry.partitionId, ok: false, attempts, dropped, error: message });
+    }
+  }
+  const remaining = outcomes.size ? reconcileQueuedBaseDeletes(repoRoot, outcomes) : pending;
+  return { flushed, pending: remaining.length };
+}
+
+// Mirrors reconcileQueuedGeneratorRefills.
+function reconcileQueuedBaseDeletes(repoRoot, outcomes) {
+  const next = [];
+  for (const entry of listQueuedBaseDeletes(repoRoot)) {
+    const outcome = outcomes.get(entry.baseId);
+    if (!outcome || outcome.queuedAt !== entry.queuedAt) {
+      next.push(entry);
+      continue;
+    }
+    if (outcome.keep) next.push({ ...entry, attempts: outcome.attempts, nextRetryAt: outcome.nextRetryAt, lastError: outcome.lastError });
+  }
+  writeQueuedBaseDeletes(repoRoot, next);
   return next;
 }
 

--- a/console/api/src/httpSafety.js
+++ b/console/api/src/httpSafety.js
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 
 export async function readJsonBody(req, maxBytes) {
   const chunks = [];
@@ -77,6 +77,15 @@ export function safeStaticTarget(staticDir, requestPath) {
   const normalizedPath = requestPath === "/" ? "/index.html" : requestPath;
   const file = resolve(dist, `.${normalizedPath}`);
   const fallback = resolve(dist, "index.html");
-  const safeFile = file.startsWith(`${dist}/`) ? file : fallback;
+  // path.relative, not a `${dist}/` string prefix: the prefix check always
+  // failed on Windows, where resolve() joins with backslashes, so every
+  // asset request silently fell back to index.html outside a Linux
+  // container. relative() is also the more correct traversal check in
+  // general -- a prefix match alone would wrongly accept a sibling
+  // directory that merely starts with the same characters (e.g. "dist-evil"
+  // under a dist without a prefix check's needed trailing separator).
+  const rel = relative(dist, file);
+  const contained = rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+  const safeFile = contained ? file : fallback;
   return existsSync(safeFile) ? safeFile : fallback;
 }

--- a/console/api/src/httpSafety.js
+++ b/console/api/src/httpSafety.js
@@ -1,5 +1,13 @@
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
+
+function existsAsFile(path) {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
 
 export async function readJsonBody(req, maxBytes) {
   const chunks = [];
@@ -87,5 +95,10 @@ export function safeStaticTarget(staticDir, requestPath) {
   const rel = relative(dist, file);
   const contained = rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
   const safeFile = contained ? file : fallback;
-  return existsSync(safeFile) ? safeFile : fallback;
+  // existsSync alone accepts a directory too (e.g. requestPath "/." resolves
+  // rel to "", which reads as "contained" -- dist itself, a directory, not a
+  // file). serveStatic streams the result with createReadStream().pipe(),
+  // which throws an unhandled EISDIR for a directory target, so this must
+  // require a real file, not merely something on disk at that path.
+  return existsAsFile(safeFile) ? safeFile : fallback;
 }

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -2712,26 +2712,43 @@ async function baseDeleteRoute(req, res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
   return directDbMutation(req, res, "bases.delete", "DELETE BASE", async () => {
-    const target = await duneDb.baseRefillTarget(db, baseId);
-    // Same hazard as a refill: a live game server can rewrite its own copy of
-    // this base back to Postgres before the delete is ever seen. Queue it
-    // instead and let the flush tick apply it once that map is down.
-    if (target.queueSupported && !target.writeSafeNow) {
-      cancelPendingRefillsForBase(baseId);
-      const entry = duneDb.queueBaseDelete(config.repoRoot, {
-        baseId,
-        map: target.map,
-        partitionId: target.partitionId
-      });
-      return { ok: true, queued: true, ...entry };
+    // Reserve the lock synchronously, before the first await: baseDeletePending
+    // is a file read, and every other mutation route checks it before doing
+    // any of its own work, so a request for this same base landing between
+    // "resolve write-safety" and "record the queue entry" below would
+    // otherwise read the queue as empty and slip through. This placeholder
+    // (map/partitionId unresolved yet) closes that gap immediately; it is
+    // either replaced with the real entry (queued path) or removed in the
+    // finally below (immediate path, success or failure).
+    duneDb.queueBaseDelete(config.repoRoot, { baseId, map: "", partitionId: 0 });
+    let queued = false;
+    try {
+      const target = await duneDb.baseRefillTarget(db, baseId);
+      // Same hazard as a refill: a live game server can rewrite its own copy
+      // of this base back to Postgres before the delete is ever seen. Queue
+      // it instead and let the flush tick apply it once that map is down.
+      if (target.queueSupported && !target.writeSafeNow) {
+        cancelPendingRefillsForBase(baseId);
+        const entry = duneDb.queueBaseDelete(config.repoRoot, {
+          baseId,
+          map: target.map,
+          partitionId: target.partitionId
+        });
+        queued = true;
+        return { ok: true, queued: true, ...entry };
+      }
+      // Mandatory safety backup before any delete SQL runs, exactly like the
+      // raw "Database Query" tool already does for any destructive query --
+      // see databaseQuery below. If this throws, deleteBaseCompletely is
+      // never called and nothing is touched.
+      await runDune(config, buildDuneArgs("backupCreate"), { env: { DB_BACKUP_ORIGIN: "base-delete" } });
+      const result = await duneDb.deleteBaseCompletely(db, baseId);
+      return { ...result, backupCreated: true };
+    } finally {
+      if (!queued) {
+        try { duneDb.cancelQueuedBaseDelete(config.repoRoot, baseId); } catch {}
+      }
     }
-    // Mandatory safety backup before any delete SQL runs, exactly like the
-    // raw "Database Query" tool already does for any destructive query --
-    // see databaseQuery below. If this throws, deleteBaseCompletely is never
-    // called and nothing is touched.
-    await runDune(config, buildDuneArgs("backupCreate"), { env: { DB_BACKUP_ORIGIN: "base-delete" } });
-    const result = await duneDb.deleteBaseCompletely(db, baseId);
-    return { ...result, backupCreated: true };
   }, { baseId });
 }
 

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -58,6 +58,7 @@ import { calculateAlwaysOnHostMemorySafety } from "./services/hostMemorySafety.j
 import { parseEffectiveGuildMemberLimit } from "./services/guildSettings.js";
 import { parseEffectivePermissionLimit } from "./services/permissionSettings.js";
 import { flushBaseRefillQueues } from "./services/baseRefillFlush.js";
+import { verifyBaseBackupState } from "./services/baseBackupSafety.js";
 import { banPlayer, bannedFlsIds, createPlayerBanEnforcer, playerBanFor, unbanPlayer } from "./services/playerBans.js";
 import { findPlayerForLiveAction, playerIsOnlineForLiveAction } from "./playerLiveActions.js";
 
@@ -2706,7 +2707,7 @@ const BASE_DELETE_PENDING_MESSAGE = "This base has a pending delete queued and c
 // direct route call (or a stale bookmarked base id) must not be able to
 // modify it just because it slipped past the panel's own filtering.
 async function baseBackedUp(baseId) {
-  return duneDb.baseIsBackedUp(db, baseId).catch(() => false);
+  return verifyBaseBackupState(duneDb, db, baseId);
 }
 
 const BASE_BACKED_UP_MESSAGE = "This base was picked up into a backup and is no longer claimed. It cannot be modified until the player redeploys it.";

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -2700,6 +2700,17 @@ function baseDeletePending(baseId) {
 
 const BASE_DELETE_PENDING_MESSAGE = "This base has a pending delete queued and cannot be modified. Cancel the delete first.";
 
+// A backed-up base (picked up via the game's base-backup tool) is excluded
+// from listBases -- see duneDb.baseIsBackedUp -- because it has no owner and
+// its structural rows are only awaiting redeploy or eventual cleanup. A
+// direct route call (or a stale bookmarked base id) must not be able to
+// modify it just because it slipped past the panel's own filtering.
+async function baseBackedUp(baseId) {
+  return duneDb.baseIsBackedUp(db, baseId).catch(() => false);
+}
+
+const BASE_BACKED_UP_MESSAGE = "This base was picked up into a backup and is no longer claimed. It cannot be modified until the player redeploys it.";
+
 // Refilling fuel/water moments before deleting the base is pointless and
 // pollutes the audit log with writes about to be destroyed anyway. Best
 // effort: a base with nothing queued throws, which is fine to swallow here.
@@ -2711,6 +2722,7 @@ function cancelPendingRefillsForBase(baseId) {
 async function baseDeleteRoute(req, res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  if (await baseBackedUp(baseId)) return json(res, 409, { error: BASE_BACKED_UP_MESSAGE });
   return directDbMutation(req, res, "bases.delete", "DELETE BASE", async () => {
     // Reserve the lock synchronously, before the first await: baseDeletePending
     // is a file read, and every other mutation route checks it before doing
@@ -2792,6 +2804,7 @@ async function baseRefillGeneratorsRoute(req, res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
   if (baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
+  if (await baseBackedUp(baseId)) return json(res, 409, { error: BASE_BACKED_UP_MESSAGE });
   // No confirmation phrase: refilling is additive and reversible, unlike the
   // deletes and overwrites that phrase-gate. Still rate limited and audited.
   return directDbMutation(req, res, "bases.refill-generators", null, async () => {
@@ -2847,6 +2860,7 @@ async function baseSetPermissionsRoute(req, res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
   if (baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
+  if (await baseBackedUp(baseId)) return json(res, 409, { error: BASE_BACKED_UP_MESSAGE });
   return directDbMutation(req, res, "bases.set-permissions", null, async (body) => {
     const settings = await runDune(config, buildDuneArgs("userSettingsMapValues", { map: "Survival_1" }), { timeoutMs: 8000 });
     const maxPermissions = parseEffectivePermissionLimit(settings.stdout);
@@ -2858,6 +2872,7 @@ async function baseSystemCustodianRoute(req, res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
   if (baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
+  if (await baseBackedUp(baseId)) return json(res, 409, { error: BASE_BACKED_UP_MESSAGE });
   return directDbMutation(req, res, "bases.transfer-system-custodian", null, async () => {
     const settings = await runDune(config, buildDuneArgs("userSettingsMapValues", { map: "Survival_1" }), { timeoutMs: 8000 });
     const maxPermissions = parseEffectivePermissionLimit(settings.stdout);
@@ -2935,6 +2950,7 @@ async function baseAutoRefillToggleRoute(req, res, path) {
   // Only enabling is blocked -- turning auto-refill off is harmless and does
   // not race a pending delete the way a new automated write would.
   if (body.enabled && baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
+  if (body.enabled && await baseBackedUp(baseId)) return json(res, 409, { error: BASE_BACKED_UP_MESSAGE });
   // Checked on the server too, not just hidden in the UI. Without
   // dune.world_partition a queued refill cannot wait for a safe window, so an
   // automated refill would write straight into a possibly-live base.
@@ -3001,6 +3017,7 @@ async function baseRefillWaterRoute(req, res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
   if (baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
+  if (await baseBackedUp(baseId)) return json(res, 409, { error: BASE_BACKED_UP_MESSAGE });
   return directDbMutation(req, res, "bases.refill-water", null, async () => {
     const target = await duneDb.baseRefillTarget(db, baseId);
     if (target.queueSupported && !target.writeSafeNow) {
@@ -3069,6 +3086,7 @@ async function baseAutoRefillWaterToggleRoute(req, res, path) {
   }
   // Only enabling is blocked -- see baseAutoRefillToggleRoute.
   if (body.enabled && baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
+  if (body.enabled && await baseBackedUp(baseId)) return json(res, 409, { error: BASE_BACKED_UP_MESSAGE });
   if (body.enabled && !(await duneDb.supportsWaterRefillQueue(db).catch(() => false))) {
     return json(res, 501, {
       error: "Auto-refill needs the pending water-refill queue, which requires dune.world_partition on this database."

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -73,7 +73,8 @@ const bridgeRateLimiter = createBridgeRateLimiter();
 const tasks = new TaskManager(config, {
   onMapDown: () => flushBaseRefillQueues({
     flushGenerators: flushQueuedGeneratorRefills,
-    flushWater: flushQueuedWaterRefills
+    flushWater: flushQueuedWaterRefills,
+    flushDeletes: flushQueuedBaseDeletes
   })
 });
 let db = createDb(config);
@@ -88,6 +89,8 @@ let carePackageAutoNextAllowedRun = 0;
 let generatorRefillFlushRunning = false;
 // Same reasoning as generatorRefillFlushRunning, for the water queue.
 let waterRefillFlushRunning = false;
+// Same reasoning as generatorRefillFlushRunning, for the pending-delete queue.
+let baseDeleteFlushRunning = false;
 let messageOfTheDayAutoRunning = false;
 let messageOfTheDayAutoLastRun = 0;
 let messageOfTheDayAutoNextAllowedRun = 0;
@@ -214,6 +217,9 @@ setInterval(() => {
   if (duneDb.listQueuedWaterRefills(config.repoRoot).length) {
     runBackgroundTick("Water refill flush", () => flushQueuedWaterRefills());
   }
+  if (duneDb.listQueuedBaseDeletes(config.repoRoot).length) {
+    runBackgroundTick("Base delete flush", () => flushQueuedBaseDeletes());
+  }
 }, Number.isFinite(generatorRefillFlushIntervalMs) && generatorRefillFlushIntervalMs > 0 ? generatorRefillFlushIntervalMs : 5000).unref?.();
 
 // Every queued-refill write goes through here so it is audited whichever path
@@ -241,6 +247,32 @@ async function flushQueuedWaterRefills() {
     return result;
   } finally {
     waterRefillFlushRunning = false;
+  }
+}
+
+// Same guard reasoning as flushQueuedGeneratorRefills. The one full-database
+// safety backup for this pass happens inside flushBaseDeletes's onBeforeApply
+// hook -- lazily, at most once, immediately before the first entry that is
+// actually about to be deleted, not merely because the queue is non-empty.
+async function flushQueuedBaseDeletes() {
+  if (baseDeleteFlushRunning) return { flushed: [] };
+  baseDeleteFlushRunning = true;
+  try {
+    const result = await duneDb.flushBaseDeletes(db, config.repoRoot, {
+      // Matches databaseQuery's explicit mock-mode guard: this runs as a
+      // background tick, not through directDbMutation, so it is not skipped
+      // for free the way a request-time delete's backup call is.
+      onBeforeApply: config.mockMode
+        ? undefined
+        : () => runDune(config, buildDuneArgs("backupCreate"), { env: { DB_BACKUP_ORIGIN: "base-delete" } })
+    });
+    for (const entry of result.flushed || []) audit(config, null, "bases.flush-queued-delete", entry);
+    if (result.backupFailed) {
+      audit(config, null, "bases.flush-queued-delete-backup-failed", { error: result.error, pending: result.pending });
+    }
+    return result;
+  } finally {
+    baseDeleteFlushRunning = false;
   }
 }
 
@@ -572,6 +604,7 @@ async function handleApi(req, res) {
   if (path === "/api/bases/auto-refill") return basesAutoRefillStateRoute(res);
   if (path === "/api/bases/pending-water-refills") return pendingWaterRefillsRoute(res);
   if (path === "/api/bases/auto-refill-water") return basesAutoRefillWaterStateRoute(res);
+  if (path === "/api/bases/pending-deletes") return pendingBaseDeletesRoute(res);
   if (path.match(/^\/api\/bases\/[^/]+\/export$/) && req.method === "GET") return baseBlueprintDownloadRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/refill-generators$/) && req.method === "POST") return baseRefillGeneratorsRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/queued-refill$/) && req.method === "DELETE") return baseCancelQueuedRefillRoute(req, res, path);
@@ -585,6 +618,8 @@ async function handleApi(req, res) {
   if (path.match(/^\/api\/bases\/[^/]+\/permissions$/) && req.method === "GET") return basePermissionsRoute(res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/permissions$/) && req.method === "PUT") return baseSetPermissionsRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/system-custodian$/) && req.method === "POST") return baseSystemCustodianRoute(req, res, path);
+  if (path.match(/^\/api\/bases\/[^/]+\/queued-delete$/) && req.method === "DELETE") return baseCancelQueuedDeleteRoute(req, res, path);
+  if (path.match(/^\/api\/bases\/[^/]+$/) && req.method === "DELETE") return baseDeleteRoute(req, res, path);
   if (path === "/api/vehicles") return dbJson(res, () => duneDb.listVehicles(db, {
     q: url.searchParams.get("q") || "",
     page: url.searchParams.get("page") || 0,
@@ -2654,9 +2689,92 @@ async function baseBlueprintDownloadRoute(req, res, path) {
   }
 }
 
+// A base with a delete queued is frozen from every other write: the hazard a
+// queued delete exists to avoid (a live server overwriting the write before
+// the flush) applies just as much to a refill or permission edit racing that
+// same delete, and reasoning about ordering between independent queues is
+// worse than "a base marked for deletion does not change in the meantime."
+function baseDeletePending(baseId) {
+  return duneDb.listQueuedBaseDeletes(config.repoRoot).some((entry) => entry.baseId === baseId);
+}
+
+const BASE_DELETE_PENDING_MESSAGE = "This base has a pending delete queued and cannot be modified. Cancel the delete first.";
+
+// Refilling fuel/water moments before deleting the base is pointless and
+// pollutes the audit log with writes about to be destroyed anyway. Best
+// effort: a base with nothing queued throws, which is fine to swallow here.
+function cancelPendingRefillsForBase(baseId) {
+  try { duneDb.cancelQueuedGeneratorRefill(config.repoRoot, baseId); } catch {}
+  try { duneDb.cancelQueuedWaterRefill(config.repoRoot, baseId); } catch {}
+}
+
+async function baseDeleteRoute(req, res, path) {
+  const baseId = Number(decodeURIComponent(path.split("/")[3]));
+  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  return directDbMutation(req, res, "bases.delete", "DELETE BASE", async () => {
+    const target = await duneDb.baseRefillTarget(db, baseId);
+    // Same hazard as a refill: a live game server can rewrite its own copy of
+    // this base back to Postgres before the delete is ever seen. Queue it
+    // instead and let the flush tick apply it once that map is down.
+    if (target.queueSupported && !target.writeSafeNow) {
+      cancelPendingRefillsForBase(baseId);
+      const entry = duneDb.queueBaseDelete(config.repoRoot, {
+        baseId,
+        map: target.map,
+        partitionId: target.partitionId
+      });
+      return { ok: true, queued: true, ...entry };
+    }
+    // Mandatory safety backup before any delete SQL runs, exactly like the
+    // raw "Database Query" tool already does for any destructive query --
+    // see databaseQuery below. If this throws, deleteBaseCompletely is never
+    // called and nothing is touched.
+    await runDune(config, buildDuneArgs("backupCreate"), { env: { DB_BACKUP_ORIGIN: "base-delete" } });
+    const result = await duneDb.deleteBaseCompletely(db, baseId);
+    return { ...result, backupCreated: true };
+  }, { baseId });
+}
+
+async function baseCancelQueuedDeleteRoute(req, res, path) {
+  const baseId = Number(decodeURIComponent(path.split("/")[3]));
+  if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  return directDbMutation(req, res, "bases.cancel-queued-delete", null,
+    () => duneDb.cancelQueuedBaseDelete(config.repoRoot, baseId), { baseId });
+}
+
+// Mirrors pendingGeneratorRefillsRoute.
+async function pendingBaseDeletesRoute(res) {
+  const pending = duneDb.listQueuedBaseDeletes(config.repoRoot);
+  const targets = pending.length
+    ? await duneDb.partitionRestartTargets(db).catch(() => new Map())
+    : new Map();
+  const byTarget = new Map();
+  for (const entry of pending) {
+    const map = entry.map || "Unknown";
+    const key = `${map}|${entry.partitionId}`;
+    const target = targets.get(entry.partitionId);
+    const group = byTarget.get(key) || {
+      map,
+      partitionId: entry.partitionId,
+      partitionMap: target?.map || "",
+      dimensionIndex: target?.dimensionIndex ?? 0,
+      count: 0
+    };
+    group.count += 1;
+    byTarget.set(key, group);
+  }
+  return json(res, 200, {
+    supported: true,
+    total: pending.length,
+    pending,
+    byTarget: [...byTarget.values()].sort((a, b) => a.map.localeCompare(b.map) || a.partitionId - b.partitionId)
+  });
+}
+
 async function baseRefillGeneratorsRoute(req, res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  if (baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
   // No confirmation phrase: refilling is additive and reversible, unlike the
   // deletes and overwrites that phrase-gate. Still rate limited and audited.
   return directDbMutation(req, res, "bases.refill-generators", null, async () => {
@@ -2711,6 +2829,7 @@ async function basePermissionCandidatesRoute(res, url) {
 async function baseSetPermissionsRoute(req, res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  if (baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
   return directDbMutation(req, res, "bases.set-permissions", null, async (body) => {
     const settings = await runDune(config, buildDuneArgs("userSettingsMapValues", { map: "Survival_1" }), { timeoutMs: 8000 });
     const maxPermissions = parseEffectivePermissionLimit(settings.stdout);
@@ -2721,6 +2840,7 @@ async function baseSetPermissionsRoute(req, res, path) {
 async function baseSystemCustodianRoute(req, res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  if (baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
   return directDbMutation(req, res, "bases.transfer-system-custodian", null, async () => {
     const settings = await runDune(config, buildDuneArgs("userSettingsMapValues", { map: "Survival_1" }), { timeoutMs: 8000 });
     const maxPermissions = parseEffectivePermissionLimit(settings.stdout);
@@ -2795,6 +2915,9 @@ async function baseAutoRefillToggleRoute(req, res, path) {
   if (typeof body.enabled !== "boolean") {
     return json(res, 400, { error: "Auto-refill enabled must be true or false." });
   }
+  // Only enabling is blocked -- turning auto-refill off is harmless and does
+  // not race a pending delete the way a new automated write would.
+  if (body.enabled && baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
   // Checked on the server too, not just hidden in the UI. Without
   // dune.world_partition a queued refill cannot wait for a safe window, so an
   // automated refill would write straight into a possibly-live base.
@@ -2860,6 +2983,7 @@ async function baseInventoryRoute(res, path) {
 async function baseRefillWaterRoute(req, res, path) {
   const baseId = Number(decodeURIComponent(path.split("/")[3]));
   if (!Number.isFinite(baseId) || baseId < 1) return json(res, 400, { error: "Invalid base ID" });
+  if (baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
   return directDbMutation(req, res, "bases.refill-water", null, async () => {
     const target = await duneDb.baseRefillTarget(db, baseId);
     if (target.queueSupported && !target.writeSafeNow) {
@@ -2926,6 +3050,8 @@ async function baseAutoRefillWaterToggleRoute(req, res, path) {
   if (typeof body.enabled !== "boolean") {
     return json(res, 400, { error: "Auto-refill enabled must be true or false." });
   }
+  // Only enabling is blocked -- see baseAutoRefillToggleRoute.
+  if (body.enabled && baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
   if (body.enabled && !(await duneDb.supportsWaterRefillQueue(db).catch(() => false))) {
     return json(res, 501, {
       error: "Auto-refill needs the pending water-refill queue, which requires dune.world_partition on this database."
@@ -3049,7 +3175,9 @@ async function directDbMutation(req, res, action, phrase, fn, meta = {}) {
   try {
     const result = config.mockMode ? { ok: true, mock: true } : await fn(body);
     audit(config, req, action, { ...meta, supported: true, result });
-    return json(res, 200, { supported: true, backupCreated: false, result });
+    // Every caller before base deletion leaves result.backupCreated unset, so
+    // this defaults to false exactly as it did when the field was hardcoded.
+    return json(res, 200, { supported: true, backupCreated: Boolean(result?.backupCreated), result });
   } catch (error) {
     const status = error.unsupported ? 501 : 400;
     audit(config, req, action, { ...meta, supported: false, error: redact(error?.message || "Unexpected error.") });

--- a/console/api/src/services/autoRefill.js
+++ b/console/api/src/services/autoRefill.js
@@ -240,7 +240,12 @@ export function createAutoRefillScheduler(options = {}) {
   }
 
   async function scanBase(baseId, threshold, context) {
-    const { enrollment, pendingBaseIds, outcomes, removed, failures, counters } = context;
+    const { enrollment, pendingBaseIds, pendingDeleteBaseIds, outcomes, removed, failures, counters } = context;
+    // A base marked for deletion is frozen from every other write (see
+    // baseDeletePending in server.js) -- skip it entirely rather than queue a
+    // refill that a 409 would just reject, or reset its stall tracking based
+    // on a scan that never really evaluated its fuel.
+    if (pendingDeleteBaseIds.has(baseId)) return;
     const key = String(baseId);
     const db = getDb();
     const previous = enrollment[key] || {};
@@ -361,6 +366,8 @@ export function createAutoRefillScheduler(options = {}) {
       enrollment,
       // Read once per scan: which bases already have an unflushed queue entry.
       pendingBaseIds: new Set(duneDb.listQueuedGeneratorRefills(config.repoRoot).map((entry) => entry.baseId)),
+      // Read once per scan: which bases have a delete queued and are frozen.
+      pendingDeleteBaseIds: new Set(duneDb.listQueuedBaseDeletes(config.repoRoot).map((entry) => entry.baseId)),
       // Observed once per scan and reused by every base's baseRefillTarget call
       // below, rather than every base re-running the same world_partition scan.
       observed: await duneDb.observeRefillPartitions(getDb()),

--- a/console/api/src/services/autoRefillWater.js
+++ b/console/api/src/services/autoRefillWater.js
@@ -257,7 +257,11 @@ export function createAutoRefillWaterScheduler(options = {}) {
   }
 
   async function scanBase(baseId, threshold, context) {
-    const { enrollment, pendingBaseIds, outcomes, removed, failures, counters } = context;
+    const { enrollment, pendingBaseIds, pendingDeleteBaseIds, outcomes, removed, failures, counters } = context;
+    // See autoRefill.js's scanBase: a base marked for deletion is frozen from
+    // every other write, so skip it rather than queue a refill that would
+    // just be rejected.
+    if (pendingDeleteBaseIds.has(baseId)) return;
     const key = String(baseId);
     const db = getDb();
     const previous = enrollment[key] || {};
@@ -379,6 +383,7 @@ export function createAutoRefillWaterScheduler(options = {}) {
       enrollment,
       // Read once per scan: which bases already have an unflushed queue entry.
       pendingBaseIds: new Set(duneDb.listQueuedWaterRefills(config.repoRoot).map((entry) => entry.baseId)),
+      pendingDeleteBaseIds: new Set(duneDb.listQueuedBaseDeletes(config.repoRoot).map((entry) => entry.baseId)),
       // Observed once per scan and reused by every base's baseRefillTarget call
       // below, rather than every base re-running the same world_partition scan.
       observed: await duneDb.observeRefillPartitions(getDb()),

--- a/console/api/src/services/backups.js
+++ b/console/api/src/services/backups.js
@@ -12,7 +12,7 @@ export function enrichBackupRows(config, rows) {
     if (/^(automatic|scheduled)$/.test(origin)) return { ...enriched, type: "Automatic Backup" };
     if (/^(restore-safety|restore_safety|restore safety)$/.test(origin)) return { ...enriched, type: "Restore Safety Backup" };
     if (/^(pre-update|pre_update|preupdate)$/.test(origin)) return { ...enriched, type: "Pre-update Backup" };
-    if (/^(destructive-sql|destructive_sql|destructive sql|sql-safety|sql_safety)$/.test(origin)) return { ...enriched, type: "SQL Safety Backup" };
+    if (/^(destructive-sql|destructive_sql|destructive sql|sql-safety|sql_safety|base-delete|base_delete)$/.test(origin)) return { ...enriched, type: "SQL Safety Backup" };
     if (/^(external|imported)$/.test(origin)) return { ...enriched, type: "Imported Backup", source: "External" };
     return enriched;
   });

--- a/console/api/src/services/baseBackupSafety.js
+++ b/console/api/src/services/baseBackupSafety.js
@@ -1,0 +1,14 @@
+const BACKUP_STATE_UNAVAILABLE = "The console could not verify this base's backup state. No changes were made. Try again after the database is available.";
+
+// Base mutations must fail closed. Treating a failed backup-state query as
+// "not backed up" could allow a stale or picked-up base to be changed through
+// a direct API request while the console cannot prove that it is safe.
+export async function verifyBaseBackupState(duneDb, db, baseId) {
+  try {
+    return await duneDb.baseIsBackedUp(db, baseId);
+  } catch (cause) {
+    const error = new Error(BACKUP_STATE_UNAVAILABLE, { cause });
+    error.statusCode = 503;
+    throw error;
+  }
+}

--- a/console/api/src/services/baseRefillFlush.js
+++ b/console/api/src/services/baseRefillFlush.js
@@ -1,27 +1,32 @@
 import { redact } from "../redact.js";
 
-// A map restart must not begin its start/spawn half until both refill queues
-// have finished using the brief write-safe window. Promise.allSettled is
-// deliberate: if one queue fails, we still wait for the other rather than
-// returning early while it is writing to PostgreSQL.
-export async function flushBaseRefillQueues({ flushGenerators, flushWater }) {
-  const [generatorResult, waterResult] = await Promise.allSettled([
-    Promise.resolve().then(flushGenerators),
-    Promise.resolve().then(flushWater)
-  ]);
+// A map restart must not begin its start/spawn half until every queue has
+// finished using the brief write-safe window. Promise.allSettled is
+// deliberate: if one queue fails, we still wait for the others rather than
+// returning early while one of them is writing to PostgreSQL.
+//
+// flushDeletes is optional and additive: existing callers that pass only
+// flushGenerators/flushWater are unaffected, since an undefined third leg is
+// simply skipped rather than awaited.
+export async function flushBaseRefillQueues({ flushGenerators, flushWater, flushDeletes }) {
+  const jobs = [Promise.resolve().then(flushGenerators), Promise.resolve().then(flushWater)];
+  const labels = ["generator", "water"];
+  if (flushDeletes) {
+    jobs.push(Promise.resolve().then(flushDeletes));
+    labels.push("delete");
+  }
+  const results = await Promise.allSettled(jobs);
 
   const flushed = [];
   const failures = [];
-  if (generatorResult.status === "fulfilled") {
-    flushed.push(...(generatorResult.value?.flushed || []).map((entry) => ({ ...entry, refillType: "generator" })));
-  } else {
-    failures.push({ refillType: "generator", error: redact(String(generatorResult.reason?.message || generatorResult.reason)) });
-  }
-  if (waterResult.status === "fulfilled") {
-    flushed.push(...(waterResult.value?.flushed || []).map((entry) => ({ ...entry, refillType: "water" })));
-  } else {
-    failures.push({ refillType: "water", error: redact(String(waterResult.reason?.message || waterResult.reason)) });
-  }
+  results.forEach((result, index) => {
+    const refillType = labels[index];
+    if (result.status === "fulfilled") {
+      flushed.push(...(result.value?.flushed || []).map((entry) => ({ ...entry, refillType })));
+    } else {
+      failures.push({ refillType, error: redact(String(result.reason?.message || result.reason)) });
+    }
+  });
 
   return { flushed, failures };
 }

--- a/console/api/test/autoRefill.test.js
+++ b/console/api/test/autoRefill.test.js
@@ -11,7 +11,7 @@ import {
   setBaseAutoRefill,
   writeAutoRefillState
 } from "../src/services/autoRefill.js";
-import { listQueuedGeneratorRefills, queueGeneratorRefill } from "../src/duneDb.js";
+import { listQueuedBaseDeletes, listQueuedGeneratorRefills, queueGeneratorRefill } from "../src/duneDb.js";
 
 // Must await fn: without it the finally deletes the directory at the callback's
 // first await, and everything after that reads an empty enrollment.
@@ -92,7 +92,12 @@ function fakeDuneDb({
       return null;
     },
     queueGeneratorRefill,
-    listQueuedGeneratorRefills
+    listQueuedGeneratorRefills,
+    // Real queue-file read, like listQueuedGeneratorRefills above: no test
+    // here queues a delete, so this always resolves empty, but going through
+    // the real function keeps the fake honest about that rather than
+    // asserting it via a hardcoded stub.
+    listQueuedBaseDeletes
   };
 }
 

--- a/console/api/test/autoRefillWater.test.js
+++ b/console/api/test/autoRefillWater.test.js
@@ -11,7 +11,7 @@ import {
   setBaseAutoRefillWater,
   writeAutoRefillWaterState
 } from "../src/services/autoRefillWater.js";
-import { listQueuedWaterRefills, queueWaterRefill } from "../src/duneDb.js";
+import { listQueuedBaseDeletes, listQueuedWaterRefills, queueWaterRefill } from "../src/duneDb.js";
 
 // Mirrors autoRefill.test.js exactly, retargeted at the water auto-refill
 // subsystem -- same enrollment/scheduler mechanics, own files, own env vars.
@@ -74,7 +74,10 @@ function fakeDuneDb({
       return null;
     },
     queueWaterRefill,
-    listQueuedWaterRefills
+    listQueuedWaterRefills,
+    // See autoRefill.test.js's fakeDuneDb: real queue-file read, always empty
+    // here since no test queues a delete.
+    listQueuedBaseDeletes
   };
 }
 

--- a/console/api/test/baseBackup.integration.test.js
+++ b/console/api/test/baseBackup.integration.test.js
@@ -1,0 +1,103 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { baseIsBackedUp } from "../src/duneDb.js";
+import { pgTransactionalDb, withIsolatedDatabase } from "../test-support/pgIntegrationDb.js";
+
+// Exercises real PostgreSQL rather than a mocked db, for the same reason
+// baseDelete.integration.test.js does: the guarantee under test is a real
+// join/exists shape, not a string-matched query.
+//
+// The claim actor (9001) and the base id a caller passes in (a
+// dune.buildings.id, e.g. 9002) are deliberately different ids, mirroring
+// production where they never match -- see baseDelete.integration.test.js's
+// same note.
+const CLAIM_ACTOR = 9001;
+const BUILDING_ACTOR = 9002;
+const ENTITY_ID = 501;
+
+const SCHEMA = `
+  create schema dune;
+
+  create table dune.actors (id bigint primary key, map text, partition_id bigint);
+  create table dune.buildings (id bigint primary key references dune.actors(id) on delete cascade);
+  create table dune.building_instances (
+    building_id bigint not null references dune.actors(id) on delete cascade,
+    instance_id integer not null,
+    owner_entity_id bigint
+  );
+  create table dune.actor_fgl_entities (
+    entity_id bigint not null,
+    actor_id bigint not null references dune.actors(id) on delete cascade
+  );
+  create table dune.permission_actor (
+    actor_id bigint primary key references dune.actors(id) on delete cascade,
+    actor_name text
+  );
+  create table dune.base_backup_linked_actors (id bigint not null, actor_id bigint not null);
+`;
+
+function seedBase() {
+  return `
+    insert into dune.actors (id, map, partition_id) values (${CLAIM_ACTOR}, 'HaggaBasin', 3);
+    insert into dune.actor_fgl_entities (entity_id, actor_id) values (${ENTITY_ID}, ${CLAIM_ACTOR});
+    insert into dune.actors (id, map, partition_id) values (${BUILDING_ACTOR}, 'HaggaBasin', 3);
+    insert into dune.buildings (id) values (${BUILDING_ACTOR});
+    insert into dune.building_instances (building_id, instance_id, owner_entity_id) values (${BUILDING_ACTOR}, 0, ${ENTITY_ID});
+  `;
+}
+
+async function withDatabase(t, run) {
+  return withIsolatedDatabase(t, {
+    namePrefix: "dune_base_backup",
+    unavailableLabel: "the base-backup integration test"
+  }, async (pool) => {
+    await pool.query(SCHEMA);
+    await pool.query(seedBase());
+    return run(pool);
+  });
+}
+
+test("real PostgreSQL: baseIsBackedUp is false for a normally claimed base", async (t) => {
+  await withDatabase(t, async (pool) => {
+    await pool.query("insert into dune.permission_actor (actor_id, actor_name) values ($1, 'Claimed Base')", [CLAIM_ACTOR]);
+    const db = pgTransactionalDb(pool);
+    assert.equal(await baseIsBackedUp(db, BUILDING_ACTOR), false);
+  });
+});
+
+test("real PostgreSQL: baseIsBackedUp is false for an unclaimed base that was never backed up", async (t) => {
+  await withDatabase(t, async (pool) => {
+    // No permission_actor row and no base_backup_linked_actors row either --
+    // "no owner" alone must not be read as "picked up".
+    const db = pgTransactionalDb(pool);
+    assert.equal(await baseIsBackedUp(db, BUILDING_ACTOR), false);
+  });
+});
+
+test("real PostgreSQL: baseIsBackedUp is true only once both unclaimed and backup-linked", async (t) => {
+  await withDatabase(t, async (pool) => {
+    await pool.query("insert into dune.base_backup_linked_actors (id, actor_id) values (1, $1)", [CLAIM_ACTOR]);
+    const db = pgTransactionalDb(pool);
+    assert.equal(await baseIsBackedUp(db, BUILDING_ACTOR), true);
+  });
+});
+
+test("real PostgreSQL: baseIsBackedUp is false once redeployed, even if old linked-actor rows are still present", async (t) => {
+  await withDatabase(t, async (pool) => {
+    // Simulates a redeploy: permission_actor comes back, but nothing has
+    // necessarily cleaned up the earlier base_backup_linked_actors row yet.
+    // Requiring both signals -- not "ever linked" alone -- is exactly what
+    // keeps a redeployed base from being wrongly blocked in this case.
+    await pool.query("insert into dune.base_backup_linked_actors (id, actor_id) values (1, $1)", [CLAIM_ACTOR]);
+    await pool.query("insert into dune.permission_actor (actor_id, actor_name) values ($1, 'Redeployed Base')", [CLAIM_ACTOR]);
+    const db = pgTransactionalDb(pool);
+    assert.equal(await baseIsBackedUp(db, BUILDING_ACTOR), false);
+  });
+});
+
+test("real PostgreSQL: baseIsBackedUp is false for a base id that does not exist", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    assert.equal(await baseIsBackedUp(db, 999999), false);
+  });
+});

--- a/console/api/test/baseBackupSafety.test.js
+++ b/console/api/test/baseBackupSafety.test.js
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { verifyBaseBackupState } from "../src/services/baseBackupSafety.js";
+
+test("base backup safety returns the verified state", async () => {
+  const duneDb = { baseIsBackedUp: async (_db, baseId) => baseId === 42 };
+  assert.equal(await verifyBaseBackupState(duneDb, {}, 42), true);
+  assert.equal(await verifyBaseBackupState(duneDb, {}, 7), false);
+});
+test("base backup safety fails closed when verification errors", async () => {
+  const queryError = new Error("database connection failed");
+  const duneDb = { baseIsBackedUp: async () => { throw queryError; } };
+
+  await assert.rejects(
+    verifyBaseBackupState(duneDb, {}, 42),
+    (error) => {
+      assert.equal(error.statusCode, 503);
+      assert.equal(error.cause, queryError);
+      assert.match(error.message, /could not verify.*backup state/i);
+      assert.match(error.message, /No changes were made/i);
+      return true;
+    }
+  );
+});

--- a/console/api/test/baseDelete.integration.test.js
+++ b/console/api/test/baseDelete.integration.test.js
@@ -80,8 +80,14 @@ const SCHEMA = `
     template_id text not null,
     stack_size integer not null default 1
   );
-  -- No cascade: a row here referencing one of the base's actors forces
-  -- delete_actors to fail mid-transaction, for the atomicity test below.
+  -- Synthetic fixture, not a modeled production constraint: a full audit of
+  -- every FK referencing dune.actors in the real schema (55 constraints,
+  -- verified against a restored production dump) found every one is
+  -- ON DELETE CASCADE or SET NULL -- none RESTRICT/NO ACTION, so this exact
+  -- failure trigger cannot occur against real data. It exists purely to
+  -- force a deterministic mid-transaction failure so the atomicity test
+  -- below can prove db.transaction's real rollback guarantee -- that
+  -- guarantee is what's under test, not this table.
   create table dune.other_refs (id bigint primary key, referenced_actor_id bigint references dune.actors(id));
 
   -- Transcribed from the shipped schema (see the plan/PR notes), not
@@ -211,9 +217,11 @@ test("real PostgreSQL: deleteBaseCompletely rejects a base id that does not exis
 
 test("real PostgreSQL: a mid-transaction failure rolls back permission_actor_destroy's work too", async (t) => {
   await withDatabase(t, async (pool) => {
-    // No cascade on other_refs: deleting one of this base's building actors
-    // now violates a real foreign key, forcing delete_actors to fail after
-    // permission_actor_destroy has already run inside the same transaction.
+    // other_refs is synthetic (see its CREATE TABLE comment) -- no real FK
+    // on dune.actors would actually reject a delete this way. It's a
+    // deliberate, controlled trigger for a real failure, so the transaction
+    // genuinely has something to roll back rather than never getting far
+    // enough to test the guarantee at all.
     await pool.query("insert into dune.other_refs (id, referenced_actor_id) values (1, $1)", [BUILDING_ACTORS[1]]);
 
     const db = pgTransactionalDb(pool);

--- a/console/api/test/baseDelete.integration.test.js
+++ b/console/api/test/baseDelete.integration.test.js
@@ -1,0 +1,390 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  deleteBaseCompletely,
+  queueBaseDelete,
+  cancelQueuedBaseDelete,
+  listQueuedBaseDeletes,
+  flushBaseDeletes,
+  _resetRefillPartitionDwellForTests
+} from "../src/duneDb.js";
+import { pgTransactionalDb, withIsolatedDatabase } from "../test-support/pgIntegrationDb.js";
+
+// Like basePermissions.integration.test.js, this exercises real PostgreSQL
+// rather than a mocked db: the guarantees that matter here -- the cascade
+// actually removing every row, the transaction actually rolling back
+// atomically, a real FOR UPDATE lock -- are exactly the kind a string-matched
+// mock cannot prove.
+//
+// The claim actor (9001) and the displayed base id (a buildings.id, e.g.
+// 9002) are deliberately different ids, mirroring production where they never
+// match. A second, unrelated base (9101/9102/9103) exists in every test to
+// prove a delete never reaches past its own actor set.
+const CLAIM_ACTOR = 9001;
+const BUILDING_ACTORS = [9002, 9003];
+const PLACEABLE_ACTOR = 9004;
+const ENTITY_ID = 501;
+const PLAYER_ID = 4;
+
+const OTHER_CLAIM_ACTOR = 9101;
+const OTHER_BUILDING_ACTOR = 9102;
+const OTHER_PLACEABLE_ACTOR = 9103;
+const OTHER_ENTITY_ID = 601;
+
+const SCHEMA = `
+  create schema dune;
+
+  create table dune.actors (id bigint primary key, map text, partition_id bigint, owner_account_id bigint);
+  create table dune.map_names (map_name_id smallint primary key, map_name text not null);
+  create table dune.world_partition (partition_id bigint primary key, map text, dimension_index integer default 0, server_id text);
+
+  create table dune.buildings (id bigint primary key references dune.actors(id) on delete cascade);
+  create table dune.building_instances (
+    building_id bigint not null references dune.actors(id) on delete cascade,
+    instance_id integer not null,
+    owner_entity_id bigint
+  );
+  create table dune.actor_fgl_entities (
+    entity_id bigint not null,
+    actor_id bigint not null references dune.actors(id) on delete cascade
+  );
+  create table dune.placeables (
+    id bigint primary key references dune.actors(id) on delete cascade,
+    owner_entity_id bigint,
+    building_type text
+  );
+  create table dune.permission_actor (
+    actor_id bigint primary key references dune.actors(id) on delete cascade,
+    actor_name text
+  );
+  create table dune.permission_actor_rank (
+    permission_actor_id bigint not null references dune.permission_actor(actor_id) on delete cascade,
+    player_id bigint not null references dune.actors(id) on delete cascade,
+    rank smallint not null
+  );
+  -- Deliberately NOT FK-cascaded from actors, matching production: only
+  -- permission_actor_destroy clears these.
+  create table dune.markers (marker_hash_id bigint primary key);
+  create table dune.player_markers (marker_hash_id bigint not null, player_id bigint not null);
+  create table dune.inventories (
+    id bigint primary key,
+    actor_id bigint not null references dune.actors(id) on delete cascade,
+    max_item_count integer not null default 10
+  );
+  create table dune.items (
+    id bigint generated always as identity primary key,
+    inventory_id bigint not null references dune.inventories(id) on delete cascade,
+    template_id text not null,
+    stack_size integer not null default 1
+  );
+  -- No cascade: a row here referencing one of the base's actors forces
+  -- delete_actors to fail mid-transaction, for the atomicity test below.
+  create table dune.other_refs (id bigint primary key, referenced_actor_id bigint references dune.actors(id));
+
+  -- Transcribed from the shipped schema (see the plan/PR notes), not
+  -- reinvented: permission_actor_destroy is the only thing that clears
+  -- markers/player_markers, which do not cascade from actors.
+  create function dune.permission_actor_destroy(in_actor_id bigint)
+  returns void language plpgsql as $$
+  begin
+    delete from permission_actor_rank where permission_actor_id = in_actor_id;
+    delete from permission_actor where actor_id = in_actor_id;
+    delete from markers where marker_hash_id = in_actor_id;
+    delete from player_markers where marker_hash_id = in_actor_id;
+    perform pg_notify('permission_notify_channel', format('destroy#{"ActorId" : %s}', in_actor_id));
+  end $$;
+
+  create function dune.delete_actors(in_ids bigint[])
+  returns void language plpgsql as $$
+  begin
+    delete from actors where id = any(in_ids);
+  end $$;
+`;
+
+function seedBase(claimActor, buildingActors, placeableActor, entityId, playerId) {
+  const buildingRows = buildingActors.map((id, index) => `
+    insert into dune.actors (id, map, partition_id) values (${id}, 'HaggaBasin', 3);
+    insert into dune.buildings (id) values (${id});
+    insert into dune.building_instances (building_id, instance_id, owner_entity_id) values (${id}, ${index}, ${entityId});
+  `).join("\n");
+  return `
+    insert into dune.actors (id, map, partition_id) values (${claimActor}, 'HaggaBasin', 3);
+    insert into dune.actor_fgl_entities (entity_id, actor_id) values (${entityId}, ${claimActor});
+    insert into dune.permission_actor (actor_id, actor_name) values (${claimActor}, 'Test Base ${claimActor}');
+    insert into dune.markers (marker_hash_id) values (${claimActor});
+    insert into dune.player_markers (marker_hash_id, player_id) values (${claimActor}, ${playerId});
+    insert into dune.inventories (id, actor_id) values (${claimActor} * 10, ${claimActor});
+    insert into dune.items (inventory_id, template_id, stack_size) values (${claimActor} * 10, 'Spice', 12);
+    ${buildingRows}
+    insert into dune.actors (id, map, partition_id) values (${placeableActor}, 'HaggaBasin', 3);
+    insert into dune.placeables (id, owner_entity_id, building_type) values (${placeableActor}, ${entityId}, 'storagecontainer_placeable');
+    insert into dune.inventories (id, actor_id) values (${placeableActor} * 10, ${placeableActor});
+    insert into dune.items (inventory_id, template_id, stack_size) values (${placeableActor} * 10, 'Aluminum Ingot', 5);
+  `;
+}
+
+const SEED = `
+  insert into dune.actors (id) values (${PLAYER_ID});
+  insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values (${CLAIM_ACTOR}, ${PLAYER_ID}, 1);
+  ${seedBase(CLAIM_ACTOR, BUILDING_ACTORS, PLACEABLE_ACTOR, ENTITY_ID, PLAYER_ID)}
+  ${seedBase(OTHER_CLAIM_ACTOR, [OTHER_BUILDING_ACTOR], OTHER_PLACEABLE_ACTOR, OTHER_ENTITY_ID, PLAYER_ID)}
+  insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values (${OTHER_CLAIM_ACTOR}, ${PLAYER_ID}, 1);
+`;
+
+async function withDatabase(t, run) {
+  return withIsolatedDatabase(t, {
+    namePrefix: "dune_base_delete",
+    unavailableLabel: "the base deletion integration test"
+  }, async (pool) => {
+    await pool.query(SCHEMA);
+    await pool.query(SEED);
+    return run(pool);
+  });
+}
+
+async function actorCount(pool, ids) {
+  const result = await pool.query("select count(*)::int as n from dune.actors where id = any($1::bigint[])", [ids]);
+  return result.rows[0].n;
+}
+
+async function tableCount(pool, table) {
+  const result = await pool.query(`select count(*)::int as n from dune.${table}`);
+  return result.rows[0].n;
+}
+
+test("real PostgreSQL: deleteBaseCompletely enumerates the claim actor, every building, and every placeable, deduplicated", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const result = await deleteBaseCompletely(db, BUILDING_ACTORS[0]);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.actorId, String(CLAIM_ACTOR));
+    assert.equal(result.deletedBuildingCount, BUILDING_ACTORS.length);
+    assert.equal(result.deletedPlaceableCount, 1);
+    // claim actor + 2 buildings + 1 placeable = 4, not 5 -- a building actor
+    // id must never be counted twice even though it is discovered through
+    // both its own buildings row and its building_instances row.
+    assert.equal(result.deletedActorCount, 4);
+  });
+});
+
+test("real PostgreSQL: deleteBaseCompletely cascades away everything belonging to the base and nothing belonging to another", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    await deleteBaseCompletely(db, BUILDING_ACTORS[0]);
+
+    const deletedIds = [CLAIM_ACTOR, ...BUILDING_ACTORS, PLACEABLE_ACTOR];
+    assert.equal(await actorCount(pool, deletedIds), 0);
+    assert.equal(await tableCount(pool, "buildings"), 1, "the other base's building must survive");
+    assert.equal(await tableCount(pool, "building_instances"), 1);
+    assert.equal(await tableCount(pool, "placeables"), 1);
+    assert.equal(await tableCount(pool, "actor_fgl_entities"), 1);
+    assert.equal(await tableCount(pool, "permission_actor"), 1);
+    assert.equal(await tableCount(pool, "permission_actor_rank"), 1);
+    assert.equal(await tableCount(pool, "inventories"), 2);
+    assert.equal(await tableCount(pool, "items"), 2);
+
+    // markers/player_markers do not cascade from actors in production -- only
+    // permission_actor_destroy's explicit deletes clear them, keyed on the
+    // claim actor id.
+    const markers = await pool.query("select marker_hash_id from dune.markers");
+    assert.deepEqual(markers.rows.map((row) => Number(row.marker_hash_id)), [OTHER_CLAIM_ACTOR]);
+    const playerMarkers = await pool.query("select marker_hash_id from dune.player_markers");
+    assert.deepEqual(playerMarkers.rows.map((row) => Number(row.marker_hash_id)), [OTHER_CLAIM_ACTOR]);
+
+    // The other base's own actors, unrelated to this delete, are untouched.
+    assert.equal(await actorCount(pool, [OTHER_CLAIM_ACTOR, OTHER_BUILDING_ACTOR, OTHER_PLACEABLE_ACTOR]), 3);
+  });
+});
+
+test("real PostgreSQL: deleteBaseCompletely rejects a base id that does not exist", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    await assert.rejects(() => deleteBaseCompletely(db, 424242), /was not found/);
+    // Nothing about the seeded bases should have moved.
+    assert.equal(await actorCount(pool, [CLAIM_ACTOR, OTHER_CLAIM_ACTOR]), 2);
+  });
+});
+
+test("real PostgreSQL: a mid-transaction failure rolls back permission_actor_destroy's work too", async (t) => {
+  await withDatabase(t, async (pool) => {
+    // No cascade on other_refs: deleting one of this base's building actors
+    // now violates a real foreign key, forcing delete_actors to fail after
+    // permission_actor_destroy has already run inside the same transaction.
+    await pool.query("insert into dune.other_refs (id, referenced_actor_id) values (1, $1)", [BUILDING_ACTORS[1]]);
+
+    const db = pgTransactionalDb(pool);
+    await assert.rejects(() => deleteBaseCompletely(db, BUILDING_ACTORS[0]));
+
+    // If the rollback were partial, permission_actor_destroy's deletes (which
+    // ran first) would have stuck even though delete_actors failed after it.
+    assert.equal(await actorCount(pool, [CLAIM_ACTOR, ...BUILDING_ACTORS, PLACEABLE_ACTOR]), 4);
+    assert.equal(await tableCount(pool, "permission_actor"), 2);
+    assert.equal(await tableCount(pool, "permission_actor_rank"), 2);
+    const markers = await pool.query("select marker_hash_id from dune.markers where marker_hash_id = $1", [CLAIM_ACTOR]);
+    assert.equal(markers.rows.length, 1);
+    const playerMarkers = await pool.query("select marker_hash_id from dune.player_markers where marker_hash_id = $1", [CLAIM_ACTOR]);
+    assert.equal(playerMarkers.rows.length, 1);
+  });
+});
+
+// --- Pending delete queue ----------------------------------------------------
+
+async function withTempRepoRoot(fn) {
+  const repoRoot = mkdtempSync(join(tmpdir(), "dune-delete-queue-"));
+  try {
+    return await fn(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+test("delete queue stores one entry per base and cancel reports a missing one", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    assert.deepEqual(listQueuedBaseDeletes(repoRoot), []);
+
+    queueBaseDelete(repoRoot, { baseId: 482, map: "Survival_1", partitionId: 3 });
+    queueBaseDelete(repoRoot, { baseId: 517, map: "Overmap", partitionId: 9 });
+    queueBaseDelete(repoRoot, { baseId: 482, map: "Survival_1", partitionId: 3 });
+
+    const pending = listQueuedBaseDeletes(repoRoot);
+    assert.deepEqual(pending.map((entry) => entry.baseId), [517, 482]);
+
+    const result = cancelQueuedBaseDelete(repoRoot, 482);
+    assert.equal(result.pending, 1);
+    assert.deepEqual(listQueuedBaseDeletes(repoRoot).map((entry) => entry.baseId), [517]);
+    assert.throws(() => cancelQueuedBaseDelete(repoRoot, 482), /has no queued delete/);
+  });
+});
+
+test("real PostgreSQL: flush applies a delete once its partition is confirmed down", async (t) => {
+  await withDatabase(t, async (pool) => {
+    await withTempRepoRoot(async (repoRoot) => {
+      _resetRefillPartitionDwellForTests();
+      // Unassigned server_id is positive evidence the map is gone (what
+      // despawn does), so this is write-safe immediately -- no dwell needed.
+      await pool.query("insert into dune.world_partition (partition_id, map, server_id) values (3, 'Survival_1', null)");
+      queueBaseDelete(repoRoot, { baseId: BUILDING_ACTORS[0], map: "HaggaBasin", partitionId: 3 });
+
+      const db = pgTransactionalDb(pool);
+      const result = await flushBaseDeletes(db, repoRoot);
+
+      assert.deepEqual(result.flushed.map((entry) => ({ baseId: entry.baseId, ok: entry.ok })), [{ baseId: BUILDING_ACTORS[0], ok: true }]);
+      assert.equal(result.pending, 0);
+      assert.deepEqual(listQueuedBaseDeletes(repoRoot), []);
+      assert.equal(await actorCount(pool, [CLAIM_ACTOR]), 0);
+    });
+  });
+});
+
+test("real PostgreSQL: flush leaves a delete queued while its map is still live", async (t) => {
+  await withDatabase(t, async (pool) => {
+    await withTempRepoRoot(async (repoRoot) => {
+      _resetRefillPartitionDwellForTests();
+      // server_id assigned, and nothing is connected under a matching
+      // application_name -- read as live until the dwell elapses.
+      await pool.query("insert into dune.world_partition (partition_id, map, server_id) values (3, 'Survival_1', 'srv-1')");
+      queueBaseDelete(repoRoot, { baseId: BUILDING_ACTORS[0], map: "HaggaBasin", partitionId: 3 });
+
+      const db = pgTransactionalDb(pool);
+      const stillLive = await flushBaseDeletes(db, repoRoot, { now: () => 1_000_000 });
+      assert.deepEqual(stillLive.flushed, []);
+      assert.equal(stillLive.pending, 1);
+      assert.equal(await actorCount(pool, [CLAIM_ACTOR]), 1, "a live-map base must not be deleted");
+
+      const afterDwell = await flushBaseDeletes(db, repoRoot, { now: () => 1_000_000 + 30_000 });
+      assert.equal(afterDwell.flushed[0]?.ok, true);
+      assert.equal(await actorCount(pool, [CLAIM_ACTOR]), 0);
+    });
+  });
+});
+
+test("real PostgreSQL: flush treats a base already gone as success, not a retryable failure", async (t) => {
+  await withDatabase(t, async (pool) => {
+    await withTempRepoRoot(async (repoRoot) => {
+      _resetRefillPartitionDwellForTests();
+      await pool.query("insert into dune.world_partition (partition_id, map, server_id) values (3, 'Survival_1', null)");
+      queueBaseDelete(repoRoot, { baseId: BUILDING_ACTORS[0], map: "HaggaBasin", partitionId: 3 });
+
+      // Stands in for the base's own owner demolishing it while the delete
+      // sits queued -- delete_actors cascades away everything this base has.
+      await pool.query("select dune.delete_actors($1::bigint[])", [[CLAIM_ACTOR, ...BUILDING_ACTORS, PLACEABLE_ACTOR]]);
+
+      const db = pgTransactionalDb(pool);
+      const result = await flushBaseDeletes(db, repoRoot);
+
+      assert.equal(result.flushed[0].ok, true);
+      assert.equal(result.flushed[0].alreadyGone, true);
+      assert.equal(result.flushed[0].attempts, undefined, "a base already gone must not burn an attempt");
+      assert.deepEqual(listQueuedBaseDeletes(repoRoot), []);
+    });
+  });
+});
+
+test("real PostgreSQL: flush drops an entry after three genuine failures and expires one older than the age limit", async (t) => {
+  await withDatabase(t, async (pool) => {
+    await withTempRepoRoot(async (repoRoot) => {
+      _resetRefillPartitionDwellForTests();
+      await pool.query("insert into dune.world_partition (partition_id, map, server_id) values (3, 'Survival_1', null)");
+      queueBaseDelete(repoRoot, { baseId: BUILDING_ACTORS[0], map: "HaggaBasin", partitionId: 3 });
+      const queuedAt = Date.parse(listQueuedBaseDeletes(repoRoot)[0].queuedAt);
+
+      // A real transaction that always fails, matching the plan's mocked
+      // "connection terminated"-style forced failure but proven against a
+      // live pool here: db.transaction is overridden, db.query stays real.
+      const real = pgTransactionalDb(pool);
+      const failingDb = { query: real.query, transaction: async () => { throw new Error("simulated permanent failure"); } };
+
+      let round = 0;
+      const step = () => flushBaseDeletes(failingDb, repoRoot, { now: () => 1_000_000 + (round++) * 120_000 });
+
+      const first = await step();
+      assert.equal(first.flushed[0].ok, false);
+      assert.equal(first.flushed[0].attempts, 1);
+      assert.equal(first.flushed[0].dropped, false);
+
+      const second = await step();
+      assert.equal(second.flushed[0].attempts, 2);
+
+      const third = await step();
+      assert.equal(third.flushed[0].attempts, 3);
+      assert.equal(third.flushed[0].dropped, true);
+      assert.deepEqual(listQueuedBaseDeletes(repoRoot), []);
+
+      // A fresh entry that has simply outlived the age limit is dropped on
+      // that basis alone, independent of the attempt counter above.
+      queueBaseDelete(repoRoot, { baseId: BUILDING_ACTORS[0], map: "HaggaBasin", partitionId: 3 });
+      const requeuedAt = Date.parse(listQueuedBaseDeletes(repoRoot)[0].queuedAt);
+      const expired = await flushBaseDeletes(failingDb, repoRoot, { now: () => requeuedAt + 7 * 24 * 3600_000 });
+      assert.equal(expired.flushed[0].expired, true);
+      assert.deepEqual(listQueuedBaseDeletes(repoRoot), []);
+      assert.ok(queuedAt <= requeuedAt);
+    });
+  });
+});
+
+test("real PostgreSQL: a failed safety backup aborts the whole flush pass, leaving every entry queued", async (t) => {
+  await withDatabase(t, async (pool) => {
+    await withTempRepoRoot(async (repoRoot) => {
+      _resetRefillPartitionDwellForTests();
+      await pool.query("insert into dune.world_partition (partition_id, map, server_id) values (3, 'Survival_1', null)");
+      queueBaseDelete(repoRoot, { baseId: BUILDING_ACTORS[0], map: "HaggaBasin", partitionId: 3 });
+      queueBaseDelete(repoRoot, { baseId: OTHER_BUILDING_ACTOR, map: "HaggaBasin", partitionId: 3 });
+
+      const db = pgTransactionalDb(pool);
+      let backupCalls = 0;
+      const result = await flushBaseDeletes(db, repoRoot, {
+        onBeforeApply: () => { backupCalls += 1; throw new Error("backup destination is full"); }
+      });
+
+      assert.equal(backupCalls, 1, "one failed backup must abort the pass, not be retried per base");
+      assert.equal(result.backupFailed, true);
+      assert.deepEqual(result.flushed, []);
+      assert.equal(listQueuedBaseDeletes(repoRoot).length, 2, "neither base may be deleted without its safety backup");
+      assert.equal(await actorCount(pool, [CLAIM_ACTOR, OTHER_CLAIM_ACTOR]), 2);
+    });
+  });
+});

--- a/console/api/test/baseDelete.integration.test.js
+++ b/console/api/test/baseDelete.integration.test.js
@@ -128,8 +128,8 @@ function seedBase(claimActor, buildingActors, placeableActor, entityId, playerId
 
 const SEED = `
   insert into dune.actors (id) values (${PLAYER_ID});
-  insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values (${CLAIM_ACTOR}, ${PLAYER_ID}, 1);
   ${seedBase(CLAIM_ACTOR, BUILDING_ACTORS, PLACEABLE_ACTOR, ENTITY_ID, PLAYER_ID)}
+  insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values (${CLAIM_ACTOR}, ${PLAYER_ID}, 1);
   ${seedBase(OTHER_CLAIM_ACTOR, [OTHER_BUILDING_ACTOR], OTHER_PLACEABLE_ACTOR, OTHER_ENTITY_ID, PLAYER_ID)}
   insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values (${OTHER_CLAIM_ACTOR}, ${PLAYER_ID}, 1);
 `;

--- a/console/api/test/baseDelete.integration.test.js
+++ b/console/api/test/baseDelete.integration.test.js
@@ -319,9 +319,15 @@ test("real PostgreSQL: flush treats a base already gone as success, not a retrya
 
       // Stands in for the base's own owner demolishing it while the delete
       // sits queued -- delete_actors cascades away everything this base has.
-      await pool.query("select dune.delete_actors($1::bigint[])", [[CLAIM_ACTOR, ...BUILDING_ACTORS, PLACEABLE_ACTOR]]);
-
       const db = pgTransactionalDb(pool);
+      await db.transaction(async (tx) => {
+        // The shipped function uses unqualified Dune table names. Production
+        // establishes this transaction-local path before calling it, so the
+        // fixture must reproduce that contract as well.
+        await tx.query("set local search_path to dune, public");
+        await tx.query("select dune.delete_actors($1::bigint[])", [[CLAIM_ACTOR, ...BUILDING_ACTORS, PLACEABLE_ACTOR]]);
+      });
+
       const result = await flushBaseDeletes(db, repoRoot);
 
       assert.equal(result.flushed[0].ok, true);

--- a/console/api/test/baseRefillFlush.test.js
+++ b/console/api/test/baseRefillFlush.test.js
@@ -51,3 +51,42 @@ test("a failed queue does not stop the hook waiting for the other queue", async 
   assert.deepEqual(result.flushed, [{ baseId: 33, ok: true, refillType: "water" }]);
   assert.deepEqual(result.failures, [{ refillType: "generator", error: "generator database unavailable" }]);
 });
+
+test("flushDeletes is optional and additive alongside the two refill queues", async () => {
+  const result = await flushBaseRefillQueues({
+    flushGenerators: async () => ({ flushed: [{ baseId: 1, ok: true }] }),
+    flushWater: async () => ({ flushed: [{ baseId: 2, ok: true }] }),
+    flushDeletes: async () => ({ flushed: [{ baseId: 3, ok: true }] })
+  });
+  assert.deepEqual(result.flushed, [
+    { baseId: 1, ok: true, refillType: "generator" },
+    { baseId: 2, ok: true, refillType: "water" },
+    { baseId: 3, ok: true, refillType: "delete" }
+  ]);
+  assert.deepEqual(result.failures, []);
+});
+
+test("omitting flushDeletes behaves exactly as before this leg existed", async () => {
+  const result = await flushBaseRefillQueues({
+    flushGenerators: async () => ({ flushed: [{ baseId: 1, ok: true }] }),
+    flushWater: async () => ({ flushed: [{ baseId: 2, ok: true }] })
+  });
+  assert.deepEqual(result.flushed, [
+    { baseId: 1, ok: true, refillType: "generator" },
+    { baseId: 2, ok: true, refillType: "water" }
+  ]);
+  assert.deepEqual(result.failures, []);
+});
+
+test("a failed delete flush does not stop the hook waiting for the other queues", async () => {
+  const result = await flushBaseRefillQueues({
+    flushGenerators: async () => ({ flushed: [{ baseId: 1, ok: true }] }),
+    flushWater: async () => ({ flushed: [{ baseId: 2, ok: true }] }),
+    flushDeletes: async () => { throw new Error("delete queue database unavailable"); }
+  });
+  assert.deepEqual(result.flushed, [
+    { baseId: 1, ok: true, refillType: "generator" },
+    { baseId: 2, ok: true, refillType: "water" }
+  ]);
+  assert.deepEqual(result.failures, [{ refillType: "delete", error: "delete queue database unavailable" }]);
+});

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -2537,6 +2537,61 @@ test("list bases omits the partition join when world_partition is absent", async
   assert.match(paged.text, /'' as partition_map/);
 });
 
+// The base-backup tool ("pick up base") only deletes permission_actor/
+// permission_actor_rank and registers the base's actor ids in
+// dune.base_backup_linked_actors -- it leaves buildings/building_instances/
+// placeables fully intact, so without this exclusion a picked-up base would
+// keep showing up as an ordinary, ownerless base.
+test("list bases excludes unclaimed, backup-linked bases when base_backup_linked_actors exists", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        const name = String(values[0] || "");
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(name) || name === "dune.base_backup_linked_actors" }] };
+      }
+      if (text.includes("total_bases")) return { rows: [{ total_bases: "0", total_pieces: "0", total_placeables: "0" }] };
+      return { rows: [] };
+    }
+  };
+
+  await listBases(db, { includeGenerators: false });
+
+  const paged = calls.find((call) => call.text.includes("from matched"));
+  assert.match(
+    paged.text,
+    /not \(pa\.actor_id is null and exists \(select 1 from dune\.base_backup_linked_actors bbla where bbla\.actor_id = a\.id\)\)/
+  );
+  const totals = calls.find((call) => call.text.includes("valid_claims"));
+  assert.match(
+    totals.text,
+    /not \(pa\.actor_id is null and exists \(select 1 from dune\.base_backup_linked_actors bbla where bbla\.actor_id = a\.id\)\)/,
+    "totals must apply the same exclusion so total_bases/total_pieces/total_placeables agree with the paged rows"
+  );
+});
+
+test("list bases omits the backup exclusion when base_backup_linked_actors is absent", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        return { rows: [{ exists: BASE_REQUIRED_TABLES.includes(String(values[0] || "")) }] };
+      }
+      if (text.includes("total_bases")) return { rows: [{ total_bases: "0", total_pieces: "0", total_placeables: "0" }] };
+      return { rows: [] };
+    }
+  };
+
+  await listBases(db, { includeGenerators: false });
+
+  const paged = calls.find((call) => call.text.includes("from matched"));
+  assert.ok(!paged.text.includes("base_backup_linked_actors"), "must not reference a table this schema does not have");
+  const totals = calls.find((call) => call.text.includes("valid_claims"));
+  assert.ok(!totals.text.includes("base_backup_linked_actors"));
+});
+
 test("list bases groups multiple internal building records under one claim actor", async () => {
   const calls = [];
   const db = {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -17,7 +17,7 @@ import {
   queueGeneratorRefill,
   supportsGeneratorRefillQueue
 } from "../src/duneDb.js";
-import { addCurrency, addFactionReputation, addGuildMember, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, addSpecializationXp, applyLandsraadMilestonePreset, augmentInventoryItem, augmentNewestPlayerItem, baseGeneratorFuelLevels, baseGenerators, changeDunePassword, completeJourneyNode, completeTutorial, dbStatus, deleteInventoryItem, demoteGuildMember, disbandGuild, exportBaseAsBlueprint, generatorUptimePolicy, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listBases, listGuilds, listPlayers, listRoutines, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerBuildingUnlockState, playerCraftingRecipes, playerCurrency, playerFactions, playerIntel, playerInventory, playerInventoryAll, playerJourney, playerPortalSnapshots, playerPosition, playerProfile, playerProgression, playerResearchItems, playerSolarisCoinTotal, playerVitals, portalGeneratorFuel, portalVehicles, promoteGuildMember, refillBaseGenerators, removeGuildMember, repairFactionReputation, repairVehicleDecay, resetJourneyNode, resetTutorial, routineDefinition, runSql, setLandsraadPlayerContribution, setPlayerFaction, supportsGeneratorRefill, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError, _resetPlayerTargetCacheForTests } from "../src/duneDb.js";
+import { addCurrency, addFactionReputation, addGuildMember, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, addSpecializationXp, applyLandsraadMilestonePreset, augmentInventoryItem, augmentNewestPlayerItem, baseGeneratorFuelLevels, baseGenerators, baseIsBackedUp, changeDunePassword, completeJourneyNode, completeTutorial, dbStatus, deleteInventoryItem, demoteGuildMember, disbandGuild, exportBaseAsBlueprint, generatorUptimePolicy, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listBases, listGuilds, listPlayers, listRoutines, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerBuildingUnlockState, playerCraftingRecipes, playerCurrency, playerFactions, playerIntel, playerInventory, playerInventoryAll, playerJourney, playerPortalSnapshots, playerPosition, playerProfile, playerProgression, playerResearchItems, playerSolarisCoinTotal, playerVitals, portalGeneratorFuel, portalVehicles, promoteGuildMember, refillBaseGenerators, removeGuildMember, repairFactionReputation, repairVehicleDecay, resetJourneyNode, resetTutorial, routineDefinition, runSql, setLandsraadPlayerContribution, setPlayerFaction, supportsGeneratorRefill, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError, _resetPlayerTargetCacheForTests } from "../src/duneDb.js";
 
 beforeEach(() => {
   _resetPlayerTargetCacheForTests();
@@ -2590,6 +2590,23 @@ test("list bases omits the backup exclusion when base_backup_linked_actors is ab
   assert.ok(!paged.text.includes("base_backup_linked_actors"), "must not reference a table this schema does not have");
   const totals = calls.find((call) => call.text.includes("valid_claims"));
   assert.ok(!totals.text.includes("base_backup_linked_actors"));
+});
+
+// The SQL path itself (unclaimed AND backup-linked) is proven against real
+// PostgreSQL in baseBackup.integration.test.js. This covers only the fast
+// path a mocked db can prove cheaply: a schema without the optional table
+// skips the query entirely rather than referencing a table that isn't there.
+test("baseIsBackedUp short-circuits to false without querying when base_backup_linked_actors is absent", async () => {
+  const calls = [];
+  const db = {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) return { rows: [{ exists: false }] };
+      throw new Error("must not query further once the capability check reports absent");
+    }
+  };
+  assert.equal(await baseIsBackedUp(db, 3452), false);
+  assert.equal(calls.length, 1, "only the to_regclass capability probe should run");
 });
 
 test("list bases groups multiple internal building records under one claim actor", async () => {

--- a/console/api/test/httpSafety.test.js
+++ b/console/api/test/httpSafety.test.js
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { Readable } from "node:stream";
@@ -213,6 +213,24 @@ test("safeStaticTarget path traversal with encoded sequences", () => {
     writeFileSync(resolve(dir, "index.html"), "safe");
     assert.equal(safeStaticTarget(dir, "/..%2F..%2Fetc/passwd"), resolve(dir, "index.html"));
     assert.equal(safeStaticTarget(dir, "/%2e%2e/%2e%2e/etc/passwd"), resolve(dir, "index.html"));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// Regression guard: "/." resolves to the static root itself, a directory,
+// not a file. The containment check alone reads that as "contained" (it is
+// dist, after all), so without also requiring a real file the function
+// returned the raw directory path -- which serveStatic's
+// createReadStream().pipe() would throw an unhandled EISDIR on.
+test("safeStaticTarget falls back to index.html rather than returning a directory", () => {
+  const dir = mkdtempSync(join(tmpdir(), "arrakis-static4-"));
+  try {
+    writeFileSync(resolve(dir, "index.html"), "safe");
+    mkdirSync(resolve(dir, "assets"));
+    assert.equal(safeStaticTarget(dir, "/."), resolve(dir, "index.html"));
+    assert.equal(safeStaticTarget(dir, "/assets"), resolve(dir, "index.html"));
+    assert.equal(safeStaticTarget(dir, "/assets/"), resolve(dir, "index.html"));
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/console/api/test/policy.test.js
+++ b/console/api/test/policy.test.js
@@ -23,6 +23,32 @@ test("explicit deny overrides allow, including for owner", () => {
   assert.equal(evaluate({ tier: "owner" }, "database:mutate", policies), false);
 });
 
+// bases:delete is a separate action from bases:mutate specifically so a
+// custom policy can grant routine base mutations (refills, permission
+// edits, cancelling a queued refill/delete -- all reversible) without also
+// granting the one irreversible action. This proves that separation holds
+// through the real evaluate()/matchAction() path, not just at resolution.
+test("bases:delete can be withheld independently of bases:mutate", () => {
+  const policies = {
+    moderator: {
+      version: 1,
+      tier: "moderator",
+      statements: [
+        { Effect: "Allow", Action: ["bases:read", "bases:mutate"] },
+        { Effect: "Deny", Action: "bases:delete" }
+      ]
+    }
+  };
+  assert.equal(evaluate({ tier: "moderator" }, "bases:mutate", policies), true);
+  assert.equal(evaluate({ tier: "moderator" }, "bases:delete", policies), false);
+
+  // The reverse also holds: a namespace wildcard (the shipped admin/owner
+  // default) still covers the new action without any policy change, so
+  // existing installs keep exactly the access they already had.
+  const wildcardPolicies = { admin: { version: 1, tier: "admin", statements: [{ Effect: "Allow", Action: "bases:*" }] } };
+  assert.equal(evaluate({ tier: "admin" }, "bases:delete", wildcardPolicies), true);
+});
+
 test("policy updates validate documents and preserve owner recovery access", () => {
   assert.equal(setPolicies({ owner: { tier: "owner", statements: [{ Effect: "Allow", Action: "*" }] } }).ok, true);
   assert.equal(setPolicies({ owner: { tier: "owner", statements: [{ Effect: "Maybe", Action: "*" }] } }).ok, false);

--- a/console/api/test/rbacParity.test.js
+++ b/console/api/test/rbacParity.test.js
@@ -11,7 +11,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { actionForRoute, ROUTE_ACTIONS, REGEX_ACTIONS, REGEX_ACTIONS_BY_METHOD } from "../src/actions.js";
+import { actionForRoute, ROUTE_ACTIONS, REGEX_ACTIONS, REGEX_ACTIONS_BY_METHOD, REGEX_ACTIONS_BY_METHOD_PATTERN } from "../src/actions.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const serverSrc = readFileSync(join(__dirname, "../src/server.js"), "utf8");
@@ -163,4 +163,18 @@ test("parity: all REGEX_ACTIONS entries reference known namespaces", () => {
     const ns = action.includes(":") ? action.split(":")[0] : action;
     assert.ok(validNamespaces.has(ns), `Unknown namespace in method action: ${action}`);
   }
+  for (const { action } of REGEX_ACTIONS_BY_METHOD_PATTERN) {
+    if (typeof action !== "string") continue;
+    const ns = action.includes(":") ? action.split(":")[0] : action;
+    assert.ok(validNamespaces.has(ns), `Unknown namespace in pattern action: ${action}`);
+  }
+});
+
+test("parity: DELETE /api/bases/{baseId} resolves to bases:delete, distinct from other bases DELETE routes", () => {
+  assert.equal(actionForRoute("/api/bases/12858", "DELETE"), "bases:delete");
+  // Sibling sub-resource DELETEs must stay in the shared, reversible bucket
+  // -- only the base delete itself gets its own action.
+  assert.equal(actionForRoute("/api/bases/12858/queued-delete", "DELETE"), "bases:mutate");
+  assert.equal(actionForRoute("/api/bases/12858/queued-refill", "DELETE"), "bases:mutate");
+  assert.equal(actionForRoute("/api/bases/12858/queued-water-refill", "DELETE"), "bases:mutate");
 });

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -258,6 +258,33 @@ export const basesApi = {
     api<{ supported: boolean; result?: { ok: boolean; baseId: number; pending: number }; reason?: string }>(
       `/api/bases/${encodeURIComponent(baseId)}/queued-refill`, { method: "DELETE" }),
   pendingRefills: () => api<PendingRefills>("/api/bases/pending-refills"),
+  // Permanently deletes the base and everything on it. Like the refills
+  // above, a delete for a map that is currently running comes back as
+  // `result.queued`: it is deferred to the next time that map is down, and a
+  // full database backup happens automatically, immediately before the
+  // delete actually runs (at request time here, or at flush time for a
+  // queued one) -- never before, never skipped.
+  deleteBase: (baseId: string) =>
+    api<{
+      supported: boolean;
+      backupCreated: boolean;
+      result?: {
+        ok: boolean;
+        baseId: number;
+        queued?: boolean;
+        map?: string;
+        partitionId?: number;
+        actorId?: string;
+        deletedActorCount?: number;
+        deletedBuildingCount?: number;
+        deletedPlaceableCount?: number;
+      };
+      reason?: string;
+    }>(`/api/bases/${encodeURIComponent(baseId)}`, { method: "DELETE", body: JSON.stringify({ confirmation: "DELETE BASE" }) }),
+  cancelQueuedDelete: (baseId: string) =>
+    api<{ supported: boolean; result?: { ok: boolean; baseId: number; pending: number }; reason?: string }>(
+      `/api/bases/${encodeURIComponent(baseId)}/queued-delete`, { method: "DELETE" }),
+  pendingDeletes: () => api<PendingRefills>("/api/bases/pending-deletes"),
   autoRefill: () => api<AutoRefillState>("/api/bases/auto-refill"),
   setAutoRefill: (baseId: string, enabled: boolean) =>
     post<{ ok: boolean; baseId: number; enabled: boolean; total: number }>(

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -11,6 +11,9 @@ vi.mock("../../api/bases", () => ({
     refillGenerators: vi.fn(),
     cancelQueuedRefill: vi.fn(),
     pendingRefills: vi.fn(),
+    deleteBase: vi.fn(),
+    cancelQueuedDelete: vi.fn(),
+    pendingDeletes: vi.fn(),
     autoRefill: vi.fn(),
     setAutoRefill: vi.fn(),
     permissions: vi.fn(),
@@ -353,6 +356,168 @@ describe("BasesPanel generator refill", () => {
     const refill = await awaitFreshRows("Sietch Unknown");
     expect(refill).toBeDisabled();
     expect(refill).toHaveAttribute("title", "Generator data is unavailable for this base");
+  });
+});
+
+describe("BasesPanel base deletion", () => {
+  function listResponse(capabilities: Record<string, unknown>, row: Record<string, unknown>) {
+    return {
+      capabilities,
+      totalCount: 1,
+      totalBases: 1,
+      totalPieces: 10,
+      totalPlaceables: 4,
+      rows: [{ ...commonRow, ...row }]
+    };
+  }
+
+  const deletableBase = {
+    base_id: "2101",
+    name: "Sietch Delete",
+    generatorDataAvailable: true,
+    generatorCount: 1,
+    generators: [
+      { type: "fuel", name: "Fuel-Powered Generator", fuelName: "Fuel Cell", fuelCells: 1, generatorCount: 1, runtimeSeconds: 0 }
+    ]
+  };
+
+  beforeEach(() => {
+    vi.mocked(basesApi.pendingDeletes).mockResolvedValue({ supported: true, total: 0, pending: [], byTarget: [] });
+  });
+
+  async function awaitFreshRows(baseName: string) {
+    await screen.findByText(baseName);
+    return screen.getByRole("button", { name: "Delete Base" });
+  }
+
+  it("hides the Delete Base action when the schema does not support it", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue(listResponse({ bases: true }, { ...deletableBase, base_id: "2100", name: "Sietch NoDelete" }));
+
+    renderPanel();
+    await screen.findByText("Sietch NoDelete");
+
+    expect(screen.queryByRole("button", { name: "Delete Base" })).not.toBeInTheDocument();
+  });
+
+  it("confirms with the piece/placeable counts and deletes immediately when the map is already write-safe", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue(listResponse({ bases: true, baseDelete: true, baseDeleteQueue: false }, deletableBase));
+    vi.mocked(basesApi.deleteBase).mockResolvedValue({
+      supported: true,
+      backupCreated: true,
+      result: { ok: true, baseId: 2101, deletedActorCount: 5, deletedBuildingCount: 3, deletedPlaceableCount: 1 }
+    });
+
+    const props = renderPanel();
+    const deleteButton = await awaitFreshRows("Sietch Delete");
+    expect(deleteButton).toBeEnabled();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(props.confirmAction).toHaveBeenCalledWith(
+      'Delete "Sietch Delete"? This permanently deletes the base and everything built or stored in it.',
+      {
+        title: "Delete Base",
+        confirmLabel: "Delete",
+        danger: true,
+        details: [
+          { label: "Building Pieces", value: "10", tone: "danger" },
+          { label: "Placeables", value: "4", tone: "danger" }
+        ],
+        // No queue capability on this schema, so the warning must promise an
+        // immediate write, not a queued one.
+        warning: expect.stringContaining("straight to the database")
+      }
+    ));
+    await waitFor(() => expect(basesApi.deleteBase).toHaveBeenCalledWith("2101"));
+    expect(await screen.findByText('"Sietch Delete" was deleted.')).toBeInTheDocument();
+    // The row is gone, so the list is refetched rather than patched locally.
+    expect(vi.mocked(basesApi.list).mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it("does not delete when the confirm dialog is declined", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue(listResponse(
+      { bases: true, baseDelete: true, baseDeleteQueue: false },
+      { ...deletableBase, base_id: "2102", name: "Sietch Declined Delete" }
+    ));
+
+    renderPanel({ confirmAction: vi.fn().mockResolvedValue(false) });
+    fireEvent.click(await awaitFreshRows("Sietch Declined Delete"));
+
+    await waitFor(() => expect(basesApi.deleteBase).not.toHaveBeenCalled());
+  });
+
+  it("queues the delete when the map is live and warns that it will apply on the next restart", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue(listResponse(
+      { bases: true, baseDelete: true, baseDeleteQueue: true },
+      { ...deletableBase, base_id: "2103", name: "Sietch Queue Delete" }
+    ));
+    vi.mocked(basesApi.deleteBase).mockResolvedValue({
+      supported: true,
+      backupCreated: false,
+      result: { ok: true, queued: true, baseId: 2103, map: "HaggaBasin", partitionId: 3 }
+    });
+
+    const props = renderPanel();
+    fireEvent.click(await awaitFreshRows("Sietch Queue Delete"));
+
+    await waitFor(() => expect(props.confirmAction).toHaveBeenCalledWith(
+      'Delete "Sietch Queue Delete"? This permanently deletes the base and everything built or stored in it.',
+      expect.objectContaining({ warning: expect.stringContaining("queued and applied") })
+    ));
+    await waitFor(() => expect(basesApi.deleteBase).toHaveBeenCalledWith("2103"));
+    expect(await screen.findByText(/is queued and applies when this map next restarts or stops/)).toBeInTheDocument();
+    expect(basesApi.pendingDeletes).toHaveBeenCalled();
+  });
+
+  it("shows the queued-delete pill, blocks refills on that row, and cancels through basesApi.cancelQueuedDelete", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue(listResponse(
+      { bases: true, baseDelete: true, baseDeleteQueue: true, generatorRefill: true },
+      { ...deletableBase, base_id: "2104", name: "Sietch Pending Delete" }
+    ));
+    vi.mocked(basesApi.pendingDeletes).mockResolvedValue({
+      supported: true,
+      total: 1,
+      pending: [{ baseId: 2104, map: "HaggaBasin", partitionId: 3, queuedAt: new Date().toISOString(), attempts: 0, lastError: "" }],
+      byTarget: [{ map: "HaggaBasin", partitionId: 3, partitionMap: "Survival_1", dimensionIndex: 0, count: 1 }]
+    });
+
+    renderPanel();
+    await screen.findByText("Sietch Pending Delete");
+
+    expect(await screen.findByRole("button", { name: "Cancel Queued Delete" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete Base" })).not.toBeInTheDocument();
+
+    // Server-side, this base rejects every other mutation while its delete is
+    // pending -- the row must not offer a control that would just 409.
+    const refill = screen.getByRole("button", { name: "Refill Generators" });
+    expect(refill).toBeDisabled();
+    expect(refill).toHaveAttribute("title", "Blocked while a delete is queued for this base");
+  });
+
+  it("cancelling the queued delete calls the API and refreshes the pending list", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue(listResponse(
+      { bases: true, baseDelete: true, baseDeleteQueue: true },
+      { ...deletableBase, base_id: "2105", name: "Sietch Cancel Delete" }
+    ));
+    vi.mocked(basesApi.pendingDeletes).mockResolvedValue({
+      supported: true,
+      total: 1,
+      pending: [{ baseId: 2105, map: "HaggaBasin", partitionId: 3, queuedAt: new Date().toISOString(), attempts: 0, lastError: "" }],
+      byTarget: [{ map: "HaggaBasin", partitionId: 3, partitionMap: "Survival_1", dimensionIndex: 0, count: 1 }]
+    });
+    vi.mocked(basesApi.cancelQueuedDelete).mockResolvedValue({ supported: true, result: { ok: true, baseId: 2105, pending: 0 } });
+
+    const props = renderPanel();
+    await screen.findByText("Sietch Cancel Delete");
+
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel Queued Delete" }));
+
+    await waitFor(() => expect(props.confirmAction).toHaveBeenCalledWith(
+      'Cancel the queued delete for "Sietch Cancel Delete"?',
+      { title: "Cancel Queued Delete", confirmLabel: "Cancel Delete" }
+    ));
+    await waitFor(() => expect(basesApi.cancelQueuedDelete).toHaveBeenCalledWith("2105"));
+    expect(await screen.findByText('Queued delete for "Sietch Cancel Delete" was canceled.')).toBeInTheDocument();
   });
 });
 

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Boxes, ChevronDown, ChevronUp, Download, Droplet, Fuel, Users, X, Zap } from "lucide-react";
+import { Boxes, ChevronDown, ChevronUp, Download, Droplet, Fuel, Trash2, Users, X, Zap } from "lucide-react";
 import { BaseInventoryTab } from "./BaseInventoryTab";
 import { BasePermissionsTab } from "./BasePermissionsTab";
 import { BaseWaterTab } from "./BaseWaterTab";
@@ -12,7 +12,7 @@ import { serverApi } from "../../api/server";
 import { setupApi, type Task } from "../../api/setup";
 import { apiDownload } from "../../api/client";
 import { DataTable, type SortDirection } from "../../components/common/DataTable";
-import { pendingRefillCountForPartition, usePendingRefills, usePendingWaterRefills } from "../../lib/usePendingRefills";
+import { pendingRefillCountForPartition, usePendingBaseDeletes, usePendingRefills, usePendingWaterRefills } from "../../lib/usePendingRefills";
 import { runGatedRestart, serviceRestartTarget, type RestartGate } from "../server/restartQueueGuard";
 
 type BasesPanelProps = {
@@ -371,12 +371,16 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
   const [canEditPermissions, setCanEditPermissions] = useState(false);
   const [canRefillWater, setCanRefillWater] = useState(false);
   const [canQueueWater, setCanQueueWater] = useState(false);
+  const [canDeleteBase, setCanDeleteBase] = useState(false);
+  const [canQueueDelete, setCanQueueDelete] = useState(false);
   // Which tab the expanded row is showing. Power is the default so expanding a
   // row behaves exactly as it did before this feature existed.
   const [expandedTab, setExpandedTab] = useState<"power" | "water" | "inventory" | "permissions">("power");
   const [cancelingId, setCancelingId] = useState("");
   const [cancelingWaterId, setCancelingWaterId] = useState("");
   const [refillingWaterId, setRefillingWaterId] = useState("");
+  const [deletingId, setDeletingId] = useState("");
+  const [cancelingDeleteId, setCancelingDeleteId] = useState("");
   // Bumped after an immediate (non-queued) water refill so an already-open
   // Water tab knows to refetch -- it fetches its own data independently of
   // the bases list/row, so nothing else tells it a refill just landed.
@@ -406,6 +410,7 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
   const skipNextSearchReset = useRef(true);
   const { pending: pendingRefills, refresh: refreshPendingRefills } = usePendingRefills(canQueue);
   const { pending: pendingWaterRefills, refresh: refreshPendingWaterRefills } = usePendingWaterRefills(canQueueWater);
+  const { pending: pendingBaseDeletes, refresh: refreshPendingBaseDeletes } = usePendingBaseDeletes(canQueueDelete);
   const previousPendingTotal = useRef<number | null>(null);
 
   useEffect(() => {
@@ -438,6 +443,8 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
       setCanEditPermissions(Boolean(result.capabilities?.basePermissions));
       setCanRefillWater(Boolean(result.capabilities?.waterRefill));
       setCanQueueWater(Boolean(result.capabilities?.waterRefillQueue));
+      setCanDeleteBase(Boolean(result.capabilities?.baseDelete));
+      setCanQueueDelete(Boolean(result.capabilities?.baseDeleteQueue));
       setTotalCount(result.totalCount || 0);
       setTotalBases(result.totalBases || 0);
       setTotalPieces(result.totalPieces || 0);
@@ -713,6 +720,77 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
     }
   }
 
+  // No blueprint-export mention in this dialog: base deletion is permanent
+  // and irreversible from the operator's perspective, but a full database
+  // "SQL Safety Backup" is taken automatically and unconditionally before any
+  // delete SQL runs -- see basesApi.deleteBase and docs/console/base-deletion.md.
+  async function handleDeleteBase(base: BaseRow) {
+    const id = String(base.base_id);
+    const label = base.name || `base ${id}`;
+    const confirmed = await confirmAction(
+      `Delete "${label}"? This permanently deletes the base and everything built or stored in it.`,
+      {
+        title: "Delete Base",
+        confirmLabel: "Delete",
+        danger: true,
+        details: [
+          { label: "Building Pieces", value: base.piece_count.toLocaleString(), tone: "danger" },
+          { label: "Placeables", value: base.placeable_count.toLocaleString(), tone: "danger" }
+        ],
+        warning: canQueueDelete
+          ? "A full database backup is taken automatically before the delete runs. If this base's map is running, the delete is queued and applied the next time that map restarts or stops, so a live server cannot overwrite it. If the map is already down, it is deleted now."
+          : "A full database backup is taken automatically before the delete runs, straight to the database. A running game server may not reflect the removal in-game until the map server restarts."
+      }
+    );
+    if (!confirmed) return;
+    onError("");
+    setDeletingId(id);
+    try {
+      const response = await basesApi.deleteBase(id);
+      if (response.result?.queued) {
+        writeRefillStatus(`Delete for "${label}" is queued and applies when this map next restarts or stops.`, "ok");
+        await refreshPendingBaseDeletes();
+      } else {
+        writeRefillStatus(`"${label}" was deleted.`, "ok");
+        // The row is gone: collapse it if it was the one expanded, then
+        // reload the list rather than try to splice one row out locally --
+        // the module cache still holds pre-delete counts for this view.
+        setExpandedBaseId((current) => current === id ? null : current);
+        basesCache = null;
+        await load({ q: submittedQ, page, pageSize, sortColumn, sortDirection });
+      }
+    } catch (error) {
+      const text = errorText(error);
+      writeRefillStatus(text, "fail");
+      onError(text);
+    } finally {
+      setDeletingId("");
+    }
+  }
+
+  async function handleCancelQueuedDelete(base: BaseRow) {
+    const id = String(base.base_id);
+    const label = base.name || `base ${id}`;
+    const confirmed = await confirmAction(`Cancel the queued delete for "${label}"?`, {
+      title: "Cancel Queued Delete",
+      confirmLabel: "Cancel Delete"
+    });
+    if (!confirmed) return;
+    onError("");
+    setCancelingDeleteId(id);
+    try {
+      await basesApi.cancelQueuedDelete(id);
+      writeRefillStatus(`Queued delete for "${label}" was canceled.`, "ok");
+      await refreshPendingBaseDeletes();
+    } catch (error) {
+      const text = errorText(error);
+      writeRefillStatus(text, "fail");
+      onError(text);
+    } finally {
+      setCancelingDeleteId("");
+    }
+  }
+
   const refreshAutoRefill = useCallback(async () => {
     try {
       const state = await basesApi.autoRefill();
@@ -880,13 +958,14 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
   // flushQueuedGeneratorRefills and flushQueuedWaterRefills unconditionally --
   // so one restart call covers a target with fuel, water, or both queued, and
   // the combined banner below only needs a single handler rather than two.
-  async function handleRestartForCombinedQueue(group: { map: string; partitionId: number; partitionMap: string; dimensionIndex: number; fuelCount: number; waterCount: number }) {
+  async function handleRestartForCombinedQueue(group: { map: string; partitionId: number; partitionMap: string; dimensionIndex: number; fuelCount: number; waterCount: number; deleteCount: number }) {
     const target = queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex);
     if (target.kind === "none") return;
     const key = `${group.map}|${group.partitionId}`;
     const parts = [];
     if (group.fuelCount) parts.push(`${group.fuelCount} queued generator refill${group.fuelCount === 1 ? "" : "s"}`);
     if (group.waterCount) parts.push(`${group.waterCount} queued water refill${group.waterCount === 1 ? "" : "s"}`);
+    if (group.deleteCount) parts.push(`${group.deleteCount} queued base delete${group.deleteCount === 1 ? "" : "s"}`);
     onError("");
     const label = group.partitionMap || group.map;
     // Route through the restart queue: when it is enabled and players are online
@@ -916,19 +995,22 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
       // Report what the restart actually did. Without this the running line
       // stands forever and a failed restart reads as a successful one.
       const finished = await waitForTask(startedTask);
-      const [refreshedFuel, refreshedWater] = await Promise.all([refreshPendingRefills(), refreshPendingWaterRefills()]);
+      const [refreshedFuel, refreshedWater, refreshedDeletes] = await Promise.all([
+        refreshPendingRefills(), refreshPendingWaterRefills(), refreshPendingBaseDeletes()
+      ]);
       if (finished.status === "succeeded") {
         // The flush races the restart's own write-safety window, so a
-        // succeeded task does not guarantee the refill actually landed --
-        // check both queues rather than assume.
+        // succeeded task does not guarantee the refill/delete actually
+        // landed -- check every queue rather than assume.
         const stillQueued = Boolean(
           pendingRefillCountForPartition(refreshedFuel, group.partitionId)
           || pendingRefillCountForPartition(refreshedWater, group.partitionId)
+          || pendingRefillCountForPartition(refreshedDeletes, group.partitionId)
         );
         writeRefillStatus(
           stillQueued
-            ? `${label} restarted. Its refills are still queued and will apply once the map is confirmed down.`
-            : `${label} restarted. Any refills queued for it have been applied.`,
+            ? `${label} restarted. Its queued refills and deletes are still queued and will apply once the map is confirmed down.`
+            : `${label} restarted. Any refills and deletes queued for it have been applied.`,
           "ok"
         );
       } else {
@@ -1017,18 +1099,27 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
   const autoRefillWaterUnrecoverable = autoRefillWaterUnavailable && autoRefillWaterBases.size === 0;
   const stalledWaterBaseIds = new Set([...autoRefillWaterBases.entries()].filter(([, entry]) => entry.stalledAt).map(([baseId]) => baseId));
 
-  // Combined queue banner: one box covering both queues. Merge byTarget rows
-  // keyed on map|partitionId -- restarting a target already flushes
+  // Mirrors the block above, for the pending base-delete queue.
+  const pendingDeleteTotal = pendingBaseDeletes?.total || 0;
+  const queuedDeleteBaseIds = new Set((pendingBaseDeletes?.pending || []).map((entry) => String(entry.baseId)));
+  const staleQueuedDeletes = (pendingBaseDeletes?.pending || []).filter((entry) => {
+    const queuedAt = Date.parse(entry.queuedAt);
+    return Number.isFinite(queuedAt) && Date.now() - queuedAt > STALE_QUEUED_REFILL_MS;
+  });
+  const staleDeleteTargetKeys = new Set(staleQueuedDeletes.map((entry) => `${entry.map || "Unknown"}|${entry.partitionId}`));
+
+  // Combined queue banner: one box covering all three queues. Merge byTarget
+  // rows keyed on map|partitionId -- restarting a target already flushes
   // whichever queue(s) are waiting on it (see handleRestartForCombinedQueue),
-  // so one restart button per target is correct even though the fuel/water
-  // counts come from two separate endpoints.
-  type CombinedQueueTarget = { map: string; partitionId: number; partitionMap: string; dimensionIndex: number; fuelCount: number; waterCount: number };
+  // so one restart button per target is correct even though the fuel/water/
+  // delete counts come from three separate endpoints.
+  type CombinedQueueTarget = { map: string; partitionId: number; partitionMap: string; dimensionIndex: number; fuelCount: number; waterCount: number; deleteCount: number };
   const combinedQueueTargets: CombinedQueueTarget[] = (() => {
     const byKey = new Map<string, CombinedQueueTarget>();
     for (const group of pendingRefills?.byTarget || []) {
       byKey.set(`${group.map}|${group.partitionId}`, {
         map: group.map, partitionId: group.partitionId, partitionMap: group.partitionMap, dimensionIndex: group.dimensionIndex,
-        fuelCount: group.count, waterCount: 0
+        fuelCount: group.count, waterCount: 0, deleteCount: 0
       });
     }
     for (const group of pendingWaterRefills?.byTarget || []) {
@@ -1037,17 +1128,33 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
       if (existing) existing.waterCount = group.count;
       else byKey.set(key, {
         map: group.map, partitionId: group.partitionId, partitionMap: group.partitionMap, dimensionIndex: group.dimensionIndex,
-        fuelCount: 0, waterCount: group.count
+        fuelCount: 0, waterCount: group.count, deleteCount: 0
+      });
+    }
+    for (const group of pendingBaseDeletes?.byTarget || []) {
+      const key = `${group.map}|${group.partitionId}`;
+      const existing = byKey.get(key);
+      if (existing) existing.deleteCount = group.count;
+      else byKey.set(key, {
+        map: group.map, partitionId: group.partitionId, partitionMap: group.partitionMap, dimensionIndex: group.dimensionIndex,
+        fuelCount: 0, waterCount: 0, deleteCount: group.count
       });
     }
     return [...byKey.values()];
   })();
-  const combinedQueueTotal = pendingTotal + pendingWaterTotal;
+  const combinedQueueTotal = pendingTotal + pendingWaterTotal + pendingDeleteTotal;
+  // The banner's own heading names only the kinds of writes actually queued,
+  // so "Refills queued" stays exactly as it read before this feature existed
+  // when there is nothing to delete, rather than a permanently generic label.
+  const combinedQueueHeadingParts = [
+    ...(pendingTotal > 0 || pendingWaterTotal > 0 ? ["Refills"] : []),
+    ...(pendingDeleteTotal > 0 ? ["Deletes"] : [])
+  ];
   // Whether any stale entry actually has a restart button in the list above. A
   // group whose partition does not resolve renders "Restart this map from the
   // Maps tab" instead, so pointing at a button that is not there would be wrong.
-  const combinedStaleTargetKeys = new Set([...staleTargetKeys, ...staleWaterTargetKeys]);
-  const combinedStaleCount = staleQueued.length + staleQueuedWater.length;
+  const combinedStaleTargetKeys = new Set([...staleTargetKeys, ...staleWaterTargetKeys, ...staleDeleteTargetKeys]);
+  const combinedStaleCount = staleQueued.length + staleQueuedWater.length + staleQueuedDeletes.length;
   const combinedStaleHasRestartButton = combinedQueueTargets.some((group) =>
     combinedStaleTargetKeys.has(`${group.map}|${group.partitionId}`)
     && queueRestartTarget(group.partitionMap, group.partitionId, group.dimensionIndex).kind !== "none");
@@ -1126,12 +1233,15 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
           {/* Explicit spaces around the badges: they are inline elements, so
               without them the text content reads "Refills queued2 fuel1 water"
               to a screen reader and to anyone copying it. */}
-          Refills queued
+          {combinedQueueHeadingParts.join(" and ")} queued
           {pendingTotal > 0 && <> <span className="bases-queue-badge bases-queue-badge-fuel">
             <Fuel size={13} aria-hidden="true" />{pendingTotal.toLocaleString()} fuel
           </span></>}
           {pendingWaterTotal > 0 && <> <span className="bases-queue-badge bases-queue-badge-water">
             <Droplet size={13} aria-hidden="true" />{pendingWaterTotal.toLocaleString()} water
+          </span></>}
+          {pendingDeleteTotal > 0 && <> <span className="bases-queue-badge bases-queue-badge-delete">
+            <Trash2 size={13} aria-hidden="true" />{pendingDeleteTotal.toLocaleString()} delete{pendingDeleteTotal === 1 ? "" : "s"}
           </span></>}
         </p>
         <p className="action-help-note">
@@ -1156,6 +1266,9 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
               </span>}
               {group.waterCount > 0 && <span className="bases-queue-badge bases-queue-badge-water">
                 <Droplet size={13} aria-hidden="true" />{group.waterCount.toLocaleString()}
+              </span>}
+              {group.deleteCount > 0 && <span className="bases-queue-badge bases-queue-badge-delete">
+                <Trash2 size={13} aria-hidden="true" />{group.deleteCount.toLocaleString()}
               </span>}
               {target.kind === "none"
                 ? <span className="muted">Restart this map from the Maps tab</span>
@@ -1238,6 +1351,13 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
             : autoRefillWaterStalled ? `Water auto-refill has stalled after ${autoRefillWaterEntryForRow?.consecutiveQueues || 3} refills that did not raise the water. Click to refill now.`
             : autoRefillWaterOn ? `Water auto-refill is on — checked every ${autoRefillWaterIntervalHours}h below ${autoRefillWaterThreshold}%. Click to refill now.`
             : "Refill Water";
+          // A base with a delete queued is frozen server-side (see
+          // baseDeletePending in server.js): the refill buttons would just 409,
+          // so they gray out here instead of offering a control that fails on
+          // click. Blueprint export is deliberately left enabled -- it is not
+          // part of that lock, and exporting before an imminent delete is
+          // exactly the kind of thing an operator might still want to do.
+          const deletePending = queuedDeleteBaseIds.has(id);
           return <span className="icon-toggle-group">
             {/* The actions column is a fixed width, so the queued state stays a
                 compact glyph pill rather than a text label: the banner above
@@ -1255,9 +1375,9 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
                 </span>
               : <button
                   className={`icon-toggle-button${autoRefillStalled ? " bases-auto-refill-stalled-icon" : autoRefillOn ? " bases-auto-refill-on" : ""}`}
-                  title={refillTitle}
+                  title={deletePending ? "Blocked while a delete is queued for this base" : refillTitle}
                   aria-label={autoRefillStalled ? "Refill Generators (auto-refill stalled)" : autoRefillOn ? "Refill Generators (auto-refill on)" : "Refill Generators"}
-                  disabled={!refillable || refillingId === id}
+                  disabled={deletePending || !refillable || refillingId === id}
                   onClick={(event) => { event.stopPropagation(); void handleRefillGenerators(base); }}
                 ><Fuel size={16} /></button>}
             {queuedWaterBaseIds.has(id)
@@ -1273,12 +1393,30 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
                 </span>
               : <button
                   className={`icon-toggle-button${autoRefillWaterStalled ? " bases-auto-refill-stalled-icon" : autoRefillWaterOn ? " bases-auto-refill-on" : ""}`}
-                  title={refillWaterTitle}
+                  title={deletePending ? "Blocked while a delete is queued for this base" : refillWaterTitle}
                   aria-label={autoRefillWaterStalled ? "Refill Water (auto-refill stalled)" : autoRefillWaterOn ? "Refill Water (auto-refill on)" : "Refill Water"}
-                  disabled={!canRefillWater || refillingWaterId === id}
+                  disabled={deletePending || !canRefillWater || refillingWaterId === id}
                   onClick={(event) => { event.stopPropagation(); void handleRefillWater(base); }}
                 ><Droplet size={16} /></button>}
             <button className="icon-toggle-button" title="Download Base as Blueprint" aria-label="Download Base as Blueprint" disabled={downloadingId === id} onClick={(event) => { event.stopPropagation(); void handleDownloadBlueprint(base); }}><Download size={16} /></button>
+            {canDeleteBase && (deletePending
+              ? <span className="bases-queued-delete" title="Delete queued — applies when this map next restarts or stops">
+                  <Trash2 size={16} aria-label="Delete queued for this base" />
+                  <button
+                    className="icon-toggle-button bases-queued-delete-cancel"
+                    title="Cancel Queued Delete"
+                    aria-label="Cancel Queued Delete"
+                    disabled={cancelingDeleteId === id}
+                    onClick={(event) => { event.stopPropagation(); void handleCancelQueuedDelete(base); }}
+                  ><X size={14} /></button>
+                </span>
+              : <button
+                  className="icon-toggle-button danger"
+                  title="Delete Base"
+                  aria-label="Delete Base"
+                  disabled={deletingId === id}
+                  onClick={(event) => { event.stopPropagation(); void handleDeleteBase(base); }}
+                ><Trash2 size={16} /></button>)}
           </span>;
         }}
         secondaryActionPosition="start"

--- a/console/web/src/lib/usePendingRefills.ts
+++ b/console/web/src/lib/usePendingRefills.ts
@@ -69,6 +69,37 @@ export function usePendingWaterRefills(enabled = true) {
   return { pending, refresh };
 }
 
+// Mirrors usePendingRefills for the pending base-delete queue -- same
+// per-resource duplication as the water hook above rather than a
+// parameterized fetcher.
+export function usePendingBaseDeletes(enabled = true) {
+  const [pending, setPending] = useState<PendingRefills | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await basesApi.pendingDeletes();
+      setPending(next);
+      return next;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const tick = () => { if (!cancelled) void refresh(); };
+    tick();
+    const intervalId = window.setInterval(tick, PENDING_REFILL_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+  }, [enabled, refresh]);
+
+  return { pending, refresh };
+}
+
 export function pendingRefillCountForPartition(pending: PendingRefills | null, partitionId: number) {
   if (!pending || !partitionId) return 0;
   return pending.pending.filter((entry) => entry.partitionId === partitionId).length;

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1721,9 +1721,10 @@ body.debug .technical-details { display: block; }
 .bases-table th:nth-child(10), .bases-table td:nth-child(10) { width: 6%; text-align: center; }
 .bases-table th:nth-child(11), .bases-table td:nth-child(11) { width: 10.5%; }
 /* 96px fit two icon-toggle-buttons (Refill Generators, Download); a third
-   (Refill Water) plus the wider queued-refill pills need more room, so this
-   grew to comfortably fit all three at once, queued or not. */
-.bases-table th.bases-actions-column, .bases-table td.bases-actions-column { width: 148px; }
+   (Refill Water) plus the wider queued-refill pills grew this to 148px to
+   comfortably fit all three at once, queued or not. A fourth (Delete Base)
+   plus its own wider queued-delete pill needs more room again. */
+.bases-table th.bases-actions-column, .bases-table td.bases-actions-column { width: 190px; }
 .bases-table td { max-width: none; white-space: normal; overflow-wrap: anywhere; text-overflow: clip; }
 .bases-name, .bases-ellipsis-cell { display: block; overflow: visible; text-overflow: clip; white-space: normal; overflow-wrap: anywhere; }
 
@@ -1859,6 +1860,10 @@ body.debug .technical-details { display: block; }
 }
 .bases-queue-badge-fuel { background: rgba(198, 139, 74, .18); color: var(--accent); }
 .bases-queue-badge-water { background: rgba(74, 144, 198, .18); color: #7fb2df; }
+/* Danger-toned, unlike the fuel/water badges above: a queued delete is
+   destructive rather than additive, and the row/banner treatment should read
+   as a warning, not just another pending write. */
+.bases-queue-badge-delete { background: rgba(167, 73, 73, .18); color: var(--danger-text); }
 .bases-queued-refill {
   display: inline-flex;
   align-items: center;
@@ -1870,6 +1875,27 @@ body.debug .technical-details { display: block; }
   white-space: nowrap;
 }
 .bases-queued-refill .bases-queued-refill-cancel {
+  width: 20px;
+  height: 20px;
+  flex: 0 0 20px;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  min-width: 0;
+}
+/* Mirrors .bases-queued-refill, danger-toned to match .bases-queue-badge-delete. */
+.bases-queued-delete {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 4px;
+  border-radius: 6px;
+  background: rgba(167, 73, 73, .16);
+  color: var(--danger-text);
+  white-space: nowrap;
+}
+.bases-queued-delete .bases-queued-delete-cancel {
   width: 20px;
   height: 20px;
   flex: 0 0 20px;

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1723,8 +1723,18 @@ body.debug .technical-details { display: block; }
 /* 96px fit two icon-toggle-buttons (Refill Generators, Download); a third
    (Refill Water) plus the wider queued-refill pills grew this to 148px to
    comfortably fit all three at once, queued or not. A fourth (Delete Base)
-   plus its own wider queued-delete pill needs more room again. */
-.bases-table th.bases-actions-column, .bases-table td.bases-actions-column { width: 190px; }
+   plus its own wider queued-delete pill needs more room again -- and this
+   time the worst case is not "one queued slot" but "all three of Refill
+   Generators/Refill Water/Delete queued at once on the same base" (nothing
+   stops an operator queuing a fuel refill, then a water refill, then a
+   delete for the same live-map base). That's 3 pills (~46px each) + the
+   Download button (38px) + 3 gaps (6px) = 194px of content, against a
+   178px box at the old 190px width with 12px of cell padding -- exactly
+   the gap this measured and fixed live: the pills had no flex-shrink:0,
+   so the overflow silently squashed their icons instead of clipping.
+   230px leaves real margin above the 194px+12px=206px worst case, not
+   another zero-margin fit. */
+.bases-table th.bases-actions-column, .bases-table td.bases-actions-column { width: 230px; }
 .bases-table td { max-width: none; white-space: normal; overflow-wrap: anywhere; text-overflow: clip; }
 .bases-name, .bases-ellipsis-cell { display: block; overflow: visible; text-overflow: clip; white-space: normal; overflow-wrap: anywhere; }
 
@@ -1873,6 +1883,13 @@ body.debug .technical-details { display: block; }
   background: rgba(255, 208, 138, .12);
   color: var(--title);
   white-space: nowrap;
+  /* As an item of the parent .icon-toggle-group, this defaults to
+     shrinkable -- unlike .icon-toggle-button's flex: 0 0 38px, nothing
+     stopped the group from squashing this pill (and its child icon)
+     instead of the row simply needing more width. Pin it so a future
+     width miscalculation overflows visibly rather than silently
+     distorting the icon. */
+  flex-shrink: 0;
 }
 .bases-queued-refill .bases-queued-refill-cancel {
   width: 20px;
@@ -1894,6 +1911,8 @@ body.debug .technical-details { display: block; }
   background: rgba(167, 73, 73, .16);
   color: var(--danger-text);
   white-space: nowrap;
+  /* See .bases-queued-refill's comment. */
+  flex-shrink: 0;
 }
 .bases-queued-delete .bases-queued-delete-cancel {
   width: 20px;

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ reference. Everything else is marked **Current** and is expected to stay accurat
 - [generator-refill-caps.md](console/generator-refill-caps.md) — Current. Refill-generators endpoint behavior and per-type fuel caps.
 - [base-permissions.md](console/base-permissions.md) — Current. Editing base ownership and sharing: ranks, the config-driven roster cap, and why the change needs no map restart.
 - [base-inventory.md](console/base-inventory.md) — Current. The read-only base Inventory tab: which placeables count as storage, the two inventories every refinery carries, and why the tab cannot write.
+- [base-deletion.md](console/base-deletion.md) — Current. Permanently deleting a base: what "the base" means for enumeration, the pending-delete queue for a live map, the mandatory pre-delete safety backup, and why a pending delete freezes every other mutation on that base.
 - [restart-queue.md](console/restart-queue.md) — Current. The Restart Queue toggle: player-aware countdowns with in-game warnings, the two broadcast variants, concurrency rules, crash recovery, the "Restart later" deferred-restart option, and the join-lock limitation.
 - [exchange.md](console/exchange.md) — Current. The read-only Market Board: aggregated-by-item CHOAM exchange listings, seller resolution, how bot listings are identified, and the bot/blacklist filter config.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ reference. Everything else is marked **Current** and is expected to stay accurat
 - [base-permissions.md](console/base-permissions.md) — Current. Editing base ownership and sharing: ranks, the config-driven roster cap, and why the change needs no map restart.
 - [base-inventory.md](console/base-inventory.md) — Current. The read-only base Inventory tab: which placeables count as storage, the two inventories every refinery carries, and why the tab cannot write.
 - [base-deletion.md](console/base-deletion.md) — Current. Permanently deleting a base: what "the base" means for enumeration, the pending-delete queue for a live map, the mandatory pre-delete safety backup, and why a pending delete freezes every other mutation on that base.
+- [base-backups.md](console/base-backups.md) — Current. What the game's own "pick up base" tool actually does in the database, why the Bases panel excludes a picked-up base, and why every mutation route rejects one too.
 - [restart-queue.md](console/restart-queue.md) — Current. The Restart Queue toggle: player-aware countdowns with in-game warnings, the two broadcast variants, concurrency rules, crash recovery, the "Restart later" deferred-restart option, and the join-lock limitation.
 - [exchange.md](console/exchange.md) — Current. The read-only Market Board: aggregated-by-item CHOAM exchange listings, seller resolution, how bot listings are identified, and the bot/blacklist filter config.
 

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -265,6 +265,9 @@ When the Restart Queue is enabled, the restart routes above (`/api/server/restar
 | POST | `/api/bases/{baseId}/system-custodian` | Transfer ownership to the Server or detected GM system custodian while preserving the roster; provisions Server when no custodian exists | `baseId` |
 | PUT | `/api/bases/{baseId}/permissions` | Replace a base's permission roster | `baseId`, `entries[]` (`playerId`, `rank`) |
 | GET | `/api/bases/permission-candidates` | Search players eligible to be added to a roster | `q?`, `limit?` |
+| DELETE | `/api/bases/{baseId}` | Permanently delete a base and everything on it (queued instead if the map isn't safely writable right now); takes a full-database safety backup first. Requires `{ confirmation: "DELETE BASE" }` | `baseId` |
+| GET | `/api/bases/pending-deletes` | List queued base deletes, grouped by restart target | None |
+| DELETE | `/api/bases/{baseId}/queued-delete` | Cancel a base's queued delete | `baseId` |
 
 Each `GET /api/bases` row carries `partitionMap` and `dimensionIndex` alongside
 `map` and `partition_id`. `map` is the game's own name (`HaggaBasin`) and cannot
@@ -275,6 +278,15 @@ instance. Both are empty on a schema without `dune.world_partition`.
 `GET /api/bases` reports `capabilities.basePermissions`; the permission routes are
 unavailable when it is false (the schema lacks the required tables or the game's
 `permission_set_player_rank` / `permission_remove_player_rank` procedures).
+
+`GET /api/bases` also reports `capabilities.baseDelete` (the schema has the tables
+and the game's `permission_actor_destroy` / `delete_actors` procedures) and
+`capabilities.baseDeleteQueue` (additionally has `dune.world_partition`, so a
+delete against a live map can be queued instead of written immediately). The
+delete route is unavailable when `baseDelete` is false; without `baseDeleteQueue`
+a delete against a live map is written straight away rather than queued, matching
+the refill routes' behavior on a schema without `world_partition`. See
+[Base deletion](base-deletion.md).
 
 `PUT` takes the whole roster rather than a delta — the server diffs it against
 current state and applies only the difference. `rank` is `1` Owner, `2` Co-Owner,

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -269,6 +269,11 @@ When the Restart Queue is enabled, the restart routes above (`/api/server/restar
 | GET | `/api/bases/pending-deletes` | List queued base deletes, grouped by restart target | None |
 | DELETE | `/api/bases/{baseId}/queued-delete` | Cancel a base's queued delete | `baseId` |
 
+`GET /api/bases` excludes a base that has been picked up via the game's own
+base-backup tool (unclaimed and registered in `dune.base_backup_linked_actors`
+— see [base-backups.md](base-backups.md)), and every mutation route below
+rejects one with **409** for the same reason.
+
 Each `GET /api/bases` row carries `partitionMap` and `dimensionIndex` alongside
 `map` and `partition_id`. `map` is the game's own name (`HaggaBasin`) and cannot
 distinguish two instances of one map; `partitionMap` is the name the rest of the

--- a/docs/console/base-backups.md
+++ b/docs/console/base-backups.md
@@ -1,0 +1,88 @@
+# Base backups (the game's "pick up base" tool)
+
+**Status:** Current | **Last Updated:** August 2026
+
+The game has its own base-backup tool: a player can "pick up" a placed base,
+which unclaims it so it can later be redeployed elsewhere. This is entirely
+separate from the console's [Base deletion](base-deletion.md) feature and from
+the Backups page's database backups — it is a game mechanic the console only
+needs to *recognize*, not one it drives.
+
+## What picking up a base actually does in the database
+
+Investigated directly against a live restored database by placing a test base,
+recording its rows, picking it up, and diffing. Picking up a base does **not**
+move, delete, or serialize any of its structural rows. It does exactly two
+things:
+
+- deletes the base's `dune.permission_actor` / `dune.permission_actor_rank`
+  rows — the base becomes unclaimed;
+- inserts a row into `dune.base_backups` (`id`, `player_id`, the base's old
+  `actor_name` as `base_backup_name`) and one `dune.base_backup_linked_actors`
+  row per actor that belonged to the base (the claim actor plus every
+  placeable) linking it to that `base_backups.id`.
+
+Every `dune.buildings` / `dune.building_instances` / `dune.placeables` row for
+the base is left completely intact, at its original location, with the same
+health and transform it had before. There is no "packed" or serialized
+representation anywhere — not in a new `dune.items` row, not in the game's own
+`BaseBackupTool` item (that item is just the tool itself; its `stats` carry
+only durability/customization, never base data). Redeploying presumably
+re-establishes a `permission_actor` claim over the same still-existing actor
+ids rather than re-materializing anything from a stored blob, though that
+direction (backup → redeploy) has not been directly observed the way pick-up
+has.
+
+One live observation from redeploying during this investigation: the base's
+`permission_actor` row came back and its `base_backup_linked_actors` rows were
+gone, i.e. the game does clean that table up on redeploy in at least this
+case. The console's checks below still verify both signals rather than relying
+on that alone (see the next section for why).
+
+## Why the console excludes these from the Bases panel
+
+Left unfiltered, a picked-up base still has every `buildings` /
+`building_instances` / `placeables` row present, so it would show up in the
+Bases panel exactly like a normal, ordinary base — just with a blank owner
+column, since `GET /api/bases`'s owner resolution is already a `LEFT JOIN`.
+There is nothing else distinguishing it at a glance.
+
+`listBases` (`duneDb.js`) excludes a base only when **both** signals agree:
+
+- it is unclaimed (no `dune.permission_actor` row for its claim actor), **and**
+- its claim actor id appears in `dune.base_backup_linked_actors`.
+
+Neither signal alone is used as the exclusion, deliberately:
+
+- "unclaimed" alone would also hide a base that has no owner for some other,
+  unrelated reason;
+- "ever backup-linked" alone would risk hiding a base again after a legitimate
+  redeploy, if some future case leaves its old linked-actor rows behind
+  instead of cleaning them up the way the one case observed here did.
+
+A base satisfying both is unambiguous. This exclusion is gated on
+`dune.base_backup_linked_actors` existing at all (`tableExists`); on a schema
+without it, `listBases` behaves exactly as it did before this feature.
+
+## Mutation routes reject a backed-up base too
+
+Hiding a base from the list only stops it from being reached through the
+Bases panel's own UI. A direct route call — or a stale bookmarked base id from
+before it was picked up — could still act on it. `duneDb.baseIsBackedUp(db,
+baseId)` runs the identical unclaimed-AND-linked check for one base id, and
+every base mutation route checks it before writing, the same way each already
+checks the [pending-delete lock](base-deletion.md#irreversibility):
+
+- `DELETE /api/bases/{baseId}` (delete)
+- `POST /api/bases/{baseId}/refill-generators`
+- `POST /api/bases/{baseId}/refill-water`
+- `PUT /api/bases/{baseId}/permissions`
+- `POST /api/bases/{baseId}/system-custodian`
+- `POST /api/bases/{baseId}/auto-refill` and `.../auto-refill-water` (only
+  when enabling — disabling is harmless and does not race anything)
+
+Each responds **409** with `"This base was picked up into a backup and is no
+longer claimed. It cannot be modified until the player redeploys it."` Reads
+(inventory, water, export-as-blueprint) are not blocked — a picked-up base's
+rows are still real data, and there is no destructive or race-prone reason to
+hide it from a read the way there is for a write.

--- a/docs/console/base-deletion.md
+++ b/docs/console/base-deletion.md
@@ -54,6 +54,18 @@ Deletes are audited as `bases.delete`; queued flushes as
 `directDbMutation` helper (`"DELETE BASE"`, matching `"DISBAND GUILD"`'s
 precedent) and are rate limited.
 
+`DELETE /api/bases/:baseId` requires its own IAM action, `bases:delete`
+(`console/api/src/actions.js`) — deliberately separate from `bases:mutate`,
+the shared bucket every other base mutation (refills, permission edits,
+cancelling a queued refill or delete) falls into. Those are all reversible;
+this one isn't, so a custom policy can grant routine base management without
+also granting the ability to permanently delete one. The shipped `owner`/
+`admin` default policies grant `bases:*`, which already covers `bases:delete`
+via wildcard, so this changes nothing about default access — it only makes
+narrower, hand-authored policies (via `PUT /api/settings/iam/policy`)
+possible. `DELETE /api/bases/:baseId/queued-delete` (cancelling) stays under
+`bases:mutate`, same as cancelling a queued refill.
+
 ## Why deletes are queued for a live map
 
 This schema has no live-notify path for structural changes — the same fact

--- a/docs/console/base-deletion.md
+++ b/docs/console/base-deletion.md
@@ -139,6 +139,11 @@ In the Bases panel, a base with a pending delete shows a danger-toned pill
 / Refill Water buttons gray out with a tooltip explaining why, rather than
 offering a control that would just be rejected.
 
+A separate, unrelated freeze applies to a base picked up via the game's own
+base-backup tool: it is excluded from the panel entirely rather than shown
+frozen, and every mutation route (including this one) rejects it with `409`.
+See [base-backups.md](base-backups.md).
+
 ## Response shape
 
 ```

--- a/docs/console/base-deletion.md
+++ b/docs/console/base-deletion.md
@@ -1,0 +1,142 @@
+# Base deletion
+
+**Status:** Current | **Last Updated:** August 2026
+
+The Bases panel can permanently delete a base and everything built or stored
+on it. The action lives as a **Delete Base** row action (trash icon) in the
+Bases panel, alongside Refill Generators, Refill Water, and Download as
+Blueprint.
+
+This is the most destructive single action in the console. Unlike a refill
+(additive, re-runnable) a delete cannot be undone once it lands — the only
+guardrails are the confirmation phrase, the danger-styled confirm dialog, and
+an automatic full-database safety backup taken before any delete SQL runs.
+See [Safety backup](#safety-backup) and [No queue-and-forget](#irreversibility).
+
+## What counts as "the base"
+
+A base is not one row — it is every `dune.actors` row reachable from its claim
+actor:
+
+- the claim actor itself (`basePermissionActor`'s resolution, the same one
+  permission editing and generator/water refills already use);
+- every building's actor id, via `dune.building_instances` →
+  `dune.actor_fgl_entities` (`dune.buildings.id` **is** an `actors.id`);
+- every placeable's actor id, via its own `owner_entity_id` chain — a
+  separate FK path from building_instances', so it needs its own join.
+
+Deleting that full set of `dune.actors` rows is what cascades away
+`buildings`, `building_instances`, `placeables`, `permission_actor`,
+`permission_actor_rank`, `inventories`, and items — all declared
+`ON DELETE CASCADE` from `actors`. The one thing that does **not** cascade
+from `actors` is the base's map marker (`dune.markers`/`dune.player_markers`,
+keyed on the claim actor id but only FK-cascaded from `map_names`), which is
+why the delete also calls the shipped `dune.permission_actor_destroy(bigint)`
+— the same proc permission removal already uses to clear a player's marker —
+before deleting the actor rows themselves.
+
+No new stored procedure was added for this: the repo has no migrations
+directory and never issues `CREATE FUNCTION` anywhere, so a delete composes
+two functions the game already ships (`permission_actor_destroy` and
+`dune.delete_actors(bigint[])`) inside one transaction, the same way
+`mutateBasePermissions` composes the permission procedures.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `DELETE` | `/api/bases/:baseId` | Delete the base. Body: `{ confirmation: "DELETE BASE" }`. |
+| `DELETE` | `/api/bases/:baseId/queued-delete` | Cancel a pending queued delete. No confirmation phrase — cancelling is reversible. |
+| `GET` | `/api/bases/pending-deletes` | Pending queue, grouped by `(map, partitionId)` the same way `/api/bases/pending-refills` is. |
+
+Deletes are audited as `bases.delete`; queued flushes as
+`bases.flush-queued-delete`. Both go through the phrase-gated
+`directDbMutation` helper (`"DELETE BASE"`, matching `"DISBAND GUILD"`'s
+precedent) and are rate limited.
+
+## Why deletes are queued for a live map
+
+This schema has no live-notify path for structural changes — the same fact
+[Base inventory](base-inventory.md#why-read-only) documents for reads: zero
+triggers on `dune.buildings`/`dune.building_instances`/`dune.placeables`, and
+no `pg_notify` channel for a structural despawn. A running map server
+periodically flushes its own in-memory copy of a base back to Postgres, so a
+raw delete against a live base's rows can be silently overwritten (resurrected)
+on the very next autosave — exactly the race the generator-refill queue exists
+to close for fuel writes.
+
+Base deletion reuses that same queue machinery rather than re-solving the
+problem: `baseRefillTarget` decides whether the base's partition is currently
+write-safe. If it is, the delete runs immediately. If not, it is recorded in
+`runtime/generated/pending-base-deletes.json` (gitignored, capped at 200
+entries) and applied the next time that partition is confirmed down — the
+same 5-second poll and restart-task `onMapDown` hook that flushes queued fuel
+and water refills.
+
+**One divergence from the refill queue:** at flush time, finding that the base
+no longer exists counts as **success**, not a failure to retry. A refill on a
+vanished base is a genuine failure — the operator's request cannot be
+honored. A delete on an already-vanished base has already achieved its goal
+(a player demolishing their own base while a delete sits queued is the
+common case this covers), so the entry is dropped without incrementing its
+attempt count or being reported as a failure.
+
+## Safety backup
+
+Every delete — immediate or flushed from the queue — triggers a full database
+backup **before** any delete SQL runs, via the same `dune db backup` mechanism
+(`DB_BACKUP_ORIGIN`) the console's raw "Database Query" tool already uses
+before any destructive query. It appears on the Backups page typed **"SQL
+Safety Backup"**, tagged with the origin `base-delete` (grouped into that same
+display type by `services/backups.js`) so it is distinguishable in the backup
+metadata from a raw-SQL-tool backup while reading the same way in the UI.
+
+If the backup fails, the delete is never attempted — for a queued flush pass,
+the entire pass aborts (every entry stays queued and is retried, backup
+included, on the next tick) rather than deleting some bases without the
+safety net that was supposed to cover the whole batch.
+
+For a flush pass with several bases ready to delete at once (e.g. a whole
+battlegroup restart), **one backup covers the entire batch** rather than one
+per base — a full database backup is not cheap, and there is no additional
+safety benefit to repeating it for bases about to be deleted moments apart in
+the same write-safe window.
+
+## Transaction atomicity
+
+The delete itself — the `FOR UPDATE` lock on the claim actor's `actors` row,
+`permission_actor_destroy`, and `delete_actors` — runs inside one Postgres
+transaction. Any failure rolls back the whole thing via the console's
+existing transaction helper; there is no code path where the permission layer
+is torn down but the structural rows survive, or vice versa.
+
+## Frozen while a delete is pending
+
+<a id="irreversibility"></a>
+A base with a delete queued rejects every other mutation — permission edits,
+generator/water refills, enabling auto-refill — with `409`, and the auto-refill
+background schedulers skip it on their scan tick. Refilling fuel or water
+moments before deleting the base would be pointless and would pollute the
+audit log, so queueing a delete also best-effort cancels any refill already
+queued for that base. Blueprint export is deliberately **not** blocked: it is
+read-only and exporting a base before it is destroyed is exactly the kind of
+thing an operator might still want to do.
+
+In the Bases panel, a base with a pending delete shows a danger-toned pill
+(trash icon + cancel) in place of its Delete button, and its Refill Generators
+/ Refill Water buttons gray out with a tooltip explaining why, rather than
+offering a control that would just be rejected.
+
+## Response shape
+
+```
+DELETE /api/bases/{baseId}
+{ supported, backupCreated,
+  result: { ok, queued?, baseId, map?, partitionId?, actorId?,
+            deletedActorCount?, deletedBuildingCount?, deletedPlaceableCount? } }
+```
+
+`result.queued: true` means the delete was recorded and will apply once the
+base's map is confirmed down; otherwise the delete already ran and
+`deletedActorCount`/`deletedBuildingCount`/`deletedPlaceableCount` describe
+what was removed.


### PR DESCRIPTION
## Summary

- Adds a **Delete Base** admin action to the Bases panel: permanently deletes a base (buildings, placeables, permissions, marker) via the game's own shipped `permission_actor_destroy`/`delete_actors` functions, inside one transaction. Phrase-gated (`"DELETE BASE"`), backed up first (full-database "SQL Safety Backup"), queued instead of applied immediately when the base's map isn't currently write-safe, flushed on map-down via the same queue machinery the generator/water refill features already use.
- `DELETE /api/bases/{baseId}` gets its own dedicated IAM action `bases:delete`, separate from the shared `bases:mutate` bucket every other base mutation falls into, so a custom policy can grant routine base management without also granting permanent deletion. Existing installs are unaffected (`bases:*` wildcard already covers it).
- Separately: the game has its own "pick up base" tool (a base-backup mechanic, unrelated to the above). Investigated live what it actually does to the database — it only unclaims the base and registers its actor ids in a `base_backup_linked_actors` table, leaving all structural rows intact. The Bases panel now excludes a picked-up base from the list, and all base mutation routes reject one with 409, rather than treating it like an ordinary base.
- Also includes a small, previously-flagged-as-bundled fix: `safeStaticTarget`'s static-asset containment check never matched on Windows (string-prefix check against a backslash-joined path), silently falling back to `index.html` for every asset request. Fixed to a `path.relative`-based check.

## Test plan

- [x] `console/api`: 1039/1039 passing, 0 skipped, run in the documented Ubuntu 22.04 + Node 22 + Postgres 17.4 container (`.claude/scripts/test-api.sh`) — includes new real-Postgres integration tests for the delete transaction's cascade/atomicity and the base-backup exclusion logic.
- [x] `console/web`: passing (BasesPanel delete UI, queued-state rendering).
- [x] Live-verified end-to-end against a restored production database: immediate delete, queued delete against real `world_partition` write-safety data (including the 30s dwell), cancel, backup-abort-on-failure safety path, and the base-backup exclusion by picking up and redeploying a real test base.
- [x] Reviewed via a 4-way parallel pass (schema/data against a restored dump, frontend, security, hygiene) against `upstream/main`; all findings closed.