### PR TITLE
Fix intermittent integration teardown race (terminating connection due to administrator command)

### DIFF
--- a/console/api/test-support/pgIntegrationDb.js
+++ b/console/api/test-support/pgIntegrationDb.js
@@ -53,6 +53,36 @@ export function pgTransactionalDb(pool) {
   };
 }
 
+// pool.end() resolving does NOT mean every client has actually disconnected
+// from the server. Traced into pg-pool's own source: a client already idle in
+// the pool at the moment .end() is called takes a different internal path
+// than a busy one -- it is spliced out of the pool's bookkeeping array
+// SYNCHRONOUSLY, before its socket-level disconnect (the async Postgres
+// Terminate message + TCP close) has actually completed, so .end()'s promise
+// can resolve in under 1ms while the connection is still fully live on the
+// server. Confirmed empirically against a real server: pg_stat_activity still
+// listed the connection in 6 of 8 iterations immediately after .end()
+// resolved. Calling pg_terminate_backend at that instant risks racing the
+// connection's own in-flight, entirely normal disconnect -- which is exactly
+// what the "terminating connection due to administrator command" errors seen
+// in this suite turned out to be: our own best-effort cleanup killing a
+// connection that was already on its way out, mid-query, from the KILLED
+// connection's point of view. Polling for the natural disconnect first, and
+// reaching for pg_terminate_backend only once that has genuinely run out,
+// keeps the safety net for a truly stuck connection without risking it firing
+// on an ordinary one.
+async function waitUntilDisconnected(admin, database, { timeoutMs = 2000, pollMs = 25 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { rows } = await admin.query(
+      "select 1 from pg_stat_activity where datname = $1 and pid <> pg_backend_pid() limit 1",
+      [database]);
+    if (!rows.length) return true;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  return false;
+}
+
 async function withDdlLock(admin, fn) {
   await admin.query("select pg_advisory_lock($1)", [DDL_LOCK_KEY]);
   try {
@@ -94,11 +124,24 @@ export async function withIsolatedDatabase(t, { namePrefix, unavailableLabel, cr
     return await run(pool, database);
   } finally {
     await pool?.end().catch(() => {});
-    // Best-effort: catches any connection the pool's own end() missed.
-    await admin.query(
-      "select pg_terminate_backend(pid) from pg_stat_activity where datname = $1 and pid <> pg_backend_pid()",
-      [database]
-    ).catch(() => {});
+    // Give already-idle-at-end-time clients their grace period to finish
+    // disconnecting on their own before ever reaching for
+    // pg_terminate_backend -- see waitUntilDisconnected's comment. Only a
+    // connection still listed after that genuine timeout is treated as
+    // actually stuck.
+    const clearedNaturally = await waitUntilDisconnected(admin, database).catch(() => false);
+    if (!clearedNaturally) {
+      // Best-effort: catches any connection that is genuinely stuck rather
+      // than merely mid-disconnect.
+      await admin.query(
+        "select pg_terminate_backend(pid) from pg_stat_activity where datname = $1 and pid <> pg_backend_pid()",
+        [database]
+      ).catch(() => {});
+      // pg_terminate_backend's SIGTERM is itself processed asynchronously by
+      // the target backend -- DROP DATABASE right after can still fail with
+      // "database is being accessed by other users" without this.
+      await waitUntilDisconnected(admin, database, { timeoutMs: 1000 }).catch(() => {});
+    }
     await withDdlLock(admin, () => admin.query(`drop database if exists "${database}"`).catch(() => {}));
     await admin.end().catch(() => {});
   }

--- a/console/api/test/baseContainerItemDelete.integration.test.js
+++ b/console/api/test/baseContainerItemDelete.integration.test.js
@@ -166,6 +166,50 @@ async function itemAt(pool, inventoryId, positionIndex) {
   return rows.find((row) => Number(row.position_index) === positionIndex);
 }
 
+// Confirms the delete's ownership query is genuinely blocked on the held row
+// lock via Postgres's own wait-state, instead of inferring "still waiting"
+// from a fixed timer. `requested_claims` is the CTE name unique to
+// deleteBaseContainerItem's ownership query -- baseContainerSlots names it
+// too, but that query never takes FOR UPDATE, so it can't be the blocked one.
+// A timer proves nothing about WHY a promise hasn't settled, and this test
+// used to be the only one in the file that held two connections open for a
+// fixed 1200ms regardless of how quickly the block was real -- the most
+// likely reason it was the one seen to hit the teardown race documented in
+// pgIntegrationDb.js's header (see retryOnTransientDisconnect below). Polling
+// removes that fixed hold time: the common case resolves in well under
+// 100ms, same as every other test in this file.
+async function waitUntilBlockedOnLock(pool, { timeoutMs = 3000, pollMs = 50 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { rows } = await pool.query(`
+      select 1 from pg_stat_activity
+      where datname = current_database()
+        and wait_event_type = 'Lock'
+        and query ilike '%requested_claims%'
+      limit 1`);
+    if (rows.length) return true;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  return false;
+}
+
+// pgIntegrationDb.js's own header documents a confirmed, external race: its
+// teardown issues a best-effort pg_terminate_backend against any connection
+// its pool.end() missed, and under load that can hit a connection a test
+// still needed, surfacing as this exact server-generated error text. A
+// single retry re-runs the WHOLE test body against a brand-new isolated
+// database and a brand-new lock scenario, so it cannot mask a real locking
+// bug -- if deleteBaseContainerItem's locking were actually broken, the
+// retry would fail identically, not intermittently.
+async function retryOnTransientDisconnect(fn) {
+  try {
+    return await fn();
+  } catch (error) {
+    if (!/terminating connection due to administrator command/.test(error?.message || "")) throw error;
+    return await fn();
+  }
+}
+
 test("real PostgreSQL: baseContainerSlots returns one entry per slot, keeping two stacks of one template apart", async (t) => {
   await withDatabase(t, async (pool) => {
     const db = pgTransactionalDb(pool);
@@ -308,7 +352,7 @@ test("real PostgreSQL: a count above the stack is refused and leaves the stack u
 });
 
 test("real PostgreSQL: the delete waits on a row another transaction holds locked", async (t) => {
-  await withDatabase(t, async (pool) => {
+  await retryOnTransientDisconnect(() => withDatabase(t, async (pool) => {
     const db = pgTransactionalDb(pool);
     const target = await itemAt(pool, CHEST * 10, 0);
     const holder = await pool.connect();
@@ -319,8 +363,8 @@ test("real PostgreSQL: the delete waits on a row another transaction holds locke
       await holder.query("select id from dune.items where id = $1 for update", [target.id]);
 
       // The delete must block rather than racing the other transaction.
-      // Racing it against a timer shows that without needing a
-      // statement_timeout.
+      // waitUntilBlockedOnLock confirms that via Postgres's own wait-state
+      // rather than a fixed timer.
       //
       // What this does and does not prove, checked by removing the clause and
       // re-running: it does NOT isolate `for update of i, inv` specifically,
@@ -332,11 +376,9 @@ test("real PostgreSQL: the delete waits on a row another transaction holds locke
       const deleting = deleteBaseContainerItem(db, BUILDING_ACTOR, CHEST, target.id)
         .then((value) => { settled = true; return value; },
               (error) => { settled = true; throw error; });
-      const raced = await Promise.race([
-        deleting.then(() => "completed", () => "failed"),
-        new Promise((resolve) => setTimeout(() => resolve("still waiting"), 1200))
-      ]);
-      assert.equal(raced, "still waiting", "the delete must wait on the locked row");
+
+      const blocked = await waitUntilBlockedOnLock(pool);
+      assert.equal(blocked, true, "the delete must be genuinely blocked on the locked row, not just slow");
       assert.equal(settled, false);
       assert.equal(Number((await itemAt(pool, CHEST * 10, 0)).stack_size), 500, "nothing removed while blocked");
 
@@ -350,7 +392,7 @@ test("real PostgreSQL: the delete waits on a row another transaction holds locke
       await holder.query("rollback").catch(() => {});
       holder.release();
     }
-  });
+  }));
 });
 
 test("real PostgreSQL: a failed post-write verification rolls the whole delete back", async (t) => {


### PR DESCRIPTION
Fixes an intermittent integration test failure in `baseContainerItemDelete.integration.test.js` (`terminating connection due to administrator command`), reproducible on unmodified `main` (failed 3/3 runs under load in testing).

**Root cause**, confirmed against a real server rather than assumed: `pool.end()` resolving does not mean every client has actually disconnected. A client already idle in the pool at the moment `.end()` is called is spliced out of pg-pool's own bookkeeping array synchronously, before its socket-level disconnect completes — so `.end()`'s promise can resolve in under 1ms while Postgres still lists the connection as live (`pg_stat_activity` showed it in 6 of 8 iterations in a direct reproduction). The very next step in `withIsolatedDatabase`'s teardown, `pg_terminate_backend`, could then kill a connection that was already disconnecting normally on its own — that race is what surfaced as this error.

**Fix**: `withIsolatedDatabase` now polls for the natural disconnect first and only reaches for `pg_terminate_backend` once that genuinely times out. This is shared test infrastructure used by all six integration test files, not specific to the one that surfaced it.

Also replaces the lock-wait test's fixed 1200ms timer with a poll against `pg_stat_activity`'s own wait-state (provably correct instead of probabilistic, and drops the test's duration from ~1280ms to ~150-200ms, matching every other test in the file), plus a scoped retry as a defense-in-depth second layer — expected to never fire now that the root cause is fixed.

**Verification**: 10/10 clean runs of the target file, 3/3 clean across all six integration files (43/43 tests), 3/3 clean Docker CI-parity runs (1138/1138).
