### PR TITLE
fix(bases): refuse permission writes on an unclaimed base

### DIFF
--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3246,6 +3246,35 @@ export async function basePermissionActor(db, baseId) {
   };
 }
 
+// permission_actor_rank.permission_actor_id carries a foreign key against
+// dune.permission_actor(actor_id), and basePermissionActor resolves its id from
+// the buildings -> building_instances -> actor_fgl_entities -> actors chain,
+// which says nothing about whether that actor is claimed. An unclaimed base has
+// every structural row intact and no permission_actor row, so handing its actor
+// id to permission_set_player_rank fails the FK inside the shipped procedure --
+// surfacing as a raw "violates foreign key constraint
+// permission_actor_rank_permission_actor_id_fkey" with no indication of what an
+// operator did wrong.
+//
+// Checked here rather than by widening basePermissionActor's own query: that
+// resolution is shared with the base-delete path, whose supportsBaseDelete
+// probes buildings/building_instances/actor_fgl_entities/placeables/actors but
+// not permission_actor. Joining the table into the shared query would break
+// deletion on a schema that lacks it. Both callers of this helper already gate
+// on supportsBasePermissionEditing, which does probe permission_actor.
+async function basePermissionActorClaimed(db, actorId) {
+  const result = await db.query(
+    "select exists (select 1 from dune.permission_actor where actor_id = $1::bigint) as claimed",
+    [actorId]);
+  return Boolean(result.rows[0]?.claimed);
+}
+
+// Deliberately distinct from BASE_BACKED_UP_MESSAGE in server.js: that one names
+// the base-backup tool, which is only one of the ways a base ends up unclaimed.
+// This covers the general case, including a base whose permission_actor row went
+// away without a base_backup_linked_actors entry to explain it.
+const BASE_UNCLAIMED_MESSAGE = "This base is not claimed -- it has no dune.permission_actor row, so the game has nothing to attach permissions to. A player must claim or redeploy it first.";
+
 // The base-backup tool ("pick up base") only deletes permission_actor/
 // permission_actor_rank and registers the base's actor ids in
 // base_backup_linked_actors -- see listBases' matching exclusion. That keeps
@@ -3287,6 +3316,11 @@ export async function listBasePermissions(db, baseId) {
   await requireCapability(await supportsBasePermissionEditing(db),
     "Base permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
   const { actorId, map, mapNameId } = await basePermissionActor(db, baseId);
+  // Reading an unclaimed base still succeeds -- the roster is simply empty, and
+  // seeing that is how an operator diagnoses the base in the first place. The
+  // flag rides along so the editor can disable the writes that would fail
+  // instead of offering controls that end in an FK error.
+  const claimed = await basePermissionActorClaimed(db, actorId);
   const encryptedPlayerStateColumns = await tableExists(db, "encrypted_player_state")
     ? await columnsFor(db, "encrypted_player_state")
     : new Set();
@@ -3335,6 +3369,8 @@ export async function listBasePermissions(db, baseId) {
     actorId,
     map,
     mapNameId,
+    claimed,
+    unclaimedReason: claimed ? "" : BASE_UNCLAIMED_MESSAGE,
     systemCustodian,
     entries: result.rows.map((row) => ({
       playerId: String(row.player_id),
@@ -3521,6 +3557,14 @@ async function mutateBasePermissions(db, target, safeMax, desiredRoster) {
     // rows serializes nothing. The actors row is guaranteed to exist.
     const locked = await tx.query("select id from dune.actors where id = $1::bigint for update", [actor.actorId]);
     if (!locked.rowCount) throw new Error("That base was not found.");
+
+    // After the lock, not before: this is the last read the transaction can make
+    // before it starts calling the procedures. The game's own pickup path does
+    // not take this lock, so a pickup landing mid-edit can still slip past and
+    // hit the FK -- that race is what the constraint is for. What this removes
+    // is the far more common steady-state case, an unclaimed base sitting in the
+    // panel that every route currently accepts a write for.
+    if (!(await basePermissionActorClaimed(tx, actor.actorId))) throw new Error(BASE_UNCLAIMED_MESSAGE);
 
     const existing = await tx.query(
       "select player_id::text as player_id, rank::int as rank from dune.permission_actor_rank where permission_actor_id = $1::bigint",

--- a/console/api/test/basePermissions.integration.test.js
+++ b/console/api/test/basePermissions.integration.test.js
@@ -37,6 +37,14 @@ const ENTITY_ID = 5001;
 const MAP_NAME = "DeepDesert";
 const MAP_NAME_ID = 7;
 
+// A second base carrying every structural row the actor resolution walks and no
+// dune.permission_actor row -- an unclaimed base, which the Bases panel lists
+// like any other because listBases only hides the ones that are *also*
+// registered in base_backup_linked_actors.
+const UNCLAIMED_BASE_ID = 2006;
+const UNCLAIMED_ACTOR_ID = 2004;
+const UNCLAIMED_ENTITY_ID = 6001;
+
 const SCHEMA = `
   create schema dune;
 
@@ -49,7 +57,17 @@ const SCHEMA = `
   create table dune.actors (id bigint primary key, map text, partition_id bigint, owner_account_id bigint);
   create table dune.map_names (map_name_id smallint primary key, map_name text not null);
   create table dune.permission_actor (actor_id bigint primary key, actor_name text);
-  create table dune.permission_actor_rank (permission_actor_id bigint not null, player_id bigint not null, rank smallint not null);
+  -- The foreign key is production's, transcribed from the shipped schema the
+  -- same way the procedure bodies below are, and matching the one
+  -- baseDelete.integration.test.js already declares. Without it this file
+  -- silently accepted a rank row for an unclaimed base -- the exact write that
+  -- fails against a real server with
+  -- "violates foreign key constraint permission_actor_rank_permission_actor_id_fkey".
+  create table dune.permission_actor_rank (
+    permission_actor_id bigint not null references dune.permission_actor(actor_id) on delete cascade,
+    player_id bigint not null,
+    rank smallint not null
+  );
   create table dune.player_state (account_id bigint, player_controller_id bigint, player_pawn_id bigint, character_name text);
   create table dune.encrypted_player_state (
     account_id bigint,
@@ -100,6 +118,12 @@ const SEED = `
   insert into dune.map_names (map_name_id, map_name) values (${MAP_NAME_ID}, '${MAP_NAME}');
   insert into dune.permission_actor (actor_id, actor_name) values (${ACTOR_ID}, 'DD Test');
 
+  insert into dune.buildings (id) values (${UNCLAIMED_BASE_ID});
+  insert into dune.building_instances (building_id, instance_id, owner_entity_id) values (${UNCLAIMED_BASE_ID}, 0, ${UNCLAIMED_ENTITY_ID});
+  insert into dune.actor_fgl_entities (entity_id, actor_id) values (${UNCLAIMED_ENTITY_ID}, ${UNCLAIMED_ACTOR_ID});
+  insert into dune.actors (id, map, partition_id, owner_account_id) values (${UNCLAIMED_ACTOR_ID}, '${MAP_NAME}', 8, null);
+  -- Deliberately no dune.permission_actor row for ${UNCLAIMED_ACTOR_ID}.
+
   -- Account 2 owns three actor rows; only player_controller_id 4 is a real
   -- permission holder. Ids 5 and 6 exist to prove they are rejected.
   insert into dune.actors (id, owner_account_id) values (4, 2), (5, 2), (6, 2), (23, 6), (29, 8);
@@ -135,6 +159,57 @@ async function ranks(pool) {
     [ACTOR_ID]);
   return result.rows.map((row) => ({ playerId: row.player_id, rank: row.rank }));
 }
+
+// The regression this file was extended for. Every one of these assertions is
+// one only a real database can make: a mock has no foreign key to violate, and
+// the mocked suite proves the guard fires without proving there is anything to
+// guard against.
+test("real PostgreSQL: an unclaimed base is refused rather than violating the permission_actor foreign key", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+
+    // First, the constraint really is there and really does reject this write.
+    // Without this the guard below could be passing against a schema that would
+    // have accepted the row anyway -- which is exactly how the bug shipped.
+    await assert.rejects(
+      () => pool.query(
+        "insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values ($1, 4, $2)",
+        [UNCLAIMED_ACTOR_ID, OWNER_RANK]),
+      /permission_actor_rank_permission_actor_id_fkey/);
+
+    await assert.rejects(
+      () => setBasePermissions(db, UNCLAIMED_BASE_ID, [{ playerId: "4", rank: OWNER_RANK }], 32),
+      /not claimed/);
+    await assert.rejects(
+      () => transferBaseToSystemCustodian(db, UNCLAIMED_BASE_ID, 32),
+      /not claimed/);
+
+    // The rejection must be ours, not PostgreSQL's: an FK error escaping here
+    // would still leave the operator reading constraint names.
+    await assert.rejects(
+      () => setBasePermissions(db, UNCLAIMED_BASE_ID, [{ playerId: "4", rank: OWNER_RANK }], 32),
+      (error) => !/foreign key|fkey/i.test(error.message));
+
+    const written = await pool.query(
+      "select count(*)::int as count from dune.permission_actor_rank where permission_actor_id = $1",
+      [UNCLAIMED_ACTOR_ID]);
+    assert.equal(written.rows[0].count, 0);
+  });
+});
+
+test("real PostgreSQL: an unclaimed base still reads, flagged, so the editor can explain itself", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const unclaimed = await listBasePermissions(db, UNCLAIMED_BASE_ID);
+    assert.equal(unclaimed.claimed, false);
+    assert.match(unclaimed.unclaimedReason, /not claimed/);
+    assert.deepEqual(unclaimed.entries, []);
+
+    const claimed = await listBasePermissions(db, BASE_ID);
+    assert.equal(claimed.claimed, true);
+    assert.equal(claimed.unclaimedReason, "");
+  });
+});
 
 test("real PostgreSQL: a roster save writes through the shipped procedures with the right argument order", async (t) => {
   await withDatabase(t, async (pool) => {

--- a/console/api/test/basePermissions.test.js
+++ b/console/api/test/basePermissions.test.js
@@ -17,6 +17,10 @@ function createDb({
   existing = [],
   canonicalPlayers = ["4", "23", "29", "437", "900000201"],
   mapNameId = 7,
+  // Whether dune.permission_actor holds a row for this base's claim actor.
+  // False mirrors an unclaimed base: every structural row intact, nothing for
+  // permission_actor_rank's foreign key to point at.
+  claimed = true,
   buildings = "found",
   custodians = [{ player_id: "900000201", character_name: "Server" }],
   systemIdentities = [{ table: "player_state", accountId: "9000002", playerId: "900000201" }]
@@ -51,6 +55,7 @@ function createDb({
         return { rows: [{ actor_id: ACTOR_ID, map: "DeepDesert", map_name_id: mapNameId, partition_id: 59 }] };
       }
       if (text.includes("for update")) return { rows: [{ id: ACTOR_ID }], rowCount: 1 };
+      if (text.includes("from dune.permission_actor where actor_id")) return { rows: [{ claimed }] };
       if (text.includes("from dune.permission_actor_rank")) {
         return { rows: existing.map((entry) => ({ player_id: entry.playerId, rank: entry.rank })) };
       }
@@ -138,6 +143,43 @@ test("setBasePermissions surfaces a clear error when the base's owner-entity lin
   await assert.rejects(
     () => setBasePermissions(createDb({ buildings: "orphaned" }), BASE_ID, [{ playerId: "4", rank: 1 }]),
     /no resolvable owner entity/);
+});
+
+// permission_actor_rank.permission_actor_id has a foreign key against
+// permission_actor(actor_id). An unclaimed base keeps every structural row the
+// actor resolution walks -- buildings, building_instances, actor_fgl_entities,
+// actors -- and has no permission_actor row, so the shipped procedure's insert
+// used to fail the constraint and surface the raw PostgreSQL text to the
+// operator. The write must never reach the procedure at all.
+test("setBasePermissions refuses an unclaimed base instead of failing the permission_actor foreign key", async () => {
+  const db = createDb({ claimed: false });
+  await assert.rejects(
+    () => setBasePermissions(db, BASE_ID, [{ playerId: "4", rank: 1 }]),
+    /not claimed/);
+  assert.equal(procCalls(db, "permission_set_player_rank").length, 0);
+  assert.equal(procCalls(db, "permission_remove_player_rank").length, 0);
+});
+
+// The Transfer button is the shortest path into this: an unclaimed base renders
+// "No Owner set", which is exactly the state the transfer exists to resolve.
+test("transferBaseToSystemCustodian refuses an unclaimed base", async () => {
+  const db = createDb({ claimed: false });
+  await assert.rejects(
+    () => transferBaseToSystemCustodian(db, BASE_ID),
+    /not claimed/);
+  assert.equal(procCalls(db, "permission_set_player_rank").length, 0);
+});
+
+// Reading stays allowed -- an empty roster plus the flag is how an operator
+// diagnoses the base, and the editor uses the flag to disable its controls.
+test("listBasePermissions reports an unclaimed base rather than rejecting it", async () => {
+  const claimedResult = await listBasePermissions(createDb(), BASE_ID);
+  assert.equal(claimedResult.claimed, true);
+  assert.equal(claimedResult.unclaimedReason, "");
+
+  const result = await listBasePermissions(createDb({ claimed: false }), BASE_ID);
+  assert.equal(result.claimed, false);
+  assert.match(result.unclaimedReason, /not claimed/);
 });
 
 test("setBasePermissions writes through the shipped procedures, never raw DML", async () => {
@@ -286,6 +328,7 @@ test("listBasePermissions labels ranks and flags rows the game ignores", async (
     if (text.includes("from dune.buildings b")) {
       return { rows: [{ actor_id: ACTOR_ID, map: "DeepDesert", map_name_id: 7, partition_id: 59 }] };
     }
+    if (text.includes("from dune.permission_actor where actor_id")) return { rows: [{ claimed: true }] };
     return { rows: [
       { player_id: "4", character_name: "DarkShark", rank: 1, canonical: true },
       { player_id: "29", character_name: "Yaida", rank: 2, canonical: true },

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -202,6 +202,12 @@ export type BasePermissions = {
   actorId: string;
   map: string;
   mapNameId: number;
+  // False when the base has no dune.permission_actor row -- unclaimed, so the
+  // permission table's foreign key rejects every write against it. Optional so
+  // an older API that does not send it is read as claimed, which is the
+  // behaviour that existed before the flag rather than a new lockout.
+  claimed?: boolean;
+  unclaimedReason?: string;
   systemCustodian?: {
     available: boolean;
     canCreate?: boolean;

--- a/console/web/src/features/bases/BasePermissionsTab.test.tsx
+++ b/console/web/src/features/bases/BasePermissionsTab.test.tsx
@@ -18,7 +18,11 @@ function entry(playerId: string, name: string, rank: BasePermissionRank, canonic
   return { playerId, name, rank, label: "", canonical };
 }
 
-function mockRoster(entries: BasePermissionEntry[], systemCustodian?: SystemCustodian) {
+function mockRoster(
+  entries: BasePermissionEntry[],
+  systemCustodian?: SystemCustodian,
+  claim: { claimed?: boolean; unclaimedReason?: string } = {}
+) {
   vi.mocked(basesApi.permissions).mockResolvedValue({
     supported: true,
     baseId: 1006,
@@ -26,7 +30,8 @@ function mockRoster(entries: BasePermissionEntry[], systemCustodian?: SystemCust
     map: "DeepDesert",
     mapNameId: 7,
     systemCustodian,
-    entries
+    entries,
+    ...claim
   } as never);
 }
 
@@ -212,6 +217,50 @@ describe("BasePermissionsTab ownerless state", () => {
     fireEvent.click(screen.getByRole("radio", { name: "Associate for Yaida" }));
     await waitFor(() => expect(screen.getByRole("button", { name: "Revert" })).toBeEnabled());
     expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
+  });
+});
+
+// An unclaimed base has no dune.permission_actor row, so every rank write
+// against it fails the permission_actor_rank foreign key. On screen it is
+// indistinguishable from an ordinary ownerless base, and Transfer -- the
+// control that exists to resolve ownerlessness -- was the shortest path to a
+// raw PostgreSQL constraint error.
+describe("BasePermissionsTab unclaimed base", () => {
+  const UNCLAIMED = "This base is not claimed -- it has no dune.permission_actor row.";
+
+  it("explains the unclaimed state and blocks every write, Transfer included", async () => {
+    mockRoster([], { available: true, playerId: "900000201", name: "Server" }, {
+      claimed: false,
+      unclaimedReason: UNCLAIMED
+    });
+    renderTab();
+
+    expect(await screen.findByText(UNCLAIMED)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Transfer to Server" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
+    // The generic "set an Owner" prompt would describe an action that cannot be
+    // completed here, so the reason that can be acted on stands alone.
+    expect(screen.queryByText(/This base has no Owner/)).not.toBeInTheDocument();
+  });
+
+  it("leaves the roster read-only rather than letting edits accumulate", async () => {
+    mockRoster(DEFAULT_ROSTER, undefined, { claimed: false, unclaimedReason: UNCLAIMED });
+    renderTab();
+
+    await screen.findByText(UNCLAIMED);
+    expect(screen.getByRole("radio", { name: "Associate for Yaida" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Remove Yaida" })).toBeDisabled();
+  });
+
+  // An API that predates the flag omits it. Reading that as unclaimed would
+  // disable editing on every base it serves.
+  it("treats a missing flag as claimed", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+
+    await screen.findByText("DarkShark", { selector: ".bases-permissions-owner-name" });
+    expect(screen.getByRole("radio", { name: "Associate for Yaida" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Remove Yaida" })).toBeEnabled();
   });
 });
 

--- a/console/web/src/features/bases/BasePermissionsTab.tsx
+++ b/console/web/src/features/bases/BasePermissionsTab.tsx
@@ -154,12 +154,13 @@ function RankSegments({ entry, baseId, disabled, onChange }: {
 // own card instead of being one row among many. The custodian transfer lives
 // here too -- it only ever changes the Owner, and as a section of its own it
 // was the loudest thing on the tab despite being a rare action.
-function OwnerHeroCard({ owner, isCustodian, systemCustodian, saving, dirty, onTransfer }: {
+function OwnerHeroCard({ owner, isCustodian, systemCustodian, saving, dirty, unclaimed, onTransfer }: {
   owner: DraftEntry | undefined;
   isCustodian: boolean;
   systemCustodian: { available: boolean; canCreate?: boolean; playerId?: string; name?: string; reason?: string };
   saving: boolean;
   dirty: boolean;
+  unclaimed: string;
   onTransfer: () => void;
 }) {
   const custodianName = systemCustodian.name || "Custodian";
@@ -174,11 +175,16 @@ function OwnerHeroCard({ owner, isCustodian, systemCustodian, saving, dirty, onT
       </div>
       <button
         className="warning"
-        // Still enabled on an ownerless base: that state arrives from the
-        // server with a clean draft, so parking ownership on the custodian is
-        // the fastest legitimate way out of it.
-        disabled={(!systemCustodian.available && !systemCustodian.canCreate) || ownedByCustodian || saving || dirty}
-        title={dirty
+        // Still enabled on an ownerless base that is *claimed*: that state
+        // arrives from the server with a clean draft, so parking ownership on
+        // the custodian is the fastest legitimate way out of it. An unclaimed
+        // base looks identical on screen -- "No Owner set" -- but has no
+        // permission_actor row for the rank write to reference, so this button
+        // was the shortest path to a raw foreign-key error and is blocked.
+        disabled={(!systemCustodian.available && !systemCustodian.canCreate) || ownedByCustodian || saving || dirty || Boolean(unclaimed)}
+        title={unclaimed
+          ? unclaimed
+          : dirty
           ? "Save or revert roster changes first"
           : ownedByCustodian
           ? `This base is already owned by the ${systemCustodian.name || "detected"} system custodian`
@@ -205,6 +211,10 @@ export function BasePermissionsTab({ baseId, baseName, onSaved, confirmAction }:
   const [searched, setSearched] = useState(false);
   const [addRank, setAddRank] = useState<BasePermissionRank>(ASSOCIATE_RANK);
   const [systemCustodian, setSystemCustodian] = useState<{ available: boolean; canCreate?: boolean; playerId?: string; name?: string; reason?: string }>({ available: false });
+  // The server's explanation when the base has no permission_actor row, empty
+  // otherwise. A string rather than a boolean so the banner and every disabled
+  // control's tooltip read back the same sentence the API chose.
+  const [unclaimed, setUnclaimed] = useState("");
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -214,6 +224,12 @@ export function BasePermissionsTab({ baseId, baseName, onSaved, confirmAction }:
       const entries = toDraft(result.entries || []);
       setSaved(entries);
       setDraft(entries);
+      // Only an explicit false locks the tab down. An API that predates the
+      // flag omits it, and reading that as unclaimed would disable editing on
+      // every base it serves.
+      setUnclaimed(result.claimed === false
+        ? result.unclaimedReason || "This base is not claimed, so its permissions cannot be edited."
+        : "");
       setSystemCustodian(result.systemCustodian || { available: false, reason: "System custodian detection is unavailable." });
     } catch (error) {
       setLoadError(errorText(error));
@@ -388,6 +404,7 @@ export function BasePermissionsTab({ baseId, baseName, onSaved, confirmAction }:
             systemCustodian={systemCustodian}
             saving={saving}
             dirty={dirty}
+            unclaimed={unclaimed}
             onTransfer={() => void transferToSystemCustodian()}
           />
         </div>
@@ -418,8 +435,8 @@ export function BasePermissionsTab({ baseId, baseName, onSaved, confirmAction }:
                   <span>{candidate.name}</span>
                   <button
                     className="icon-toggle-button"
-                    disabled={alreadyOnRoster.has(candidate.playerId) || saving}
-                    title={alreadyOnRoster.has(candidate.playerId) ? "Already on this base" : `Add ${candidate.name} as ${RANK_LABELS[addRank]}`}
+                    disabled={alreadyOnRoster.has(candidate.playerId) || saving || Boolean(unclaimed)}
+                    title={unclaimed || (alreadyOnRoster.has(candidate.playerId) ? "Already on this base" : `Add ${candidate.name} as ${RANK_LABELS[addRank]}`)}
                     aria-label={`Add ${candidate.name}`}
                     onClick={() => addCandidate(candidate)}
                   ><Plus size={15} /></button>
@@ -433,8 +450,8 @@ export function BasePermissionsTab({ baseId, baseName, onSaved, confirmAction }:
             <button disabled={!dirty || saving} onClick={() => setDraft(saved)}>Revert</button>
             <button
               className="update-action"
-              disabled={!dirty || !owner || saving}
-              title={`Save permissions for ${baseName}`}
+              disabled={!dirty || !owner || saving || Boolean(unclaimed)}
+              title={unclaimed || `Save permissions for ${baseName}`}
               onClick={() => void save()}
             >{saving ? "Saving…" : "Save changes"}</button>
           </div>
@@ -443,11 +460,15 @@ export function BasePermissionsTab({ baseId, baseName, onSaved, confirmAction }:
         {/* Do not reserve an empty message area. Warnings and results appear
             only when they have useful information, matching the compact action
             layouts elsewhere in the console. */}
-        {(dirty || !owner || status) && <div className="bases-permissions-banner-slot">
+        {(dirty || !owner || unclaimed || status) && <div className="bases-permissions-banner-slot">
           {dirty && <p className="confirm-modal-warning bases-permissions-warning" role="status">
             Saving writes to the live database and notifies the running map server. An online player may need to reopen the base's panel to see the change.
           </p>}
-          {!owner && <p className="bases-permissions-error" role="alert">
+          {unclaimed && <p className="bases-permissions-error" role="alert">{unclaimed}</p>}
+          {/* Suppressed on an unclaimed base: it has no Owner either, but
+              "set one before saving" describes an action that cannot be
+              completed there and would bury the reason that can. */}
+          {!owner && !unclaimed && <p className="bases-permissions-error" role="alert">
             This base has no Owner. Set one before saving.
           </p>}
           {status && <p
@@ -479,13 +500,13 @@ export function BasePermissionsTab({ baseId, baseName, onSaved, confirmAction }:
               <RankSegments
                 entry={entry}
                 baseId={baseId}
-                disabled={saving}
+                disabled={saving || Boolean(unclaimed)}
                 onChange={(rank) => changeRank(entry.playerId, rank)}
               />
               <button
                 className="icon-toggle-button bases-permissions-remove"
-                disabled={saving}
-                title={`Remove ${entry.name || entry.playerId}`}
+                disabled={saving || Boolean(unclaimed)}
+                title={unclaimed || `Remove ${entry.name || entry.playerId}`}
                 aria-label={`Remove ${entry.name || entry.playerId}`}
                 onClick={() => removeEntry(entry.playerId)}
               ><Trash2 size={15} /></button>

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -261,7 +261,7 @@ When the Restart Queue is enabled, the restart routes above (`/api/server/restar
 | GET | `/api/bases/auto-refill-water` | Get per-base water auto-refill enrollment state | None |
 | POST | `/api/bases/{baseId}/auto-refill-water` | Enable/disable water auto-refill for a base | `baseId`, `enabled` |
 | GET | `/api/bases/{baseId}/inventory` | Get a base's stored items, rolled up by item template and by container (storage, refining, crafting, other). Read-only | `baseId` |
-| GET | `/api/bases/{baseId}/permissions` | Get a base's permission roster (Owner, Co-Owners, Associates). Also returns `claimed` and, when false, `unclaimedReason` | `baseId` |
+| GET | `/api/bases/{baseId}/permissions` | Get a base's permission roster (Owner, Co-Owners, Associates) | `baseId` |
 | POST | `/api/bases/{baseId}/system-custodian` | Transfer ownership to the Server or detected GM system custodian while preserving the roster; provisions Server when no custodian exists | `baseId` |
 | PUT | `/api/bases/{baseId}/permissions` | Replace a base's permission roster | `baseId`, `entries[]` (`playerId`, `rank`) |
 | GET | `/api/bases/permission-candidates` | Search players eligible to be added to a roster | `q?`, `limit?` |

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -261,7 +261,7 @@ When the Restart Queue is enabled, the restart routes above (`/api/server/restar
 | GET | `/api/bases/auto-refill-water` | Get per-base water auto-refill enrollment state | None |
 | POST | `/api/bases/{baseId}/auto-refill-water` | Enable/disable water auto-refill for a base | `baseId`, `enabled` |
 | GET | `/api/bases/{baseId}/inventory` | Get a base's stored items, rolled up by item template and by container (storage, refining, crafting, other). Read-only | `baseId` |
-| GET | `/api/bases/{baseId}/permissions` | Get a base's permission roster (Owner, Co-Owners, Associates) | `baseId` |
+| GET | `/api/bases/{baseId}/permissions` | Get a base's permission roster (Owner, Co-Owners, Associates). Also returns `claimed` and, when false, `unclaimedReason` | `baseId` |
 | POST | `/api/bases/{baseId}/system-custodian` | Transfer ownership to the Server or detected GM system custodian while preserving the roster; provisions Server when no custodian exists | `baseId` |
 | PUT | `/api/bases/{baseId}/permissions` | Replace a base's permission roster | `baseId`, `entries[]` (`playerId`, `rank`) |
 | GET | `/api/bases/permission-candidates` | Search players eligible to be added to a roster | `q?`, `limit?` |
@@ -273,6 +273,12 @@ When the Restart Queue is enabled, the restart routes above (`/api/server/restar
 base-backup tool (unclaimed and registered in `dune.base_backup_linked_actors`
 — see [base-backups.md](base-backups.md)), and every mutation route below
 rejects one with **409** for the same reason.
+
+A base that is unclaimed for any *other* reason still lists, and `GET
+/api/bases/{baseId}/permissions` still reads it, reporting `claimed: false`. The
+two permission mutation routes reject it with **400** rather than letting the
+write fail `permission_actor_rank`'s foreign key — see
+[base-permissions.md](base-permissions.md).
 
 Each `GET /api/bases` row carries `partitionMap` and `dimensionIndex` alongside
 `map` and `partition_id`. `map` is the game's own name (`HaggaBasin`) and cannot

--- a/docs/console/base-permissions.md
+++ b/docs/console/base-permissions.md
@@ -55,6 +55,40 @@ request.
 - **The roster cap**, read from live server config (see below).
 - **Ranks limited to 1–3**, no duplicate players.
 - **Every player id must be a `player_controller_id`** (see below).
+- **The base must be claimed** (see below).
+
+## An unclaimed base is refused, not attempted
+
+`permission_actor_rank.permission_actor_id` carries a foreign key against
+`dune.permission_actor(actor_id)`. The actor id every write uses is resolved from
+`buildings → building_instances → actor_fgl_entities → actors`, which says
+nothing about whether that actor is *claimed* — an unclaimed base keeps every one
+of those rows and has no `permission_actor` row at all.
+
+Both mutation routes therefore check for that row, inside the transaction and
+after taking the claim lock, and refuse with *"This base is not claimed…"*.
+Without the check the write reached `permission_set_player_rank` and failed the
+constraint, surfacing raw PostgreSQL text
+(`violates foreign key constraint permission_actor_rank_permission_actor_id_fkey`)
+to the operator.
+
+`GET` still succeeds on such a base — the roster is simply empty, and seeing that
+is how the state gets diagnosed — and returns `claimed: false` plus
+`unclaimedReason`. The tab uses those to disable Save, Transfer, the rank
+controls and the remove buttons, rather than offering controls whose only
+outcome is an error. This matters most for **Transfer to Custodian**: an
+unclaimed base renders "No Owner set", which is exactly the state that button
+exists to resolve, making it the shortest path into the failure.
+
+The pickup ("backed-up") case is caught earlier and separately, by
+`baseIsBackedUp` in `server.js`, which returns a 409 naming the base-backup tool.
+That check requires *both* signals — unclaimed **and** registered in
+`base_backup_linked_actors` — so a base that is unclaimed for any other reason
+falls through to this one.
+
+The game's own pickup path does not take the claim lock, so a pickup landing
+mid-edit can still reach the constraint. That race is what the foreign key is
+for; the check removes the steady-state case, which is the one operators hit.
 
 ## System custodian
 


### PR DESCRIPTION
Setting ownership from the Bases tab on an unclaimed base failed with a raw
PostgreSQL error:

```
insert or update on table "permission_actor_rank" violates foreign key constraint "permission_actor_rank_permission_actor_id_fkey"
```

`permission_actor_rank.permission_actor_id` references `permission_actor(actor_id)`, but the actor id every permission write uses is resolved from `buildings → building_instances → actor_fgl_entities → actors`, which says nothing about whether that actor is claimed. An unclaimed base keeps all of those rows and has no `permission_actor` row, so the write reached `permission_set_player_rank` and failed the constraint.

`listBases` only hides a base that is unclaimed **and** registered in `base_backup_linked_actors`, so one unclaimed for any other reason still lists and every mutation route accepted it.

## Changes

- Both mutation routes check for the `permission_actor` row inside the transaction, after the claim lock, and refuse with a clear message (400).
- `GET` still reads such a base — an empty roster is how the state gets diagnosed — and returns `claimed` / `unclaimedReason`.
- The tab disables Save, Transfer, the rank controls and the remove buttons, using the server's sentence as banner and tooltip. Transfer mattered most: an unclaimed base renders "No Owner set", exactly the state that button exists to resolve.
- The check lives in its own helper rather than in `basePermissionActor`'s query — that resolution is shared with the base-delete path, whose `supportsBaseDelete` does not probe `permission_actor`, so joining the table in would break deletion on a schema lacking it.

## Why tests missed it

`basePermissions.integration.test.js` declared `permission_actor_rank` without the foreign key; `baseDelete.integration.test.js` already declared it. The constraint is now in that schema too, with an unclaimed base seeded and a test asserting the raw insert really is rejected by name, so the guard is proven against a schema that would otherwise fail.

## Verification

- `console/api` suite in the CI-parity container: 1081 tests, 1081 pass, 0 fail, 0 skipped.
- `BasePermissionsTab.test.tsx` 25/25; `tsc --noEmit` clean.
- Live Postgres 17.4 restored from a production dump: reproduced the FK error, then confirmed `GET` reports `claimed: false`, `PUT` and `POST system-custodian` return 400 with the plain message, 0 rank rows written, and a claimed base is unaffected.
