### PR TITLE
Add per-category market price multipliers (augments, ranked armor, ranked weapons)

### DIFF
--- a/console/api/src/addonJobs.js
+++ b/console/api/src/addonJobs.js
@@ -24,11 +24,13 @@ import {
   writeSeedSchedule,
   persistSeedRunCompletion,
   executeSeedRun,
+  normalizeCategoryMultipliers,
   normalizeScheduleSource,
-  resolveMarketSeedPlanPath
+  resolveMarketSeedPlanPath,
+  seedRowCategoryMultiplier
 } from "./addonSeedJob.js";
 
-export { readSeedSchedule, normalizeSeedSchedule, saveSeedSchedule, normalizeScheduleSource, resolveMarketSeedPlanPath, loadMarketSeedPlan } from "./addonSeedJob.js";
+export { CATEGORY_MULTIPLIER_FIELDS, readSeedSchedule, normalizeSeedSchedule, saveSeedSchedule, normalizeCategoryMultipliers, normalizeScheduleSource, resolveMarketSeedPlanPath, loadMarketSeedPlan, seedRowCategoryMultiplier } from "./addonSeedJob.js";
 
 export const EDA_EXCHANGE_BOT_ADDON_ID = "eda-exchange-bot";
 export const ADDON_SCHEDULER_PERMISSION = "scheduler:server";
@@ -91,6 +93,10 @@ export function normalizeBuybackSchedule(payload = {}, previous = {}) {
     intervalMinutes: clampedIntegerField(payload.intervalMinutes ?? previous.intervalMinutes ?? 30, "intervalMinutes", 10, 1440),
     exchangeId,
     priceMultiplier: integerField(payload.priceMultiplier ?? previous.priceMultiplier ?? 5, "priceMultiplier", 1, 100),
+    // Category multipliers mirror the seed schedule's: keep them in sync so
+    // the reconstructed "seeded" price basis matches what the market actually
+    // sells at (buybackPercent then means percent of the real market price).
+    ...normalizeCategoryMultipliers(payload, previous, "Buyback schedule"),
     buybackPercent: integerField(payload.buybackPercent ?? previous.buybackPercent ?? 60, "buybackPercent", 1, 100),
     buybackPriceBasis: normalizeBuybackPriceBasis(payload.buybackPriceBasis ?? previous.buybackPriceBasis ?? "seeded"),
     maxBuys: integerField(payload.maxBuys ?? previous.maxBuys ?? 500, "maxBuys", 1, 5000),
@@ -169,7 +175,12 @@ export function loadBuybackSeedPlan(config, addonId = EDA_EXCHANGE_BOT_ADDON_ID)
     if (!templateId || templateId.length > 200) throw new Error(`Addon market seed plan row ${index + 1} has an invalid template_id.`);
     const price = Number(row?.price);
     if (!Number.isFinite(price) || price <= 0) throw new Error(`Addon market seed plan row ${index + 1} has an invalid price.`);
-    return { templateId, price, qualityLevel: clampInteger(row?.quality_level, 0, 0, 5) };
+    return {
+      templateId,
+      price,
+      qualityLevel: clampInteger(row?.quality_level, 0, 0, 5),
+      categoryMask: Math.trunc(Number(row?.category_mask) || 0)
+    };
   });
   return { sourceMultiplier, rows };
 }
@@ -208,10 +219,13 @@ const BUYBACK_PLAYER_SELL_SQL = "COALESCE(o.is_npc_order, FALSE) = FALSE AND (b.
 // Buyback plan: one exact cap per (template, grade), scaled from each bundled
 // seed row. Seed prices use stepped rounding, so reconstructing higher grades
 // from a grade-0 base can differ from the actual configured market price.
-export function buybackPlanValuesSql(plan, { priceMultiplier, buybackPercent }) {
+// The schedule's category multipliers reprice each row the same way the seed
+// run does, so the "seeded" basis tracks the boosted market.
+export function buybackPlanValuesSql(plan, schedule) {
+  const { priceMultiplier, buybackPercent } = schedule;
   const maxPrice = new Map();
   for (const row of plan.rows) {
-    const repriced = roundPrice((row.price / plan.sourceMultiplier) * priceMultiplier);
+    const repriced = roundPrice((row.price / plan.sourceMultiplier) * priceMultiplier * seedRowCategoryMultiplier(row, schedule));
     const key = `${row.templateId}\0${row.qualityLevel}`;
     maxPrice.set(key, Math.max(maxPrice.get(key) || 0, repriced));
   }
@@ -405,6 +419,9 @@ export async function probeBuybackEligibility(config, db, overrides = {}) {
   const schedule = normalizeBuybackSchedule({
     exchangeId: overrides.exchangeId,
     priceMultiplier: overrides.priceMultiplier,
+    augmentMultiplier: overrides.augmentMultiplier,
+    rankedArmorMultiplier: overrides.rankedArmorMultiplier,
+    rankedWeaponMultiplier: overrides.rankedWeaponMultiplier,
     buybackPercent: overrides.buybackPercent,
     maxBuys: overrides.maxBuys
   }, saved);
@@ -415,6 +432,9 @@ export async function probeBuybackEligibility(config, db, overrides = {}) {
     eligible: eligibleCount(result),
     exchangeId: schedule.exchangeId,
     priceMultiplier: schedule.priceMultiplier,
+    augmentMultiplier: schedule.augmentMultiplier,
+    rankedArmorMultiplier: schedule.rankedArmorMultiplier,
+    rankedWeaponMultiplier: schedule.rankedWeaponMultiplier,
     buybackPercent: schedule.buybackPercent,
     maxBuys: schedule.maxBuys
   };

--- a/console/api/src/addonSeedJob.js
+++ b/console/api/src/addonSeedJob.js
@@ -40,6 +40,68 @@ export function normalizeAugmentPricing(value) {
   return value === "original" ? "original" : "discounted";
 }
 
+// Per-category price multipliers layered on top of the schedule's base
+// priceMultiplier, so an operator can price hard-to-get gear above the rest
+// of the market. Three categories are recognized:
+//   - augments and augment schematics (matched by template, like the augment
+//     pricing logic above, so both features always agree on what an augment is);
+//   - ranked armor: worn gear at grades 1-5, including stillsuits and
+//     radiation suits;
+//   - ranked weapons: weapons at grades 1-5.
+// Armor and weapons are identified by the exchange's own taxonomy: the high
+// byte of category_mask holds the top-level category (0 = armor/garments,
+// 1 = weapons). Every other row — and grade-0 stock of the same gear — keeps
+// the base multiplier alone.
+const CATEGORY_MASK_TOP_LEVEL_DIVISOR = 0x1000000;
+const ARMOR_TOP_LEVEL_CATEGORY = 0;
+const WEAPON_TOP_LEVEL_CATEGORY = 1;
+const MIN_RANKED_QUALITY_LEVEL = 1;
+const CATEGORY_MULTIPLIER_MIN = 1;
+const CATEGORY_MULTIPLIER_MAX = 5;
+export const CATEGORY_MULTIPLIER_FIELDS = ["augmentMultiplier", "rankedArmorMultiplier", "rankedWeaponMultiplier"];
+const CATEGORY_MULTIPLIER_LABELS = {
+  augmentMultiplier: "augments",
+  rankedArmorMultiplier: "ranked armor",
+  rankedWeaponMultiplier: "ranked weapons"
+};
+
+export function normalizeCategoryMultipliers(payload = {}, previous = {}, scheduleLabel = "Schedule") {
+  const multipliers = {};
+  for (const field of CATEGORY_MULTIPLIER_FIELDS) {
+    multipliers[field] = categoryMultiplierField(payload?.[field] ?? previous?.[field] ?? 1, field, scheduleLabel);
+  }
+  return multipliers;
+}
+
+// Accepts 1-5x with up to two decimals (e.g. 1.5); out-of-range values are
+// rejected rather than clamped so a typo cannot quietly reprice the market.
+function categoryMultiplierField(value, name, scheduleLabel) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number < CATEGORY_MULTIPLIER_MIN || number > CATEGORY_MULTIPLIER_MAX) {
+    throw new Error(`${scheduleLabel} ${name} must be a number from ${CATEGORY_MULTIPLIER_MIN} to ${CATEGORY_MULTIPLIER_MAX}.`);
+  }
+  return Math.round(number * 100) / 100;
+}
+
+export function seedRowCategoryMultiplier(row, multipliers = {}) {
+  if (AUGMENT_TEMPLATE_PATTERN.test(row.templateId)) return multipliers.augmentMultiplier ?? 1;
+  if (row.qualityLevel >= MIN_RANKED_QUALITY_LEVEL) {
+    const topLevelCategory = Math.floor(row.categoryMask / CATEGORY_MASK_TOP_LEVEL_DIVISOR);
+    if (topLevelCategory === ARMOR_TOP_LEVEL_CATEGORY) return multipliers.rankedArmorMultiplier ?? 1;
+    if (topLevelCategory === WEAPON_TOP_LEVEL_CATEGORY) return multipliers.rankedWeaponMultiplier ?? 1;
+  }
+  return 1;
+}
+
+// Human-readable suffix for run details: ", augments 3x, ranked armor 1.5x"
+// listing only the categories that differ from the neutral 1x.
+export function describeCategoryMultipliers(multipliers = {}) {
+  const parts = CATEGORY_MULTIPLIER_FIELDS
+    .filter((field) => (multipliers[field] ?? 1) !== 1)
+    .map((field) => `${CATEGORY_MULTIPLIER_LABELS[field]} ${multipliers[field]}x`);
+  return parts.length ? `, ${parts.join(", ")}` : "";
+}
+
 export function normalizeSeedSchedule(payload = {}, previous = {}) {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     throw new Error("Seed schedule must be a JSON object.");
@@ -62,6 +124,7 @@ export function normalizeSeedSchedule(payload = {}, previous = {}) {
     intervalMinutes: clampedIntegerField(payload.intervalMinutes ?? previous.intervalMinutes ?? 15, "intervalMinutes", 10, 1440),
     exchangeId,
     priceMultiplier: integerField(payload.priceMultiplier ?? previous.priceMultiplier ?? 5, "priceMultiplier", 1, 100),
+    ...normalizeCategoryMultipliers(payload, previous, "Seed schedule"),
     augmentPricing: normalizeAugmentPricing(payload.augmentPricing ?? previous.augmentPricing),
     // Who owns this schedule: "addon" (bridge-managed; scheduled runs re-verify
     // the addon's approved permissions) or "console" (first-class Market Bot;
@@ -212,7 +275,10 @@ export function buildMarketSeedSql(plan, schedule) {
   const augmentPricing = normalizeAugmentPricing(schedule.augmentPricing);
   const augmentSchematicPrices = augmentSchematicPriceMap(plan.rows);
   const valuesSql = plan.rows.map((row) => {
-    const price = roundPrice((seedRowBasePrice(row, augmentPricing, augmentSchematicPrices) / plan.sourceMultiplier) * multiplier);
+    // Price pipeline: plan price (with the augment pricing choice applied),
+    // normalized back to the plan's own 1x scale, then the schedule's base
+    // multiplier and the row's category multiplier, rounded to clean steps.
+    const price = roundPrice((seedRowBasePrice(row, augmentPricing, augmentSchematicPrices) / plan.sourceMultiplier) * multiplier * seedRowCategoryMultiplier(row, schedule));
     return `(${sqlLiteral(row.templateId)},${row.stackSize},${price},${row.categoryMask},${row.categoryDepth},${row.qualityLevel},${sqlLiteral(row.kind)},${row.listings},${sqlLiteral(row.itemStats)})`;
   }).join(",\n") || "(NULL,1,0,0,0,0,'equippable',0,'{}')";
 
@@ -304,7 +370,7 @@ export async function executeSeedRun(config, db, schedule, { runDuneImpl, buildD
     resourceListings: decimalString(row.resource_listings),
     priceMultiplier: schedule.priceMultiplier,
     exchangeId: schedule.exchangeId,
-    detail: `Seeded ${listingCount} listings on exchange ${schedule.exchangeId} at ${schedule.priceMultiplier}x (bot listings cleared first).`
+    detail: `Seeded ${listingCount} listings on exchange ${schedule.exchangeId} at ${schedule.priceMultiplier}x${describeCategoryMultipliers(schedule)} (bot listings cleared first).`
   };
 }
 

--- a/console/api/test/addonJobs.test.js
+++ b/console/api/test/addonJobs.test.js
@@ -134,6 +134,11 @@ test("normalizes schedule fields with clamped interval and strict ranges", () =>
     [defaults.enabled, defaults.intervalMinutes, defaults.exchangeId, defaults.priceMultiplier, defaults.buybackPercent, defaults.maxBuys],
     [false, 30, "", 5, 60, 500]
   );
+  assert.deepEqual(
+    [defaults.augmentMultiplier, defaults.rankedArmorMultiplier, defaults.rankedWeaponMultiplier],
+    [1, 1, 1],
+    "category multipliers default to a neutral 1x"
+  );
 
   assert.throws(() => normalizeBuybackSchedule({ enabled: true }), /requires an exchangeId/);
   assert.throws(() => normalizeBuybackSchedule({ enabled: "yes" }), /must be true or false/);
@@ -143,6 +148,24 @@ test("normalizes schedule fields with clamped interval and strict ranges", () =>
   assert.throws(() => normalizeBuybackSchedule({ priceMultiplier: 0 }), /priceMultiplier/);
   assert.throws(() => normalizeBuybackSchedule({ buybackPercent: 101 }), /buybackPercent/);
   assert.throws(() => normalizeBuybackSchedule({ maxBuys: 5001 }), /maxBuys/);
+});
+
+test("normalizes category multipliers within 1-5x and keeps stored values on partial saves", () => {
+  const schedule = normalizeBuybackSchedule({ augmentMultiplier: 2.5, rankedArmorMultiplier: 5, rankedWeaponMultiplier: 1.339 });
+  assert.deepEqual(
+    [schedule.augmentMultiplier, schedule.rankedArmorMultiplier, schedule.rankedWeaponMultiplier],
+    [2.5, 5, 1.34],
+    "multipliers accept decimals and round to two places"
+  );
+
+  // Saves that omit the fields (for example through the addon bridge) keep
+  // the stored values instead of resetting to 1x.
+  const kept = normalizeBuybackSchedule({ buybackPercent: 55 }, schedule);
+  assert.deepEqual([kept.augmentMultiplier, kept.rankedArmorMultiplier, kept.rankedWeaponMultiplier], [2.5, 5, 1.34]);
+
+  assert.throws(() => normalizeBuybackSchedule({ augmentMultiplier: 0.5 }), /augmentMultiplier must be a number from 1 to 5/);
+  assert.throws(() => normalizeBuybackSchedule({ rankedArmorMultiplier: 6 }), /rankedArmorMultiplier must be a number from 1 to 5/);
+  assert.throws(() => normalizeBuybackSchedule({ rankedWeaponMultiplier: "big" }), /rankedWeaponMultiplier must be a number from 1 to 5/);
 });
 
 test("persists the schedule atomically with owner-only permissions and survives reload", () => {
@@ -210,6 +233,48 @@ test("builds buyback SQL server-side from the bundled seed plan", () => {
   }
 });
 
+test("buyback caps reprice ranked categories the same way the seed run does", () => {
+  // Realistic masks: high byte 0 = armor, 1 = weapons, 4 = augments.
+  const plan = {
+    price_multiplier: 5,
+    rows: [
+      { template_id: "Combat_Heavy_Unique_Top_06", kind: "equippable", price: 8000000, category_mask: 65792, quality_level: 3 },
+      { template_id: "Combat_Heavy_Unique_Top_06", kind: "equippable", price: 5500000, category_mask: 65792, quality_level: 0 },
+      { template_id: "UniqueDualBlades_6", kind: "equippable", price: 9600000, category_mask: 16777216, quality_level: 4 },
+      { template_id: "T6_Augment_Armor1", kind: "equippable", price: 28000000, category_mask: 67239936, quality_level: 3 },
+      { template_id: "WaterBottle", kind: "resource", price: 1000, category_mask: 84017152, quality_level: 0 }
+    ]
+  };
+  const repoRoot = makeRepoRoot(plan);
+  const config = { repoRoot, mockMode: false };
+  try {
+    const loaded = loadBuybackSeedPlan(config);
+    const schedule = normalizeBuybackSchedule({
+      enabled: true,
+      exchangeId: "77",
+      priceMultiplier: 5,
+      augmentMultiplier: 2,
+      rankedArmorMultiplier: 3,
+      rankedWeaponMultiplier: 1.5,
+      buybackPercent: 50,
+      maxBuys: 100
+    });
+    // Seeded basis per row: armor grade 3 8M -> 24M, grade 0 stays 5.5M,
+    // weapon grade 4 9.6M -> 14.4M, augment 28M -> 56M, resource unchanged;
+    // caps are 50% of that basis.
+    assert.equal(
+      buybackPlanValuesSql(loaded, schedule),
+      "('Combat_Heavy_Unique_Top_06',0,2750000),\n" +
+      "('Combat_Heavy_Unique_Top_06',3,12000000),\n" +
+      "('T6_Augment_Armor1',3,28000000),\n" +
+      "('UniqueDualBlades_6',4,7200000),\n" +
+      "('WaterBottle',0,500)"
+    );
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
 test("rejects missing or malformed bundled seed plans", () => {
   const missing = makeRepoRoot(null);
   const malformed = makeRepoRoot({ price_multiplier: 5, rows: [{ template_id: "", price: 10 }] });
@@ -229,7 +294,16 @@ test("probe runs the read-only eligibility query without touching backups", asyn
     saveBuybackSchedule(config, { exchangeId: "42", buybackPercent: 70 });
     const db = fakeDb({ eligible: "3" });
     const result = await probeBuybackEligibility(config, db, {});
-    assert.deepEqual(result, { eligible: 3, exchangeId: "42", priceMultiplier: 5, buybackPercent: 70, maxBuys: 500 });
+    assert.deepEqual(result, {
+      eligible: 3,
+      exchangeId: "42",
+      priceMultiplier: 5,
+      augmentMultiplier: 1,
+      rankedArmorMultiplier: 1,
+      rankedWeaponMultiplier: 1,
+      buybackPercent: 70,
+      maxBuys: 500
+    });
     assert.equal(db.probes.length, 1);
     assert.equal(db.sweeps.length, 0);
 

--- a/console/api/test/addonSeedJob.test.js
+++ b/console/api/test/addonSeedJob.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { EDA_EXCHANGE_BOT_ADDON_ID, buildMarketSeedSql, loadMarketSeedPlan, normalizeSeedSchedule } from "../src/addonSeedJob.js";
+import { EDA_EXCHANGE_BOT_ADDON_ID, buildMarketSeedSql, loadMarketSeedPlan, normalizeSeedSchedule, seedRowCategoryMultiplier } from "../src/addonSeedJob.js";
 
 const REPO_ROOT = resolve(import.meta.dirname, "../../..");
 
@@ -120,6 +120,110 @@ test("original augment pricing keeps the plan's augment item prices", () => {
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
   }
+});
+
+// Realistic category masks: the exchange stores its top-level category in the
+// mask's high byte (0 = armor/garments, 1 = weapons, 4 = augments).
+const CATEGORY_PLAN = {
+  panel_version: "test",
+  price_multiplier: 5,
+  rows: [
+    { template_id: "Combat_Heavy_Unique_Top_06", display_name: "Bulwark Chest", kind: "equippable", stack_size: 1, price: 8000000, category_mask: 65792, category_depth: 3, quality_level: 3, listings: 1, durability_cur: 192, durability_max: 192 },
+    { template_id: "Combat_Heavy_Unique_Top_06", display_name: "Bulwark Chest", kind: "equippable", stack_size: 1, price: 5500000, category_mask: 65792, category_depth: 3, quality_level: 0, listings: 1, durability_cur: 180, durability_max: 180 },
+    { template_id: "Combat_Heavy_Unique_Top_06_Schematic", display_name: "Bulwark Chest", kind: "schematic", stack_size: 1, price: 700000, category_mask: 327936, category_depth: 3, quality_level: 2, listings: 1, durability_cur: 100, durability_max: 100 },
+    { template_id: "UniqueDualBlades_6", display_name: "Burning Blades", kind: "equippable", stack_size: 1, price: 9600000, category_mask: 16777216, category_depth: 3, quality_level: 4, listings: 1, durability_cur: 196, durability_max: 196 },
+    { template_id: "T6_Augment_Armor1", display_name: "Concussive Dampening", kind: "equippable", stack_size: 1, price: 28000000, category_mask: 67239936, category_depth: 2, quality_level: 3, listings: 1, durability_cur: 192, durability_max: 192 },
+    { template_id: "T6_Augment_Armor1_Schematic", display_name: "Concussive Dampening", kind: "schematic", stack_size: 1, price: 2800000, category_mask: 67371520, category_depth: 3, quality_level: 3, listings: 1, durability_cur: 100, durability_max: 100 },
+    { template_id: "WaterBottle", display_name: "Water Bottle", kind: "resource", stack_size: 10, price: 1000, category_mask: 84017152, category_depth: 2, quality_level: 0, listings: 1 }
+  ]
+};
+
+test("category multipliers scale seeded prices on top of the base multiplier", () => {
+  const repoRoot = makeRepoRoot({ plan: CATEGORY_PLAN });
+  try {
+    const plan = loadMarketSeedPlan({ repoRoot });
+    const sql = buildMarketSeedSql(plan, {
+      enabled: true,
+      exchangeId: "7",
+      priceMultiplier: 5,
+      augmentMultiplier: 2,
+      rankedArmorMultiplier: 3,
+      rankedWeaponMultiplier: 1.5
+    });
+    // Ranked armor grade 3: 8M base -> 3x = 24M.
+    assert.match(sql, /'Combat_Heavy_Unique_Top_06',1,24000000,/);
+    // Grade-0 stock of the same armor keeps the base multiplier alone.
+    assert.match(sql, /'Combat_Heavy_Unique_Top_06',1,5500000,/);
+    // Ranked armor schematics belong to the armor category too: 700k -> 2.1M.
+    assert.match(sql, /'Combat_Heavy_Unique_Top_06_Schematic',1,2100000,/);
+    // Ranked weapon grade 4 at a fractional 1.5x: 9.6M -> 14.4M.
+    assert.match(sql, /'UniqueDualBlades_6',1,14400000,/);
+    // Discounted augment item (half its 2.8M pattern = 1.4M) then 2x = 2.8M,
+    // and the pattern itself doubles to 5.6M — the augment multiplier
+    // preserves the "patterns cost twice the bottom-roll item" relationship.
+    assert.match(sql, /'T6_Augment_Armor1',1,2800000,/);
+    assert.match(sql, /'T6_Augment_Armor1_Schematic',1,5600000,/);
+    // Rows outside the three categories are untouched.
+    assert.match(sql, /'WaterBottle',10,1000,/);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("seed rows resolve their category multiplier by augment template and exchange category", () => {
+  const multipliers = { augmentMultiplier: 2, rankedArmorMultiplier: 3, rankedWeaponMultiplier: 4 };
+  // Augments and augment schematics match by template, whatever the mask.
+  assert.equal(seedRowCategoryMultiplier({ templateId: "T6_Augment_Melee4", qualityLevel: 2, categoryMask: 67239936 }, multipliers), 2);
+  assert.equal(seedRowCategoryMultiplier({ templateId: "T6_Augment_Melee4_Schematic", qualityLevel: 1, categoryMask: 67371520 }, multipliers), 2);
+  // Ranked armor: mask high byte 0 at grade >= 1, including stillsuits.
+  assert.equal(seedRowCategoryMultiplier({ templateId: "Stillsuit_Unique_Armored_06_Mask", qualityLevel: 1, categoryMask: 131072 }, multipliers), 3);
+  // Grade-0 stock keeps the base multiplier.
+  assert.equal(seedRowCategoryMultiplier({ templateId: "Stillsuit_Unique_Armored_06_Mask", qualityLevel: 0, categoryMask: 131072 }, multipliers), 1);
+  // Ranked weapons: mask high byte 1.
+  assert.equal(seedRowCategoryMultiplier({ templateId: "UniqueDualBlades_6", qualityLevel: 5, categoryMask: 16777216 }, multipliers), 4);
+  // Ranked rows in other top-level categories (for example vehicles) are untouched.
+  assert.equal(seedRowCategoryMultiplier({ templateId: "Sandbike_Treads_Mk6", qualityLevel: 2, categoryMask: 33554432 }, multipliers), 1);
+  // Schedules without the fields behave as a neutral 1x.
+  assert.equal(seedRowCategoryMultiplier({ templateId: "UniqueDualBlades_6", qualityLevel: 5, categoryMask: 16777216 }, {}), 1);
+});
+
+test("seed schedule normalizes category multipliers within 1-5x", () => {
+  const defaults = normalizeSeedSchedule({});
+  assert.deepEqual([defaults.augmentMultiplier, defaults.rankedArmorMultiplier, defaults.rankedWeaponMultiplier], [1, 1, 1]);
+
+  const set = normalizeSeedSchedule({ augmentMultiplier: 2.5, rankedArmorMultiplier: 5, rankedWeaponMultiplier: 1.339 });
+  assert.deepEqual([set.augmentMultiplier, set.rankedArmorMultiplier, set.rankedWeaponMultiplier], [2.5, 5, 1.34]);
+
+  // Saves that omit the fields (for example through the addon bridge) keep the stored values.
+  const kept = normalizeSeedSchedule({ intervalMinutes: 20 }, set);
+  assert.deepEqual([kept.augmentMultiplier, kept.rankedArmorMultiplier, kept.rankedWeaponMultiplier], [2.5, 5, 1.34]);
+
+  assert.throws(() => normalizeSeedSchedule({ augmentMultiplier: 0.5 }), /Seed schedule augmentMultiplier must be a number from 1 to 5/);
+  assert.throws(() => normalizeSeedSchedule({ rankedArmorMultiplier: 6 }), /rankedArmorMultiplier must be a number from 1 to 5/);
+  assert.throws(() => normalizeSeedSchedule({ rankedWeaponMultiplier: "big" }), /rankedWeaponMultiplier must be a number from 1 to 5/);
+});
+
+test("bundled plan: the three categories cover exactly the ranked rows", () => {
+  const plan = JSON.parse(readFileSync(resolve(REPO_ROOT, "runtime/data/market-seed-plan.json"), "utf8"));
+  // Distinct primes make the resolved category unambiguous.
+  const multipliers = { augmentMultiplier: 2, rankedArmorMultiplier: 3, rankedWeaponMultiplier: 5 };
+  const counts = { 1: 0, 2: 0, 3: 0, 5: 0 };
+  for (const row of plan.rows) {
+    const resolved = seedRowCategoryMultiplier(
+      { templateId: row.template_id, qualityLevel: row.quality_level, categoryMask: row.category_mask },
+      multipliers
+    );
+    counts[resolved] += 1;
+    if (row.quality_level >= 1) {
+      assert.notEqual(resolved, 1, `${row.template_id} grade ${row.quality_level} must belong to a category`);
+    } else if (!/^T\d+_Augment_/i.test(row.template_id)) {
+      assert.equal(resolved, 1, `${row.template_id} grade 0 must keep the base multiplier`);
+    }
+  }
+  assert.equal(counts[2], 908, "augment items and augment schematics");
+  assert.equal(counts[3], 435, "ranked armor including stillsuits and radiation suits");
+  assert.equal(counts[5], 400, "ranked weapons");
+  assert.equal(counts[1], plan.rows.length - 908 - 435 - 400, "everything else keeps the base multiplier");
 });
 
 test("seed schedule normalizes the augment pricing choice", () => {

--- a/console/web/src/api/marketBot.ts
+++ b/console/web/src/api/marketBot.ts
@@ -11,7 +11,16 @@ export type MarketPriceBasis = "seeded" | "average" | "lowest";
 // price, "original" keeps the seed plan's own augment item prices.
 export type MarketAugmentPricing = "discounted" | "original";
 
-export type MarketBuybackSchedule = {
+// Per-category price multipliers (1-5x, 1 = no change) layered on top of the
+// schedule's base priceMultiplier: augments & augment schematics, ranked
+// (grade 1-5) armor, and ranked weapons.
+export type MarketCategoryMultipliers = {
+  augmentMultiplier: number;
+  rankedArmorMultiplier: number;
+  rankedWeaponMultiplier: number;
+};
+
+export type MarketBuybackSchedule = MarketCategoryMultipliers & {
   enabled: boolean;
   intervalMinutes: number;
   exchangeId: string;
@@ -26,7 +35,7 @@ export type MarketBuybackSchedule = {
   nextRunAt: string;
 };
 
-export type MarketSeedSchedule = {
+export type MarketSeedSchedule = MarketCategoryMultipliers & {
   enabled: boolean;
   intervalMinutes: number;
   exchangeId: string;
@@ -56,7 +65,7 @@ export type MarketExchange = {
   playerOrders: number;
 };
 
-export type MarketProbeResult = {
+export type MarketProbeResult = MarketCategoryMultipliers & {
   eligible: number;
   exchangeId: string;
   priceMultiplier: number;
@@ -81,7 +90,7 @@ export type MarketRunResult = {
 export const marketBotApi = {
   status: () => api<MarketBotStatus>("/api/exchange/market"),
   exchanges: () => api<{ rows: MarketExchange[]; capabilities: { exchangeMarket?: boolean } }>("/api/exchange/market/exchanges"),
-  probeBuyback: (overrides: Partial<{ exchangeId: string; priceMultiplier: number; buybackPercent: number; maxBuys: number }> = {}) =>
+  probeBuyback: (overrides: Partial<{ exchangeId: string; priceMultiplier: number; buybackPercent: number; maxBuys: number } & MarketCategoryMultipliers> = {}) =>
     post<MarketProbeResult>("/api/exchange/market/buyback/probe", overrides),
   saveBuybackSchedule: (schedule: Partial<MarketBuybackSchedule>) => post<MarketBuybackSchedule>("/api/exchange/market/buyback/schedule", schedule),
   saveSeedSchedule: (schedule: Partial<MarketSeedSchedule>) => post<MarketSeedSchedule>("/api/exchange/market/seed/schedule", schedule),

--- a/console/web/src/features/exchange/ExchangePanel.test.tsx
+++ b/console/web/src/features/exchange/ExchangePanel.test.tsx
@@ -199,8 +199,8 @@ describe("ExchangePanel", () => {
     vi.mocked(marketBotApi.status).mockResolvedValue({
       capabilities: { exchangeMarket: true },
       plan: { available: true, source: "bundled", rows: 10, panelVersion: "0.14.0", generatedAt: "" },
-      buyback: { enabled: false, intervalMinutes: 30, exchangeId: "", priceMultiplier: 5, buybackPercent: 60, buybackPriceBasis: "seeded", maxBuys: 500, source: "console", lastRunAt: "", lastRunStatus: "", lastRunDetail: "", nextRunAt: "" },
-      seed: { enabled: false, intervalMinutes: 15, exchangeId: "", priceMultiplier: 5, augmentPricing: "discounted", source: "console", lastRunAt: "", lastRunStatus: "", lastRunDetail: "", nextRunAt: "" }
+      buyback: { enabled: false, intervalMinutes: 30, exchangeId: "", priceMultiplier: 5, augmentMultiplier: 1, rankedArmorMultiplier: 1, rankedWeaponMultiplier: 1, buybackPercent: 60, buybackPriceBasis: "seeded", maxBuys: 500, source: "console", lastRunAt: "", lastRunStatus: "", lastRunDetail: "", nextRunAt: "" },
+      seed: { enabled: false, intervalMinutes: 15, exchangeId: "", priceMultiplier: 5, augmentMultiplier: 1, rankedArmorMultiplier: 1, rankedWeaponMultiplier: 1, augmentPricing: "discounted", source: "console", lastRunAt: "", lastRunStatus: "", lastRunDetail: "", nextRunAt: "" }
     });
     renderPanel();
 

--- a/console/web/src/features/exchange/MarketBotOverlay.test.tsx
+++ b/console/web/src/features/exchange/MarketBotOverlay.test.tsx
@@ -21,11 +21,14 @@ function statusFixture(overrides: Partial<MarketBotStatus> = {}): MarketBotStatu
     plan: { available: true, source: "bundled", rows: 2910, panelVersion: "0.14.0", generatedAt: "2026-08-01T00:00:00+00:00" },
     buyback: {
       enabled: false, intervalMinutes: 30, exchangeId: "42", priceMultiplier: 5,
+      augmentMultiplier: 1, rankedArmorMultiplier: 1, rankedWeaponMultiplier: 1,
       buybackPercent: 60, buybackPriceBasis: "seeded", maxBuys: 500, source: "console",
       lastRunAt: "", lastRunStatus: "", lastRunDetail: "", nextRunAt: ""
     },
     seed: {
-      enabled: false, intervalMinutes: 15, exchangeId: "", priceMultiplier: 5, augmentPricing: "discounted", source: "console",
+      enabled: false, intervalMinutes: 15, exchangeId: "", priceMultiplier: 5,
+      augmentMultiplier: 1, rankedArmorMultiplier: 1, rankedWeaponMultiplier: 1,
+      augmentPricing: "discounted", source: "console",
       lastRunAt: "", lastRunStatus: "", lastRunDetail: "", nextRunAt: ""
     },
     ...overrides
@@ -83,6 +86,9 @@ describe("MarketBotOverlay", () => {
       enabled: true,
       intervalMinutes: 30,
       priceMultiplier: 5,
+      augmentMultiplier: 1,
+      rankedArmorMultiplier: 1,
+      rankedWeaponMultiplier: 1,
       buybackPercent: 70,
       buybackPriceBasis: "lowest",
       maxBuys: 250,
@@ -92,13 +98,22 @@ describe("MarketBotOverlay", () => {
   });
 
   it("probes eligibility read-only and reports the count", async () => {
-    vi.mocked(marketBotApi.probeBuyback).mockResolvedValue({ eligible: 7, exchangeId: "42", priceMultiplier: 5, buybackPercent: 60, maxBuys: 500 });
+    vi.mocked(marketBotApi.probeBuyback).mockResolvedValue({
+      eligible: 7, exchangeId: "42", priceMultiplier: 5,
+      augmentMultiplier: 1, rankedArmorMultiplier: 2, rankedWeaponMultiplier: 1,
+      buybackPercent: 60, maxBuys: 500
+    });
     renderOverlay();
 
-    fireEvent.click(await screen.findByRole("button", { name: "Probe eligibility" }));
+    const armorMultiplier = await screen.findByLabelText("Buyback ranked armor multiplier");
+    expect(armorMultiplier).toHaveValue(1);
+    fireEvent.change(armorMultiplier, { target: { value: "2" } });
+    fireEvent.click(screen.getByRole("button", { name: "Probe eligibility" }));
 
     await waitFor(() => expect(marketBotApi.probeBuyback).toHaveBeenCalledWith({
-      exchangeId: "42", priceMultiplier: 5, buybackPercent: 60, maxBuys: 500
+      exchangeId: "42", priceMultiplier: 5,
+      augmentMultiplier: 1, rankedArmorMultiplier: 2, rankedWeaponMultiplier: 1,
+      buybackPercent: 60, maxBuys: 500
     }));
     expect(await screen.findByText(/7 eligible player listing\(s\) on exchange 42 at 60%/)).toBeInTheDocument();
   });
@@ -139,10 +154,41 @@ describe("MarketBotOverlay", () => {
       enabled: false,
       intervalMinutes: 15,
       priceMultiplier: 5,
+      augmentMultiplier: 1,
+      rankedArmorMultiplier: 1,
+      rankedWeaponMultiplier: 1,
       augmentPricing: "original",
       exchangeId: "42"
     }));
     expect(await screen.findByText(/Reseed schedule saved \(disabled\)\./)).toBeInTheDocument();
+  });
+
+  it("populates saved category multipliers and saves edited ones with the reseed schedule", async () => {
+    vi.mocked(marketBotApi.status).mockResolvedValue(statusFixture({
+      seed: { ...statusFixture().seed, augmentMultiplier: 2 }
+    }));
+    vi.mocked(marketBotApi.saveSeedSchedule).mockImplementation(async (schedule) => ({
+      ...statusFixture().seed, ...schedule, exchangeId: String(schedule.exchangeId || "42"), enabled: Boolean(schedule.enabled)
+    }));
+    renderOverlay();
+
+    const augment = await screen.findByLabelText("Seed augment multiplier");
+    expect(augment).toHaveValue(2);
+    fireEvent.change(augment, { target: { value: "2.5" } });
+    fireEvent.change(screen.getByLabelText("Seed ranked armor multiplier"), { target: { value: "3" } });
+    fireEvent.change(screen.getByLabelText("Seed ranked weapon multiplier"), { target: { value: "1.5" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save reseed schedule" }));
+
+    await waitFor(() => expect(marketBotApi.saveSeedSchedule).toHaveBeenCalledWith({
+      enabled: false,
+      intervalMinutes: 15,
+      priceMultiplier: 5,
+      augmentMultiplier: 2.5,
+      rankedArmorMultiplier: 3,
+      rankedWeaponMultiplier: 1.5,
+      augmentPricing: "discounted",
+      exchangeId: "42"
+    }));
   });
 
   it("disables Run reseed now until a seed schedule has a saved exchange", async () => {

--- a/console/web/src/features/exchange/MarketBotOverlay.tsx
+++ b/console/web/src/features/exchange/MarketBotOverlay.tsx
@@ -4,6 +4,7 @@ import {
   marketBotApi,
   type MarketAugmentPricing,
   type MarketBotStatus,
+  type MarketCategoryMultipliers,
   type MarketExchange,
   type MarketPriceBasis
 } from "../../api/marketBot";
@@ -22,6 +23,53 @@ type MarketBotOverlayProps = {
 
 function errorText(error: unknown) {
   return error instanceof Error ? error.message : String(error);
+}
+
+// Per-category price multipliers (1-5x) layered on top of the base price
+// multiplier. Rendered identically in the buyback and reseed sections; the
+// aria labels are prefixed with the section so both stay addressable.
+const CATEGORY_MULTIPLIER_FIELDS: Array<{ key: keyof MarketCategoryMultipliers; label: string }> = [
+  { key: "augmentMultiplier", label: "Augment multiplier" },
+  { key: "rankedArmorMultiplier", label: "Ranked armor multiplier" },
+  { key: "rankedWeaponMultiplier", label: "Ranked weapon multiplier" }
+];
+
+function defaultCategoryMultipliers(): MarketCategoryMultipliers {
+  return { augmentMultiplier: 1, rankedArmorMultiplier: 1, rankedWeaponMultiplier: 1 };
+}
+
+function categoryMultipliersFrom(schedule: Partial<MarketCategoryMultipliers>): MarketCategoryMultipliers {
+  return {
+    augmentMultiplier: schedule.augmentMultiplier ?? 1,
+    rankedArmorMultiplier: schedule.rankedArmorMultiplier ?? 1,
+    rankedWeaponMultiplier: schedule.rankedWeaponMultiplier ?? 1
+  };
+}
+
+type CategoryMultiplierInputsProps = {
+  section: "Buyback" | "Seed";
+  values: MarketCategoryMultipliers;
+  onChange: (next: MarketCategoryMultipliers) => void;
+};
+
+function CategoryMultiplierInputs({ section, values, onChange }: CategoryMultiplierInputsProps) {
+  return (
+    <>
+      {CATEGORY_MULTIPLIER_FIELDS.map(({ key, label }) => (
+        <label key={key}>{label}
+          <input
+            aria-label={`${section} ${label.toLowerCase()}`}
+            type="number"
+            min={1}
+            max={5}
+            step={0.5}
+            value={values[key]}
+            onChange={(event) => onChange({ ...values, [key]: Number(event.target.value) })}
+          />
+        </label>
+      ))}
+    </>
+  );
 }
 
 function exchangeLabel(exchange: MarketExchange) {
@@ -51,12 +99,14 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
   const [buybackEnabled, setBuybackEnabled] = useState(false);
   const [buybackInterval, setBuybackInterval] = useState(30);
   const [buybackMultiplier, setBuybackMultiplier] = useState(5);
+  const [buybackCategoryMultipliers, setBuybackCategoryMultipliers] = useState(defaultCategoryMultipliers);
   const [buybackPercent, setBuybackPercent] = useState(60);
   const [buybackBasis, setBuybackBasis] = useState<MarketPriceBasis>("seeded");
   const [maxBuys, setMaxBuys] = useState(500);
   const [seedEnabled, setSeedEnabled] = useState(false);
   const [seedInterval, setSeedInterval] = useState(15);
   const [seedMultiplier, setSeedMultiplier] = useState(5);
+  const [seedCategoryMultipliers, setSeedCategoryMultipliers] = useState(defaultCategoryMultipliers);
   const [augmentPricing, setAugmentPricing] = useState<MarketAugmentPricing>("discounted");
 
   function applyStatus(next: MarketBotStatus, options: { populateForm?: boolean } = {}) {
@@ -65,12 +115,14 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
       setBuybackEnabled(Boolean(next.buyback.enabled));
       setBuybackInterval(next.buyback.intervalMinutes);
       setBuybackMultiplier(next.buyback.priceMultiplier);
+      setBuybackCategoryMultipliers(categoryMultipliersFrom(next.buyback));
       setBuybackPercent(next.buyback.buybackPercent);
       setBuybackBasis(next.buyback.buybackPriceBasis || "seeded");
       setMaxBuys(next.buyback.maxBuys);
       setSeedEnabled(Boolean(next.seed.enabled));
       setSeedInterval(next.seed.intervalMinutes);
       setSeedMultiplier(next.seed.priceMultiplier);
+      setSeedCategoryMultipliers(categoryMultipliersFrom(next.seed));
       setAugmentPricing(next.seed.augmentPricing === "original" ? "original" : "discounted");
       setExchangeId((current) => current || next.buyback.exchangeId || next.seed.exchangeId || "");
     }
@@ -122,6 +174,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
         enabled: buybackEnabled,
         intervalMinutes: buybackInterval,
         priceMultiplier: buybackMultiplier,
+        ...buybackCategoryMultipliers,
         buybackPercent,
         buybackPriceBasis: buybackBasis,
         maxBuys,
@@ -139,6 +192,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
         enabled: seedEnabled,
         intervalMinutes: seedInterval,
         priceMultiplier: seedMultiplier,
+        ...seedCategoryMultipliers,
         augmentPricing,
         ...(exchangeId ? { exchangeId } : {})
       });
@@ -153,6 +207,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
       const result = await marketBotApi.probeBuyback({
         ...(exchangeId ? { exchangeId } : {}),
         priceMultiplier: buybackMultiplier,
+        ...buybackCategoryMultipliers,
         buybackPercent,
         maxBuys
       });
@@ -226,7 +281,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
 
             <div className="market-bot-section">
               <strong>Buyback sweeps</strong>
-              <p className="action-help-note">Buys player sell listings whose per-unit ask is at or below the buyback percentage of the price basis (seeded NPC price at that grade, or live market average / lowest with seeded fallback). Whole listed stacks are bought in one pass. Every run probes eligibility read-only first and only backs up + sweeps when something qualifies.</p>
+              <p className="action-help-note">Buys player sell listings whose per-unit ask is at or below the buyback percentage of the price basis (seeded NPC price at that grade, or live market average / lowest with seeded fallback). Whole listed stacks are bought in one pass. Every run probes eligibility read-only first and only backs up + sweeps when something qualifies. The category multipliers reprice the seeded basis the same way the reseed does — keep them matched with the reseed section so the buyback percentage tracks the real market prices.</p>
               <div className="market-bot-grid">
                 <label>Interval (minutes)
                   <input aria-label="Buyback interval minutes" type="number" min={10} max={1440} value={buybackInterval} onChange={(event) => setBuybackInterval(Number(event.target.value))} />
@@ -234,6 +289,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
                 <label>Price multiplier
                   <input aria-label="Buyback price multiplier" type="number" min={1} max={100} value={buybackMultiplier} onChange={(event) => setBuybackMultiplier(Number(event.target.value))} />
                 </label>
+                <CategoryMultiplierInputs section="Buyback" values={buybackCategoryMultipliers} onChange={setBuybackCategoryMultipliers} />
                 <label>Buyback percent
                   <input aria-label="Buyback percent" type="number" min={1} max={100} value={buybackPercent} onChange={(event) => setBuybackPercent(Number(event.target.value))} />
                 </label>
@@ -263,6 +319,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
             <div className="market-bot-section">
               <strong>Market reseed</strong>
               <p className="action-help-note">Replaces the bot's own NPC sell listings from the seed plan at the chosen price multiplier. Every run is backup, clear bot listings on that exchange, seed. Player listings are never touched. Augment items always seed as bottom-of-range rolls; the augment pricing option chooses whether they undercut their schematics (half the pattern's price) or keep the plan's original prices.</p>
+              <p className="action-help-note">Category multipliers (1-5x, 1 = no change) additionally scale the seeded prices of augments &amp; augment schematics, ranked (grade 1-5) armor including stillsuits, and ranked weapons — on top of the base price multiplier. Grade-0 stock and everything else keeps the base multiplier alone.</p>
               <div className="market-bot-grid">
                 <label>Interval (minutes)
                   <input aria-label="Seed interval minutes" type="number" min={10} max={1440} value={seedInterval} onChange={(event) => setSeedInterval(Number(event.target.value))} />
@@ -270,6 +327,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
                 <label>Price multiplier
                   <input aria-label="Seed price multiplier" type="number" min={1} max={100} value={seedMultiplier} onChange={(event) => setSeedMultiplier(Number(event.target.value))} />
                 </label>
+                <CategoryMultiplierInputs section="Seed" values={seedCategoryMultipliers} onChange={setSeedCategoryMultipliers} />
                 <label>Augment pricing
                   <select aria-label="Augment pricing" value={augmentPricing} onChange={(event) => setAugmentPricing(event.target.value as MarketAugmentPricing)}>
                     <option value="discounted">Cheaper than patterns</option>

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -420,11 +420,19 @@ blacklist behaves.
 |--------|-------|-------------|------------|
 | GET | `/api/exchange/market` | Market Bot status: seed-plan availability and both schedules | None |
 | GET | `/api/exchange/market/exchanges` | Discover exchanges (BIGINT ids as strings; access-pointed exchanges first) | None |
-| POST | `/api/exchange/market/buyback/probe` | Read-only buyback eligibility count (no backup taken) | body: `exchangeId?`, `priceMultiplier?`, `buybackPercent?`, `maxBuys?` |
-| POST | `/api/exchange/market/buyback/schedule` | Save the buyback schedule (audited, rate-limited) | body: `enabled`, `intervalMinutes`, `exchangeId`, `priceMultiplier`, `buybackPercent`, `buybackPriceBasis`, `maxBuys` |
-| POST | `/api/exchange/market/seed/schedule` | Save the market reseed schedule (audited, rate-limited) | body: `enabled`, `intervalMinutes`, `exchangeId`, `priceMultiplier`, `augmentPricing` (`discounted`\|`original`) |
+| POST | `/api/exchange/market/buyback/probe` | Read-only buyback eligibility count (no backup taken) | body: `exchangeId?`, `priceMultiplier?`, `augmentMultiplier?`, `rankedArmorMultiplier?`, `rankedWeaponMultiplier?`, `buybackPercent?`, `maxBuys?` |
+| POST | `/api/exchange/market/buyback/schedule` | Save the buyback schedule (audited, rate-limited) | body: `enabled`, `intervalMinutes`, `exchangeId`, `priceMultiplier`, `augmentMultiplier`, `rankedArmorMultiplier`, `rankedWeaponMultiplier`, `buybackPercent`, `buybackPriceBasis`, `maxBuys` |
+| POST | `/api/exchange/market/seed/schedule` | Save the market reseed schedule (audited, rate-limited) | body: `enabled`, `intervalMinutes`, `exchangeId`, `priceMultiplier`, `augmentMultiplier`, `rankedArmorMultiplier`, `rankedWeaponMultiplier`, `augmentPricing` (`discounted`\|`original`) |
 | POST | `/api/exchange/market/buyback/run` | Run a buyback sweep now with the saved schedule (probe → backup → sweep) | None |
 | POST | `/api/exchange/market/seed/run` | Run a market reseed now with the saved schedule (backup → clear bot listings → seed) | None |
+
+The three category multipliers (`augmentMultiplier`, `rankedArmorMultiplier`,
+`rankedWeaponMultiplier`) accept 1–5 (up to two decimals, default 1 = no change)
+and scale prices on top of the base `priceMultiplier` for augments & augment
+schematics, ranked (grade 1–5) armor including stillsuits, and ranked weapons
+respectively. On the seed schedule they raise the seeded sell prices; on the
+buyback schedule they reprice the reconstructed "seeded" price basis the same
+way, so `buybackPercent` keeps meaning a percentage of the real market price.
 
 Unlike the board above, these routes **do write the game database** (through the
 same engine as the EDA Exchange Bot addon's scheduler: `addonJobs.js` /

--- a/docs/console/exchange.md
+++ b/docs/console/exchange.md
@@ -97,14 +97,28 @@ Exchange Bot addon drives through the scheduler bridge, now first-class):
   pricing** option sells them either below their schematics (half the pattern's
   price at the same grade — the default) or at the plan's original prices. Either
   way, buying the pattern and crafting for a better roll stays the premium path.
+- **Category multipliers** (1–5x, default 1 = no change) additionally scale the
+  seeded prices of three endgame categories on top of the base price multiplier:
+  **augments & augment schematics** (matched by template, so the augment pricing
+  discount and the multiplier always agree on what an augment is), **ranked
+  armor** (worn gear at grades 1–5, including stillsuits and radiation suits),
+  and **ranked weapons** (grades 1–5). Armor and weapons are identified by the
+  exchange's own taxonomy — the top-level category in the high byte of
+  `category_mask` (0 = armor/garments, 1 = weapons) — so grade-0 stock of the
+  same gear and every other catalog row keep the base multiplier alone. The
+  multiplier is applied before the usual stepped price rounding, and relative
+  pricing within a category is preserved (a discounted augment item stays at
+  half its pattern's price when both are boosted).
 - **Buyback sweeps** buy player sell listings whose per-unit ask is at or below the
   buyback percentage of the chosen **price basis** — seeded NPC price at that
   listing's grade (default), or the live player-market average / lowest ask with
-  seeded fallback. Whole listed stacks are bought in one pass, sellers are paid
-  through never-expiring "Take Solari" payment entries, and concurrent sweeps are
-  safe at the database level (`FOR UPDATE ... SKIP LOCKED`). Every run probes
-  eligibility with a read-only query first and only takes a backup + sweeps when
-  something qualifies.
+  seeded fallback. The buyback schedule carries its own copy of the category
+  multipliers: keep them matched with the reseed schedule so the reconstructed
+  seeded basis tracks what the market actually sells at. Whole listed stacks are
+  bought in one pass, sellers are paid through never-expiring "Take Solari"
+  payment entries, and concurrent sweeps are safe at the database level
+  (`FOR UPDATE ... SKIP LOCKED`). Every run probes eligibility with a read-only
+  query first and only takes a backup + sweeps when something qualifies.
 - **Schedules** run unattended inside the console API process (no browser page needs
   to stay open) and survive restarts. Schedules saved from this UI are
   `source: "console"`: they are authorized by RBAC at save time and do not require


### PR DESCRIPTION
What was built. The Market Bot overlay now has three per-category price multiplier inputs (1–5x, step 0.5, default 1 = no change) in both the reseed and buyback sections, alongside the existing base price multiplier:

Augment multiplier — augment items and augment schematics, matched by the same template rule the existing augment-discount logic uses, so both features always agree on what an augment is.
Ranked armor multiplier — worn gear at grades 1–5, including stillsuits and radiation suits.
Ranked weapon multiplier — weapons at grades 1–5.