### PR TITLE
Fix HIGH/MED findings from base-container-delete review

### DIFF
--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -436,7 +436,9 @@ export function actionForRoute(path, method) {
     if (path.startsWith(prefix)) return action;
   }
 
-  // Unknown route — return null (server.js handles untracked routes
-  // gracefully by allowing owner-tier and denying all others)
+  // Unknown route — return null. server.js's `!action || !evaluate(...)`
+  // check fails CLOSED on null: every tier, owner included, gets denied
+  // rather than allowed. A new route is invisible to every policy until it is
+  // added here, not silently open to the top tier.
   return null;
 }

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -7979,9 +7979,14 @@ export async function baseContainerSlots(db, baseId, placeableId) {
   const [groups, buildingTypes, typeNames] = baseInventoryTypeParams();
 
   // The claim-resolution CTEs are baseInventory's, narrowed to one placeable.
-  // Keeping the inventory_types join and is_hologram/max_item_count filters is
-  // load-bearing, not tidiness: they are what stops this reaching generator and
-  // windtrap fuel, which the Power and Water tabs own.
+  // The inventory_types join is load-bearing, not tidiness: it is what keeps
+  // this off generator and windtrap fuel, which the Power and Water tabs own
+  // -- both carry max_item_count = 5, so the >= 0 filter admits them same as
+  // any storage container, and only the allowlist join excludes them.
+  // is_hologram/max_item_count >= 0 are kept for the other reason baseInventory
+  // has them: a hologram preview and a refinery's second (uncapped) inventory
+  // are not real storage, so both would otherwise double-count or divide by a
+  // negative capacity.
   const result = await db.query(`
     with requested_claims as (
       select distinct b.id, afe.actor_id
@@ -8102,12 +8107,45 @@ export async function deleteBaseContainerItem(db, baseId, placeableId, itemId, {
   const requestedCount = count === null || count === undefined ? null : intParam(count, "count", 1);
   const [groups, buildingTypes, typeNames] = baseInventoryTypeParams();
 
+  // Column-probed the same way baseContainerSlots reads them: a missing
+  // column is a parse-time error, not a null, so a schema without these would
+  // fail a delete that used to work. They exist only to enrich the audit
+  // record (below) with what was actually destroyed -- quality and durability
+  // in particular, since without them a destroyed pristine legendary logs
+  // identically to a broken common of the same template.
+  const itemColumns = await columnsFor(db, "items");
+  const hasPositionIndex = itemColumns.has("position_index");
+  const hasStats = itemColumns.has("stats");
+  const stateSelect = [
+    hasPositionIndex ? "i.position_index" : "null::bigint as position_index",
+    itemColumns.has("quality_level") ? "i.quality_level" : "0::bigint as quality_level",
+    hasStats
+      ? "coalesce((i.stats->'FItemStackAndDurabilityStats'->1->>'CurrentDurability'), null) as current_durability"
+      : "null::text as current_durability",
+    hasStats
+      ? `coalesce(
+             nullif((i.stats->'FItemStackAndDurabilityStats'->1->>'MaxDurability')::numeric, 0),
+             nullif((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::numeric, 0),
+             null
+           ) as max_durability`
+      : "null::numeric as max_durability"
+  ].join(",\n           ");
+
   return db.transaction(async (tx) => {
+    // Same reason mutateBasePermissions and deleteBaseCompletely set it: the
+    // shipped procedures reference their tables unqualified and carry no
+    // `SET search_path` of their own (pg_proc.proconfig is null for both
+    // dune.delete_item and dune.delete_inventory_item), so they resolve only
+    // because the console connects as the `dune` role. Against any other role
+    // they raise `relation "items" does not exist`, which aborts the
+    // transaction before the raw-delete fallback below can run.
+    await tx.query("set local search_path to dune, public");
+
     // for update OF i, inv -- not a bare `for update`. Postgres cannot lock a
     // CTE reference, so naming the real relations is required, not stylistic.
-    // inv is locked as well as i because locking only the item row locks
-    // nothing when the row is already gone; the inventory row is the parent
-    // guaranteed to exist for as long as the container does.
+    // Note inv is reached by an inner join through i, so when the item row is
+    // already gone neither relation is locked -- the zero-row result falls to
+    // the "not found" throw below, which is the intended outcome.
     const found = await tx.query(`
       with requested_claims as (
         select distinct b.id, afe.actor_id
@@ -8131,7 +8169,8 @@ export async function deleteBaseContainerItem(db, baseId, placeableId, itemId, {
         where p.is_hologram = false and p.id = $5
       )
       select i.id::text as item_id, i.template_id, i.stack_size, i.inventory_id,
-             c.placeable_id::text as placeable_id, c.group_key, c.type_name
+             c.placeable_id::text as placeable_id, c.group_key, c.type_name,
+             ${stateSelect}
       from containers c
       join dune.items i on i.inventory_id = c.inventory_id
       join dune.inventories inv on inv.id = i.inventory_id
@@ -8147,6 +8186,17 @@ export async function deleteBaseContainerItem(db, baseId, placeableId, itemId, {
     const stackSize = Number(item.stack_size) || 0;
     const inventoryId = item.inventory_id;
     const label = item.template_id || "Item";
+    // Captured before the delete, since the row -- and the state that came
+    // with it -- is gone once the delete succeeds.
+    const destroyedState = {
+      positionIndex: item.position_index === null || item.position_index === undefined
+        ? null : Number(item.position_index),
+      qualityLevel: Number(item.quality_level) || 0,
+      currentDurability: item.current_durability === null || item.current_durability === undefined
+        ? null : Number(item.current_durability),
+      maxDurability: item.max_durability === null || item.max_durability === undefined
+        ? null : Number(item.max_durability)
+    };
 
     // An explicit count larger than the stack is refused rather than rounded
     // down to "delete it all". The two are not the same request, and the gap
@@ -8188,7 +8238,7 @@ export async function deleteBaseContainerItem(db, baseId, placeableId, itemId, {
         typeName: item.type_name,
         group: item.group_key,
         partial: true,
-        removed: { itemId: item.item_id, templateId: item.template_id, count: requestedCount, remaining },
+        removed: { itemId: item.item_id, templateId: item.template_id, count: requestedCount, remaining, ...destroyedState },
         message: `Removed ${requestedCount} of ${label} from the database, leaving ${remaining}.`
       };
     }
@@ -8212,7 +8262,7 @@ export async function deleteBaseContainerItem(db, baseId, placeableId, itemId, {
       typeName: item.type_name,
       group: item.group_key,
       partial: false,
-      removed: { itemId: item.item_id, templateId: item.template_id, count: stackSize, remaining: 0 },
+      removed: { itemId: item.item_id, templateId: item.template_id, count: stackSize, remaining: 0, ...destroyedState },
       message: `${label} was deleted from the database.`
     };
   });

--- a/console/api/test/baseContainerItemDelete.integration.test.js
+++ b/console/api/test/baseContainerItemDelete.integration.test.js
@@ -36,9 +36,17 @@ const SCHEMA = `
     instance_id integer not null,
     owner_entity_id bigint
   );
+  -- Both columns are nullable in production and carry a third NOT NULL column,
+  -- plus two UNIQUE constraints. The uniques matter here: entity_id being
+  -- unique is what makes the placeables -> base_entities join single-valued,
+  -- so declaring them keeps the ownership-isolation tests honest rather than
+  -- passing because the fixture happens not to contain a duplicate.
   create table dune.actor_fgl_entities (
-    entity_id bigint not null,
-    actor_id bigint not null references dune.actors(id) on delete cascade
+    entity_id bigint,
+    actor_id bigint references dune.actors(id) on delete cascade,
+    slot_name text not null default '',
+    constraint actor_fgl_entities_entity_id_key unique (entity_id),
+    constraint actor_fgl_no_slot_duplication unique (actor_id, slot_name)
   );
   create table dune.placeables (
     id bigint primary key references dune.actors(id) on delete cascade,
@@ -50,23 +58,38 @@ const SCHEMA = `
     actor_id bigint primary key references dune.actors(id) on delete cascade,
     actor_name text
   );
+  -- actor_id is nullable in production, guarded by a CHECK that at least one
+  -- of the four owner columns is set: an inventory can belong to an exchange,
+  -- an item or a vehicle module instead of an actor. max_item_count is
+  -- nullable with no default. Declaring the loose production shape is what
+  -- lets the max_item_count >= 0 filter be exercised against a NULL.
   create table dune.inventories (
     id bigint primary key,
-    actor_id bigint not null references dune.actors(id) on delete cascade,
-    max_item_count integer not null default 10
+    actor_id bigint references dune.actors(id) on delete cascade,
+    exchange_id bigint,
+    item_id bigint,
+    vehicle_module_id bigint,
+    max_item_count integer,
+    constraint valid_fkey check (actor_id is not null or exchange_id is not null
+      or item_id is not null or vehicle_module_id is not null)
   );
   -- The production constraints, not a convenient subset: position_index is NOT
   -- NULL with a >= 0 check and has NO unique constraint against
   -- (inventory_id, position_index), which is exactly why the grid has to cope
   -- with duplicates. stack_size > 0 is why a partial removal to zero must go
   -- through delete_item rather than an UPDATE.
+  -- stats has NO default in production, so every insert must supply it; a
+  -- default here would let a seed omit it and pass a test production would
+  -- reject. id uses a sequence default rather than GENERATED ALWAYS, which
+  -- would refuse the explicit ids production accepts.
+  create sequence dune.items_id_seq;
   create table dune.items (
-    id bigint generated always as identity primary key,
+    id bigint primary key default nextval('dune.items_id_seq'),
     inventory_id bigint references dune.inventories(id) on delete cascade,
     stack_size bigint not null,
     position_index bigint not null,
     template_id text not null,
-    stats jsonb not null default '{}'::jsonb,
+    stats jsonb not null,
     quality_level bigint not null default 0,
     constraint items_position_index_check check (position_index >= 0),
     constraint items_stack_size_check check (stack_size > 0)
@@ -131,16 +154,16 @@ const SEED = `
     insert into dune.placeables (id, owner_entity_id, building_type) values (${GENERATOR}, ${ENTITY_ID}, 'oilgenerator_placeable');
     insert into dune.inventories (id, actor_id, max_item_count) values (${GENERATOR} * 10, ${GENERATOR}, 4);
   `)}
-  insert into dune.items (inventory_id, template_id, stack_size, position_index) values
-    (${CHEST} * 10, 'ScrapMetal', 500, 0),
-    (${CHEST} * 10, 'MagnetiteOre', 200, 1),
-    (${CHEST} * 10, 'ScrapMetal', 400, 2);
-  insert into dune.items (inventory_id, template_id, stack_size, position_index) values
-    (${GENERATOR} * 10, 'Oil', 900, 0);
+  insert into dune.items (inventory_id, template_id, stack_size, position_index, stats) values
+    (${CHEST} * 10, 'ScrapMetal', 500, 0, '{}'::jsonb),
+    (${CHEST} * 10, 'MagnetiteOre', 200, 1, '{}'::jsonb),
+    (${CHEST} * 10, 'ScrapMetal', 400, 2, '{}'::jsonb);
+  insert into dune.items (inventory_id, template_id, stack_size, position_index, stats) values
+    (${GENERATOR} * 10, 'Oil', 900, 0, '{}'::jsonb);
 
   ${seedBase(OTHER_CLAIM_ACTOR, OTHER_BUILDING_ACTOR, OTHER_ENTITY_ID, OTHER_CHEST)}
-  insert into dune.items (inventory_id, template_id, stack_size, position_index) values
-    (${OTHER_CHEST} * 10, 'Spice', 77, 0);
+  insert into dune.items (inventory_id, template_id, stack_size, position_index, stats) values
+    (${OTHER_CHEST} * 10, 'Spice', 77, 0, '{}'::jsonb);
 `;
 
 async function withDatabase(t, run) {
@@ -236,8 +259,8 @@ test("real PostgreSQL: deleting preserves a bigint item id beyond Number.MAX_SAF
     const db = pgTransactionalDb(pool);
     const largeId = "9007199254740993";
     await pool.query(`
-      insert into dune.items (id, inventory_id, template_id, stack_size, position_index)
-      overriding system value values ($1, $2, 'SpiceMelange', 12, 4)
+      insert into dune.items (id, inventory_id, template_id, stack_size, position_index, stats)
+      values ($1, $2, 'SpiceMelange', 12, 4, '{}'::jsonb)
     `, [largeId, CHEST * 10]);
 
     const result = await deleteBaseContainerItem(db, BUILDING_ACTOR, CHEST, largeId);
@@ -380,5 +403,27 @@ test("real PostgreSQL: a failed post-write verification rolls the whole delete b
     const after = await itemAt(pool, CHEST * 10, 0);
     assert.equal(Number(after.stack_size), 500, "the interfered-with write must have rolled back");
     assert.equal((await itemsIn(pool, CHEST * 10)).length, 3);
+  });
+});
+
+test("real PostgreSQL: the audit result carries the destroyed item's quality and durability", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    // Without these, a destroyed pristine legendary and a destroyed broken
+    // common of the same template log identically -- this is the fixture that
+    // would tell them apart.
+    const seeded = await pool.query(`
+      insert into dune.items (inventory_id, template_id, stack_size, position_index, quality_level, stats)
+      values ($1, 'Ornithopter_Rudder', 1, 5, 3,
+        '{"FItemStackAndDurabilityStats": [[], {"CurrentDurability": "812", "MaxDurability": "1000"}]}'::jsonb)
+      returning id
+    `, [CHEST * 10]);
+    const itemId = seeded.rows[0].id;
+
+    const result = await deleteBaseContainerItem(db, BUILDING_ACTOR, CHEST, itemId);
+    assert.equal(result.removed.positionIndex, 5);
+    assert.equal(result.removed.qualityLevel, 3);
+    assert.equal(result.removed.currentDurability, 812);
+    assert.equal(result.removed.maxDurability, 1000);
   });
 });

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -3548,12 +3548,16 @@ function fakeContainerDeleteDb(calls, fixtures = {}) {
     partialResult = 1,
     remainingAfterPartial = null,
     procedures = true,
-    deleteLeavesRow = false
+    deleteLeavesRow = false,
+    itemColumns = ["id", "inventory_id", "stack_size", "position_index", "template_id", "stats", "quality_level"]
   } = fixtures;
   const run = async (text, values = []) => {
     calls.push({ text, values });
     if (text.includes("to_regclass")) return { rows: [{ exists: true }] };
     if (text.includes("to_regprocedure")) return { rows: [{ exists: procedures }] };
+    if (text.includes("information_schema.columns")) {
+      return { rows: itemColumns.map((column_name) => ({ column_name })) };
+    }
     if (text.includes("requested_claims")) return { rows: itemRows };
     if (text.includes("dune.delete_inventory_item")) return { rows: [{ result: partialResult }] };
     if (text.includes("select stack_size from dune.items")) {
@@ -3568,7 +3572,8 @@ function fakeContainerDeleteDb(calls, fixtures = {}) {
 
 const CONTAINER_ITEM_ROW = {
   item_id: "99", template_id: "ScrapMetal", stack_size: 500, inventory_id: 7,
-  placeable_id: "42", group_key: "storage", type_name: "Small Storage Container"
+  placeable_id: "42", group_key: "storage", type_name: "Small Storage Container",
+  position_index: 3, quality_level: 2, current_durability: "45", max_durability: 90
 };
 
 test("container item delete verifies base ownership before calling dune.delete_item", async () => {
@@ -3693,6 +3698,40 @@ test("container item delete refuses a partial removal when the schema lacks the 
   // Capability failure, not a silent widening to a whole-slot delete.
   await assert.rejects(() => deleteBaseContainerItem(db, 16836, 42, 99, { count: 150 }));
   assert.equal(calls.some((call) => call.text.includes("dune.delete_item($1::bigint)")), false);
+});
+
+test("container item delete records what was destroyed in the audit result", async () => {
+  const calls = [];
+  const db = fakeContainerDeleteDb(calls, { itemRows: [CONTAINER_ITEM_ROW] });
+  const result = await deleteBaseContainerItem(db, 16836, 42, 99);
+  // Without these, a destroyed pristine legendary logs identically to a
+  // broken common of the same template -- the audit trail for the console's
+  // first irreversible per-item destruction needs to distinguish them.
+  assert.equal(result.removed.positionIndex, 3);
+  assert.equal(result.removed.qualityLevel, 2);
+  assert.equal(result.removed.currentDurability, 45);
+  assert.equal(result.removed.maxDurability, 90);
+});
+
+test("container item delete degrades to null state fields on a schema without them, rather than failing", async () => {
+  const calls = [];
+  // A schema lacking these columns cannot select them, so the row the real
+  // query would return has no such keys either -- the fake db does not parse
+  // SQL, so this fixture has to omit them itself to match.
+  const { position_index, quality_level, current_durability, max_durability, ...bareItemRow } = CONTAINER_ITEM_ROW;
+  const db = fakeContainerDeleteDb(calls, {
+    itemRows: [bareItemRow],
+    itemColumns: ["id", "inventory_id", "stack_size", "template_id"]
+  });
+  const result = await deleteBaseContainerItem(db, 16836, 42, 99);
+  assert.equal(result.ok, true);
+  assert.equal(result.removed.positionIndex, null);
+  assert.equal(result.removed.qualityLevel, 0);
+  assert.equal(result.removed.currentDurability, null);
+  assert.equal(result.removed.maxDurability, null);
+  const query = calls.find((call) => call.text.includes("requested_claims"));
+  assert.match(query.text, /null::bigint as position_index/);
+  assert.ok(!query.text.includes("i.position_index"), "must not select a column this schema lacks");
 });
 
 // baseContainerSlots: the per-slot read the contents overlay and its delete

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -397,7 +397,16 @@ export const basesApi = {
         partial: boolean;
         typeName: string;
         group: BaseInventoryGroupKey;
-        removed: { itemId: string; templateId: string; count: number; remaining: number };
+        removed: {
+          itemId: string;
+          templateId: string;
+          count: number;
+          remaining: number;
+          positionIndex: number | null;
+          qualityLevel: number;
+          currentDurability: number | null;
+          maxDurability: number | null;
+        };
         message: string;
         deleteSafety: BaseContainerDeleteSafety;
       };

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -642,6 +642,7 @@ describe("BaseInventoryTab", () => {
     fireEvent.click(screen.getByRole("button", { name: /Remove 150/ }));
     await waitFor(() => expect(basesApi.deleteContainerItem).toHaveBeenCalled());
     expect(vi.mocked(basesApi.deleteContainerItem).mock.calls[0][4]).toBe(150);
+    await waitFor(() => expect(input.value).toBe("450"));
   });
 
   it("keeps crafting and refining contents read-only", async () => {

--- a/console/web/src/features/bases/BaseInventoryTab.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.tsx
@@ -80,8 +80,7 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
   const [contentsFor, setContentsFor] = useState("");
   const [showAllItems, setShowAllItems] = useState(false);
   const closeContentsRef = useRef<HTMLButtonElement>(null);
-  // Slots for the open container only, fetched on open. List is the default so
-  // the modal opens on the denser, sortable view; grid is a deliberate switch.
+  // Slots for the open container only, fetched on open.
   const [slots, setSlots] = useState<BaseContainerSlots | null>(null);
   const [slotsLoading, setSlotsLoading] = useState(false);
   const [slotsError, setSlotsError] = useState("");
@@ -243,6 +242,11 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
 
   useEffect(() => {
     if (!contentsFor) {
+      // Invalidates a request that was still in flight when the overlay
+      // closed, the same way opening a different container does -- closing
+      // is itself a reason the response no longer matters, even though
+      // nothing currently renders slots while contentsFor is empty.
+      slotsRequestIdRef.current += 1;
       setSlots(null);
       setSlotsError("");
       setDeleteNotice("");
@@ -263,7 +267,13 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
     if (!openContainer) return undefined;
     closeContentsRef.current?.focus();
     function closeOnEscape(event: KeyboardEvent) {
-      if (event.key === "Escape") setContentsFor("");
+      if (event.key !== "Escape") return;
+      // ConfirmDialog listens on window too, so a single Escape reached both
+      // and cancelling a delete confirmation also tore down the overlay behind
+      // it, losing the operator's place. When a second modal is stacked on
+      // top, let it take the key and leave this one open.
+      if (document.querySelectorAll(".confirm-modal").length > 1) return;
+      setContentsFor("");
     }
     window.addEventListener("keydown", closeOnEscape);
     return () => window.removeEventListener("keydown", closeOnEscape);
@@ -315,6 +325,13 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
         throw new Error(response.error || response.reason || "The item could not be deleted.");
       }
       setDeleteNotice(result.message);
+      // A whole-slot delete removes the slot entirely, so the vanished-slot
+      // effect below clears amount once the refetch lands. A partial delete
+      // leaves the same slot selected with a smaller stack, and that effect
+      // does not fire for it -- left alone, the stale (larger) amount would
+      // exceed the new quantity on the very next render and immediately show
+      // the "enter an amount" error on what was actually a successful delete.
+      if (result.partial) setAmount(String(result.removed.remaining));
       // Refetch both: the slot list for this container, and the tab totals,
       // group counts and rollup, all of which the delete just invalidated.
       await Promise.all([loadSlots(contentsFor), load()]);
@@ -649,6 +666,11 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
                         key={slot.itemId}
                         className={`bases-inventory-slot-cell${selectedSlotId === slot.itemId ? " selected" : ""}`}
                         aria-pressed={selectedSlotId === slot.itemId}
+                        // Without the explicit label the quantity badge below
+                        // becomes the accessible name, so a filled cell
+                        // announced as a bare number and the title fallback
+                        // never applied.
+                        aria-label={`${slot.name} ×${slot.quantity.toLocaleString()}, slot ${index}`}
                         title={`${slot.name} ×${slot.quantity.toLocaleString()} (slot ${index})`}
                         onClick={() => { setSelectedSlotId(slot.itemId); setAmount(String(slot.quantity)); }}
                       >

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2917,7 +2917,13 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
    themselves, whatever is present. */
 .bases-inventory-contents-modal {
   width: min(560px, calc(100vw - 32px));
-  max-height: min(72vh, 720px);
+  /* No max-height override here: the shared `.confirm-modal { max-height:
+     calc(100dvh - clamp(20px, 6vw, 48px)); overflow: auto }` rule further
+     down this file already applies to every confirm-modal, including this
+     one, at equal specificity and later in the cascade -- an override here
+     would be dead on arrival. That rule is the more correct one anyway (a
+     real viewport-safe cap vs this modal's own fixed 72vh/720px guess), so
+     this modal just inherits it like every other one. */
   display: flex;
   flex-direction: column;
   padding-left: 24px;
@@ -2960,12 +2966,19 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   display: grid;
   align-content: start;
 }
-/* Five columns now: icon, name, slot number, quantity, delete. The slot
-   number is what makes two rows of the same template distinguishable, which
-   is the whole point of the per-slot view. */
+/* Five columns: icon, name, slot number, quantity, delete. The slot number is
+   what makes two rows of the same template distinguishable, which is the whole
+   point of the per-slot view.
+   Every track is fixed except the name. Each row is its own grid, so an `auto`
+   track sizes against that row's content alone -- quantities of different
+   digit-widths gave every row a different column layout and left the header
+   labels aligned with nothing. The delete track is 38px because
+   .icon-toggle-button is `width: 38px; flex: 0 0 38px`; as a grid item its
+   flex-basis cannot shrink it, so a narrower track was overflowed, not
+   respected. */
 .bases-inventory-contents-row {
   display: grid;
-  grid-template-columns: 40px minmax(0, 1fr) 48px auto 30px;
+  grid-template-columns: 40px minmax(0, 1fr) 48px 64px 38px;
   gap: 10px;
   align-items: center;
   padding: 7px 2px;
@@ -2974,7 +2987,13 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
 }
 .bases-inventory-contents-row:last-child { border-bottom: 0; }
 .bases-inventory-contents-row.head { color: var(--muted-warm); font-size: 12px; border-bottom-color: var(--border-strong); }
-.bases-inventory-contents-row.selected { background: var(--surface-raised); }
+/* --surface-raised was never defined, so selection had no visible effect at
+   all. The inset rule carries the state on its own if the background shift
+   alone reads as too subtle against the modal's own panel colour. */
+.bases-inventory-contents-row.selected {
+  background: var(--panel-muted);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
 /* The third and last CatalogItemThumb in this tab, and the one that has to be
    sized here too: .small is a 42px box, which overflowed the old 24px column
    and ran under the item name. The other two are handled at
@@ -2997,7 +3016,10 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
 }
 .bases-inventory-contents-name:hover { border-color: transparent; color: var(--accent); }
 .bases-inventory-contents-slot { font-variant-numeric: tabular-nums; font-size: 12px; }
-.bases-inventory-contents-qty { color: var(--muted-warm); font-variant-numeric: tabular-nums; }
+/* Right-aligned so digits line up down the column now that the track is a
+   fixed width -- ragged-left numbers in a fixed track read as misaligned. */
+.bases-inventory-contents-qty { color: var(--muted-warm); font-variant-numeric: tabular-nums; text-align: right; }
+.bases-inventory-contents-row.head > span:nth-child(4) { text-align: right; }
 .bases-inventory-note { margin: 0; font-size: 12px; }
 
 /* The in-game-style slot grid. auto-fill rather than a fixed column count so
@@ -3081,6 +3103,18 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   padding: 10px 12px;
   border: 1px solid var(--border-strong);
   border-radius: 6px;
+}
+/* Below this the two `auto` control tracks take their content width and the
+   1fr body is squeezed to 0, leaving an armed Delete button with nothing
+   naming what it deletes. Wrapping to two rows keeps the identity visible;
+   the app already ships a 430px breakpoint, so this range is in scope. */
+@media (max-width: 600px) {
+  .bases-inventory-slot-detail {
+    grid-template-columns: 48px minmax(0, 1fr);
+    row-gap: 10px;
+  }
+  .bases-inventory-slot-amount,
+  .bases-inventory-slot-detail > button { grid-column: 2; justify-self: start; }
 }
 /* The WRAPPER has to be sized, not just the img inside it: CatalogItemThumb
    defaults to a 72px box, which overflowed this column and put the item name

--- a/docs/console/base-deletion.md
+++ b/docs/console/base-deletion.md
@@ -75,7 +75,7 @@ but consent, since base inventory shipped read-only and no existing
 ## Why deletes are queued for a live map
 
 This schema has no live-notify path for structural changes — the same fact
-[Base inventory](base-inventory.md#why-read-only) documents for reads: zero
+[Base inventory](base-inventory.md#why-deletion-requires-a-stopped-map) documents for reads: zero
 triggers on `dune.buildings`/`dune.building_instances`/`dune.placeables`, and
 no `pg_notify` channel for a structural despawn. A running map server
 periodically flushes its own in-memory copy of a base back to Postgres, so a


### PR DESCRIPTION
Fixes HIGH/MED findings from a four-reviewer `/review` pass (schema, frontend, security, hygiene) over the merged per-slot base-container-delete feature.

- `deleteBaseContainerItem` never set `search_path`, unlike its two siblings (`mutateBasePermissions`, `deleteBaseCompletely`) — harmless while the console connects as role `dune`, latent otherwise.
- The undefined `--surface-raised` CSS variable left list-row selection invisible.
- Contents list rows were independent CSS grids with a mismatched header, and the delete button overflowed its track. All rows now share one layout.
- The slot-detail strip collapsed to 0px below 600px, hiding what a live Delete button would remove.
- Escape closed both the contents overlay and a stacked delete-confirmation dialog on one keypress.
- A grid cell with a quantity badge announced only the number to screen readers, not the item name.
- The integration test's hand-written schema invented a `stats` default and dropped real `actor_fgl_entities`/`inventories` constraints present in production — corrected to match `.claude/dune_backup.sql` exactly.

Also closed while in the same code: the audit record now carries quality and durability so a destroyed legendary doesn't log identically to a broken common; two code comments describing why fuel inventories are protected and why the row lock is taken were factually wrong and are corrected; a stale `amount` left in the delete strip after a successful partial removal showed a false validation error on success — confirmed live against real data and fixed.

Verified before rebasing that every finding still applied against the current `main` tip (none of the intervening commits touched these regions). Backend: `db.test.js` 308/308, `policy`/`rbacParity` 7/7 + 4/4, Docker CI-parity 1141/1141. Frontend: 418/418, clean build.

The integration suite's separately-known flaky lock-wait test (`terminating connection due to administrator command`) is deliberately **not** touched here — that's #167, an independent fix.
