### PR TITLE
Per-slot base container contents, with item deletion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,12 @@ ADMIN_REFILL_RETRY_DELAY_MS=60000
 ADMIN_AUTO_REFILL_THRESHOLD_PERCENT=50
 ADMIN_AUTO_REFILL_INTERVAL_HOURS=24
 
+# Base-delete queue tuning. Same shape as the generator refill queue above:
+# a delete queued for a live map is dropped after MAX_AGE_MS without applying,
+# and a failed flush attempt waits RETRY_DELAY_MS before retrying.
+ADMIN_BASE_DELETE_MAX_AGE_MS=604800000
+ADMIN_BASE_DELETE_RETRY_DELAY_MS=60000
+
 # Public servers are listed automatically on https://dunedocker.app.
 # Set this to false to opt out while keeping SERVER_IP_MODE=public.
 # Listed servers also receive automatic personalized browser latency checks.

--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -393,7 +393,16 @@ export const REGEX_ACTIONS_BY_METHOD_PATTERN = [
   // other bases DELETE route (queued-refill, queued-water-refill, queued-
   // delete — all cancellations) still falls through to the
   // "DELETE /api/bases/" prefix rule above, unaffected.
-  { method: "DELETE", pattern: /^\/api\/bases\/[^/]+$/, action: "bases:delete" }
+  { method: "DELETE", pattern: /^\/api\/bases\/[^/]+$/, action: "bases:delete" },
+  // DELETE /api/bases/{baseId}/containers/{placeableId}/items/{itemId} —
+  // destroying one stored item. Its own action for a different reason than
+  // bases:delete above: not blast radius, but consent. Base inventory shipped
+  // read-only, so an operator whose hand-authored policy grants bases:mutate
+  // agreed to refills and permission edits and could not have agreed to item
+  // destruction — folding this into that bucket would silently widen every
+  // existing narrow policy. The shipped owner/admin policies grant bases:*,
+  // so default access is unchanged.
+  { method: "DELETE", pattern: /^\/api\/bases\/[^/]+\/containers\/[^/]+\/items\/[^/]+$/, action: "bases:delete-item" }
 ];
 
 // ---- Action resolution ----

--- a/console/api/src/db.js
+++ b/console/api/src/db.js
@@ -120,6 +120,17 @@ export function intParam(value, label, min = 0, max = Number.MAX_SAFE_INTEGER) {
   return n;
 }
 
+// PostgreSQL bigint identifiers must stay as decimal strings. Converting one
+// to Number first silently rounds values above Number.MAX_SAFE_INTEGER and can
+// make a destructive request target a different row.
+export function bigintParam(value, label, min = 1n, max = 9223372036854775807n) {
+  const raw = String(value ?? "").trim();
+  if (!/^[0-9]+$/.test(raw)) throw new Error(`Invalid ${label}`);
+  const n = BigInt(raw);
+  if (n < min || n > max) throw new Error(`Invalid ${label}`);
+  return n.toString();
+}
+
 export function isReadOnlySql(query) {
   const stripped = String(query || "")
     .replace(/\/\*[\s\S]*?\*\//g, " ")

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -1,4 +1,4 @@
-import { assertIdentifier, intParam, isReadOnlySql, quoteIdentifier, quoteQualified, rowsResult } from "./db.js";
+import { assertIdentifier, bigintParam, intParam, isReadOnlySql, quoteIdentifier, quoteQualified, rowsResult } from "./db.js";
 import { getBridgeRequestSummary } from "./audit.js";
 import { resolvePorts } from "./config.js";
 import { existsSync, readFileSync } from "node:fs";
@@ -7922,11 +7922,11 @@ export async function baseContainerSlots(db, baseId, placeableId) {
 // actor and picks one arbitrarily.
 //
 // There is no live-sync path for inventory (no pg_notify channel, no triggers
-// on dune.items) and, worse, a running map server periodically flushes its
-// in-memory copy of a base back to Postgres -- so a delete against a live map
-// can be resurrected on the next autosave. The write still happens immediately;
-// the caller is responsible for surfacing that risk, and baseRefillTarget is
-// what tells it whether this base's map is currently running.
+// on dune.items), so the API route refuses this operation unless it can verify
+// that the owning map is safely down. This lower layer also restricts deletion
+// to plain storage: crafting/refining inventories can have active jobs that
+// reference these rows, and deleting an allocated ingredient can corrupt that
+// job even while the map is stopped.
 export async function deleteBaseContainerItem(db, baseId, placeableId, itemId, { count = null } = {}) {
   await requireCapability(
     await supportsBaseContainerItemDelete(db),
@@ -7934,7 +7934,7 @@ export async function deleteBaseContainerItem(db, baseId, placeableId, itemId, {
   );
   const target = intParam(baseId, "base id", 1);
   const container = intParam(placeableId, "container id", 1);
-  const safeItemId = intParam(itemId, "item id", 1);
+  const safeItemId = bigintParam(itemId, "item id");
   const requestedCount = count === null || count === undefined ? null : intParam(count, "count", 1);
   const [groups, buildingTypes, typeNames] = baseInventoryTypeParams();
 
@@ -7976,6 +7976,9 @@ export async function deleteBaseContainerItem(db, baseId, placeableId, itemId, {
 
     const item = found.rows[0];
     if (!item) throw new Error("That item was not found in a storage container at the selected base.");
+    if (item.group_key !== "storage") {
+      throw new Error("Items can only be deleted from Storage containers. Crafting and Refining contents are read-only to protect active jobs.");
+    }
 
     const stackSize = Number(item.stack_size) || 0;
     const inventoryId = item.inventory_id;

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3681,6 +3681,24 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
   const backupExclusion = hasBaseBackups
     ? "and not (pa.actor_id is null and exists (select 1 from dune.base_backup_linked_actors bbla where bbla.actor_id = a.id))"
     : "";
+  // What counts as a base, defined once. The paged query (`matched`) and the
+  // totals query (`valid_claims`) run in separate round trips but must agree
+  // exactly on the candidate set -- if they diverge, total_bases/total_pieces/
+  // total_placeables silently stop describing the rows actually being listed.
+  // Emitting both from here makes that divergence unrepresentable rather than
+  // merely tested for. `extraJoin` is the one sanctioned variation: `matched`
+  // needs the owner LATERAL joined before its group-by when searching or
+  // sorting by owner, and that join cannot affect which rows qualify (it is a
+  // LEFT JOIN LATERAL ... ON TRUE returning at most one row).
+  const baseCandidateSource = (extraJoin = "") => `
+        from dune.buildings b
+        join dune.building_instances bi on bi.building_id = b.id
+        join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+        join dune.actors a on a.id = afe.actor_id
+        left join dune.permission_actor pa on pa.actor_id = a.id
+        ${extraJoin}
+        where a.transform is not null
+        ${backupExclusion}`;
   // A base's own a.map is the game's map name ("HaggaBasin"), which cannot tell
   // two instances of it apart. world_partition resolves the partition to the
   // name the rest of the console uses ("Survival_1") plus its dimension --
@@ -3766,14 +3784,7 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
                coalesce(a.partition_id, 0) as partition_id,
                a.transform,
                ${matchedSortSelect}
-        from dune.buildings b
-        join dune.building_instances bi on bi.building_id = b.id
-        join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
-        join dune.actors a on a.id = afe.actor_id
-        left join dune.permission_actor pa on pa.actor_id = a.id
-        ${matchedOwnerJoin}
-        where a.transform is not null
-        ${backupExclusion}
+        ${baseCandidateSource(matchedOwnerJoin)}
         group by a.id, a.class, pa.actor_name, ${matchedGroupByOwner}a.map, a.partition_id, a.transform
         ${having}
       ),
@@ -3816,13 +3827,7 @@ export async function listBases(db, { q = "", page = 0, pageSize = 50, sortColum
     const totalsResult = await db.query(`
       with valid_claims as (
         select distinct a.id as actor_id
-        from dune.buildings b
-        join dune.building_instances bi on bi.building_id = b.id
-        join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
-        join dune.actors a on a.id = afe.actor_id
-        left join dune.permission_actor pa on pa.actor_id = a.id
-        where a.transform is not null
-        ${backupExclusion}
+        ${baseCandidateSource()}
       )
       select (select count(*) from valid_claims)::int as total_bases,
              (select count(*) from dune.building_instances bi join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id join valid_claims vc on vc.actor_id = afe.actor_id)::int as total_pieces,

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -7753,6 +7753,304 @@ export async function baseInventory(db, baseId, { repoRoot = "" } = {}) {
   };
 }
 
+// The per-slot view of ONE container, kept off baseInventory deliberately.
+// Slots roughly triple that response (238KB -> 656KB on the largest base in the
+// reference dump, +176%) and it loads on every base expand and auto-refresh,
+// while the contents modal only ever shows a single container. So slots are
+// fetched per container, on open.
+//
+// baseInventory's items[] stays template-merged and is unchanged: it backs the
+// "N distinct" label and the search filter, both of which mean distinct
+// templates rather than stacks. This is the per-slot truth beside it.
+//
+// Slots hang off an inventory rather than the container because max_item_count
+// is summed across every inventory a placeable backs while position_index is
+// scoped to one of them -- two inventories would both have a slot 0.
+export async function baseContainerSlots(db, baseId, placeableId) {
+  const target = intParam(baseId, "base id", 1);
+  const container = intParam(placeableId, "container id", 1);
+  // Same relations baseInventory probes, minus permission_actor: this query
+  // does not resolve display names, so it must not fail on a schema that lacks
+  // that table when baseInventory already reported the container.
+  const required = [
+    "buildings", "building_instances", "actor_fgl_entities",
+    "placeables", "inventories", "items"
+  ];
+  const present = await Promise.all(required.map((table) => tableExists(db, table)));
+  const missing = required.filter((_, index) => !present[index]);
+  if (missing.length) {
+    return {
+      supported: false,
+      reason: `Unsupported by detected schema. Missing required table(s): ${missing.map((table) => `dune.${table}`).join(", ")}`,
+      baseId: target,
+      placeableId: String(container),
+      inventories: []
+    };
+  }
+
+  // Probed rather than assumed: a missing column is a parse-time error, not a
+  // null, so selecting position_index against a schema without it would 500 a
+  // container that used to open. Slots still come back; only the grid degrades,
+  // and the frontend falls back to the list when positionIndex is null.
+  const itemColumns = await columnsFor(db, "items");
+  const hasPositionIndex = itemColumns.has("position_index");
+  const hasStats = itemColumns.has("stats");
+  const slotSelect = [
+    hasPositionIndex ? "i.position_index" : "null::bigint as position_index",
+    itemColumns.has("quality_level") ? "i.quality_level" : "0::bigint as quality_level",
+    // Lifted verbatim from INVENTORY_ITEM_SELECT so the two paths cannot
+    // disagree about where durability lives.
+    hasStats
+      ? "coalesce((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'), null) as current_durability"
+      : "null::text as current_durability",
+    hasStats
+      ? `coalesce(
+             nullif((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::numeric, 0),
+             nullif((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::numeric, 0),
+             null
+           ) as max_durability`
+      : "null::numeric as max_durability"
+  ].join(",\n           ");
+  const slotOrder = hasPositionIndex ? "i.position_index nulls last, i.id" : "i.id";
+  const [groups, buildingTypes, typeNames] = baseInventoryTypeParams();
+
+  // The claim-resolution CTEs are baseInventory's, narrowed to one placeable.
+  // Keeping the inventory_types join and is_hologram/max_item_count filters is
+  // load-bearing, not tidiness: they are what stops this reaching generator and
+  // windtrap fuel, which the Power and Water tabs own.
+  const result = await db.query(`
+    with requested_claims as (
+      select distinct b.id, afe.actor_id
+      from dune.buildings b
+      join dune.building_instances bi on bi.building_id = b.id
+      join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+      where b.id = $1
+    ), base_entities as (
+      select distinct rc.id, claim_afe.entity_id as owner_entity_id
+      from requested_claims rc
+      join dune.actor_fgl_entities claim_afe on claim_afe.actor_id = rc.actor_id
+    ), inventory_types as (
+      select * from unnest($2::text[], $3::text[], $4::text[]) as t(group_key, building_type, type_name)
+    ), containers as (
+      select distinct p.id as placeable_id, inv.id as inventory_id,
+             it.group_key, it.type_name, inv.max_item_count
+      from base_entities be
+      join dune.placeables p on p.owner_entity_id = be.owner_entity_id
+      join inventory_types it on it.building_type = lower(p.building_type)
+      join dune.inventories inv on inv.actor_id = p.id and inv.max_item_count >= 0
+      where p.is_hologram = false and p.id = $5
+    )
+    select c.inventory_id::text as inventory_id,
+           c.group_key, c.type_name, c.max_item_count,
+           i.id::text as item_id, i.template_id, i.stack_size,
+           ${slotSelect}
+    from containers c
+    left join dune.items i on i.inventory_id = c.inventory_id
+    order by c.inventory_id, ${slotOrder}`, [target, groups, buildingTypes, typeNames, container]);
+
+  if (!result.rows.length) {
+    return {
+      supported: true,
+      found: false,
+      reason: "That container was not found at the selected base.",
+      baseId: target,
+      placeableId: String(container),
+      inventories: []
+    };
+  }
+
+  const itemMetadata = adminItemMetadata();
+  const inventoriesById = new Map();
+  for (const row of result.rows) {
+    const inventoryId = String(row.inventory_id);
+    let inventory = inventoriesById.get(inventoryId);
+    if (!inventory) {
+      inventory = {
+        inventoryId,
+        maxSlots: Math.max(0, Number(row.max_item_count) || 0),
+        usedSlots: 0,
+        slots: []
+      };
+      inventoriesById.set(inventoryId, inventory);
+    }
+    // The left join emits one all-null item row for an empty inventory, which
+    // still needs its entry above so the grid can render empty slots.
+    const templateId = String(row.template_id || "");
+    if (!templateId) continue;
+    inventory.usedSlots += 1;
+    inventory.slots.push({
+      itemId: String(row.item_id),
+      templateId,
+      name: itemMetadata.get(templateId)?.name || templateId,
+      positionIndex: row.position_index === null || row.position_index === undefined
+        ? null
+        : Number(row.position_index),
+      quantity: Number(row.stack_size) || 0,
+      qualityLevel: Number(row.quality_level) || 0,
+      currentDurability: row.current_durability === null || row.current_durability === undefined
+        ? null
+        : Number(row.current_durability),
+      maxDurability: row.max_durability === null || row.max_durability === undefined
+        ? null
+        : Number(row.max_durability)
+    });
+  }
+
+  const inventories = [...inventoriesById.values()];
+  return {
+    supported: true,
+    found: true,
+    baseId: target,
+    placeableId: String(container),
+    typeName: result.rows[0].type_name,
+    group: result.rows[0].group_key,
+    maxSlots: inventories.reduce((total, inventory) => total + inventory.maxSlots, 0),
+    usedSlots: inventories.reduce((total, inventory) => total + inventory.usedSlots, 0),
+    inventories
+  };
+}
+
+// Deletes one stored item, or part of its stack, from a base container.
+//
+// Ownership is the whole job here. The query re-resolves the base's claim from
+// scratch rather than trusting the placeable id the caller sent, and keeps
+// baseInventory's inventory_types join plus the is_hologram / max_item_count
+// filters: together they prove the item sits in an allowlisted container at the
+// requested base, which is what stops this reaching a generator or windtrap
+// fuel inventory that the Power and Water tabs own. Deliberately NOT the
+// giveItemToStorage shape, which only checks that some inventory exists for an
+// actor and picks one arbitrarily.
+//
+// There is no live-sync path for inventory (no pg_notify channel, no triggers
+// on dune.items) and, worse, a running map server periodically flushes its
+// in-memory copy of a base back to Postgres -- so a delete against a live map
+// can be resurrected on the next autosave. The write still happens immediately;
+// the caller is responsible for surfacing that risk, and baseRefillTarget is
+// what tells it whether this base's map is currently running.
+export async function deleteBaseContainerItem(db, baseId, placeableId, itemId, { count = null } = {}) {
+  await requireCapability(
+    await supportsBaseContainerItemDelete(db),
+    "Container item delete requires dune.buildings, dune.building_instances, dune.actor_fgl_entities, dune.placeables, dune.inventories, dune.items, and dune.delete_item(bigint)."
+  );
+  const target = intParam(baseId, "base id", 1);
+  const container = intParam(placeableId, "container id", 1);
+  const safeItemId = intParam(itemId, "item id", 1);
+  const requestedCount = count === null || count === undefined ? null : intParam(count, "count", 1);
+  const [groups, buildingTypes, typeNames] = baseInventoryTypeParams();
+
+  return db.transaction(async (tx) => {
+    // for update OF i, inv -- not a bare `for update`. Postgres cannot lock a
+    // CTE reference, so naming the real relations is required, not stylistic.
+    // inv is locked as well as i because locking only the item row locks
+    // nothing when the row is already gone; the inventory row is the parent
+    // guaranteed to exist for as long as the container does.
+    const found = await tx.query(`
+      with requested_claims as (
+        select distinct b.id, afe.actor_id
+        from dune.buildings b
+        join dune.building_instances bi on bi.building_id = b.id
+        join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+        where b.id = $1
+      ), base_entities as (
+        select distinct rc.id, claim_afe.entity_id as owner_entity_id
+        from requested_claims rc
+        join dune.actor_fgl_entities claim_afe on claim_afe.actor_id = rc.actor_id
+      ), inventory_types as (
+        select * from unnest($2::text[], $3::text[], $4::text[]) as t(group_key, building_type, type_name)
+      ), containers as (
+        select distinct p.id as placeable_id, inv.id as inventory_id,
+               it.group_key, it.type_name
+        from base_entities be
+        join dune.placeables p on p.owner_entity_id = be.owner_entity_id
+        join inventory_types it on it.building_type = lower(p.building_type)
+        join dune.inventories inv on inv.actor_id = p.id and inv.max_item_count >= 0
+        where p.is_hologram = false and p.id = $5
+      )
+      select i.id::text as item_id, i.template_id, i.stack_size, i.inventory_id,
+             c.placeable_id::text as placeable_id, c.group_key, c.type_name
+      from containers c
+      join dune.items i on i.inventory_id = c.inventory_id
+      join dune.inventories inv on inv.id = i.inventory_id
+      where i.id = $6
+      for update of i, inv`, [target, groups, buildingTypes, typeNames, container, safeItemId]);
+
+    const item = found.rows[0];
+    if (!item) throw new Error("That item was not found in a storage container at the selected base.");
+
+    const stackSize = Number(item.stack_size) || 0;
+    const inventoryId = item.inventory_id;
+    const label = item.template_id || "Item";
+
+    // An explicit count larger than the stack is refused rather than rounded
+    // down to "delete it all". The two are not the same request, and the gap
+    // between them is a real race: the caller saw 500, asked for 400, and the
+    // stack has since dropped to 300 -- widening that into destroying all 300
+    // would remove more than was ever agreed to. Only an omitted count means
+    // "the whole slot".
+    if (requestedCount !== null && requestedCount > stackSize) {
+      throw new Error(`Cannot remove ${requestedCount}: the stack holds ${stackSize}. It may have changed since this view was loaded.`);
+    }
+    const partial = requestedCount !== null && requestedCount < stackSize;
+
+    if (partial) {
+      // Refused rather than widened: silently deleting the whole stack because
+      // the schema cannot do a partial removal would destroy more than asked.
+      await requireCapability(
+        await supportsPartialStackDelete(db),
+        "Removing part of a stack requires dune.delete_inventory_item(bigint,bigint)."
+      );
+      // The shipped procedure returns NULL instead of raising when the count
+      // exceeds the stack, so a null result is a failure, not a no-op success.
+      const applied = await tx.query(
+        "select dune.delete_inventory_item($1::bigint, $2::bigint) as result",
+        [safeItemId, requestedCount]
+      );
+      if (applied.rows[0]?.result === null || applied.rows[0]?.result === undefined) {
+        throw new Error("Partial stack removal was rejected by the database. The requested count may exceed the stack.");
+      }
+      const after = await tx.query("select stack_size from dune.items where id = $1 and inventory_id = $2", [safeItemId, inventoryId]);
+      const remaining = after.rows[0] ? Number(after.rows[0].stack_size) || 0 : 0;
+      if (remaining !== stackSize - requestedCount) {
+        throw new Error("Partial stack removal did not change the stack by the requested amount.");
+      }
+      return {
+        ok: true,
+        baseId: target,
+        placeableId: item.placeable_id,
+        inventoryId: String(inventoryId),
+        typeName: item.type_name,
+        group: item.group_key,
+        partial: true,
+        removed: { itemId: item.item_id, templateId: item.template_id, count: requestedCount, remaining },
+        message: `Removed ${requestedCount} of ${label} from the database, leaving ${remaining}.`
+      };
+    }
+
+    // Whole slot. Same verify -> raw-delete fallback -> verify shape as
+    // deleteInventoryItem: the shipped procedure is preferred for its item
+    // tracking log, but the row disappearing is what actually matters.
+    await tx.query("select dune.delete_item($1::bigint)", [safeItemId]);
+    const stillExists = await tx.query("select exists(select 1 from dune.items where id = $1 and inventory_id = $2) as exists", [safeItemId, inventoryId]);
+    if (stillExists.rows[0]?.exists) {
+      await tx.query("delete from dune.items where id = $1 and inventory_id = $2", [safeItemId, inventoryId]);
+    }
+    const deleted = await tx.query("select not exists(select 1 from dune.items where id = $1 and inventory_id = $2) as deleted", [safeItemId, inventoryId]);
+    if (!deleted.rows[0]?.deleted) throw new Error("Stored item delete did not remove the item from the database.");
+
+    return {
+      ok: true,
+      baseId: target,
+      placeableId: item.placeable_id,
+      inventoryId: String(inventoryId),
+      typeName: item.type_name,
+      group: item.group_key,
+      partial: false,
+      removed: { itemId: item.item_id, templateId: item.template_id, count: stackSize, remaining: 0 },
+      message: `${label} was deleted from the database.`
+    };
+  });
+}
+
 // Pending water-refill queue. Same reasoning and shape as the generator
 // queue above (a live map can overwrite an immediate write, so a refill
 // aimed at one is recorded here and applied once that map is confirmed
@@ -8449,6 +8747,27 @@ async function supportsInventoryDelete(db) {
 
 async function supportsInventoryEdit(db) {
   return await tableExists(db, "items") && await tableExists(db, "inventories");
+}
+
+// Every relation deleteBaseContainerItem's ownership query names, not just the
+// two it writes through. Postgres resolves a relation at parse time, so a
+// missing buildings raises exactly as hard as a missing items -- a partial
+// probe would report the capability as present and then fail on use.
+// dune.delete_inventory_item is probed separately: it is only needed for a
+// partial-stack delete, and a schema without it should still allow whole-slot
+// deletes rather than losing the feature entirely.
+async function supportsBaseContainerItemDelete(db) {
+  const required = [
+    "buildings", "building_instances", "actor_fgl_entities",
+    "placeables", "inventories", "items"
+  ];
+  const present = await Promise.all(required.map((table) => tableExists(db, table)));
+  if (present.some((exists) => !exists)) return false;
+  return functionExists(db, "dune.delete_item(bigint)");
+}
+
+async function supportsPartialStackDelete(db) {
+  return functionExists(db, "dune.delete_inventory_item(bigint,bigint)");
 }
 
 async function supportsStorageGiveItem(db) {

--- a/console/api/src/policy.js
+++ b/console/api/src/policy.js
@@ -19,7 +19,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { ROUTE_ACTIONS } from "./actions.js";
+import { ROUTE_ACTIONS, REGEX_ACTIONS, REGEX_ACTIONS_BY_METHOD, REGEX_ACTIONS_BY_METHOD_PATTERN } from "./actions.js";
 import { writeJsonAtomic } from "./jsonStore.js";
 
 // ---- Policy evaluation ----
@@ -107,11 +107,24 @@ export function loadPolicies(repoRoot = null) {
 
 let _allowedActions = {};
 
+// A parameterized route (e.g. DELETE /api/bases/{baseId}) has no exact
+// ROUTE_ACTIONS entry -- actionForRoute resolves it through one of three
+// other tiers instead (see actions.js). bases:delete is the reason this
+// enumerates all four: it exists only in REGEX_ACTIONS_BY_METHOD_PATTERN, so
+// a version of this that only read ROUTE_ACTIONS would never surface it.
+function allKnownActions() {
+  const actions = new Set(Object.values(ROUTE_ACTIONS));
+  for (const [, action] of REGEX_ACTIONS) actions.add(action);
+  for (const action of Object.values(REGEX_ACTIONS_BY_METHOD)) actions.add(action);
+  for (const { action } of REGEX_ACTIONS_BY_METHOD_PATTERN) actions.add(action);
+  return actions;
+}
+
 export function resolveAllowedActions(tier) {
   if (!tier) return [];
   if (_allowedActions[tier]) return _allowedActions[tier];
 
-  const allActions = new Set(Object.values(ROUTE_ACTIONS));
+  const allActions = allKnownActions();
   const mockSession = { tier };
   const allowed = [];
 

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -612,6 +612,8 @@ async function handleApi(req, res) {
   if (path.match(/^\/api\/bases\/[^/]+\/auto-refill$/) && req.method === "POST") return baseAutoRefillToggleRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/water$/) && req.method === "GET") return baseWaterRoute(res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/inventory$/) && req.method === "GET") return baseInventoryRoute(res, path);
+  if (path.match(/^\/api\/bases\/[^/]+\/containers\/[^/]+$/) && req.method === "GET") return baseContainerSlotsRoute(res, path);
+  if (path.match(/^\/api\/bases\/[^/]+\/containers\/[^/]+\/items\/[^/]+$/) && req.method === "DELETE") return baseContainerItemDeleteRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/refill-water$/) && req.method === "POST") return baseRefillWaterRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/queued-water-refill$/) && req.method === "DELETE") return baseCancelQueuedWaterRefillRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/auto-refill-water$/) && req.method === "POST") return baseAutoRefillWaterToggleRoute(req, res, path);
@@ -3021,6 +3023,64 @@ async function baseInventoryRoute(res, path) {
     // or connection failure.
     return json(res, 500, { supported: false, error: redact(error?.message || "Unexpected error."), reason: redact(error?.message || "Unexpected error.") });
   }
+}
+
+// One container's slots, fetched when the contents modal opens rather than
+// folded into baseInventoryRoute -- see baseContainerSlots for why (slots
+// roughly triple that response, on a tab that loads per base expand).
+async function baseContainerSlotsRoute(res, path) {
+  const parts = path.split("/");
+  const baseId = Number(decodeURIComponent(parts[3]));
+  const placeableId = Number(decodeURIComponent(parts[5]));
+  // Same intParam-matching validation baseInventoryRoute uses, for both ids.
+  for (const id of [baseId, placeableId]) {
+    if (!Number.isInteger(id) || id < 1 || id > Number.MAX_SAFE_INTEGER) {
+      return json(res, 400, { error: "Invalid base or container ID" });
+    }
+  }
+  try {
+    return json(res, 200, await duneDb.baseContainerSlots(db, baseId, placeableId));
+  } catch (error) {
+    return json(res, 500, { supported: false, error: redact(error?.message || "Unexpected error."), reason: redact(error?.message || "Unexpected error.") });
+  }
+}
+
+// Phrase-gated, unlike the refills above: this destroys a player's stored item
+// and there is no undo short of a database restore.
+//
+// Deliberately NOT queued the way a refill or a base delete is. The write goes
+// through immediately even when the base's map is running; baseRefillTarget is
+// consulted only to tell the caller whether this base is currently exposed to
+// the autosave-resurrection race, so the UI can say so instead of pretending
+// the delete is final. queueSupported false means "cannot tell", not "safe".
+async function baseContainerItemDeleteRoute(req, res, path) {
+  const parts = path.split("/");
+  const baseId = Number(decodeURIComponent(parts[3]));
+  const placeableId = Number(decodeURIComponent(parts[5]));
+  const itemId = Number(decodeURIComponent(parts[7]));
+  for (const id of [baseId, placeableId, itemId]) {
+    if (!Number.isInteger(id) || id < 1 || id > Number.MAX_SAFE_INTEGER) {
+      return json(res, 400, { error: "Invalid base, container, or item ID" });
+    }
+  }
+  if (baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
+  if (await baseBackedUp(baseId)) return json(res, 409, { error: BASE_BACKED_UP_MESSAGE });
+  return directDbMutation(req, res, "bases.container-item-delete", "DELETE ITEM", async (body) => {
+    const count = body?.count === undefined || body?.count === null ? null : Number(body.count);
+    const result = await duneDb.deleteBaseContainerItem(db, baseId, placeableId, itemId, { count });
+    // Resolved after the write, not before: the delete is not conditional on
+    // it, and a failure to resolve the map must not fail the delete itself.
+    let live = { known: false, running: false, map: "", partitionId: 0 };
+    try {
+      const target = await duneDb.baseRefillTarget(db, baseId);
+      live = target.queueSupported
+        ? { known: true, running: !target.writeSafeNow, map: target.map, partitionId: target.partitionId }
+        : { known: false, running: false, map: target.map || "", partitionId: target.partitionId || 0 };
+    } catch {
+      // Leave live.known false -- the UI then warns that it cannot tell.
+    }
+    return { ...result, live };
+  }, { baseId, placeableId, itemId });
 }
 
 // Mirrors baseRefillGeneratorsRoute: no confirmation phrase (additive and

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -3039,47 +3039,90 @@ async function baseContainerSlotsRoute(res, path) {
     }
   }
   try {
-    return json(res, 200, await duneDb.baseContainerSlots(db, baseId, placeableId));
+    const slots = await duneDb.baseContainerSlots(db, baseId, placeableId);
+    return json(res, 200, { ...slots, deleteSafety: await baseContainerDeleteSafety(baseId, slots.group) });
   } catch (error) {
     return json(res, 500, { supported: false, error: redact(error?.message || "Unexpected error."), reason: redact(error?.message || "Unexpected error.") });
+  }
+}
+
+async function baseContainerDeleteSafety(baseId, group = "storage") {
+  if (group && group !== "storage") {
+    return {
+      safe: false,
+      known: true,
+      map: "",
+      partitionId: 0,
+      reason: "Item deletion is available only for Storage containers. Crafting and Refining contents are read-only to protect active jobs."
+    };
+  }
+  try {
+    const target = await duneDb.baseRefillTarget(db, baseId);
+    if (!target.queueSupported) {
+      return {
+        safe: false,
+        known: false,
+        map: target.map || "",
+        partitionId: target.partitionId || 0,
+        reason: "The console cannot verify that this base's map is safely stopped, so item deletion is disabled."
+      };
+    }
+    if (!target.writeSafeNow) {
+      const location = `${target.map || "This base's map"}${target.partitionId ? ` · Partition ${target.partitionId}` : ""}`;
+      return {
+        safe: false,
+        known: true,
+        map: target.map || "",
+        partitionId: target.partitionId || 0,
+        reason: `${location} is running. Stop that map before deleting stored items.`
+      };
+    }
+    return {
+      safe: true,
+      known: true,
+      map: target.map || "",
+      partitionId: target.partitionId || 0,
+      reason: ""
+    };
+  } catch {
+    return {
+      safe: false,
+      known: false,
+      map: "",
+      partitionId: 0,
+      reason: "The console could not verify that this base's map is safely stopped, so item deletion is disabled."
+    };
   }
 }
 
 // Phrase-gated, unlike the refills above: this destroys a player's stored item
 // and there is no undo short of a database restore.
 //
-// Deliberately NOT queued the way a refill or a base delete is. The write goes
-// through immediately even when the base's map is running; baseRefillTarget is
-// consulted only to tell the caller whether this base is currently exposed to
-// the autosave-resurrection race, so the UI can say so instead of pretending
-// the delete is final. queueSupported false means "cannot tell", not "safe".
+// Deliberately not queued: inventory rows can change before a deferred delete
+// is applied. Instead, deletion is allowed only when the owning map is known to
+// be safely down. The safety check is repeated here immediately before the
+// write; disabling the UI alone is never a security or consistency boundary.
 async function baseContainerItemDeleteRoute(req, res, path) {
   const parts = path.split("/");
   const baseId = Number(decodeURIComponent(parts[3]));
   const placeableId = Number(decodeURIComponent(parts[5]));
-  const itemId = Number(decodeURIComponent(parts[7]));
-  for (const id of [baseId, placeableId, itemId]) {
+  const itemId = decodeURIComponent(parts[7]);
+  for (const id of [baseId, placeableId]) {
     if (!Number.isInteger(id) || id < 1 || id > Number.MAX_SAFE_INTEGER) {
       return json(res, 400, { error: "Invalid base, container, or item ID" });
     }
+  }
+  if (!/^[1-9][0-9]*$/.test(itemId) || BigInt(itemId) > 9223372036854775807n) {
+    return json(res, 400, { error: "Invalid base, container, or item ID" });
   }
   if (baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
   if (await baseBackedUp(baseId)) return json(res, 409, { error: BASE_BACKED_UP_MESSAGE });
   return directDbMutation(req, res, "bases.container-item-delete", "DELETE ITEM", async (body) => {
     const count = body?.count === undefined || body?.count === null ? null : Number(body.count);
+    const safety = await baseContainerDeleteSafety(baseId);
+    if (!safety.safe) throw new Error(safety.reason);
     const result = await duneDb.deleteBaseContainerItem(db, baseId, placeableId, itemId, { count });
-    // Resolved after the write, not before: the delete is not conditional on
-    // it, and a failure to resolve the map must not fail the delete itself.
-    let live = { known: false, running: false, map: "", partitionId: 0 };
-    try {
-      const target = await duneDb.baseRefillTarget(db, baseId);
-      live = target.queueSupported
-        ? { known: true, running: !target.writeSafeNow, map: target.map, partitionId: target.partitionId }
-        : { known: false, running: false, map: target.map || "", partitionId: target.partitionId || 0 };
-    } catch {
-      // Leave live.known false -- the UI then warns that it cannot tell.
-    }
-    return { ...result, live };
+    return { ...result, deleteSafety: safety };
   }, { baseId, placeableId, itemId });
 }
 

--- a/console/api/test/baseContainerItemDelete.integration.test.js
+++ b/console/api/test/baseContainerItemDelete.integration.test.js
@@ -1,0 +1,369 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { baseContainerSlots, deleteBaseContainerItem } from "../src/duneDb.js";
+import { pgTransactionalDb, withIsolatedDatabase } from "../test-support/pgIntegrationDb.js";
+
+// Real PostgreSQL rather than a mocked db, for the same reason
+// baseDelete.integration.test.js uses it: the guarantees that matter here are
+// ones a string-matched mock cannot prove -- that the ownership query actually
+// isolates one base from another, that `for update of i, inv` actually takes a
+// row lock, that a failed verification actually rolls back the write, and that
+// the shipped procedures behave as the code assumes.
+//
+// The procedures below are transcribed from the shipped schema
+// (.claude/dune_backup.sql), not reinvented. delete_inventory_item returning
+// the REMAINING stack size -- and NULL only when the count exceeds it -- is
+// load-bearing: a remaining size of 0 is a success, so any check that treats
+// the return as a plain truthy value would be wrong.
+const CLAIM_ACTOR = 8001;
+const BUILDING_ACTOR = 8002;
+const ENTITY_ID = 701;
+const CHEST = 8003;          // storagecontainer_placeable, on the allowlist
+const GENERATOR = 8004;      // oilgenerator_placeable, NOT on the allowlist
+
+const OTHER_CLAIM_ACTOR = 8101;
+const OTHER_BUILDING_ACTOR = 8102;
+const OTHER_ENTITY_ID = 801;
+const OTHER_CHEST = 8103;
+
+const SCHEMA = `
+  create schema dune;
+
+  create table dune.actors (id bigint primary key, map text, partition_id bigint, owner_account_id bigint);
+  create table dune.buildings (id bigint primary key references dune.actors(id) on delete cascade);
+  create table dune.building_instances (
+    building_id bigint not null references dune.actors(id) on delete cascade,
+    instance_id integer not null,
+    owner_entity_id bigint
+  );
+  create table dune.actor_fgl_entities (
+    entity_id bigint not null,
+    actor_id bigint not null references dune.actors(id) on delete cascade
+  );
+  create table dune.placeables (
+    id bigint primary key references dune.actors(id) on delete cascade,
+    owner_entity_id bigint,
+    building_type text,
+    is_hologram boolean not null default false
+  );
+  create table dune.permission_actor (
+    actor_id bigint primary key references dune.actors(id) on delete cascade,
+    actor_name text
+  );
+  create table dune.inventories (
+    id bigint primary key,
+    actor_id bigint not null references dune.actors(id) on delete cascade,
+    max_item_count integer not null default 10
+  );
+  -- The production constraints, not a convenient subset: position_index is NOT
+  -- NULL with a >= 0 check and has NO unique constraint against
+  -- (inventory_id, position_index), which is exactly why the grid has to cope
+  -- with duplicates. stack_size > 0 is why a partial removal to zero must go
+  -- through delete_item rather than an UPDATE.
+  create table dune.items (
+    id bigint generated always as identity primary key,
+    inventory_id bigint references dune.inventories(id) on delete cascade,
+    stack_size bigint not null,
+    position_index bigint not null,
+    template_id text not null,
+    stats jsonb not null default '{}'::jsonb,
+    quality_level bigint not null default 0,
+    constraint items_position_index_check check (position_index >= 0),
+    constraint items_stack_size_check check (stack_size > 0)
+  );
+
+  -- delete_item's item-tracking log. Early-returns in production unless
+  -- dune.item_tracking_enabled is set; stubbed to a no-op so the signature and
+  -- call shape match without needing the setting.
+  create function dune._add_item_delete_log(in_item_id bigint, in_inventory_id bigint, in_template_id text)
+  returns void language plpgsql as $$ begin return; end $$;
+
+  create function dune.delete_item(in_id bigint) returns void
+  language sql as $$
+    delete from dune.items i
+    using dune.inventories inv
+    where i.inventory_id = inv.id
+      and i.id = in_id
+    returning dune._add_item_delete_log(i.id, inv.id, i.template_id);
+  $$;
+
+  create function dune.delete_inventory_item(in_item_id bigint, in_count bigint) returns bigint
+  language plpgsql as $$
+  declare
+    remaining_stack_size bigint;
+  begin
+    select into strict remaining_stack_size stack_size from dune.items where id = in_item_id;
+    remaining_stack_size := remaining_stack_size - in_count;
+    if remaining_stack_size < 0 then
+      return null;
+    end if;
+    if remaining_stack_size > 0 then
+      update dune.items set stack_size = remaining_stack_size where id = in_item_id;
+    else
+      perform dune.delete_item(in_item_id);
+    end if;
+    return remaining_stack_size;
+  end $$;
+`;
+
+function seedBase(claimActor, buildingActor, entityId, chestId, extraPlaceables = "") {
+  return `
+    insert into dune.actors (id, map, partition_id) values (${claimActor}, 'HaggaBasin', 3);
+    insert into dune.actor_fgl_entities (entity_id, actor_id) values (${entityId}, ${claimActor});
+    insert into dune.permission_actor (actor_id, actor_name) values (${claimActor}, 'Base ${claimActor}');
+
+    insert into dune.actors (id, map, partition_id) values (${buildingActor}, 'HaggaBasin', 3);
+    insert into dune.buildings (id) values (${buildingActor});
+    insert into dune.building_instances (building_id, instance_id, owner_entity_id) values (${buildingActor}, 0, ${entityId});
+
+    insert into dune.actors (id, map, partition_id) values (${chestId}, 'HaggaBasin', 3);
+    insert into dune.placeables (id, owner_entity_id, building_type) values (${chestId}, ${entityId}, 'storagecontainer_placeable');
+    insert into dune.inventories (id, actor_id, max_item_count) values (${chestId} * 10, ${chestId}, 45);
+    ${extraPlaceables}
+  `;
+}
+
+// Two stacks of ONE template, plus a second template. The duplicate template is
+// the case the merged items[] collapses and the per-slot view must keep apart.
+const SEED = `
+  ${seedBase(CLAIM_ACTOR, BUILDING_ACTOR, ENTITY_ID, CHEST, `
+    insert into dune.actors (id, map, partition_id) values (${GENERATOR}, 'HaggaBasin', 3);
+    insert into dune.placeables (id, owner_entity_id, building_type) values (${GENERATOR}, ${ENTITY_ID}, 'oilgenerator_placeable');
+    insert into dune.inventories (id, actor_id, max_item_count) values (${GENERATOR} * 10, ${GENERATOR}, 4);
+  `)}
+  insert into dune.items (inventory_id, template_id, stack_size, position_index) values
+    (${CHEST} * 10, 'ScrapMetal', 500, 0),
+    (${CHEST} * 10, 'MagnetiteOre', 200, 1),
+    (${CHEST} * 10, 'ScrapMetal', 400, 2);
+  insert into dune.items (inventory_id, template_id, stack_size, position_index) values
+    (${GENERATOR} * 10, 'Oil', 900, 0);
+
+  ${seedBase(OTHER_CLAIM_ACTOR, OTHER_BUILDING_ACTOR, OTHER_ENTITY_ID, OTHER_CHEST)}
+  insert into dune.items (inventory_id, template_id, stack_size, position_index) values
+    (${OTHER_CHEST} * 10, 'Spice', 77, 0);
+`;
+
+async function withDatabase(t, run) {
+  return withIsolatedDatabase(t, {
+    namePrefix: "dune_container_item_delete",
+    unavailableLabel: "the base container item delete integration test"
+  }, async (pool) => {
+    await pool.query(SCHEMA);
+    await pool.query(SEED);
+    return run(pool);
+  });
+}
+
+async function itemsIn(pool, inventoryId) {
+  const result = await pool.query(
+    "select id, template_id, stack_size, position_index from dune.items where inventory_id = $1 order by position_index",
+    [inventoryId]);
+  return result.rows;
+}
+
+async function itemAt(pool, inventoryId, positionIndex) {
+  const rows = await itemsIn(pool, inventoryId);
+  return rows.find((row) => Number(row.position_index) === positionIndex);
+}
+
+test("real PostgreSQL: baseContainerSlots returns one entry per slot, keeping two stacks of one template apart", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const result = await baseContainerSlots(db, BUILDING_ACTOR, CHEST);
+
+    assert.equal(result.supported, true);
+    assert.equal(result.found, true);
+    assert.equal(result.group, "storage");
+    assert.equal(result.usedSlots, 3);
+    assert.equal(result.maxSlots, 45);
+    assert.equal(result.inventories.length, 1);
+
+    const slots = result.inventories[0].slots;
+    assert.equal(slots.length, 3);
+    // Ordered by slot, not by template or quantity.
+    assert.deepEqual(slots.map((slot) => slot.positionIndex), [0, 1, 2]);
+    // The two ScrapMetal stacks stay separate at their own quantities rather
+    // than merging into 900.
+    const scrap = slots.filter((slot) => slot.templateId === "ScrapMetal");
+    assert.equal(scrap.length, 2);
+    assert.deepEqual(scrap.map((slot) => slot.quantity).sort((a, b) => a - b), [400, 500]);
+    // Every slot carries a distinct item id -- the delete target.
+    assert.equal(new Set(slots.map((slot) => slot.itemId)).size, 3);
+  });
+});
+
+test("real PostgreSQL: baseContainerSlots does not expose a generator's fuel inventory", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    // The generator is a genuine placeable at this base with a real inventory;
+    // it is excluded solely by the container allowlist, which is what keeps
+    // the Power tab's fuel out of this surface.
+    const result = await baseContainerSlots(db, BUILDING_ACTOR, GENERATOR);
+    assert.equal(result.found, false);
+  });
+});
+
+test("real PostgreSQL: a container at another base is not reachable through this one", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    assert.equal((await baseContainerSlots(db, BUILDING_ACTOR, OTHER_CHEST)).found, false);
+    assert.equal((await baseContainerSlots(db, OTHER_BUILDING_ACTOR, OTHER_CHEST)).found, true);
+  });
+});
+
+test("real PostgreSQL: deleting a whole slot removes that row and nothing else", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const target = await itemAt(pool, CHEST * 10, 0);
+
+    const result = await deleteBaseContainerItem(db, BUILDING_ACTOR, CHEST, target.id);
+    assert.equal(result.ok, true);
+    assert.equal(result.partial, false);
+    assert.equal(result.removed.count, 500);
+
+    const remaining = await itemsIn(pool, CHEST * 10);
+    assert.deepEqual(remaining.map((row) => Number(row.position_index)), [1, 2]);
+    // The other ScrapMetal stack, sharing the template, must survive -- a
+    // delete addresses a row, never a template.
+    assert.ok(remaining.some((row) => row.template_id === "ScrapMetal" && Number(row.stack_size) === 400));
+    // And the other base is untouched.
+    assert.equal((await itemsIn(pool, OTHER_CHEST * 10)).length, 1);
+  });
+});
+
+test("real PostgreSQL: an item in another base's container cannot be deleted through this base", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const victim = (await itemsIn(pool, OTHER_CHEST * 10))[0];
+
+    // Both the wrong-base and the wrong-container framings must fail.
+    await assert.rejects(
+      () => deleteBaseContainerItem(db, BUILDING_ACTOR, OTHER_CHEST, victim.id),
+      /not found in a storage container/);
+    await assert.rejects(
+      () => deleteBaseContainerItem(db, BUILDING_ACTOR, CHEST, victim.id),
+      /not found in a storage container/);
+
+    assert.equal((await itemsIn(pool, OTHER_CHEST * 10)).length, 1, "the other base's item must survive");
+  });
+});
+
+test("real PostgreSQL: a generator's fuel cannot be deleted through the container route", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const fuel = (await itemsIn(pool, GENERATOR * 10))[0];
+
+    await assert.rejects(
+      () => deleteBaseContainerItem(db, BUILDING_ACTOR, GENERATOR, fuel.id),
+      /not found in a storage container/);
+    assert.equal((await itemsIn(pool, GENERATOR * 10)).length, 1, "generator fuel must survive");
+  });
+});
+
+test("real PostgreSQL: a partial removal decrements the real stack through the shipped procedure", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const target = await itemAt(pool, CHEST * 10, 0);
+
+    const result = await deleteBaseContainerItem(db, BUILDING_ACTOR, CHEST, target.id, { count: 150 });
+    assert.equal(result.partial, true);
+    assert.equal(result.removed.remaining, 350);
+
+    const after = await itemAt(pool, CHEST * 10, 0);
+    assert.equal(Number(after.stack_size), 350);
+    assert.equal((await itemsIn(pool, CHEST * 10)).length, 3, "the slot must still exist");
+  });
+});
+
+test("real PostgreSQL: a count above the stack is refused and leaves the stack untouched", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const target = await itemAt(pool, CHEST * 10, 0);
+
+    // The race this guards: the stack shrank since the view loaded. Rounding
+    // the request down to "delete it all" would destroy more than was asked.
+    await assert.rejects(
+      () => deleteBaseContainerItem(db, BUILDING_ACTOR, CHEST, target.id, { count: 900 }),
+      /Cannot remove 900: the stack holds 500/);
+
+    const after = await itemAt(pool, CHEST * 10, 0);
+    assert.equal(Number(after.stack_size), 500);
+    assert.equal((await itemsIn(pool, CHEST * 10)).length, 3);
+  });
+});
+
+test("real PostgreSQL: the delete waits on a row another transaction holds locked", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const target = await itemAt(pool, CHEST * 10, 0);
+    const holder = await pool.connect();
+    let settled = false;
+    try {
+      // Someone else holds the item row.
+      await holder.query("begin");
+      await holder.query("select id from dune.items where id = $1 for update", [target.id]);
+
+      // The delete must block rather than racing the other transaction.
+      // Racing it against a timer shows that without needing a
+      // statement_timeout.
+      //
+      // What this does and does not prove, checked by removing the clause and
+      // re-running: it does NOT isolate `for update of i, inv` specifically,
+      // because dune.delete_item's own DELETE takes a row lock anyway, so the
+      // call serializes either way. What it proves is the guarantee that
+      // actually matters -- two concurrent deletes of one item cannot
+      // interleave, and nothing is removed while the other holder is live.
+      // The clause itself is pinned by a string assertion in db.test.js.
+      const deleting = deleteBaseContainerItem(db, BUILDING_ACTOR, CHEST, target.id)
+        .then((value) => { settled = true; return value; },
+              (error) => { settled = true; throw error; });
+      const raced = await Promise.race([
+        deleting.then(() => "completed", () => "failed"),
+        new Promise((resolve) => setTimeout(() => resolve("still waiting"), 1200))
+      ]);
+      assert.equal(raced, "still waiting", "the delete must wait on the locked row");
+      assert.equal(settled, false);
+      assert.equal(Number((await itemAt(pool, CHEST * 10, 0)).stack_size), 500, "nothing removed while blocked");
+
+      // Releasing the lock lets the same call through, so the wait was the
+      // lock and not a hang.
+      await holder.query("rollback");
+      const result = await deleting;
+      assert.equal(result.ok, true);
+      assert.equal(await itemAt(pool, CHEST * 10, 0), undefined, "the slot is gone once the lock clears");
+    } finally {
+      await holder.query("rollback").catch(() => {});
+      holder.release();
+    }
+  });
+});
+
+test("real PostgreSQL: a failed post-write verification rolls the whole delete back", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const target = await itemAt(pool, CHEST * 10, 0);
+
+    // Forces the partial path's "did not change the stack by the requested
+    // amount" check to fire: the trigger overwrites the procedure's result, so
+    // the verification disagrees and throws AFTER the write has happened. What
+    // is under test is that the enclosing transaction takes the write back
+    // with it -- not the trigger, which is a synthetic way to reach that state.
+    await pool.query(`
+      create function dune.meddle() returns trigger language plpgsql as $$
+      begin
+        new.stack_size := 999;
+        return new;
+      end $$;
+      create trigger meddle_items before update on dune.items
+      for each row execute function dune.meddle();
+    `);
+
+    await assert.rejects(
+      () => deleteBaseContainerItem(db, BUILDING_ACTOR, CHEST, target.id, { count: 150 }),
+      /did not change the stack/);
+
+    const after = await itemAt(pool, CHEST * 10, 0);
+    assert.equal(Number(after.stack_size), 500, "the interfered-with write must have rolled back");
+    assert.equal((await itemsIn(pool, CHEST * 10)).length, 3);
+  });
+});

--- a/console/api/test/baseContainerItemDelete.integration.test.js
+++ b/console/api/test/baseContainerItemDelete.integration.test.js
@@ -231,6 +231,21 @@ test("real PostgreSQL: deleting a whole slot removes that row and nothing else",
   });
 });
 
+test("real PostgreSQL: deleting preserves a bigint item id beyond Number.MAX_SAFE_INTEGER", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const largeId = "9007199254740993";
+    await pool.query(`
+      insert into dune.items (id, inventory_id, template_id, stack_size, position_index)
+      overriding system value values ($1, $2, 'SpiceMelange', 12, 4)
+    `, [largeId, CHEST * 10]);
+
+    const result = await deleteBaseContainerItem(db, BUILDING_ACTOR, CHEST, largeId);
+    assert.equal(result.removed.itemId, largeId);
+    assert.equal((await pool.query("select id from dune.items where id = $1", [largeId])).rowCount, 0);
+  });
+});
+
 test("real PostgreSQL: an item in another base's container cannot be deleted through this base", async (t) => {
   await withDatabase(t, async (pool) => {
     const db = pgTransactionalDb(pool);

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -2601,6 +2601,12 @@ test("list bases omits the partition join when world_partition is absent", async
 // dune.base_backup_linked_actors -- it leaves buildings/building_instances/
 // placeables fully intact, so without this exclusion a picked-up base would
 // keep showing up as an ordinary, ownerless base.
+//
+// Both query strings are asserted because the paged rows and the totals are
+// two separate round trips that must describe the same candidate set. They
+// are emitted from one baseCandidateSource() helper in duneDb.js, so this is
+// now a regression test on that helper reaching both call sites rather than a
+// guard against hand-copied clauses drifting apart.
 test("list bases excludes unclaimed, backup-linked bases when base_backup_linked_actors exists", async () => {
   const calls = [];
   const db = {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -17,7 +17,7 @@ import {
   queueGeneratorRefill,
   supportsGeneratorRefillQueue
 } from "../src/duneDb.js";
-import { addCurrency, addFactionReputation, addGuildMember, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, addSpecializationXp, applyLandsraadMilestonePreset, augmentInventoryItem, augmentNewestPlayerItem, baseGeneratorFuelLevels, baseGenerators, baseIsBackedUp, changeDunePassword, completeJourneyNode, completeTutorial, dbStatus, deleteInventoryItem, demoteGuildMember, disbandGuild, exportBaseAsBlueprint, generatorUptimePolicy, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listBases, listGuilds, listPlayers, listRoutines, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerBuildingUnlockState, playerCraftingRecipes, playerCurrency, playerFactions, playerIntel, playerInventory, playerInventoryAll, playerJourney, playerPortalSnapshots, playerPosition, playerProfile, playerProgression, playerResearchItems, playerSolarisCoinTotal, playerVitals, portalGeneratorFuel, portalVehicles, promoteGuildMember, refillBaseGenerators, removeGuildMember, repairFactionReputation, repairVehicleDecay, resetJourneyNode, resetTutorial, routineDefinition, runSql, setLandsraadPlayerContribution, setPlayerFaction, supportsGeneratorRefill, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError, _resetPlayerTargetCacheForTests } from "../src/duneDb.js";
+import { addCurrency, addFactionReputation, addGuildMember, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, addSpecializationXp, applyLandsraadMilestonePreset, augmentInventoryItem, augmentNewestPlayerItem, baseContainerSlots, baseGeneratorFuelLevels, baseGenerators, baseIsBackedUp, changeDunePassword, completeJourneyNode, completeTutorial, dbStatus, deleteBaseContainerItem, deleteInventoryItem, demoteGuildMember, disbandGuild, exportBaseAsBlueprint, generatorUptimePolicy, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listBases, listGuilds, listPlayers, listRoutines, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerBuildingUnlockState, playerCraftingRecipes, playerCurrency, playerFactions, playerIntel, playerInventory, playerInventoryAll, playerJourney, playerPortalSnapshots, playerPosition, playerProfile, playerProgression, playerResearchItems, playerSolarisCoinTotal, playerVitals, portalGeneratorFuel, portalVehicles, promoteGuildMember, refillBaseGenerators, removeGuildMember, repairFactionReputation, repairVehicleDecay, resetJourneyNode, resetTutorial, routineDefinition, runSql, setLandsraadPlayerContribution, setPlayerFaction, supportsGeneratorRefill, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError, _resetPlayerTargetCacheForTests } from "../src/duneDb.js";
 
 beforeEach(() => {
   _resetPlayerTargetCacheForTests();
@@ -3463,6 +3463,150 @@ test("inventory delete rejects rows not owned by the selected player", async () 
   const db = fakeMutationDb(calls, { itemRows: [] });
   await assert.rejects(() => deleteInventoryItem(db, 123, 99), /selected player's directly-owned inventory/);
   assert.equal(calls.some((call) => call.text.includes("dune.delete_item")), false);
+});
+
+// Container-item delete. The ownership query is the whole safety story here --
+// it is what keeps a delete inside an allowlisted container at the requested
+// base, and out of the generator/windtrap fuel inventories the Power and Water
+// tabs own -- so most of these assert on it rather than on the happy path.
+function fakeContainerDeleteDb(calls, fixtures = {}) {
+  const {
+    itemRows = [],
+    partialResult = 1,
+    remainingAfterPartial = null,
+    procedures = true,
+    deleteLeavesRow = false
+  } = fixtures;
+  const run = async (text, values = []) => {
+    calls.push({ text, values });
+    if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+    if (text.includes("to_regprocedure")) return { rows: [{ exists: procedures }] };
+    if (text.includes("requested_claims")) return { rows: itemRows };
+    if (text.includes("dune.delete_inventory_item")) return { rows: [{ result: partialResult }] };
+    if (text.includes("select stack_size from dune.items")) {
+      return { rows: remainingAfterPartial === null ? [] : [{ stack_size: remainingAfterPartial }] };
+    }
+    if (text.includes("as exists")) return { rows: [{ exists: deleteLeavesRow }] };
+    if (text.includes("as deleted")) return { rows: [{ deleted: !deleteLeavesRow }] };
+    return { rows: [] };
+  };
+  return { query: run, transaction: async (fn) => fn({ query: run }) };
+}
+
+const CONTAINER_ITEM_ROW = {
+  item_id: "99", template_id: "ScrapMetal", stack_size: 500, inventory_id: 7,
+  placeable_id: "42", group_key: "storage", type_name: "Small Storage Container"
+};
+
+test("container item delete verifies base ownership before calling dune.delete_item", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW] });
+  const result = await deleteBaseContainerItem(db, 16836, 42, 99);
+  assert.equal(result.ok, true);
+  assert.equal(result.partial, false);
+  assert.equal(result.removed.count, 500);
+  const ownership = calls.find((call) => call.text.includes("requested_claims"));
+  assert.ok(ownership, "ownership query ran");
+  // The base id, the placeable and the item all constrain the lookup -- an
+  // item id alone must never be enough to reach a row.
+  assert.equal(ownership.values[0], 16836);
+  assert.equal(ownership.values[4], 42);
+  assert.equal(ownership.values[5], 99);
+  assert.ok(calls.some((call) => call.text.includes("dune.delete_item($1::bigint)") && call.values[0] === 99));
+});
+
+test("container item delete locks the item and its inventory rather than the CTE", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW] });
+  await deleteBaseContainerItem(db, 16836, 42, 99);
+  const ownership = calls.find((call) => call.text.includes("requested_claims"));
+  // `for update of i, inv`, not a bare `for update`: Postgres cannot lock a CTE
+  // reference, and locking only the item row locks nothing once it is gone.
+  assert.match(ownership.text, /for update of i, inv/);
+});
+
+test("container item delete keeps the container allowlist and hologram filters in the ownership query", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW] });
+  await deleteBaseContainerItem(db, 16836, 42, 99);
+  const ownership = calls.find((call) => call.text.includes("requested_claims"));
+  // Dropping either of these would let a delete reach a generator or windtrap
+  // fuel inventory, which this route must never touch.
+  assert.match(ownership.text, /join inventory_types it on it\.building_type = lower\(p\.building_type\)/);
+  assert.match(ownership.text, /p\.is_hologram = false/);
+  assert.match(ownership.text, /inv\.max_item_count >= 0/);
+});
+
+test("container item delete rejects an item that is not in a container at the selected base", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, { itemRows: [] });
+  await assert.rejects(() => deleteBaseContainerItem(db, 16836, 42, 99), /not found in a storage container/);
+  assert.equal(calls.some((call) => call.text.includes("dune.delete_item")), false);
+  assert.equal(calls.some((call) => call.text.includes("dune.delete_inventory_item")), false);
+});
+
+test("container item delete refuses a count larger than the stack instead of clearing the slot", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW] });
+  // The dangerous case: a stack that shrank between the read and the delete.
+  // Rounding 999 down to "all 500" would destroy more than was asked for.
+  await assert.rejects(
+    () => deleteBaseContainerItem(db, 16836, 42, 99, { count: 999 }),
+    /Cannot remove 999: the stack holds 500/
+  );
+  assert.equal(calls.some((call) => call.text.includes("dune.delete_item")), false);
+  assert.equal(calls.some((call) => call.text.includes("dune.delete_inventory_item")), false);
+});
+
+test("container item delete routes a partial removal through dune.delete_inventory_item", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW], remainingAfterPartial: 350 });
+  const result = await deleteBaseContainerItem(db, 16836, 42, 99, { count: 150 });
+  assert.equal(result.partial, true);
+  assert.equal(result.removed.count, 150);
+  assert.equal(result.removed.remaining, 350);
+  assert.ok(calls.some((call) => call.text.includes("dune.delete_inventory_item") && call.values[0] === 99 && call.values[1] === 150));
+  // A partial removal must not also fire the whole-slot delete.
+  assert.equal(calls.some((call) => call.text.includes("dune.delete_item($1::bigint)")), false);
+});
+
+test("a count equal to the whole stack clears the slot rather than decrementing it", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW] });
+  const result = await deleteBaseContainerItem(db, 16836, 42, 99, { count: 500 });
+  assert.equal(result.partial, false);
+  assert.ok(calls.some((call) => call.text.includes("dune.delete_item($1::bigint)")));
+  assert.equal(calls.some((call) => call.text.includes("dune.delete_inventory_item")), false);
+});
+
+test("container item delete treats a null from dune.delete_inventory_item as a failure", async () => {
+  const calls = [];
+  // The shipped procedure returns NULL rather than raising when the count
+  // exceeds the stack, so a null result must not read as success.
+  const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW], partialResult: null });
+  await assert.rejects(() => deleteBaseContainerItem(db, 16836, 42, 99, { count: 150 }), /rejected by the database/);
+});
+
+test("container item delete raises when the stack did not change by the requested amount", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW], remainingAfterPartial: 500 });
+  await assert.rejects(() => deleteBaseContainerItem(db, 16836, 42, 99, { count: 150 }), /did not change the stack/);
+});
+
+test("container item delete raises when dune.delete_item leaves the row behind", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW], deleteLeavesRow: true });
+  await assert.rejects(() => deleteBaseContainerItem(db, 16836, 42, 99), /did not remove the item/);
+  // The raw fallback delete is attempted before giving up.
+  assert.ok(calls.some((call) => call.text.includes("delete from dune.items where id = $1")));
+});
+
+test("container item delete refuses a partial removal when the schema lacks the procedure", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW], procedures: false });
+  // Capability failure, not a silent widening to a whole-slot delete.
+  await assert.rejects(() => deleteBaseContainerItem(db, 16836, 42, 99, { count: 150 }));
+  assert.equal(calls.some((call) => call.text.includes("dune.delete_item($1::bigint)")), false);
 });
 
 test("inventory update rejects rows not owned by the selected player", async () => {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -3609,6 +3609,131 @@ test("container item delete refuses a partial removal when the schema lacks the 
   assert.equal(calls.some((call) => call.text.includes("dune.delete_item($1::bigint)")), false);
 });
 
+// baseContainerSlots: the per-slot read the contents overlay and its delete
+// both rest on. Deliberately separate from baseInventory, whose items[] stays
+// template-merged.
+function fakeContainerSlotsDb(calls, fixtures = {}) {
+  const { rows = [], itemColumns = ["id", "inventory_id", "stack_size", "position_index", "template_id", "stats", "quality_level"] } = fixtures;
+  return {
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
+      if (text.includes("information_schema.columns")) {
+        return { rows: itemColumns.map((column_name) => ({ column_name })) };
+      }
+      if (text.includes("requested_claims")) return { rows };
+      return { rows: [] };
+    }
+  };
+}
+
+const SLOT_ROW = {
+  inventory_id: "77", group_key: "storage", type_name: "Storage Container", max_item_count: 45,
+  quality_level: 0, current_durability: null, max_durability: null
+};
+
+test("baseContainerSlots keeps two stacks of one template apart instead of merging them", async () => {
+  const calls = [];
+  const db = fakeContainerSlotsDb(calls, {
+    rows: [
+      { ...SLOT_ROW, item_id: "1", template_id: "ScrapMetal", stack_size: 500, position_index: 0 },
+      { ...SLOT_ROW, item_id: "2", template_id: "MagnetiteOre", stack_size: 200, position_index: 1 },
+      { ...SLOT_ROW, item_id: "3", template_id: "ScrapMetal", stack_size: 400, position_index: 2 }
+    ]
+  });
+  const result = await baseContainerSlots(db, 16836, 40001);
+
+  assert.equal(result.found, true);
+  assert.equal(result.usedSlots, 3);
+  assert.equal(result.maxSlots, 45);
+  const slots = result.inventories[0].slots;
+  assert.equal(slots.length, 3);
+  // The whole point: the merged items[] would report one ScrapMetal of 900.
+  assert.deepEqual(slots.filter((slot) => slot.templateId === "ScrapMetal").map((slot) => slot.quantity), [500, 400]);
+  assert.deepEqual(slots.map((slot) => slot.positionIndex), [0, 1, 2]);
+  assert.deepEqual(slots.map((slot) => slot.itemId), ["1", "2", "3"]);
+});
+
+test("baseContainerSlots groups slots per inventory rather than flat on the container", async () => {
+  const calls = [];
+  // A placeable can back more than one inventory. maxSlots is their sum while
+  // position_index is scoped to one, so a flat array would collide two slot 0s.
+  const db = fakeContainerSlotsDb(calls, {
+    rows: [
+      { ...SLOT_ROW, inventory_id: "77", max_item_count: 5, item_id: "1", template_id: "MagnetiteOre", stack_size: 10, position_index: 0 },
+      { ...SLOT_ROW, inventory_id: "78", max_item_count: 10, item_id: "2", template_id: "AluminiumBar", stack_size: 20, position_index: 0 }
+    ]
+  });
+  const result = await baseContainerSlots(db, 16836, 40001);
+
+  assert.equal(result.inventories.length, 2);
+  assert.equal(result.maxSlots, 15);
+  assert.deepEqual(result.inventories.map((inventory) => inventory.slots.length), [1, 1]);
+  // Both really are slot 0 -- of different inventories.
+  assert.deepEqual(result.inventories.map((inventory) => inventory.slots[0].positionIndex), [0, 0]);
+});
+
+test("baseContainerSlots keeps an empty inventory so the grid can render its empty slots", async () => {
+  const calls = [];
+  // The LEFT JOIN emits one all-null item row for an empty container.
+  const db = fakeContainerSlotsDb(calls, {
+    rows: [{ ...SLOT_ROW, item_id: null, template_id: null, stack_size: null, position_index: null }]
+  });
+  const result = await baseContainerSlots(db, 16836, 40001);
+
+  assert.equal(result.found, true);
+  assert.equal(result.usedSlots, 0);
+  assert.equal(result.inventories.length, 1);
+  assert.equal(result.inventories[0].maxSlots, 45);
+  assert.deepEqual(result.inventories[0].slots, []);
+});
+
+test("baseContainerSlots answers found:false for a container that is not at the base", async () => {
+  const calls = [];
+  const db = fakeContainerSlotsDb(calls, { rows: [] });
+  const result = await baseContainerSlots(db, 16836, 999999);
+  // An ownership answer, not an error -- and the same shape the route returns
+  // 200 with.
+  assert.equal(result.supported, true);
+  assert.equal(result.found, false);
+  assert.deepEqual(result.inventories, []);
+});
+
+test("baseContainerSlots degrades rather than failing when dune.items lacks the per-slot columns", async () => {
+  const calls = [];
+  // A missing column is a parse-time error, not a null, so an older schema
+  // would 500 a container that used to open if these were assumed.
+  const db = fakeContainerSlotsDb(calls, {
+    itemColumns: ["id", "inventory_id", "stack_size", "template_id"],
+    rows: [{ ...SLOT_ROW, item_id: "1", template_id: "ScrapMetal", stack_size: 500, position_index: null }]
+  });
+  const result = await baseContainerSlots(db, 16836, 40001);
+
+  assert.equal(result.inventories[0].slots[0].positionIndex, null);
+  const query = calls.find((call) => call.text.includes("requested_claims"));
+  // The literals stand in for the absent columns; nothing references them.
+  assert.match(query.text, /null::bigint as position_index/);
+  assert.ok(!query.text.includes("i.position_index"), "must not select a column this schema lacks");
+  assert.match(query.text, /null::numeric as max_durability/);
+});
+
+test("baseContainerSlots scopes to the base and keeps the container allowlist filters", async () => {
+  const calls = [];
+  const db = fakeContainerSlotsDb(calls, { rows: [] });
+  await baseContainerSlots(db, 16836, 40001);
+  const query = calls.find((call) => call.text.includes("requested_claims"));
+
+  // Dropping any of these would let the overlay reach a generator or windtrap
+  // fuel inventory that the Power and Water tabs own.
+  assert.match(query.text, /join inventory_types it on it\.building_type = lower\(p\.building_type\)/);
+  assert.match(query.text, /p\.is_hologram = false/);
+  assert.match(query.text, /inv\.max_item_count >= 0/);
+  assert.equal(query.values[0], 16836);
+  assert.equal(query.values[4], 40001);
+  // Slot order, not template order -- the overlay renders a row per slot.
+  assert.match(query.text, /order by c\.inventory_id, i\.position_index nulls last, i\.id/);
+});
+
 test("inventory update rejects rows not owned by the selected player", async () => {
   const calls = [];
   const db = fakeMutationDb(calls, { itemRows: [] });

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -5,7 +5,7 @@ import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { assertIdentifier, discoverDbConfig, isReadOnlySql, quoteQualified, redactDbError, rowsResult } from "../src/db.js";
+import { assertIdentifier, bigintParam, discoverDbConfig, isReadOnlySql, quoteQualified, redactDbError, rowsResult } from "../src/db.js";
 import {
   _resetRefillPartitionDwellForTests,
   baseRefillTarget,
@@ -21,6 +21,13 @@ import { addCurrency, addFactionReputation, addGuildMember, addIntel, addonLeade
 
 beforeEach(() => {
   _resetPlayerTargetCacheForTests();
+});
+
+test("bigint parameters preserve identifiers beyond JavaScript's safe integer range", () => {
+  assert.equal(bigintParam("9007199254740993", "item id"), "9007199254740993");
+  assert.equal(bigintParam("9223372036854775807", "item id"), "9223372036854775807");
+  assert.throws(() => bigintParam("9223372036854775808", "item id"), /Invalid item id/);
+  assert.throws(() => bigintParam("1.5", "item id"), /Invalid item id/);
 });
 
 test("discovers RedBlink Postgres defaults and env overrides", () => {
@@ -3511,8 +3518,8 @@ test("container item delete verifies base ownership before calling dune.delete_i
   // item id alone must never be enough to reach a row.
   assert.equal(ownership.values[0], 16836);
   assert.equal(ownership.values[4], 42);
-  assert.equal(ownership.values[5], 99);
-  assert.ok(calls.some((call) => call.text.includes("dune.delete_item($1::bigint)") && call.values[0] === 99));
+  assert.equal(ownership.values[5], "99");
+  assert.ok(calls.some((call) => call.text.includes("dune.delete_item($1::bigint)") && call.values[0] === "99"));
 });
 
 test("container item delete locks the item and its inventory rather than the CTE", async () => {
@@ -3545,6 +3552,19 @@ test("container item delete rejects an item that is not in a container at the se
   assert.equal(calls.some((call) => call.text.includes("dune.delete_inventory_item")), false);
 });
 
+test("container item delete keeps crafting and refining inventories read-only", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, {
+    itemRows: [{ ...CONTAINER_ITEM_ROW, group_key: "refining", type_name: "Small Ore Refinery" }]
+  });
+  await assert.rejects(
+    () => deleteBaseContainerItem(db, 16836, 42, 99),
+    /only be deleted from Storage containers/
+  );
+  assert.equal(calls.some((call) => call.text.includes("dune.delete_item")), false);
+  assert.equal(calls.some((call) => call.text.includes("dune.delete_inventory_item")), false);
+});
+
 test("container item delete refuses a count larger than the stack instead of clearing the slot", async () => {
   const calls = [];
   const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW] });
@@ -3565,7 +3585,7 @@ test("container item delete routes a partial removal through dune.delete_invento
   assert.equal(result.partial, true);
   assert.equal(result.removed.count, 150);
   assert.equal(result.removed.remaining, 350);
-  assert.ok(calls.some((call) => call.text.includes("dune.delete_inventory_item") && call.values[0] === 99 && call.values[1] === 150));
+  assert.ok(calls.some((call) => call.text.includes("dune.delete_inventory_item") && call.values[0] === "99" && call.values[1] === 150));
   // A partial removal must not also fire the whole-slot delete.
   assert.equal(calls.some((call) => call.text.includes("dune.delete_item($1::bigint)")), false);
 });

--- a/console/api/test/policy.test.js
+++ b/console/api/test/policy.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { evaluate, matchAction, setPolicies } from "../src/policy.js";
+import { evaluate, matchAction, resolveAllowedActions, setPolicies } from "../src/policy.js";
 
 test("policy matching supports exact and namespace wildcards", () => {
   assert.equal(matchAction("players:read", "players:read"), true);
@@ -47,6 +47,36 @@ test("bases:delete can be withheld independently of bases:mutate", () => {
   // existing installs keep exactly the access they already had.
   const wildcardPolicies = { admin: { version: 1, tier: "admin", statements: [{ Effect: "Allow", Action: "bases:*" }] } };
   assert.equal(evaluate({ tier: "admin" }, "bases:delete", wildcardPolicies), true);
+});
+
+// resolveAllowedActions has no caller yet (planned for a future policy-editor
+// UI), but it must already surface every action actionForRoute can resolve,
+// not just the ones with an exact ROUTE_ACTIONS entry -- bases:delete only
+// exists via the REGEX_ACTIONS_BY_METHOD_PATTERN tier (see actions.js), so
+// this is the case an implementation reading ROUTE_ACTIONS alone would miss.
+test("resolveAllowedActions surfaces an action that only exists via the regex-pattern resolution tier", () => {
+  const policies = {
+    owner: { version: 1, tier: "owner", statements: [{ Effect: "Allow", Action: "*" }] },
+    moderator: {
+      version: 1,
+      tier: "moderator",
+      statements: [
+        { Effect: "Allow", Action: ["bases:read", "bases:mutate"] },
+        { Effect: "Deny", Action: "bases:delete" }
+      ]
+    },
+    admin: { version: 1, tier: "admin", statements: [{ Effect: "Allow", Action: "bases:*" }] }
+  };
+  assert.equal(setPolicies(policies).ok, true);
+
+  const moderatorActions = resolveAllowedActions("moderator");
+  assert.ok(moderatorActions.includes("bases:mutate"));
+  assert.ok(!moderatorActions.includes("bases:delete"), "bases:delete is explicitly denied for moderator");
+
+  // Confirms the wildcard-covered case reaches an action with no exact
+  // ROUTE_ACTIONS entry at all -- not just an explicit grant/deny of it.
+  const adminActions = resolveAllowedActions("admin");
+  assert.ok(adminActions.includes("bases:delete"));
 });
 
 test("policy updates validate documents and preserve owner recovery access", () => {

--- a/console/api/test/policy.test.js
+++ b/console/api/test/policy.test.js
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { actionForRoute } from "../src/actions.js";
 import { evaluate, matchAction, resolveAllowedActions, setPolicies } from "../src/policy.js";
 
 test("policy matching supports exact and namespace wildcards", () => {
@@ -47,6 +48,40 @@ test("bases:delete can be withheld independently of bases:mutate", () => {
   // existing installs keep exactly the access they already had.
   const wildcardPolicies = { admin: { version: 1, tier: "admin", statements: [{ Effect: "Allow", Action: "bases:*" }] } };
   assert.equal(evaluate({ tier: "admin" }, "bases:delete", wildcardPolicies), true);
+});
+
+// bases:delete-item is separate from bases:mutate for a different reason than
+// bases:delete: consent, not blast radius. Base inventory shipped read-only, so
+// an operator whose policy already grants bases:mutate agreed to refills and
+// permission edits and could not have agreed to item destruction -- folding it
+// in would silently widen every existing narrow policy.
+test("bases:delete-item can be withheld independently of bases:mutate", () => {
+  const policies = {
+    owner: { version: 1, tier: "owner", statements: [{ Effect: "Allow", Action: "*" }] },
+    moderator: {
+      version: 1,
+      tier: "moderator",
+      statements: [{ Effect: "Allow", Action: ["bases:read", "bases:mutate"] }]
+    },
+    admin: { version: 1, tier: "admin", statements: [{ Effect: "Allow", Action: "bases:*" }] }
+  };
+  assert.equal(setPolicies(policies).ok, true);
+  // Granting bases:mutate alone must not carry item deletion with it.
+  assert.equal(evaluate({ tier: "moderator" }, "bases:mutate", policies), true);
+  assert.equal(evaluate({ tier: "moderator" }, "bases:delete-item", policies), false);
+  // The shipped wildcard policies are unaffected.
+  assert.equal(evaluate({ tier: "admin" }, "bases:delete-item", policies), true);
+});
+
+test("the container item delete route resolves to bases:delete-item without shadowing its neighbours", () => {
+  assert.equal(actionForRoute("/api/bases/5/containers/9/items/77", "DELETE"), "bases:delete-item");
+  // The base delete and the cancellation routes must keep their own actions --
+  // the new pattern sits alongside them, it does not swallow them.
+  assert.equal(actionForRoute("/api/bases/5", "DELETE"), "bases:delete");
+  assert.equal(actionForRoute("/api/bases/5/queued-delete", "DELETE"), "bases:mutate");
+  assert.equal(actionForRoute("/api/bases/5/queued-refill", "DELETE"), "bases:mutate");
+  // Reading a container's slots stays an ordinary base read.
+  assert.equal(actionForRoute("/api/bases/5/containers/9", "GET"), "bases:read");
 });
 
 // resolveAllowedActions has no caller yet (planned for a future policy-editor

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -143,6 +143,64 @@ export type BaseInventoryContainer = {
   items: BaseInventoryEntry[];
 };
 
+// One occupied slot -- a real dune.items row, unlike BaseInventoryEntry above.
+// This is what the contents modal renders and what a delete addresses.
+export type BaseInventorySlot = {
+  // dune.items.id. Globally unique, so it is the React key and the delete
+  // target; templateId is not unique within a container.
+  itemId: string;
+  templateId: string;
+  name: string;
+  // 0-based slot within its inventory. Null when the schema lacks the column,
+  // in which case the grid view is not offered. There is no unique constraint
+  // on (inventory_id, position_index), so duplicates and values beyond
+  // maxSlots are both possible and must not be dropped when laying out a grid.
+  positionIndex: number | null;
+  quantity: number;
+  qualityLevel: number;
+  currentDurability: number | null;
+  maxDurability: number | null;
+};
+
+// Slots hang off an inventory rather than the container because a placeable can
+// back more than one: the container's maxSlots is their sum, while
+// positionIndex is scoped to a single inventory, so two of them would both
+// have a slot 0.
+export type BaseContainerInventory = {
+  inventoryId: string;
+  maxSlots: number;
+  usedSlots: number;
+  slots: BaseInventorySlot[];
+};
+
+// Fetched per container when the contents modal opens, not folded into
+// BaseInventory: slots roughly triple that response on a tab that loads on
+// every base expand, while the modal only ever shows one container.
+export type BaseContainerSlots = {
+  supported: boolean;
+  // False when the container is not at this base -- an ownership answer, not
+  // an error, and the same 200-with-a-reason shape used elsewhere here.
+  found?: boolean;
+  baseId: number;
+  placeableId: string;
+  typeName?: string;
+  group?: BaseInventoryGroupKey;
+  maxSlots?: number;
+  usedSlots?: number;
+  inventories: BaseContainerInventory[];
+  reason?: string;
+};
+
+// Whether this base's map is running, resolved after the delete lands. The
+// write is immediate either way; this only decides how the result is worded.
+// `known: false` means the console cannot tell -- never render it as "safe".
+export type BaseContainerDeleteLive = {
+  known: boolean;
+  running: boolean;
+  map: string;
+  partitionId: number;
+};
+
 // How much of one item a single container holds. `name` is the container's,
 // not the item's -- the item is the parent -- and is empty for a placeable the
 // player has never renamed, same as BaseInventoryContainer.name.
@@ -314,6 +372,32 @@ export const basesApi = {
   // cards, so switching between them never refetches.
   inventory: (baseId: string) =>
     api<BaseInventory>(`/api/bases/${encodeURIComponent(baseId)}/inventory`),
+  // One container's slots, fetched when the contents modal opens. Kept off
+  // inventory() above so the base tab does not carry every slot at the base.
+  containerSlots: (baseId: string, placeableId: string) =>
+    api<BaseContainerSlots>(
+      `/api/bases/${encodeURIComponent(baseId)}/containers/${encodeURIComponent(placeableId)}`),
+  // Destroys a stored item. `count` omitted removes the whole slot; a count
+  // below the stack removes part of it. A count ABOVE the stack is rejected by
+  // the server rather than clearing the slot -- the stack may have shrunk since
+  // this view loaded, and widening that into "delete it all" would remove more
+  // than was asked for.
+  deleteContainerItem: (baseId: string, placeableId: string, itemId: string, confirmation: string, count?: number) =>
+    api<{
+      supported: boolean;
+      result?: {
+        ok: boolean;
+        partial: boolean;
+        typeName: string;
+        group: BaseInventoryGroupKey;
+        removed: { itemId: string; templateId: string; count: number; remaining: number };
+        message: string;
+        live: BaseContainerDeleteLive;
+      };
+      error?: string;
+      reason?: string;
+    }>(`/api/bases/${encodeURIComponent(baseId)}/containers/${encodeURIComponent(placeableId)}/items/${encodeURIComponent(itemId)}`,
+      { method: "DELETE", body: JSON.stringify(count === undefined ? { confirmation } : { confirmation, count }) }),
   // A refill for a map that is currently running comes back as
   // `result.queued`: the write is deferred to the next time that map is down.
   refillWater: (baseId: string) =>

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -189,16 +189,17 @@ export type BaseContainerSlots = {
   usedSlots?: number;
   inventories: BaseContainerInventory[];
   reason?: string;
+  deleteSafety?: BaseContainerDeleteSafety;
 };
 
-// Whether this base's map is running, resolved after the delete lands. The
-// write is immediate either way; this only decides how the result is worded.
-// `known: false` means the console cannot tell -- never render it as "safe".
-export type BaseContainerDeleteLive = {
+// Item deletion is deliberately fail-closed: only plain storage on a map that
+// the backend can verify is safely down may be changed.
+export type BaseContainerDeleteSafety = {
+  safe: boolean;
   known: boolean;
-  running: boolean;
   map: string;
   partitionId: number;
+  reason: string;
 };
 
 // How much of one item a single container holds. `name` is the container's,
@@ -392,7 +393,7 @@ export const basesApi = {
         group: BaseInventoryGroupKey;
         removed: { itemId: string; templateId: string; count: number; remaining: number };
         message: string;
-        live: BaseContainerDeleteLive;
+        deleteSafety: BaseContainerDeleteSafety;
       };
       error?: string;
       reason?: string;

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -81,6 +81,7 @@ const SLOTS: BaseContainerSlots = {
   group: "storage",
   maxSlots: 45,
   usedSlots: 3,
+  deleteSafety: { safe: true, known: true, map: "HaggaBasin", partitionId: 1, reason: "" },
   inventories: [
     {
       inventoryId: "9001",
@@ -564,7 +565,7 @@ describe("BaseInventoryTab", () => {
         ok: true, partial: false, typeName: "Storage Container", group: "storage",
         removed: { itemId: "501", templateId: "Stone", count: 600, remaining: 0 },
         message: "Stone was deleted from the database.",
-        live: { known: true, running: false, map: "HaggaBasin", partitionId: 1 }
+        deleteSafety: { safe: true, known: true, map: "HaggaBasin", partitionId: 1, reason: "" }
       }
     } as never);
     renderTab();
@@ -594,37 +595,23 @@ describe("BaseInventoryTab", () => {
     expect(basesApi.deleteContainerItem).not.toHaveBeenCalled();
   });
 
-  it("warns that a running map may restore the item, and never calls an unknown map safe", async () => {
+  it("disables deletion when the map is running or its state cannot be verified", async () => {
     mockInventory();
-    const respondWith = (live: { known: boolean; running: boolean; map: string; partitionId: number }) =>
-      vi.mocked(basesApi.deleteContainerItem).mockResolvedValue({
-        supported: true,
-        result: {
-          ok: true, partial: false, typeName: "Storage Container", group: "storage",
-          removed: { itemId: "501", templateId: "Stone", count: 600, remaining: 0 },
-          message: "Stone was deleted from the database.",
-          live
-        }
-      } as never);
-
-    respondWith({ known: true, running: true, map: "HaggaBasin", partitionId: 68 });
+    mockSlots({
+      ...SLOTS,
+      deleteSafety: {
+        safe: false, known: true, map: "HaggaBasin", partitionId: 68,
+        reason: "HaggaBasin · Partition 68 is running. Stop that map before deleting stored items."
+      }
+    });
     renderTab();
     await loaded();
     await openVaultContents();
-    fireEvent.click(screen.getAllByRole("button", { name: /^Delete Granite Stone/ })[0]);
-    await waitFor(() => expect(document.querySelector(".bases-inventory-delete-notice")).toBeTruthy());
-    const running = document.querySelector(".bases-inventory-delete-notice")?.textContent || "";
-    expect(running).toContain("HaggaBasin");
-    expect(running).toMatch(/autosave/i);
-
-    // known:false means "cannot tell" -- it must not read as safe.
-    respondWith({ known: false, running: false, map: "", partitionId: 0 });
-    fireEvent.click(screen.getAllByRole("button", { name: /^Delete Granite Stone/ })[0]);
-    await waitFor(() => {
-      const text = document.querySelector(".bases-inventory-delete-notice")?.textContent || "";
-      expect(text).toMatch(/cannot tell/i);
-    });
-    expect(document.querySelector(".bases-inventory-delete-notice")?.textContent).not.toMatch(/will stick/i);
+    const button = screen.getAllByRole("button", { name: /^Delete Granite Stone/ })[0] as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(screen.getByText(/HaggaBasin · Partition 68 is running/i)).toBeTruthy();
+    expect(confirmAction).not.toHaveBeenCalled();
+    expect(basesApi.deleteContainerItem).not.toHaveBeenCalled();
   });
 
   it("sends a count for a partial removal and rejects an amount above the stack", async () => {
@@ -635,7 +622,7 @@ describe("BaseInventoryTab", () => {
         ok: true, partial: true, typeName: "Storage Container", group: "storage",
         removed: { itemId: "501", templateId: "Stone", count: 150, remaining: 450 },
         message: "Removed 150 of Stone from the database, leaving 450.",
-        live: { known: true, running: false, map: "HaggaBasin", partitionId: 1 }
+        deleteSafety: { safe: true, known: true, map: "HaggaBasin", partitionId: 1, reason: "" }
       }
     } as never);
     renderTab();
@@ -657,7 +644,7 @@ describe("BaseInventoryTab", () => {
     expect(vi.mocked(basesApi.deleteContainerItem).mock.calls[0][4]).toBe(150);
   });
 
-  it("warns about live crafting state when the container is not plain storage", async () => {
+  it("keeps crafting and refining contents read-only", async () => {
     mockInventory();
     // The game's own crafting routine consumes allocated ingredients from
     // these same rows, so removing one mid-craft can leave a recipe pointing
@@ -683,9 +670,11 @@ describe("BaseInventoryTab", () => {
     fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: /List/ }));
     await waitFor(() => expect(document.querySelectorAll(".bases-inventory-contents-row:not(.head)").length).toBe(1));
 
-    fireEvent.click(screen.getByRole("button", { name: /^Delete Iron Ore/ }));
-    await waitFor(() => expect(confirmAction).toHaveBeenCalled());
-    expect(confirmAction.mock.calls[0][1]?.warning).toMatch(/feeds crafting/i);
+    const deleteButton = screen.getByRole("button", { name: /^Delete Iron Ore/ }) as HTMLButtonElement;
+    expect(deleteButton.disabled).toBe(true);
+    expect(screen.getByText(/available only for Storage containers/i)).toBeTruthy();
+    expect(confirmAction).not.toHaveBeenCalled();
+    expect(basesApi.deleteContainerItem).not.toHaveBeenCalled();
   });
 
   it("does not warn about crafting for a plain storage container", async () => {

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -1,12 +1,14 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { basesApi, type BaseInventory } from "../../api/bases";
+import { basesApi, type BaseContainerSlots, type BaseInventory } from "../../api/bases";
 import { BaseInventoryTab } from "./BaseInventoryTab";
 
 vi.mock("../../api/bases", () => ({
   basesApi: {
-    inventory: vi.fn()
+    inventory: vi.fn(),
+    containerSlots: vi.fn(),
+    deleteContainerItem: vi.fn()
   }
 }));
 
@@ -67,12 +69,56 @@ const PAYLOAD: BaseInventory = {
   totals: { items: 1660, distinct: 3, containers: 3, usedSlots: 4, maxSlots: 60 }
 };
 
+// The Vault's slots. Deliberately two stacks of the SAME template: that is the
+// case the merged items[] collapses into one line and the per-slot view must
+// keep apart.
+const SLOTS: BaseContainerSlots = {
+  supported: true,
+  found: true,
+  baseId: 1006,
+  placeableId: "40001",
+  typeName: "Storage Container",
+  group: "storage",
+  maxSlots: 45,
+  usedSlots: 3,
+  inventories: [
+    {
+      inventoryId: "9001",
+      maxSlots: 45,
+      usedSlots: 3,
+      slots: [
+        { itemId: "501", templateId: "Stone", name: "Granite Stone", positionIndex: 0, quantity: 600, qualityLevel: 0, currentDurability: null, maxDurability: null },
+        { itemId: "502", templateId: "MagnetiteOre", name: "Iron Ore", positionIndex: 1, quantity: 200, qualityLevel: 0, currentDurability: null, maxDurability: null },
+        { itemId: "503", templateId: "Stone", name: "Granite Stone", positionIndex: 2, quantity: 400, qualityLevel: 0, currentDurability: null, maxDurability: null }
+      ]
+    }
+  ]
+};
+
 function mockInventory(payload: BaseInventory = PAYLOAD) {
   vi.mocked(basesApi.inventory).mockResolvedValue(payload as never);
 }
 
+function mockSlots(payload: BaseContainerSlots = SLOTS) {
+  vi.mocked(basesApi.containerSlots).mockResolvedValue(payload as never);
+}
+
+const confirmAction = vi.fn(async () => true);
+const onError = vi.fn();
+
 function renderTab() {
-  render(<BaseInventoryTab baseId="1006" />);
+  render(<BaseInventoryTab baseId="1006" baseName="Test Base" confirmAction={confirmAction} onError={onError} />);
+}
+
+// Opens the Vault's contents overlay and waits for its slots to land. Finds
+// the card by name rather than taking the first: the cards sort on their
+// rendered label, so "Small Storage Container #40002" precedes "Vault".
+async function openVaultContents() {
+  const vault = [...document.querySelectorAll(".bases-inventory-cards .bases-card")]
+    .find((card) => card.textContent?.includes("Vault")) as HTMLElement;
+  fireEvent.click(within(vault).getByRole("button", { name: /View Contents/ }));
+  await waitFor(() => expect(screen.getByRole("dialog")).toBeTruthy());
+  await waitFor(() => expect(document.querySelectorAll(".bases-inventory-contents-row:not(.head)").length).toBeGreaterThan(0));
 }
 
 // The totals row is the single "the tab has loaded" signal every test needs.
@@ -107,6 +153,10 @@ function total(label: string) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  confirmAction.mockResolvedValue(true);
+  // Every test that opens the contents overlay needs slots; the ones that
+  // don't are unaffected by the default.
+  mockSlots();
 });
 
 describe("BaseInventoryTab", () => {
@@ -349,11 +399,15 @@ describe("BaseInventoryTab", () => {
 
     const dialog = open();
     expect(dialog.getAttribute("aria-modal")).toBe("true");
-    // Header identifies the container, body lists every stack with quantities.
+    // Header identifies the container, body lists every SLOT with quantities.
+    // Slots arrive in their own request, so the body fills in after the open.
     expect(within(dialog).getByRole("heading", { name: "Vault" })).toBeTruthy();
     expect(dialog.textContent).toContain("Storage Container · #40001");
-    expect(within(dialog).getByText("Granite Stone")).toBeTruthy();
-    expect(within(dialog).getByText("1,000")).toBeTruthy();
+    await waitFor(() => expect(within(dialog).getAllByText("Granite Stone").length).toBe(2));
+    // Two stacks of one template stay apart at their own quantities rather
+    // than merging into the 1,000 the rollup reports.
+    expect(within(dialog).getByText("600")).toBeTruthy();
+    expect(within(dialog).getByText("400")).toBeTruthy();
     expect(within(dialog).getByText("Iron Ore")).toBeTruthy();
     expect(within(dialog).getByText("200")).toBeTruthy();
     // Not the other containers' contents.
@@ -402,10 +456,194 @@ describe("BaseInventoryTab", () => {
 
     fireEvent.click(within(cards().find((c) => c.textContent?.includes("Vault")) as HTMLElement)
       .getByRole("button", { name: /View Contents/ }));
+    // Wait for the slots request before filtering, so this tests the filter
+    // rather than racing the fetch.
+    await waitFor(() => expect(screen.getByRole("dialog").textContent).toContain("Granite Stone"));
     fireEvent.click(screen.getByRole("button", { name: /Refining/ }));
 
     expect(screen.getByRole("dialog")).toBeTruthy();
     expect(screen.getByRole("dialog").textContent).toContain("Granite Stone");
+  });
+
+  it("fetches slots per container rather than with the tab", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    // The base tab must not carry every slot at the base -- that tripled the
+    // response on large bases -- so nothing is requested until a container
+    // is actually opened.
+    expect(basesApi.containerSlots).not.toHaveBeenCalled();
+    await openVaultContents();
+    expect(basesApi.containerSlots).toHaveBeenCalledWith("1006", "40001");
+  });
+
+  it("shows each slot separately with its own slot number", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+
+    const rows = [...document.querySelectorAll(".bases-inventory-contents-row:not(.head)")];
+    expect(rows.length).toBe(3);
+    // The two Granite Stone stacks are only distinguishable by slot number.
+    expect(rows[0].textContent).toContain("#0");
+    expect(rows[2].textContent).toContain("#2");
+  });
+
+  it("switches to a grid that renders every empty slot", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+
+    fireEvent.click(screen.getByRole("button", { name: /Grid/ }));
+    await waitFor(() => expect(document.querySelector(".bases-inventory-slot-grid")).toBeTruthy());
+    // 45 capacity: 3 filled, 42 empty.
+    expect(document.querySelectorAll(".bases-inventory-slot-cell").length).toBe(45);
+    expect(document.querySelectorAll(".bases-inventory-slot-cell.empty").length).toBe(42);
+  });
+
+  it("keeps a duplicate or out-of-range slot reachable instead of dropping it", async () => {
+    mockInventory();
+    // position_index has no unique constraint and is not bounded by
+    // max_item_count, so both of these are reachable in real data. An item the
+    // delete button cannot reach is the worst outcome, so neither may vanish.
+    mockSlots({
+      ...SLOTS,
+      inventories: [{
+        inventoryId: "9001", maxSlots: 4, usedSlots: 3,
+        slots: [
+          { itemId: "601", templateId: "Stone", name: "Granite Stone", positionIndex: 1, quantity: 10, qualityLevel: 0, currentDurability: null, maxDurability: null },
+          { itemId: "602", templateId: "MagnetiteOre", name: "Iron Ore", positionIndex: 1, quantity: 20, qualityLevel: 0, currentDurability: null, maxDurability: null },
+          { itemId: "603", templateId: "SpiceSand", name: "Spice Sand", positionIndex: 99, quantity: 30, qualityLevel: 0, currentDurability: null, maxDurability: null }
+        ]
+      }]
+    });
+    renderTab();
+    await loaded();
+    await openVaultContents();
+    fireEvent.click(screen.getByRole("button", { name: /Grid/ }));
+
+    await waitFor(() => expect(document.querySelector(".bases-inventory-slot-overflow-note")).toBeTruthy());
+    // One wins the cell; the duplicate and the out-of-range one are listed below.
+    const overflow = [...document.querySelectorAll(".bases-inventory-contents-row:not(.head)")];
+    expect(overflow.length).toBe(2);
+    const dialog = screen.getByRole("dialog");
+    expect(dialog.textContent).toContain("Iron Ore");
+    expect(dialog.textContent).toContain("Spice Sand");
+  });
+
+  it("deletes a whole stack and refetches both the slots and the tab", async () => {
+    mockInventory();
+    vi.mocked(basesApi.deleteContainerItem).mockResolvedValue({
+      supported: true,
+      result: {
+        ok: true, partial: false, typeName: "Storage Container", group: "storage",
+        removed: { itemId: "501", templateId: "Stone", count: 600, remaining: 0 },
+        message: "Stone was deleted from the database.",
+        live: { known: true, running: false, map: "HaggaBasin", partitionId: 1 }
+      }
+    } as never);
+    renderTab();
+    await loaded();
+    await openVaultContents();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^Delete Granite Stone/ })[0]);
+    await waitFor(() => expect(basesApi.deleteContainerItem).toHaveBeenCalled());
+    // Whole-slot delete sends no count at all -- an explicit count equal to the
+    // stack would be a different request shape.
+    expect(vi.mocked(basesApi.deleteContainerItem).mock.calls[0].slice(0, 4))
+      .toEqual(["1006", "40001", "501", "DELETE ITEM"]);
+    expect(vi.mocked(basesApi.deleteContainerItem).mock.calls[0][4]).toBeUndefined();
+    // Totals, group counts and the rollup are all derived, so the tab reloads too.
+    await waitFor(() => expect(vi.mocked(basesApi.inventory).mock.calls.length).toBeGreaterThan(1));
+  });
+
+  it("does not call the API when the confirmation is declined", async () => {
+    mockInventory();
+    confirmAction.mockResolvedValue(false);
+    renderTab();
+    await loaded();
+    await openVaultContents();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^Delete Granite Stone/ })[0]);
+    await waitFor(() => expect(confirmAction).toHaveBeenCalled());
+    expect(basesApi.deleteContainerItem).not.toHaveBeenCalled();
+  });
+
+  it("warns that a running map may restore the item, and never calls an unknown map safe", async () => {
+    mockInventory();
+    const respondWith = (live: { known: boolean; running: boolean; map: string; partitionId: number }) =>
+      vi.mocked(basesApi.deleteContainerItem).mockResolvedValue({
+        supported: true,
+        result: {
+          ok: true, partial: false, typeName: "Storage Container", group: "storage",
+          removed: { itemId: "501", templateId: "Stone", count: 600, remaining: 0 },
+          message: "Stone was deleted from the database.",
+          live
+        }
+      } as never);
+
+    respondWith({ known: true, running: true, map: "HaggaBasin", partitionId: 68 });
+    renderTab();
+    await loaded();
+    await openVaultContents();
+    fireEvent.click(screen.getAllByRole("button", { name: /^Delete Granite Stone/ })[0]);
+    await waitFor(() => expect(document.querySelector(".bases-inventory-delete-notice")).toBeTruthy());
+    const running = document.querySelector(".bases-inventory-delete-notice")?.textContent || "";
+    expect(running).toContain("HaggaBasin");
+    expect(running).toMatch(/autosave/i);
+
+    // known:false means "cannot tell" -- it must not read as safe.
+    respondWith({ known: false, running: false, map: "", partitionId: 0 });
+    fireEvent.click(screen.getAllByRole("button", { name: /^Delete Granite Stone/ })[0]);
+    await waitFor(() => {
+      const text = document.querySelector(".bases-inventory-delete-notice")?.textContent || "";
+      expect(text).toMatch(/cannot tell/i);
+    });
+    expect(document.querySelector(".bases-inventory-delete-notice")?.textContent).not.toMatch(/will stick/i);
+  });
+
+  it("sends a count for a partial removal and rejects an amount above the stack", async () => {
+    mockInventory();
+    vi.mocked(basesApi.deleteContainerItem).mockResolvedValue({
+      supported: true,
+      result: {
+        ok: true, partial: true, typeName: "Storage Container", group: "storage",
+        removed: { itemId: "501", templateId: "Stone", count: 150, remaining: 450 },
+        message: "Removed 150 of Stone from the database, leaving 450.",
+        live: { known: true, running: false, map: "HaggaBasin", partitionId: 1 }
+      }
+    } as never);
+    renderTab();
+    await loaded();
+    await openVaultContents();
+
+    // Selecting a slot moves its controls into the strip below the list.
+    fireEvent.click(screen.getAllByRole("button", { name: "Granite Stone" })[0]);
+    await waitFor(() => expect(document.querySelector(".bases-inventory-slot-detail")).toBeTruthy());
+    const input = screen.getByLabelText(/Amount of Granite Stone/) as HTMLInputElement;
+
+    // Above the stack: blocked in the UI as well as on the server.
+    fireEvent.change(input, { target: { value: "9999" } });
+    await waitFor(() => expect(document.querySelector(".bases-inventory-amount-error")).toBeTruthy());
+
+    fireEvent.change(input, { target: { value: "150" } });
+    fireEvent.click(screen.getByRole("button", { name: /Remove 150/ }));
+    await waitFor(() => expect(basesApi.deleteContainerItem).toHaveBeenCalled());
+    expect(vi.mocked(basesApi.deleteContainerItem).mock.calls[0][4]).toBe(150);
+  });
+
+  it("reports a failed delete through onError and leaves the slot listed", async () => {
+    mockInventory();
+    vi.mocked(basesApi.deleteContainerItem).mockRejectedValue(new Error("database is unreachable"));
+    renderTab();
+    await loaded();
+    await openVaultContents();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^Delete Granite Stone/ })[0]);
+    await waitFor(() => expect(onError).toHaveBeenCalledWith("database is unreachable"));
+    expect([...document.querySelectorAll(".bases-inventory-contents-row:not(.head)")].length).toBe(3);
   });
 
   // StrictMode double-invokes the load effect, so two requests are genuinely
@@ -418,7 +656,7 @@ describe("BaseInventoryTab", () => {
       gates.push({ resolve, reject });
     }) as never);
 
-    render(<StrictMode><BaseInventoryTab baseId="1006" /></StrictMode>);
+    render(<StrictMode><BaseInventoryTab baseId="1006" baseName="Test Base" confirmAction={confirmAction} onError={onError} /></StrictMode>);
     await waitFor(() => expect(gates.length).toBe(2));
 
     // Newest request wins the tab...

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -103,7 +103,17 @@ function mockSlots(payload: BaseContainerSlots = SLOTS) {
   vi.mocked(basesApi.containerSlots).mockResolvedValue(payload as never);
 }
 
-const confirmAction = vi.fn(async () => true);
+// Typed with the real signature rather than inferred from `async () => true`,
+// so assertions can reach the options argument (the crafting warning) instead
+// of indexing into an empty tuple.
+type ConfirmOptions = {
+  title?: string;
+  confirmLabel?: string;
+  warning?: string;
+  danger?: boolean;
+  details?: { label: string; value: string; tone?: "accent" | "success" | "danger" }[];
+};
+const confirmAction = vi.fn(async (_message: string, _options?: ConfirmOptions) => true);
 const onError = vi.fn();
 
 function renderTab() {
@@ -632,6 +642,47 @@ describe("BaseInventoryTab", () => {
     fireEvent.click(screen.getByRole("button", { name: /Remove 150/ }));
     await waitFor(() => expect(basesApi.deleteContainerItem).toHaveBeenCalled());
     expect(vi.mocked(basesApi.deleteContainerItem).mock.calls[0][4]).toBe(150);
+  });
+
+  it("warns about live crafting state when the container is not plain storage", async () => {
+    mockInventory();
+    // The game's own crafting routine consumes allocated ingredients from
+    // these same rows, so removing one mid-craft can leave a recipe pointing
+    // at an item that no longer exists. This warning is the only thing
+    // standing between an operator and that, so it is worth pinning.
+    mockSlots({
+      ...SLOTS,
+      placeableId: "40003",
+      typeName: "Small Ore Refinery",
+      group: "refining",
+      inventories: [{
+        inventoryId: "9003", maxSlots: 5, usedSlots: 1,
+        slots: [{ itemId: "701", templateId: "MagnetiteOre", name: "Iron Ore", positionIndex: 0, quantity: 420, qualityLevel: 0, currentDurability: null, maxDurability: null }]
+      }]
+    });
+    renderTab();
+    await loaded();
+
+    const refinery = [...document.querySelectorAll(".bases-inventory-cards .bases-card")]
+      .find((card) => card.textContent?.includes("Small Ore Refinery")) as HTMLElement;
+    fireEvent.click(within(refinery).getByRole("button", { name: /View Contents/ }));
+    await waitFor(() => expect(document.querySelectorAll(".bases-inventory-contents-row:not(.head)").length).toBe(1));
+
+    fireEvent.click(screen.getByRole("button", { name: /^Delete Iron Ore/ }));
+    await waitFor(() => expect(confirmAction).toHaveBeenCalled());
+    expect(confirmAction.mock.calls[0][1]?.warning).toMatch(/feeds crafting/i);
+  });
+
+  it("does not warn about crafting for a plain storage container", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /^Delete Granite Stone/ })[0]);
+    await waitFor(() => expect(confirmAction).toHaveBeenCalled());
+    // A chest holds no live game state, so the extra warning would be noise.
+    expect(confirmAction.mock.calls[0][1]?.warning).toBeUndefined();
   });
 
   it("reports a failed delete through onError and leaves the slot listed", async () => {

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -123,11 +123,18 @@ function renderTab() {
 // Opens the Vault's contents overlay and waits for its slots to land. Finds
 // the card by name rather than taking the first: the cards sort on their
 // rendered label, so "Small Storage Container #40002" precedes "Vault".
-async function openVaultContents() {
+//
+// The overlay opens on GRID, so this waits for cells, then switches to list
+// for the tests that assert on rows. Tests about the grid itself call
+// openVaultContents({ stayOnGrid: true }).
+async function openVaultContents({ stayOnGrid = false } = {}) {
   const vault = [...document.querySelectorAll(".bases-inventory-cards .bases-card")]
     .find((card) => card.textContent?.includes("Vault")) as HTMLElement;
   fireEvent.click(within(vault).getByRole("button", { name: /View Contents/ }));
   await waitFor(() => expect(screen.getByRole("dialog")).toBeTruthy());
+  await waitFor(() => expect(document.querySelectorAll(".bases-inventory-slot-cell").length).toBeGreaterThan(0));
+  if (stayOnGrid) return;
+  fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: /List/ }));
   await waitFor(() => expect(document.querySelectorAll(".bases-inventory-contents-row:not(.head)").length).toBeGreaterThan(0));
 }
 
@@ -413,6 +420,10 @@ describe("BaseInventoryTab", () => {
     // Slots arrive in their own request, so the body fills in after the open.
     expect(within(dialog).getByRole("heading", { name: "Vault" })).toBeTruthy();
     expect(dialog.textContent).toContain("Storage Container · #40001");
+    // The overlay opens on grid, where names live in tile tooltips rather than
+    // as text; switch to list to read them.
+    await waitFor(() => expect(document.querySelectorAll(".bases-inventory-slot-cell").length).toBeGreaterThan(0));
+    fireEvent.click(within(dialog).getByRole("button", { name: /List/ }));
     await waitFor(() => expect(within(dialog).getAllByText("Granite Stone").length).toBe(2));
     // Two stacks of one template stay apart at their own quantities rather
     // than merging into the 1,000 the rollup reports.
@@ -466,8 +477,10 @@ describe("BaseInventoryTab", () => {
 
     fireEvent.click(within(cards().find((c) => c.textContent?.includes("Vault")) as HTMLElement)
       .getByRole("button", { name: /View Contents/ }));
-    // Wait for the slots request before filtering, so this tests the filter
-    // rather than racing the fetch.
+    // Wait for the slots request, and read names from the list view -- the
+    // grid the overlay opens on keeps them in tooltips.
+    await waitFor(() => expect(document.querySelectorAll(".bases-inventory-slot-cell").length).toBeGreaterThan(0));
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: /List/ }));
     await waitFor(() => expect(screen.getByRole("dialog").textContent).toContain("Granite Stone"));
     fireEvent.click(screen.getByRole("button", { name: /Refining/ }));
 
@@ -666,6 +679,8 @@ describe("BaseInventoryTab", () => {
     const refinery = [...document.querySelectorAll(".bases-inventory-cards .bases-card")]
       .find((card) => card.textContent?.includes("Small Ore Refinery")) as HTMLElement;
     fireEvent.click(within(refinery).getByRole("button", { name: /View Contents/ }));
+    await waitFor(() => expect(document.querySelectorAll(".bases-inventory-slot-cell").length).toBeGreaterThan(0));
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: /List/ }));
     await waitFor(() => expect(document.querySelectorAll(".bases-inventory-contents-row:not(.head)").length).toBe(1));
 
     fireEvent.click(screen.getByRole("button", { name: /^Delete Iron Ore/ }));

--- a/console/web/src/features/bases/BaseInventoryTab.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.tsx
@@ -1,16 +1,48 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Boxes, ChevronDown, ChevronRight, X } from "lucide-react";
+import { Boxes, ChevronDown, ChevronRight, LayoutGrid, List, Trash2, TriangleAlert, X } from "lucide-react";
+import { CatalogItemThumb } from "../../components/common/ItemCatalog";
 import {
   basesApi,
+  type BaseContainerSlots,
   type BaseInventory,
   type BaseInventoryContainer,
   type BaseInventoryGroupKey,
-  type BaseInventoryItem
+  type BaseInventoryItem,
+  type BaseInventorySlot
 } from "../../api/bases";
 
 type BaseInventoryTabProps = {
   baseId: string;
+  baseName: string;
+  onError: (message: string) => void;
+  // Shape copied from BasePermissionsTab, which is what BasesPanel actually
+  // passes -- it carries `warning`, which the non-storage delete needs.
+  confirmAction: (message: string, options?: { title?: string; confirmLabel?: string; warning?: string; danger?: boolean; details?: { label: string; value: string; tone?: "accent" | "success" | "danger" }[] }) => Promise<boolean>;
 };
+
+// Guards a corrupt or absurd max_item_count from rendering tens of thousands
+// of cells. Above this the modal stays in list mode.
+const GRID_CELL_CAP = 200;
+
+type ContentsView = "list" | "grid";
+
+// Lays one inventory's slots into a fixed grid. position_index has no unique
+// constraint in the schema and is not validated against max_item_count, so all
+// three of "sparse", "two slots claim the same index" and "index past the end"
+// are reachable. Anything that cannot be placed goes to `overflow` and is
+// rendered below the grid -- never dropped, because an item the delete button
+// cannot reach is the worst outcome here.
+function layoutSlots(inventory: { maxSlots: number; slots: BaseInventorySlot[] }) {
+  const size = Math.min(Math.max(0, inventory.maxSlots), GRID_CELL_CAP);
+  const cells: (BaseInventorySlot | null)[] = new Array(size).fill(null);
+  const overflow: BaseInventorySlot[] = [];
+  for (const slot of inventory.slots) {
+    const at = slot.positionIndex;
+    if (at !== null && Number.isInteger(at) && at >= 0 && at < size && cells[at] === null) cells[at] = slot;
+    else overflow.push(slot);
+  }
+  return { cells, overflow };
+}
 
 // The rollup is capped so the tab cannot blow out the height of an already
 // expanded table row; "Show all" lifts it.
@@ -29,7 +61,7 @@ function containerLabel(container: { name: string; typeName: string; placeableId
   return container.name || `${container.typeName} #${container.placeableId}`;
 }
 
-export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
+export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: BaseInventoryTabProps) {
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState("");
   const [data, setData] = useState<BaseInventory | null>(null);
@@ -48,6 +80,25 @@ export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
   const [contentsFor, setContentsFor] = useState("");
   const [showAllItems, setShowAllItems] = useState(false);
   const closeContentsRef = useRef<HTMLButtonElement>(null);
+  // Slots for the open container only, fetched on open. List is the default so
+  // the modal opens on the denser, sortable view; grid is a deliberate switch.
+  const [slots, setSlots] = useState<BaseContainerSlots | null>(null);
+  const [slotsLoading, setSlotsLoading] = useState(false);
+  const [slotsError, setSlotsError] = useState("");
+  const [contentsView, setContentsView] = useState<ContentsView>("list");
+  const [deletingItemId, setDeletingItemId] = useState("");
+  const [deleteNotice, setDeleteNotice] = useState("");
+  // Separate from slotsError on purpose: that one means "the slots could not
+  // be loaded" and hides the list behind a Retry. A delete that failed leaves
+  // the list perfectly valid, so blanking it would lose the operator's place
+  // over an error about one row.
+  const [deleteError, setDeleteError] = useState("");
+  // Selecting a slot moves its controls into one strip below the list/grid
+  // rather than repeating a quantity input on every row -- a packed 100-slot
+  // container would otherwise render a hundred of them.
+  const [selectedSlotId, setSelectedSlotId] = useState("");
+  const [amount, setAmount] = useState("");
+  const slotsRequestIdRef = useRef(0);
 
   // Only the newest request may write state. StrictMode double-invokes this
   // effect, so two requests really are open at once here, and whichever settles
@@ -133,6 +184,69 @@ export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
   const itemImage = (templateId: string) =>
     imagesByTemplate.get(templateId) || "/images/items/image-unavailable.png";
 
+  // Re-resolved from the current slots rather than held as an object, so a
+  // refetch after a partial delete updates the strip's quantity instead of
+  // leaving it showing the pre-delete stack.
+  const selectedSlot = useMemo(() => {
+    if (!selectedSlotId || !slots?.inventories) return null;
+    for (const inventory of slots.inventories) {
+      const found = inventory.slots.find((slot) => slot.itemId === selectedSlotId);
+      if (found) return found;
+    }
+    return null;
+  }, [selectedSlotId, slots]);
+
+  // The server rejects an over-count rather than clearing the slot, so this is
+  // a courtesy check, not the guard.
+  const amountNumber = Number(amount);
+  const amountValid = Boolean(selectedSlot)
+    && Number.isInteger(amountNumber)
+    && amountNumber >= 1
+    && amountNumber <= (selectedSlot?.quantity ?? 0);
+
+  // A slot that vanished (deleted, or moved by a player between refetches)
+  // must not leave a stale strip pointing at an id the server no longer has.
+  useEffect(() => {
+    if (selectedSlotId && slots && !selectedSlot) {
+      setSelectedSlotId("");
+      setAmount("");
+    }
+  }, [selectedSlotId, slots, selectedSlot]);
+
+  // Same newest-request-wins guard as load(): reopening a different container
+  // before the first response lands must not paint the wrong container's slots.
+  const loadSlots = useCallback(async (placeableId: string) => {
+    const requestId = ++slotsRequestIdRef.current;
+    setSlotsLoading(true);
+    setSlotsError("");
+    try {
+      const result = await basesApi.containerSlots(baseId, placeableId);
+      if (slotsRequestIdRef.current !== requestId) return;
+      setSlots(result);
+    } catch (error) {
+      if (slotsRequestIdRef.current !== requestId) return;
+      setSlotsError(errorText(error));
+    } finally {
+      if (slotsRequestIdRef.current === requestId) setSlotsLoading(false);
+    }
+  }, [baseId]);
+
+  useEffect(() => {
+    if (!contentsFor) {
+      setSlots(null);
+      setSlotsError("");
+      setDeleteNotice("");
+      setDeleteError("");
+      setSelectedSlotId("");
+      setAmount("");
+      return;
+    }
+    setSelectedSlotId("");
+    setAmount("");
+    setDeleteError("");
+    void loadSlots(contentsFor);
+  }, [contentsFor, loadSlots]);
+
   // Matches ConfirmDialog: Escape closes, and focus moves to the close button
   // so the overlay is reachable without a mouse.
   useEffect(() => {
@@ -149,6 +263,65 @@ export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
     setSubmittedQ(next);
     setExpandedItem("");
     setShowAllItems(false);
+  }
+
+  async function deleteSlot(slot: BaseInventorySlot, amount: number, containerName: string, group?: BaseInventoryGroupKey) {
+    const whole = amount >= slot.quantity;
+    const confirmed = await confirmAction(
+      whole ? "Delete this item from the container?" : "Remove part of this stack?",
+      {
+        title: whole ? "Delete Stored Item" : "Remove From Stack",
+        confirmLabel: whole ? "Delete" : "Remove",
+        danger: true,
+        // Refineries and fabricators hold live crafting state -- the game's own
+        // crafting routine consumes allocated ingredients from these same rows.
+        warning: group && group !== "storage"
+          ? "This container feeds crafting. Removing items a recipe has already reserved may leave that job referencing an item that no longer exists."
+          : undefined,
+        details: [
+          { label: "Base", value: baseName },
+          { label: "Container", value: containerName, tone: "accent" },
+          { label: "Slot", value: slot.positionIndex === null ? "—" : `#${slot.positionIndex}` },
+          {
+            label: whole ? "Item" : "Removing",
+            value: whole
+              ? `${slot.name} ×${slot.quantity.toLocaleString()}`
+              : `${amount.toLocaleString()} of ${slot.quantity.toLocaleString()} ${slot.name}`,
+            tone: "danger"
+          }
+        ]
+      }
+    );
+    if (!confirmed) return;
+    setDeletingItemId(slot.itemId);
+    setDeleteNotice("");
+    setDeleteError("");
+    try {
+      const response = await basesApi.deleteContainerItem(
+        baseId, contentsFor, slot.itemId, "DELETE ITEM", whole ? undefined : amount);
+      const result = response.result;
+      if (!response.supported || !result?.ok) {
+        throw new Error(response.error || response.reason || "The item could not be deleted.");
+      }
+      // Stated per delete rather than once up front: whether the change can be
+      // undone by the map server depends on that map's state right now, and
+      // `known: false` means the console cannot tell -- never say "safe".
+      const live = result.live;
+      setDeleteNotice(live.known
+        ? live.running
+          ? `${result.message} ${live.map || "This base's map"}${live.partitionId ? ` · Partition ${live.partitionId}` : ""} is running, so the server may restore it on its next autosave. Restart that map to make the change stick.`
+          : `${result.message} That map is down, so the change will stick.`
+        : `${result.message} The console cannot tell whether this base's map is running, so it may be restored on the next autosave.`);
+      // Refetch both: the slot list for this container, and the tab totals,
+      // group counts and rollup, all of which the delete just invalidated.
+      await Promise.all([loadSlots(contentsFor), load()]);
+    } catch (error) {
+      const text = errorText(error);
+      setDeleteError(text);
+      onError(text);
+    } finally {
+      setDeletingItemId("");
+    }
   }
 
   if (loading) {
@@ -180,8 +353,13 @@ export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
         {/* Stated before the data rather than after it: it governs how to read
             everything below, and at the foot of a 27-card list it was never
             seen. */}
+        {/* The read-only caveat is gone but the sync caveat is not: these are
+            database rows, and a running map server keeps its own copy. The
+            per-delete result says whether THIS base's map is running; this
+            line only sets the expectation. */}
         <p className="bases-inventory-note muted">
-          Read-only. Base inventory has no live-sync path, so the console cannot write items here.
+          A database snapshot, not a live view. Items can be deleted from a container's contents,
+          but a running map server may restore a deleted item on its next autosave.
         </p>
 
         {/* summary-stats/summary-stat are the app's stat tiles, shared with
@@ -385,26 +563,152 @@ export function BaseInventoryTab({ baseId }: BaseInventoryTabProps) {
                   : `#${openContainer.placeableId}`}
               </p>
             </div>
-            <button ref={closeContentsRef} className="icon-action" aria-label="Close contents" onClick={() => setContentsFor("")}>
-              <X size={18} />
-            </button>
+            <div className="bases-inventory-contents-head-actions">
+              <div className="bases-inventory-views" role="group" aria-label="Contents view">
+                <button
+                  className={`bases-inventory-view${contentsView === "list" ? " active" : ""}`}
+                  aria-pressed={contentsView === "list"}
+                  onClick={() => setContentsView("list")}
+                ><List size={14} aria-hidden="true" /> List</button>
+                <button
+                  className={`bases-inventory-view${contentsView === "grid" ? " active" : ""}`}
+                  aria-pressed={contentsView === "grid"}
+                  onClick={() => setContentsView("grid")}
+                ><LayoutGrid size={14} aria-hidden="true" /> Grid</button>
+              </div>
+              <button ref={closeContentsRef} className="icon-action" aria-label="Close contents" onClick={() => setContentsFor("")}>
+                <X size={18} />
+              </button>
+            </div>
           </div>
 
           <dl className="bases-inventory-contents-summary">
             <div><dt>Slots Used</dt><dd>{openContainer.usedSlots.toLocaleString()} / {openContainer.maxSlots.toLocaleString()}</dd></div>
             <div><dt>Items</dt><dd>{openContainer.itemCount.toLocaleString()}</dd></div>
+            {/* Distinct templates, not stacks -- the count below the list is
+                the stack count, and the two differ whenever a template
+                occupies more than one slot. */}
             <div><dt>Distinct</dt><dd>{openContainer.items.length.toLocaleString()}</dd></div>
           </dl>
 
-          <div className="bases-inventory-contents-list">
-            {openContainer.items.map((stack) => (
-              <div className="bases-inventory-contents-row" key={stack.templateId}>
-                <img src={itemImage(stack.templateId)} alt="" aria-hidden="true" />
-                <span className="bases-inventory-contents-name" title={stack.templateId}>{stack.name}</span>
-                <span className="bases-inventory-contents-qty">{stack.quantity.toLocaleString()}</span>
+          {slotsLoading && <p className="muted" role="status">Loading slots…</p>}
+          {slotsError && <p className="bases-permissions-error" role="alert">
+            {slotsError} <button onClick={() => void loadSlots(contentsFor)}>Retry</button>
+          </p>}
+          {deleteNotice && <p className="bases-inventory-delete-notice" role="status">{deleteNotice}</p>}
+          {deleteError && <p className="bases-inventory-amount-error" role="alert">{deleteError}</p>}
+
+          {!slotsLoading && !slotsError && slots && slots.found === false && <p className="muted" role="status">
+            {slots.reason || "That container is no longer at this base."}
+          </p>}
+
+          {!slotsLoading && !slotsError && slots?.found && slots.inventories.map((inventory) => {
+            const { cells, overflow } = layoutSlots(inventory);
+            // Grid needs real slot positions and a sane capacity; without
+            // either it would be a wall of empty cells, so it is not offered.
+            const gridUsable = inventory.maxSlots > 0
+              && inventory.maxSlots <= GRID_CELL_CAP
+              && inventory.slots.some((slot) => slot.positionIndex !== null);
+            const showGrid = contentsView === "grid" && gridUsable;
+            const rows = showGrid ? overflow : inventory.slots;
+            return (
+              <div className="bases-inventory-slots" key={inventory.inventoryId}>
+                {slots.inventories.length > 1 && <p className="bases-inventory-card-subtitle">
+                  Inventory #{inventory.inventoryId} · {inventory.usedSlots.toLocaleString()} / {inventory.maxSlots.toLocaleString()} slots
+                </p>}
+
+                {showGrid && <div
+                  className="bases-inventory-slot-grid"
+                  role="group"
+                  aria-label={`${inventory.usedSlots} of ${inventory.maxSlots} slots used`}
+                >
+                  {cells.map((slot, index) => slot
+                    ? <button
+                        key={slot.itemId}
+                        className={`bases-inventory-slot-cell${selectedSlotId === slot.itemId ? " selected" : ""}`}
+                        aria-pressed={selectedSlotId === slot.itemId}
+                        title={`${slot.name} ×${slot.quantity.toLocaleString()} (slot ${index})`}
+                        onClick={() => { setSelectedSlotId(slot.itemId); setAmount(String(slot.quantity)); }}
+                      >
+                        <CatalogItemThumb item={{ id: slot.templateId, itemId: slot.templateId, name: slot.name, image: itemImage(slot.templateId) }} small />
+                        {slot.quantity > 1 && <span className="bases-inventory-slot-qty">{slot.quantity.toLocaleString()}</span>}
+                      </button>
+                    : <span className="bases-inventory-slot-cell empty" key={`empty-${index}`} aria-hidden="true" />)}
+                </div>}
+
+                {showGrid && overflow.length > 0 && <p className="muted bases-inventory-slot-overflow-note">
+                  {/* position_index has no unique constraint and is not bounded
+                      by max_item_count, so a slot can duplicate another or sit
+                      past the end of the grid. Listed rather than dropped. */}
+                  {overflow.length.toLocaleString()} {overflow.length === 1 ? "item has" : "items have"} no place in the grid — a duplicate or out-of-range slot number.
+                </p>}
+
+                {rows.length > 0 && <div className="bases-inventory-contents-list">
+                  {!showGrid && <div className="bases-inventory-contents-row head">
+                    <span /><span>Item</span><span>Slot</span><span>Qty</span><span />
+                  </div>}
+                  {rows.map((slot) => (
+                    <div
+                      className={`bases-inventory-contents-row${selectedSlotId === slot.itemId ? " selected" : ""}`}
+                      key={slot.itemId}
+                    >
+                      <CatalogItemThumb item={{ id: slot.templateId, itemId: slot.templateId, name: slot.name, image: itemImage(slot.templateId) }} small />
+                      <button
+                        className="bases-inventory-contents-name"
+                        title={slot.templateId}
+                        aria-pressed={selectedSlotId === slot.itemId}
+                        onClick={() => { setSelectedSlotId(slot.itemId); setAmount(String(slot.quantity)); }}
+                      >{slot.name}</button>
+                      <span className="bases-inventory-contents-slot muted">
+                        {slot.positionIndex === null ? "—" : `#${slot.positionIndex}`}
+                      </span>
+                      <span className="bases-inventory-contents-qty">{slot.quantity.toLocaleString()}</span>
+                      <button
+                        className="icon-toggle-button danger"
+                        title="Delete this stack"
+                        aria-label={`Delete ${slot.name} from slot ${slot.positionIndex ?? "unknown"}`}
+                        disabled={deletingItemId === slot.itemId}
+                        onClick={() => void deleteSlot(slot, slot.quantity, containerLabel(openContainer), slots.group)}
+                      ><Trash2 size={15} /></button>
+                    </div>
+                  ))}
+                </div>}
               </div>
-            ))}
-          </div>
+            );
+          })}
+
+          {selectedSlot && <div className="bases-inventory-slot-detail">
+            <CatalogItemThumb item={{ id: selectedSlot.templateId, itemId: selectedSlot.templateId, name: selectedSlot.name, image: itemImage(selectedSlot.templateId) }} />
+            <div className="bases-inventory-slot-detail-body">
+              <strong>{selectedSlot.name}</strong>
+              <span className="muted">
+                {selectedSlot.positionIndex === null ? "Unplaced" : `Slot #${selectedSlot.positionIndex}`}
+                {" · "}{selectedSlot.quantity.toLocaleString()} held
+                {selectedSlot.currentDurability !== null && selectedSlot.maxDurability
+                  ? ` · ${Math.round((selectedSlot.currentDurability / selectedSlot.maxDurability) * 100)}% durability`
+                  : ""}
+              </span>
+            </div>
+            <label className="bases-inventory-slot-amount">
+              <span>Remove</span>
+              <input
+                type="number"
+                min={1}
+                max={selectedSlot.quantity}
+                value={amount}
+                aria-label={`Amount of ${selectedSlot.name} to remove`}
+                onChange={(event) => setAmount(event.target.value)}
+              />
+            </label>
+            <button
+              className="danger"
+              disabled={!amountValid || deletingItemId === selectedSlot.itemId}
+              onClick={() => void deleteSlot(selectedSlot, Number(amount), containerLabel(openContainer), slots?.group)}
+            >{Number(amount) >= selectedSlot.quantity ? "Delete stack" : `Remove ${Number(amount).toLocaleString()}`}</button>
+          </div>}
+          {selectedSlot && !amountValid && <p className="bases-inventory-amount-error" role="alert">
+            Enter an amount between 1 and {selectedSlot.quantity.toLocaleString()}.
+          </p>}
 
           <div className="confirm-modal-actions">
             <button onClick={() => setContentsFor("")}>Close</button>

--- a/console/web/src/features/bases/BaseInventoryTab.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.tsx
@@ -85,7 +85,11 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
   const [slots, setSlots] = useState<BaseContainerSlots | null>(null);
   const [slotsLoading, setSlotsLoading] = useState(false);
   const [slotsError, setSlotsError] = useState("");
-  const [contentsView, setContentsView] = useState<ContentsView>("list");
+  // Grid by default: the overlay's job is "what is actually in this box", and
+  // the slot layout answers that at a glance. List is a click away, and is
+  // still the automatic fallback for a container whose slots carry no usable
+  // position_index or whose capacity is unusable.
+  const [contentsView, setContentsView] = useState<ContentsView>("grid");
   const [deletingItemId, setDeletingItemId] = useState("");
   const [deleteNotice, setDeleteNotice] = useState("");
   // Separate from slotsError on purpose: that one means "the slots could not
@@ -442,7 +446,19 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
                             {item.containers.map((holder) => (
                               <div key={holder.placeableId}>
                                 <span>{containerLabel(holder)}</span>
-                                <span>{holder.quantity.toLocaleString()}</span>
+                                <span className="bases-inventory-breakdown-actions">
+                                  {holder.quantity.toLocaleString()}
+                                  {/* Same label and icon as the container
+                                      cards': one action, one name for it,
+                                      wherever a container is listed. */}
+                                  <button
+                                    className="bases-inventory-view-contents compact"
+                                    onClick={() => setContentsFor(holder.placeableId)}
+                                  >
+                                    <Boxes size={13} aria-hidden="true" />
+                                    View Contents
+                                  </button>
+                                </span>
                               </div>
                             ))}
                           </div>}
@@ -602,6 +618,12 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
             {slots.reason || "That container is no longer at this base."}
           </p>}
 
+          {/* One scroll container around every inventory, and the only part of
+              the modal that grows. The per-inventory wrapper below cannot own
+              the scrolling: an intermediate block with no height of its own
+              breaks the constraint chain, and the list inside then renders at
+              its full natural height straight over the controls beneath it. */}
+          <div className="bases-inventory-contents-scroll">
           {!slotsLoading && !slotsError && slots?.found && slots.inventories.map((inventory) => {
             const { cells, overflow } = layoutSlots(inventory);
             // Grid needs real slot positions and a sane capacity; without
@@ -676,6 +698,8 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
               </div>
             );
           })}
+
+          </div>
 
           {selectedSlot && <div className="bases-inventory-slot-detail">
             <CatalogItemThumb item={{ id: selectedSlot.templateId, itemId: selectedSlot.templateId, name: selectedSlot.name, image: itemImage(selectedSlot.templateId) }} />

--- a/console/web/src/features/bases/BaseInventoryTab.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.tsx
@@ -207,6 +207,12 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
     && Number.isInteger(amountNumber)
     && amountNumber >= 1
     && amountNumber <= (selectedSlot?.quantity ?? 0);
+  const deleteAllowed = slots?.group === "storage" && slots?.deleteSafety?.safe === true;
+  const deleteUnavailableReason = slots?.found && !deleteAllowed
+    ? slots.group !== "storage"
+      ? "Item deletion is available only for Storage containers. Crafting and Refining contents are read-only to protect active jobs."
+      : slots.deleteSafety?.reason || "Item deletion is unavailable for this container."
+    : "";
 
   // A slot that vanished (deleted, or moved by a player between refetches)
   // must not leave a stale strip pointing at an id the server no longer has.
@@ -269,7 +275,13 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
     setShowAllItems(false);
   }
 
-  async function deleteSlot(slot: BaseInventorySlot, amount: number, containerName: string, group?: BaseInventoryGroupKey) {
+  async function deleteSlot(slot: BaseInventorySlot, amount: number, containerName: string) {
+    if (!deleteAllowed) {
+      const text = deleteUnavailableReason || "Item deletion is unavailable for this container.";
+      setDeleteError(text);
+      onError(text);
+      return;
+    }
     const whole = amount >= slot.quantity;
     const confirmed = await confirmAction(
       whole ? "Delete this item from the container?" : "Remove part of this stack?",
@@ -277,11 +289,6 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
         title: whole ? "Delete Stored Item" : "Remove From Stack",
         confirmLabel: whole ? "Delete" : "Remove",
         danger: true,
-        // Refineries and fabricators hold live crafting state -- the game's own
-        // crafting routine consumes allocated ingredients from these same rows.
-        warning: group && group !== "storage"
-          ? "This container feeds crafting. Removing items a recipe has already reserved may leave that job referencing an item that no longer exists."
-          : undefined,
         details: [
           { label: "Base", value: baseName },
           { label: "Container", value: containerName, tone: "accent" },
@@ -307,15 +314,7 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
       if (!response.supported || !result?.ok) {
         throw new Error(response.error || response.reason || "The item could not be deleted.");
       }
-      // Stated per delete rather than once up front: whether the change can be
-      // undone by the map server depends on that map's state right now, and
-      // `known: false` means the console cannot tell -- never say "safe".
-      const live = result.live;
-      setDeleteNotice(live.known
-        ? live.running
-          ? `${result.message} ${live.map || "This base's map"}${live.partitionId ? ` · Partition ${live.partitionId}` : ""} is running, so the server may restore it on its next autosave. Restart that map to make the change stick.`
-          : `${result.message} That map is down, so the change will stick.`
-        : `${result.message} The console cannot tell whether this base's map is running, so it may be restored on the next autosave.`);
+      setDeleteNotice(result.message);
       // Refetch both: the slot list for this container, and the tab totals,
       // group counts and rollup, all of which the delete just invalidated.
       await Promise.all([loadSlots(contentsFor), load()]);
@@ -357,13 +356,11 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
         {/* Stated before the data rather than after it: it governs how to read
             everything below, and at the foot of a 27-card list it was never
             seen. */}
-        {/* The read-only caveat is gone but the sync caveat is not: these are
-            database rows, and a running map server keeps its own copy. The
-            per-delete result says whether THIS base's map is running; this
-            line only sets the expectation. */}
+        {/* These are database rows and a running map keeps its own copy, so
+            destructive controls remain disabled until the backend verifies a
+            safe stopped-map window. */}
         <p className="bases-inventory-note muted">
-          A database snapshot, not a live view. Items can be deleted from a container's contents,
-          but a running map server may restore a deleted item on its next autosave.
+          A database snapshot, not a live view. Stored items can be deleted only while their map is safely stopped.
         </p>
 
         {/* summary-stats/summary-stat are the app's stat tiles, shared with
@@ -613,6 +610,9 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
           </p>}
           {deleteNotice && <p className="bases-inventory-delete-notice" role="status">{deleteNotice}</p>}
           {deleteError && <p className="bases-inventory-amount-error" role="alert">{deleteError}</p>}
+          {deleteUnavailableReason && <p className="bases-inventory-amount-error" role="status">
+            {deleteUnavailableReason}
+          </p>}
 
           {!slotsLoading && !slotsError && slots && slots.found === false && <p className="muted" role="status">
             {slots.reason || "That container is no longer at this base."}
@@ -689,8 +689,8 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
                         className="icon-toggle-button danger"
                         title="Delete this stack"
                         aria-label={`Delete ${slot.name} from slot ${slot.positionIndex ?? "unknown"}`}
-                        disabled={deletingItemId === slot.itemId}
-                        onClick={() => void deleteSlot(slot, slot.quantity, containerLabel(openContainer), slots.group)}
+                        disabled={!deleteAllowed || deletingItemId === slot.itemId}
+                        onClick={() => void deleteSlot(slot, slot.quantity, containerLabel(openContainer))}
                       ><Trash2 size={15} /></button>
                     </div>
                   ))}
@@ -726,8 +726,8 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
             </label>
             <button
               className="danger"
-              disabled={!amountValid || deletingItemId === selectedSlot.itemId}
-              onClick={() => void deleteSlot(selectedSlot, Number(amount), containerLabel(openContainer), slots?.group)}
+              disabled={!deleteAllowed || !amountValid || deletingItemId === selectedSlot.itemId}
+              onClick={() => void deleteSlot(selectedSlot, Number(amount), containerLabel(openContainer))}
             >{Number(amount) >= selectedSlot.quantity ? "Delete stack" : `Remove ${Number(amount).toLocaleString()}`}</button>
           </div>}
           {selectedSlot && !amountValid && <p className="bases-inventory-amount-error" role="alert">

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { basesApi, type AutoRefillBase } from "../../api/bases";
 import { mapsApi } from "../../api/maps";
@@ -992,6 +992,9 @@ describe("BasesPanel permissions editing", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /View Contents/ }));
     await waitFor(() => expect(basesApi.containerSlots).toHaveBeenCalledWith("1006", "40001"));
+    // The overlay opens on grid; the per-row delete button lives in the list.
+    await waitFor(() => expect(document.querySelectorAll(".bases-inventory-slot-cell").length).toBeGreaterThan(0));
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: /List/ }));
 
     fireEvent.click(await screen.findByRole("button", { name: /^Delete Granite Stone/ }));
     await waitFor(() => expect(props.confirmAction).toHaveBeenCalled());

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -970,6 +970,7 @@ describe("BasesPanel permissions editing", () => {
     vi.mocked(basesApi.containerSlots).mockResolvedValue({
       supported: true, found: true, baseId: 1006, placeableId: "40001",
       typeName: "Storage Container", group: "storage", maxSlots: 45, usedSlots: 1,
+      deleteSafety: { safe: true, known: true, map: "HaggaBasin", partitionId: 1, reason: "" },
       inventories: [{
         inventoryId: "9001", maxSlots: 45, usedSlots: 1,
         slots: [{ itemId: "501", templateId: "Stone", name: "Granite Stone", positionIndex: 0, quantity: 500, qualityLevel: 0, currentDurability: null, maxDurability: null }]
@@ -981,7 +982,7 @@ describe("BasesPanel permissions editing", () => {
         ok: true, partial: false, typeName: "Storage Container", group: "storage",
         removed: { itemId: "501", templateId: "Stone", count: 500, remaining: 0 },
         message: "Stone was deleted from the database.",
-        live: { known: true, running: false, map: "HaggaBasin", partitionId: 1 }
+        deleteSafety: { safe: true, known: true, map: "HaggaBasin", partitionId: 1, reason: "" }
       }
     } as never);
 

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -26,7 +26,9 @@ vi.mock("../../api/bases", () => ({
     pendingWaterRefills: vi.fn(),
     autoRefillWater: vi.fn(),
     setAutoRefillWater: vi.fn(),
-    inventory: vi.fn()
+    inventory: vi.fn(),
+    containerSlots: vi.fn(),
+    deleteContainerItem: vi.fn()
   }
 }));
 
@@ -936,6 +938,69 @@ describe("BasesPanel permissions editing", () => {
     expect(await screen.findByText("Vault")).toBeInTheDocument();
     expect(document.querySelectorAll(".bases-inventory-cards .bases-card")).toHaveLength(1);
     await waitFor(() => expect(basesApi.inventory).toHaveBeenCalledWith("1006"));
+  });
+
+  // BaseInventoryTab reaches confirmAction/onError/baseName only through this
+  // panel. Types prove the props are passed at all; this proves the values are
+  // the right ones, which is what a delete confirmation actually shows the
+  // operator before destroying something.
+  it("wires the inventory tab's delete through to the panel's confirm and base name", async () => {
+    mockList(false);
+    vi.mocked(basesApi.inventory).mockResolvedValue({
+      supported: true,
+      baseId: 1006,
+      groups: [
+        { key: "storage", name: "Storage", containerCount: 1, itemCount: 500 },
+        { key: "refining", name: "Refining", containerCount: 0, itemCount: 0 },
+        { key: "crafting", name: "Crafting", containerCount: 0, itemCount: 0 },
+        { key: "other", name: "Other", containerCount: 0, itemCount: 0 }
+      ],
+      containers: [{
+        placeableId: "40001", name: "Vault", typeName: "Storage Container", group: "storage",
+        usedSlots: 1, maxSlots: 45, itemCount: 500,
+        items: [{ templateId: "Stone", name: "Granite Stone", quantity: 500 }]
+      }],
+      items: [{
+        templateId: "Stone", name: "Granite Stone", image: "/images/items/image-unavailable.png",
+        category: "resources", quantity: 500, containerCount: 1,
+        containers: [{ placeableId: "40001", name: "Vault", typeName: "Storage Container", group: "storage", quantity: 500 }]
+      }],
+      totals: { items: 500, distinct: 1, containers: 1, usedSlots: 1, maxSlots: 45 }
+    } as never);
+    vi.mocked(basesApi.containerSlots).mockResolvedValue({
+      supported: true, found: true, baseId: 1006, placeableId: "40001",
+      typeName: "Storage Container", group: "storage", maxSlots: 45, usedSlots: 1,
+      inventories: [{
+        inventoryId: "9001", maxSlots: 45, usedSlots: 1,
+        slots: [{ itemId: "501", templateId: "Stone", name: "Granite Stone", positionIndex: 0, quantity: 500, qualityLevel: 0, currentDurability: null, maxDurability: null }]
+      }]
+    } as never);
+    vi.mocked(basesApi.deleteContainerItem).mockResolvedValue({
+      supported: true,
+      result: {
+        ok: true, partial: false, typeName: "Storage Container", group: "storage",
+        removed: { itemId: "501", templateId: "Stone", count: 500, remaining: 0 },
+        message: "Stone was deleted from the database.",
+        live: { known: true, running: false, map: "HaggaBasin", partitionId: 1 }
+      }
+    } as never);
+
+    const props = renderPanel();
+    fireEvent.click(await screen.findByRole("button", { name: "Show details for Sietch One" }));
+    fireEvent.click(screen.getByRole("tab", { name: "Inventory" }));
+    expect(await screen.findByText("Vault")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /View Contents/ }));
+    await waitFor(() => expect(basesApi.containerSlots).toHaveBeenCalledWith("1006", "40001"));
+
+    fireEvent.click(await screen.findByRole("button", { name: /^Delete Granite Stone/ }));
+    await waitFor(() => expect(props.confirmAction).toHaveBeenCalled());
+    // The panel's own confirm, carrying the panel's own base name -- not a
+    // placeholder and not the base id.
+    const options = vi.mocked(props.confirmAction).mock.calls[0][1] as { details?: { label: string; value: string }[] };
+    expect(options.details?.find((detail) => detail.label === "Base")?.value).toBe("Sietch One");
+    await waitFor(() => expect(basesApi.deleteContainerItem)
+      .toHaveBeenCalledWith("1006", "40001", "501", "DELETE ITEM", undefined));
   });
 
   // A base with no generators had no expand chevron before this feature. It

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1614,7 +1614,12 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
                   </div>
                 : expandedTab === "inventory"
                 ? <div role="tabpanel" id={`bases-panel-inventory-${id}`} aria-labelledby={`bases-tab-inventory-${id}`}>
-                    <BaseInventoryTab baseId={id} />
+                    <BaseInventoryTab
+                      baseId={id}
+                      baseName={String(base.name || `base ${id}`)}
+                      confirmAction={confirmAction}
+                      onError={onError}
+                    />
                   </div>
                 : <div role="tabpanel" id={`bases-panel-permissions-${id}`} aria-labelledby={`bases-tab-permissions-${id}`}>
                     <BasePermissionsTab

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2821,15 +2821,17 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
    rather than trailing 400px away at the far right. Its 22px + the 8px gap put
    the item name at 40px from the row edge, which is where the expanded
    breakdown indents to. */
+/* Header, row, icon and breakdown scale together rather than the row font
+   alone -- bumping one leaves the block looking mismatched. */
 .bases-inventory-item-head,
 .bases-inventory-item-row {
   display: grid;
-  grid-template-columns: 22px minmax(0, 1fr) 90px 92px;
+  grid-template-columns: 26px minmax(0, 1fr) 100px 100px;
   gap: 8px;
   align-items: center;
   text-align: left;
 }
-.bases-inventory-item-head { padding: 6px 10px; color: var(--muted); font-size: 11px; border-bottom: 1px solid var(--border); }
+.bases-inventory-item-head { padding: 7px 12px; color: var(--muted); font-size: 12px; border-bottom: 1px solid var(--border); }
 .bases-inventory-item-head > span:nth-child(3), .bases-inventory-item-head > span:nth-child(4) { text-align: right; }
 .bases-inventory-item-row {
   width: 100%;
@@ -2838,16 +2840,16 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   border-radius: 0;
   background: transparent;
   color: var(--text);
-  font-size: 13px;
-  padding: 9px 10px;
+  font-size: 15px;
+  padding: 11px 12px;
 }
 .bases-inventory-item-row:hover { border-color: var(--border); background: var(--panel-muted); }
 .bases-inventory-item-name { display: flex; align-items: center; gap: 8px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.bases-inventory-item-name img { width: 22px; height: 22px; flex: 0 0 22px; object-fit: contain; border-radius: 4px; background: #25201b; }
+.bases-inventory-item-name img { width: 26px; height: 26px; flex: 0 0 26px; object-fit: contain; border-radius: 4px; background: #25201b; }
 .bases-inventory-qty, .bases-inventory-count { text-align: right; }
 .bases-inventory-count { color: var(--muted); }
-.bases-inventory-breakdown { background: var(--panel-muted); padding: 6px 10px 9px 40px; border-bottom: 1px solid var(--border); }
-.bases-inventory-breakdown > div { display: flex; justify-content: space-between; gap: 12px; color: var(--muted-warm); font-size: 12px; padding: 4px 0; }
+.bases-inventory-breakdown { background: var(--panel-muted); padding: 7px 12px 11px 46px; border-bottom: 1px solid var(--border); }
+.bases-inventory-breakdown > div { display: flex; justify-content: space-between; align-items: center; gap: 12px; color: var(--muted-warm); font-size: 13px; padding: 5px 0; }
 .bases-inventory-show-all { width: 100%; margin-top: 10px; background: transparent; border-color: transparent; color: var(--muted-warm); font-size: 12px; }
 .bases-inventory-show-all:hover { border-color: var(--border-strong); }
 
@@ -2888,15 +2890,41 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   color: #f7e7c7;
 }
 .bases-inventory-view-contents .muted { font-size: 11.5px; }
+/* Smaller inside the item breakdown, where it repeats once per container and
+   sits on a 12px row -- the card's full-size button would dominate it. */
+.bases-inventory-view-contents.compact { padding: 4px 9px; gap: 5px; font-size: 12px; }
+.bases-inventory-breakdown-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-shrink: 0;
+}
 
 /* Taller and wider than .confirm-modal's 440px: this is a scrolling list, not
    a sentence and two buttons. */
+/* Flex column rather than .confirm-modal's grid: this modal's children are
+   conditional (loading, load error, delete notice, delete error, the detail
+   strip), and a fixed grid-template-rows assigns the growing row by position,
+   so any one of them appearing shifted the scroll region onto the wrong
+   child. In a flex column only the scroll container grows and the rest size
+   themselves, whatever is present. */
 .bases-inventory-contents-modal {
   width: min(560px, calc(100vw - 32px));
   max-height: min(72vh, 720px);
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   padding-left: 24px;
   padding-right: 24px;
+}
+/* min-height: 0 is load-bearing -- a flex item defaults to min-content, which
+   for a long list is its full height, and it would overflow the modal
+   instead of scrolling. */
+.bases-inventory-contents-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  padding-right: 10px;
 }
 .bases-inventory-contents-modal .confirm-modal-title { align-items: start; }
 .bases-inventory-contents-modal .confirm-modal-title > div { min-width: 0; }
@@ -2918,20 +2946,19 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
    12px when the scrollbar appears. The padding-right then holds the quantity
    column clear of that track -- without it the numbers sit under the
    scrollbar, which is exactly where they are hardest to read. */
+/* Scrolling moved up to .bases-inventory-contents-scroll, which wraps every
+   inventory -- a per-inventory scroll area would give a two-inventory
+   refinery two independent scrollbars. */
 .bases-inventory-contents-list {
-  min-height: 0;
-  overflow-y: auto;
-  scrollbar-gutter: stable;
   display: grid;
   align-content: start;
-  padding-right: 10px;
 }
 /* Five columns now: icon, name, slot number, quantity, delete. The slot
    number is what makes two rows of the same template distinguishable, which
    is the whole point of the per-slot view. */
 .bases-inventory-contents-row {
   display: grid;
-  grid-template-columns: 24px minmax(0, 1fr) 48px auto 30px;
+  grid-template-columns: 40px minmax(0, 1fr) 48px auto 30px;
   gap: 10px;
   align-items: center;
   padding: 7px 2px;
@@ -2941,11 +2968,27 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
 .bases-inventory-contents-row:last-child { border-bottom: 0; }
 .bases-inventory-contents-row.head { color: var(--muted-warm); font-size: 12px; border-bottom-color: var(--border-strong); }
 .bases-inventory-contents-row.selected { background: var(--surface-raised); }
-.bases-inventory-contents-row img { width: 24px; height: 24px; object-fit: contain; border-radius: 4px; background: #25201b; }
+/* The third and last CatalogItemThumb in this tab, and the one that has to be
+   sized here too: .small is a 42px box, which overflowed the old 24px column
+   and ran under the item name. The other two are handled at
+   .bases-inventory-slot-cell and .bases-inventory-slot-detail -- if a fourth
+   is ever added, it needs a rule as well or it will overflow the same way. */
+.bases-inventory-contents-row .catalog-item-preview {
+  width: 40px;
+  height: 40px;
+  flex-basis: 40px;
+  margin-inline: 0;
+}
+.bases-inventory-contents-row img { width: 100%; height: 100%; object-fit: contain; border-radius: 4px; background: #25201b; }
+/* justify-content, not just text-align: the global button rule makes every
+   button an inline-flex centred box, so text-align alone left the item names
+   centred in their column. */
 .bases-inventory-contents-name {
   min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-  background: none; border: 0; padding: 0; text-align: left; color: inherit; font: inherit; cursor: pointer;
+  display: block; text-align: left; justify-content: flex-start;
+  background: none; border: 0; padding: 0; color: inherit; font: inherit; cursor: pointer;
 }
+.bases-inventory-contents-name:hover { border-color: transparent; color: var(--accent); }
 .bases-inventory-contents-slot { font-variant-numeric: tabular-nums; font-size: 12px; }
 .bases-inventory-contents-qty { color: var(--muted-warm); font-variant-numeric: tabular-nums; }
 .bases-inventory-note { margin: 0; font-size: 12px; }
@@ -2955,8 +2998,8 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
    cells stay square via aspect-ratio instead of a hardcoded height. */
 .bases-inventory-slot-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(46px, 1fr));
-  gap: 5px;
+  grid-template-columns: repeat(auto-fill, minmax(68px, 1fr));
+  gap: 6px;
   margin-bottom: 10px;
 }
 .bases-inventory-slot-cell {
@@ -2974,12 +3017,48 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
 /* Dashed and dimmer so an empty slot reads as absence at a glance rather than
    as an item that failed to load. */
 .bases-inventory-slot-cell.empty { background: #1b1610; border-style: dashed; cursor: default; }
+/* Purely decorative, matching the game's own empty slot. Pseudo-elements
+   rather than markup: the cell is already aria-hidden and non-interactive, so
+   nothing should announce a "+" to a screen reader or suggest it can be
+   clicked -- there is no add-item action here yet.
+   Drawn as two bars rather than typed as a "+" glyph. A glyph is centred by
+   its line box, not by its ink, and the plus in this font sits above that
+   centre -- it read as noticeably high in the slot. Two absolutely positioned
+   bars are centred geometrically, and being percentage-sized they track the
+   tile, which auto-fill grows from its 68px minimum to fill the row. */
+.bases-inventory-slot-cell.empty::before,
+.bases-inventory-slot-cell.empty::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #6b5b44;
+  border-radius: 1px;
+}
+.bases-inventory-slot-cell.empty::before { width: 52%; height: 2px; }
+.bases-inventory-slot-cell.empty::after { width: 2px; height: 52%; }
 .bases-inventory-slot-cell.selected { border-color: var(--danger); }
-.bases-inventory-slot-cell img { width: 62%; height: 62%; object-fit: contain; }
+/* CatalogItemThumb carries its own bordered, backgrounded box (72px by
+   default, 42px as .small). In a slot the cell IS the frame, so its chrome is
+   stripped and it fills the cell -- otherwise every tile draws a box inside a
+   box, which is what made the icons read as inset rather than seated. */
+.bases-inventory-slot-cell .catalog-item-preview {
+  width: 100%;
+  height: 100%;
+  flex-basis: auto;
+  border: 0;
+  border-radius: 0;
+  background: none;
+  margin-inline: 0;
+}
+.bases-inventory-slot-cell img { width: 78%; height: 78%; object-fit: contain; }
 .bases-inventory-slot-qty {
-  position: absolute; right: 3px; bottom: 1px;
-  font-size: 11px; font-variant-numeric: tabular-nums;
-  text-shadow: 0 1px 2px #000;
+  position: absolute; right: 4px; bottom: 2px;
+  font-size: 12px; font-variant-numeric: tabular-nums;
+  /* Two shadows, not one: quantities sit over the icon itself, and a single
+     offset shadow disappears against a light-coloured item. */
+  text-shadow: 0 1px 2px #000, 0 0 3px #000;
 }
 .bases-inventory-slot-overflow-note { margin: 0 0 8px; font-size: 12px; }
 .bases-inventory-slots + .bases-inventory-slots { margin-top: 12px; }
@@ -2988,15 +3067,24 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
    every row -- a packed 100-slot container would render a hundred of them. */
 .bases-inventory-slot-detail {
   display: grid;
-  grid-template-columns: 34px minmax(0, 1fr) auto auto;
-  gap: 10px;
+  grid-template-columns: 48px minmax(0, 1fr) auto auto;
+  gap: 12px;
   align-items: center;
   margin-top: 10px;
-  padding: 9px 10px;
+  padding: 10px 12px;
   border: 1px solid var(--border-strong);
   border-radius: 6px;
 }
-.bases-inventory-slot-detail img { width: 34px; height: 34px; object-fit: contain; }
+/* The WRAPPER has to be sized, not just the img inside it: CatalogItemThumb
+   defaults to a 72px box, which overflowed this column and put the item name
+   on top of the picture. */
+.bases-inventory-slot-detail .catalog-item-preview {
+  width: 48px;
+  height: 48px;
+  flex-basis: 48px;
+  margin-inline: 0;
+}
+.bases-inventory-slot-detail img { width: 100%; height: 100%; object-fit: contain; }
 .bases-inventory-slot-detail-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; font-size: 13px; }
 .bases-inventory-slot-detail-body span { font-size: 12px; }
 .bases-inventory-slot-amount { display: flex; align-items: center; gap: 6px; font-size: 12px; }

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2926,9 +2926,12 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   align-content: start;
   padding-right: 10px;
 }
+/* Five columns now: icon, name, slot number, quantity, delete. The slot
+   number is what makes two rows of the same template distinguishable, which
+   is the whole point of the per-slot view. */
 .bases-inventory-contents-row {
   display: grid;
-  grid-template-columns: 24px minmax(0, 1fr) auto;
+  grid-template-columns: 24px minmax(0, 1fr) 48px auto 30px;
   gap: 10px;
   align-items: center;
   padding: 7px 2px;
@@ -2936,10 +2939,71 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   font-size: 13px;
 }
 .bases-inventory-contents-row:last-child { border-bottom: 0; }
+.bases-inventory-contents-row.head { color: var(--muted-warm); font-size: 12px; border-bottom-color: var(--border-strong); }
+.bases-inventory-contents-row.selected { background: var(--surface-raised); }
 .bases-inventory-contents-row img { width: 24px; height: 24px; object-fit: contain; border-radius: 4px; background: #25201b; }
-.bases-inventory-contents-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bases-inventory-contents-name {
+  min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  background: none; border: 0; padding: 0; text-align: left; color: inherit; font: inherit; cursor: pointer;
+}
+.bases-inventory-contents-slot { font-variant-numeric: tabular-nums; font-size: 12px; }
 .bases-inventory-contents-qty { color: var(--muted-warm); font-variant-numeric: tabular-nums; }
 .bases-inventory-note { margin: 0; font-size: 12px; }
+
+/* The in-game-style slot grid. auto-fill rather than a fixed column count so
+   a 10-slot container and a 100-slot one both fill the modal width, and the
+   cells stay square via aspect-ratio instead of a hardcoded height. */
+.bases-inventory-slot-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(46px, 1fr));
+  gap: 5px;
+  margin-bottom: 10px;
+}
+.bases-inventory-slot-cell {
+  position: relative;
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #221b12;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0;
+  cursor: pointer;
+}
+/* Dashed and dimmer so an empty slot reads as absence at a glance rather than
+   as an item that failed to load. */
+.bases-inventory-slot-cell.empty { background: #1b1610; border-style: dashed; cursor: default; }
+.bases-inventory-slot-cell.selected { border-color: var(--danger); }
+.bases-inventory-slot-cell img { width: 62%; height: 62%; object-fit: contain; }
+.bases-inventory-slot-qty {
+  position: absolute; right: 3px; bottom: 1px;
+  font-size: 11px; font-variant-numeric: tabular-nums;
+  text-shadow: 0 1px 2px #000;
+}
+.bases-inventory-slot-overflow-note { margin: 0 0 8px; font-size: 12px; }
+.bases-inventory-slots + .bases-inventory-slots { margin-top: 12px; }
+
+/* One control strip for the selected slot instead of a quantity input on
+   every row -- a packed 100-slot container would render a hundred of them. */
+.bases-inventory-slot-detail {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto auto;
+  gap: 10px;
+  align-items: center;
+  margin-top: 10px;
+  padding: 9px 10px;
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+}
+.bases-inventory-slot-detail img { width: 34px; height: 34px; object-fit: contain; }
+.bases-inventory-slot-detail-body { display: flex; flex-direction: column; gap: 2px; min-width: 0; font-size: 13px; }
+.bases-inventory-slot-detail-body span { font-size: 12px; }
+.bases-inventory-slot-amount { display: flex; align-items: center; gap: 6px; font-size: 12px; }
+.bases-inventory-slot-amount input { width: 90px; }
+.bases-inventory-amount-error { margin: 6px 0 0; font-size: 12px; color: var(--danger); }
+.bases-inventory-delete-notice { margin: 0 0 8px; font-size: 12px; color: var(--muted-warm); }
+.bases-inventory-contents-head-actions { display: flex; align-items: center; gap: 8px; }
 
 /* Permissions is a single reading column with the Revert/Save bar full-bleed
    beneath it. The inset padding lives on .bases-permissions-content rather than

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ reference. Everything else is marked **Current** and is expected to stay accurat
 - [generator-fuel-burn-rates.md](console/generator-fuel-burn-rates.md) — Current. Per-generator fuel burn constants and where they live in code.
 - [generator-refill-caps.md](console/generator-refill-caps.md) — Current. Refill-generators endpoint behavior and per-type fuel caps.
 - [base-permissions.md](console/base-permissions.md) — Current. Editing base ownership and sharing: ranks, the config-driven roster cap, and why the change needs no map restart.
-- [base-inventory.md](console/base-inventory.md) — Current. The base Inventory tab: which placeables count as storage, the two inventories every refinery carries, per-slot container contents, and what deleting a stored item can and cannot guarantee against a running map.
+- [base-inventory.md](console/base-inventory.md) — Current. The base Inventory tab: which placeables count as storage, the two inventories every refinery carries, per-slot container contents, and the stopped-map safety boundary for deleting stored items.
 - [base-deletion.md](console/base-deletion.md) — Current. Permanently deleting a base: what "the base" means for enumeration, the pending-delete queue for a live map, the mandatory pre-delete safety backup, and why a pending delete freezes every other mutation on that base.
 - [base-backups.md](console/base-backups.md) — Current. What the game's own "pick up base" tool actually does in the database, why the Bases panel excludes a picked-up base, and why every mutation route rejects one too.
 - [database-backups.md](console/database-backups.md) — Current. Safe database restore behavior when the backup and current deployment use different Battlegroup IDs.

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,7 +44,7 @@ reference. Everything else is marked **Current** and is expected to stay accurat
 - [generator-fuel-burn-rates.md](console/generator-fuel-burn-rates.md) — Current. Per-generator fuel burn constants and where they live in code.
 - [generator-refill-caps.md](console/generator-refill-caps.md) — Current. Refill-generators endpoint behavior and per-type fuel caps.
 - [base-permissions.md](console/base-permissions.md) — Current. Editing base ownership and sharing: ranks, the config-driven roster cap, and why the change needs no map restart.
-- [base-inventory.md](console/base-inventory.md) — Current. The read-only base Inventory tab: which placeables count as storage, the two inventories every refinery carries, and why the tab cannot write.
+- [base-inventory.md](console/base-inventory.md) — Current. The base Inventory tab: which placeables count as storage, the two inventories every refinery carries, per-slot container contents, and what deleting a stored item can and cannot guarantee against a running map.
 - [base-deletion.md](console/base-deletion.md) — Current. Permanently deleting a base: what "the base" means for enumeration, the pending-delete queue for a live map, the mandatory pre-delete safety backup, and why a pending delete freezes every other mutation on that base.
 - [base-backups.md](console/base-backups.md) — Current. What the game's own "pick up base" tool actually does in the database, why the Bases panel excludes a picked-up base, and why every mutation route rejects one too.
 - [database-backups.md](console/database-backups.md) — Current. Safe database restore behavior when the backup and current deployment use different Battlegroup IDs.

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -261,8 +261,8 @@ When the Restart Queue is enabled, the restart routes above (`/api/server/restar
 | GET | `/api/bases/auto-refill-water` | Get per-base water auto-refill enrollment state | None |
 | POST | `/api/bases/{baseId}/auto-refill-water` | Enable/disable water auto-refill for a base | `baseId`, `enabled` |
 | GET | `/api/bases/{baseId}/inventory` | Get a base's stored items, rolled up by item template and by container (storage, refining, crafting, other). Merged per template, not per slot | `baseId` |
-| GET | `/api/bases/{baseId}/containers/{placeableId}` | Get one container's inventories and their individual slots (item id, slot number, quantity, quality, durability). Answers `found: false` when that container is not at the base | `baseId`, `placeableId` |
-| DELETE | `/api/bases/{baseId}/containers/{placeableId}/items/{itemId}` | Delete a stored item, or part of its stack with `count`. Written immediately -- a running map may restore it on its next autosave, and the response's `live` says whether that applies. Requires `{ confirmation: "DELETE ITEM" }` | `baseId`, `placeableId`, `itemId`, `count?` |
+| GET | `/api/bases/{baseId}/containers/{placeableId}` | Get one container's inventories and their individual slots (item id, slot number, quantity, quality, durability), plus `deleteSafety`. Answers `found: false` when that container is not at the base | `baseId`, `placeableId` |
+| DELETE | `/api/bases/{baseId}/containers/{placeableId}/items/{itemId}` | Delete an item from a plain Storage container, or part of its stack with `count`. Refused unless the owning map is verifiably and safely stopped; Crafting and Refining contents are read-only. Requires `{ confirmation: "DELETE ITEM" }` | `baseId`, `placeableId`, `itemId`, `count?` |
 | GET | `/api/bases/{baseId}/permissions` | Get a base's permission roster (Owner, Co-Owners, Associates) | `baseId` |
 | POST | `/api/bases/{baseId}/system-custodian` | Transfer ownership to the Server or detected GM system custodian while preserving the roster; provisions Server when no custodian exists | `baseId` |
 | PUT | `/api/bases/{baseId}/permissions` | Replace a base's permission roster | `baseId`, `entries[]` (`playerId`, `rank`) |
@@ -312,12 +312,13 @@ routes above. Its `containers[].items[]` is merged per item template, not per
 slot — `GET /api/bases/{baseId}/containers/{placeableId}` is the per-slot view,
 fetched one container at a time because slots roughly triple the response.
 
-`DELETE /api/bases/{baseId}/containers/{placeableId}/items/{itemId}` is written
-immediately rather than queued, and a running map can restore the row on its
-next autosave; the response's `live` reports whether that applies, with
-`known: false` meaning the console cannot tell rather than that it is safe. The
-same allowlist that keeps fuel inventories out of the read keeps them out of the
-delete. It needs `bases:delete-item`, not `bases:mutate`. See
+`DELETE /api/bases/{baseId}/containers/{placeableId}/items/{itemId}` is refused
+unless `baseRefillTarget` can verify that the owning map is safely stopped. An
+unknown state fails closed, and the route repeats the check immediately before
+the write. Only plain Storage contents are mutable; Crafting and Refining remain
+read-only because active jobs can reference their item rows. The same allowlist
+that keeps fuel inventories out of the read keeps them out of the delete. It
+needs `bases:delete-item`, not `bases:mutate`. See
 [base-inventory.md](base-inventory.md).
 
 Both `GET /api/bases/{baseId}/water` and `GET /api/bases/{baseId}/inventory`

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -260,7 +260,9 @@ When the Restart Queue is enabled, the restart routes above (`/api/server/restar
 | DELETE | `/api/bases/{baseId}/queued-water-refill` | Cancel a base's queued water refill | `baseId` |
 | GET | `/api/bases/auto-refill-water` | Get per-base water auto-refill enrollment state | None |
 | POST | `/api/bases/{baseId}/auto-refill-water` | Enable/disable water auto-refill for a base | `baseId`, `enabled` |
-| GET | `/api/bases/{baseId}/inventory` | Get a base's stored items, rolled up by item template and by container (storage, refining, crafting, other). Read-only | `baseId` |
+| GET | `/api/bases/{baseId}/inventory` | Get a base's stored items, rolled up by item template and by container (storage, refining, crafting, other). Merged per template, not per slot | `baseId` |
+| GET | `/api/bases/{baseId}/containers/{placeableId}` | Get one container's inventories and their individual slots (item id, slot number, quantity, quality, durability). Answers `found: false` when that container is not at the base | `baseId`, `placeableId` |
+| DELETE | `/api/bases/{baseId}/containers/{placeableId}/items/{itemId}` | Delete a stored item, or part of its stack with `count`. Written immediately -- a running map may restore it on its next autosave, and the response's `live` says whether that applies. Requires `{ confirmation: "DELETE ITEM" }` | `baseId`, `placeableId`, `itemId`, `count?` |
 | GET | `/api/bases/{baseId}/permissions` | Get a base's permission roster (Owner, Co-Owners, Associates) | `baseId` |
 | POST | `/api/bases/{baseId}/system-custodian` | Transfer ownership to the Server or detected GM system custodian while preserving the roster; provisions Server when no custodian exists | `baseId` |
 | PUT | `/api/bases/{baseId}/permissions` | Replace a base's permission roster | `baseId`, `entries[]` (`playerId`, `rank`) |
@@ -306,8 +308,17 @@ generator refill routes above. See [base-permissions.md](base-permissions.md).
 `GET /api/bases/{baseId}/inventory` covers storage containers plus refinery,
 fabricator, and other inventories (recycler, repair station, the base's own
 Sub-Fief console); generator and windtrap fuel belong to the refill and water
-routes above. It is read-only — inventory writes have no path to a running
-map. See [base-inventory.md](base-inventory.md).
+routes above. Its `containers[].items[]` is merged per item template, not per
+slot — `GET /api/bases/{baseId}/containers/{placeableId}` is the per-slot view,
+fetched one container at a time because slots roughly triple the response.
+
+`DELETE /api/bases/{baseId}/containers/{placeableId}/items/{itemId}` is written
+immediately rather than queued, and a running map can restore the row on its
+next autosave; the response's `live` reports whether that applies, with
+`known: false` meaning the console cannot tell rather than that it is safe. The
+same allowlist that keeps fuel inventories out of the read keeps them out of the
+delete. It needs `bases:delete-item`, not `bases:mutate`. See
+[base-inventory.md](base-inventory.md).
 
 Both `GET /api/bases/{baseId}/water` and `GET /api/bases/{baseId}/inventory`
 answer **200 with `supported: false` and a `reason`** when the detected schema

--- a/docs/console/base-deletion.md
+++ b/docs/console/base-deletion.md
@@ -66,6 +66,12 @@ narrower, hand-authored policies (via `PUT /api/settings/iam/policy`)
 possible. `DELETE /api/bases/:baseId/queued-delete` (cancelling) stays under
 `bases:mutate`, same as cancelling a queued refill.
 
+`bases:delete-item` is the other carve-out from that bucket — deleting one
+stored item out of a container. Its reasoning is different: not blast radius,
+but consent, since base inventory shipped read-only and no existing
+`bases:mutate` grant could have anticipated item destruction. See
+[base-inventory.md](base-inventory.md#deleting-a-stored-item).
+
 ## Why deletes are queued for a live map
 
 This schema has no live-notify path for structural changes — the same fact

--- a/docs/console/base-inventory.md
+++ b/docs/console/base-inventory.md
@@ -180,6 +180,28 @@ a container. `currentDurability`/`maxDurability` come out of the `stats` jsonb u
 column is a parse-time error rather than a null, so a schema without them would 500 a container that used
 to open. They come back null instead, and the grid view is withheld.
 
+### The contents overlay
+
+Opened by **View Contents**, either on a container card or on any container listed under an expanded
+item in the Items view — the same overlay, reached either way.
+
+It offers two views, and **opens on Grid**:
+
+- **Grid** lays the container out at its real capacity, one cell per slot, with empty slots marked by a
+  plus. It is the closest thing to the in-game container and answers "what is in this box" at a glance.
+  Empty cells are `aria-hidden` and non-interactive; the plus is decorative, drawn as two positioned
+  bars rather than a `+` glyph, since a glyph centres on its line box rather than its ink.
+- **List** is one row per slot with its slot number, quantity and a delete button. It sorts and scans
+  better on a full 100-slot container, and is the automatic fallback whenever the grid is withheld.
+
+Selecting a slot — a grid cell or an item name in the list — moves its controls into a strip below,
+carrying the item, its slot, an amount field defaulting to the whole stack, and the delete button.
+One strip rather than a control per row: a packed 100-slot container would otherwise render a hundred
+quantity inputs.
+
+Every inventory shares a single scroll region, so a placeable backing two inventories does not get two
+independent scrollbars.
+
 ### position_index is not trustworthy
 
 `dune.items` has no unique constraint on `(inventory_id, position_index)`, and nothing bounds the value by
@@ -194,3 +216,6 @@ an item the delete control cannot reach is the worst outcome available:
 
 The grid is also withheld when capacity is 0, above a 200-cell cap, or when every `positionIndex` is null;
 the list stands in and can still delete.
+
+A stack of exactly 1 shows no quantity badge in the grid — the badge is gated on `quantity > 1`, so a
+single item renders as a bare icon.

--- a/docs/console/base-inventory.md
+++ b/docs/console/base-inventory.md
@@ -1,8 +1,10 @@
 # Base Inventory
 
-The **Inventory** tab on an expanded base row (Bases panel → expand a base → Power / Water / Inventory / Sub-Fief Permissions) lists everything stored at that base. It is read-only.
+The **Inventory** tab on an expanded base row (Bases panel → expand a base → Power / Water / Inventory / Sub-Fief Permissions) lists everything stored at that base. Reads are a snapshot; a container's contents can be opened per slot and individual items deleted.
 
-Backed by `GET /api/bases/{baseId}/inventory` → `duneDb.baseInventory()`.
+Backed by `GET /api/bases/{baseId}/inventory` → `duneDb.baseInventory()`, plus
+`GET /api/bases/{baseId}/containers/{placeableId}` → `duneDb.baseContainerSlots()` for one container's
+slots and `DELETE …/containers/{placeableId}/items/{itemId}` to remove one.
 
 ## What counts as base inventory
 
@@ -68,15 +70,67 @@ Every label was ultimately read off the in-game build menu. Two would have been 
 
 `SpiceRefinery_Placeable` is plain "Spice Refinery"; Medium and Large are separate buildables, unlike the size-prefixed ore refineries.
 
-## Why read-only
+## Deleting a stored item
 
-Base inventory writes have no live-sync path:
+A container's contents overlay can delete a whole stack, or part of one. Backed by
+`DELETE /api/bases/{baseId}/containers/{placeableId}/items/{itemId}` → `duneDb.deleteBaseContainerItem()`,
+body `{ confirmation: "DELETE ITEM", count? }`. Omit `count` to clear the slot; pass a smaller number to
+remove part of the stack. Whole-slot removal goes through the shipped `dune.delete_item(bigint)`, partial
+through `dune.delete_inventory_item(bigint, bigint)`.
+
+**A count larger than the stack is refused, not rounded down.** "Remove 400" and "remove everything" are
+different requests, and the gap between them is a real race: the operator saw 500, asked for 400, and the
+stack has since dropped to 300. Widening that into destroying all 300 would remove more than was ever
+agreed to. The overlay is a snapshot, so this case is reachable in normal use.
+
+**Ownership is re-resolved, never trusted.** The delete re-runs this page's claim CTEs from the base id
+rather than believing the `placeableId` it was handed, and keeps the `inventory_types` allowlist join plus
+`is_hologram = false` and `max_item_count >= 0`. That allowlist is what stops a delete reaching the
+generator and windtrap fuel inventories the Power and Water tabs own — a placeable outside
+`BASE_INVENTORY_TYPES` answers "not found" even when it genuinely belongs to the base.
+
+The row lock is `for update of i, inv`, not a bare `for update`: Postgres cannot lock a CTE reference, and
+locking only the item row locks nothing once that row is gone.
+
+`DELETE …/items/{itemId}` requires its own IAM action, **`bases:delete-item`**, separate from the
+`bases:mutate` bucket every other base mutation falls into. The reason differs from
+[`bases:delete`](base-deletion.md)'s: not blast radius, but consent. This tab shipped read-only, so an
+operator whose hand-authored policy grants `bases:mutate` agreed to refills and permission edits and could
+not have agreed to item destruction — folding this in would silently widen every existing narrow policy.
+The shipped `owner`/`admin` policies grant `bases:*`, so default access is unchanged.
+
+Both of the usual base preconditions apply: a base with a queued delete, or one picked up via the game's
+base-backup tool, rejects this with `409`.
+
+## Why writes are immediate, and what that costs
+
+Unlike a base delete or a generator refill, an item delete is **not** queued behind the map going down. It
+is written immediately, and the response says whether that was safe.
+
+The reason a queue exists at all still holds here:
 
 - No `pg_notify` routine covers inventory or buildings. The game's 8 notify channels are guild, landsraad, party, permission, taxation, faction, vehicle_recovery, player_info.
 - There are zero triggers on `dune.items`, `dune.inventories`, `dune.buildings`, `dune.placeables`.
 - The RMQ command bus has no per-item edit or delete. `AddItemToInventory` addresses items by *template name*; every id here is a row id.
 
-So an edit could not reach a running map without a relog or a map restart. The tab states this inline rather than offering writes that would silently not apply.
+So a delete cannot reach a running map without a relog or a map restart, and — the sharper problem — a
+running map server periodically flushes its own in-memory copy of a base back to Postgres, so the deleted
+row can be **resurrected** on the next autosave. That is the same race
+[base deletion](base-deletion.md#why-deletes-are-queued-for-a-live-map) queues to avoid.
+
+Rather than queue, the route resolves `baseRefillTarget()` after the write and returns `live`:
+
+| `live` | What the overlay says |
+|---|---|
+| `known: true, running: false` | Deleted; that map is down, so the change will stick. |
+| `known: true, running: true` | Deleted, but the named map is running and may restore it on its next autosave. |
+| `known: false` | Deleted; the console **cannot tell** whether the map is running. |
+
+`known: false` is the case worth care: `baseRefillTarget` reports `writeSafeNow: true` when it has no
+`world_partition` to check against, meaning "cannot tell" rather than "safe". It is never rendered as safe.
+
+The queue machinery remains available if immediate writes prove too surprising in practice; the decision
+was deliberate, not a limitation.
 
 ## Response shape
 
@@ -95,3 +149,48 @@ One response backs both views, so switching between Items and Containers never r
 `usedSlots` counts item *rows* — one stack occupies one slot — while `quantity` sums `stack_size`. Capacity is summed once per inventory, not per item row, since every row repeats its inventory's `max_item_count`.
 
 **A container's `items[]` is not its stacks.** Rows sharing a template are merged into one entry, so `items.length` is the number of distinct templates and is **≤ `usedSlots`**. On the reference base, Chem Storage fills 8 slots with 3 templates, and 5 of 17 containers disagree the same way. The UI therefore says "3 distinct", never "3 stacks" — the stack count is `usedSlots`, already shown as Slots Used. The type is named `BaseInventoryEntry` rather than `…Stack` for the same reason.
+
+This merge is deliberate and stays: `items[]` is what backs the "N distinct" label and the container search
+filter, both of which genuinely mean distinct templates. The per-slot truth lives in a second response.
+
+## Per-container slots
+
+```
+GET /api/bases/{baseId}/containers/{placeableId}
+{ supported, found, baseId, placeableId, typeName, group, maxSlots, usedSlots,
+  inventories: [{ inventoryId, maxSlots, usedSlots,
+                  slots: [{ itemId, templateId, name, positionIndex, quantity,
+                            qualityLevel, currentDurability, maxDurability }] }] }
+```
+
+**Fetched per container, not with the tab.** Folding slots into `baseInventory` tripled that response —
+238 KB to 656 KB on the largest base in the reference dump, +176% — on a tab that loads on every base
+expand and auto-refresh, while the overlay only ever shows one container. One container is under a
+kilobyte.
+
+**Slots hang off an inventory, not the container.** A placeable can back more than one surviving inventory:
+`container.maxSlots` is their sum, while `position_index` is scoped to a single inventory. A flat
+per-container array would collide two slot 0s on anything with two inventories.
+
+`itemId` is `dune.items.id` — the delete target, and the only stable key, since `templateId` repeats within
+a container. `currentDurability`/`maxDurability` come out of the `stats` jsonb using the same expression as
+`INVENTORY_ITEM_SELECT`, so the two paths cannot disagree about where durability lives.
+
+`positionIndex`, `qualityLevel` and the durability pair are all **column-probed**, not assumed: a missing
+column is a parse-time error rather than a null, so a schema without them would 500 a container that used
+to open. They come back null instead, and the grid view is withheld.
+
+### position_index is not trustworthy
+
+`dune.items` has no unique constraint on `(inventory_id, position_index)`, and nothing bounds the value by
+`max_item_count`. All three of these are reachable, and the grid handles each rather than dropping a slot —
+an item the delete control cannot reach is the worst outcome available:
+
+| Case | Handling |
+|---|---|
+| Sparse / non-contiguous | Empty cells. This is the in-game look and the point of the view. |
+| Two slots claim one index | First by `(positionIndex, itemId)` takes the cell; the other is listed as unplaced. |
+| Index ≥ `maxSlots` | Listed as unplaced beneath the grid. |
+
+The grid is also withheld when capacity is 0, above a 200-cell cap, or when every `positionIndex` is null;
+the list stands in and can still delete.

--- a/docs/console/base-inventory.md
+++ b/docs/console/base-inventory.md
@@ -102,10 +102,10 @@ The shipped `owner`/`admin` policies grant `bases:*`, so default access is uncha
 Both of the usual base preconditions apply: a base with a queued delete, or one picked up via the game's
 base-backup tool, rejects this with `409`.
 
-## Why writes are immediate, and what that costs
+## Why deletion requires a stopped map
 
-Unlike a base delete or a generator refill, an item delete is **not** queued behind the map going down. It
-is written immediately, and the response says whether that was safe.
+An item delete is **not** queued: a specific inventory row may move, merge, or disappear before a deferred
+operation runs. Instead, the route refuses the write until it can verify that the owning map is safely down.
 
 The reason a queue exists at all still holds here:
 
@@ -113,24 +113,18 @@ The reason a queue exists at all still holds here:
 - There are zero triggers on `dune.items`, `dune.inventories`, `dune.buildings`, `dune.placeables`.
 - The RMQ command bus has no per-item edit or delete. `AddItemToInventory` addresses items by *template name*; every id here is a row id.
 
-So a delete cannot reach a running map without a relog or a map restart, and — the sharper problem — a
-running map server periodically flushes its own in-memory copy of a base back to Postgres, so the deleted
-row can be **resurrected** on the next autosave. That is the same race
-[base deletion](base-deletion.md#why-deletes-are-queued-for-a-live-map) queues to avoid.
+So a running map can neither miss the delete nor resurrect the row on its next autosave. The container GET
+returns `deleteSafety`; the overlay disables deletion and explains why when the map is running or its state
+cannot be verified. The DELETE route then repeats the check immediately before changing the database, so a
+stale or hand-built request cannot bypass the UI.
 
-Rather than queue, the route resolves `baseRefillTarget()` after the write and returns `live`:
+Deletion is limited to plain **Storage** containers. Refinery and fabricator inventories are visible but
+read-only because the game's crafting state can reference their item rows; removing a reserved ingredient
+can leave an active job pointing at an item that no longer exists.
 
-| `live` | What the overlay says |
-|---|---|
-| `known: true, running: false` | Deleted; that map is down, so the change will stick. |
-| `known: true, running: true` | Deleted, but the named map is running and may restore it on its next autosave. |
-| `known: false` | Deleted; the console **cannot tell** whether the map is running. |
-
-`known: false` is the case worth care: `baseRefillTarget` reports `writeSafeNow: true` when it has no
-`world_partition` to check against, meaning "cannot tell" rather than "safe". It is never rendered as safe.
-
-The queue machinery remains available if immediate writes prove too surprising in practice; the decision
-was deliberate, not a limitation.
+Item identifiers remain decimal strings from the URL through the PostgreSQL query. They are `bigint` values,
+and converting one to JavaScript `Number` could round an id above `Number.MAX_SAFE_INTEGER` into a different
+row — unacceptable for a destructive operation.
 
 ## Response shape
 


### PR DESCRIPTION
Base inventory containers now show their contents **per slot** instead of merging every stack of the same template into one line, and individual items can be deleted — a whole stack or part of one.

Previously a container holding four ScrapMetal stacks read as a single line of 1,500, and a Small Storage Container summarised as "3 / 10 slots, 1 distinct". The slots were there; the view could not show them.

### Changes

- `GET /api/bases/{baseId}/containers/{placeableId}` returns one container's inventories and their slots. Kept off `baseInventory` deliberately: folding slots in tripled that response (238 KB → 656 KB on the largest base in the reference dump) on a tab that loads on every base expand, while the overlay only ever shows one container.
- `DELETE /api/bases/{baseId}/containers/{placeableId}/items/{itemId}` deletes a stored item, phrase-gated on `DELETE ITEM`. Ownership re-resolves from the base's claim rather than trusting the caller's placeable id, and keeps the container allowlist plus the `is_hologram` and `max_item_count` filters — together these are what keep generator and windtrap fuel unreachable.
- An explicit `count` larger than the stack is **refused**, not rounded down to "delete it all". The gap between those is a real race: the caller saw 500, asked for 400, and the stack has since dropped to 300.
- New `bases:delete-item` IAM action, separate from `bases:mutate`. The reason differs from `bases:delete`'s: consent, not blast radius. This tab shipped read-only, so an existing `bases:mutate` grant could not have anticipated item destruction.
- Contents open on an in-game-style slot grid at the container's real capacity, with a list view for scanning and sorting.

`baseInventory`'s template-merged `items[]` is unchanged — it still backs the "N distinct" label and the container search filter, both of which genuinely mean distinct templates.

### Writes are immediate, not queued

Base inventory has no live-sync path, and a running map server periodically flushes its in-memory copy back to Postgres, so a delete against a live base **can be resurrected on the next autosave**. Rather than queue, the route resolves `baseRefillTarget` after the write and reports whether that base's map is running; when it cannot tell, it says so rather than implying the change is safe. The queue machinery stays available if this proves too surprising in practice.

### Verification

1106/1106 backend (CI-parity container), 412/412 frontend, clean build. A new integration suite exercises real Postgres for what a mocked db cannot prove: cross-base isolation, generator-fuel isolation, partial removal, over-count refusal, locking, and rollback on a failed verification. Its schema declares the production constraints and transcribes both shipped procedures from the dump.

### Known limitations

- **A partial delete on a refinery mid-craft is unproven.** The game's crafting routine consumes allocated ingredients from these same rows, and the reference dump cannot produce an in-progress job. The confirm dialog carries an extra warning for non-storage containers.
- **Resurrection is accepted, not solved.** On a live map the UI warning is the only mitigation; there is no way to observe the overwrite after the fact.
