### PR TITLE
feat(discord): add command catalog endpoint (GET /api/integrations/discord/catalog)

### DIFF
--- a/console/api/src/integrations/discord/adapter.js
+++ b/console/api/src/integrations/discord/adapter.js
@@ -124,7 +124,15 @@ export function validateDiscordActor(actorPayload) {
 // its meaning changes) -- NOT bumped for ordinary route additions, which
 // are additive and always safe for a bot that doesn't yet know about them.
 // See commandCatalog.js and docs/rfc-command-discovery.md §3.4.
-export const DISCORD_CATALOG_PROTOCOL_VERSION = 1;
+//
+// Bumped 1 -> 2 alongside commandCatalog.js's own CATALOG_VERSION: a
+// subcommand's `route` (a single string) became `routes` (an array),
+// needed to correctly represent 3 (group, subcommand) pairs that
+// genuinely fan out to two backing adapter routes each (upstream PR #171
+// review). No live consumer exists yet to break (Phase 2/3 bot-side
+// generator is still unimplemented), so this is forward hygiene per this
+// comment's own stated policy, not a fix for an active breakage.
+export const DISCORD_CATALOG_PROTOCOL_VERSION = 2;
 
 export async function discordAdapterHealth(config) {
   return {

--- a/console/api/src/integrations/discord/adapter.js
+++ b/console/api/src/integrations/discord/adapter.js
@@ -37,7 +37,16 @@ export const DISCORD_ADAPTER_ROUTES = Object.freeze({
   VERSION: "/api/integrations/discord/version",
   SERVERS: "/api/integrations/discord/servers",
   PORTS: "/api/integrations/discord/ports",
-  DB: "/api/integrations/discord/db"
+  DB: "/api/integrations/discord/db",
+  // CATALOG is deliberately NOT added to DISCORD_LIVE_ADAPTER_ROUTES below.
+  // It is metadata ABOUT the live routes, not itself one of them -- adding
+  // it there would require commandCatalog.js's COMMAND_METADATA to have an
+  // entry describing itself, which is circular and not meaningful (a
+  // catalog entry for "the catalog"). Its own liveness/auth is handled
+  // directly by its route.js dispatch entry (bearer-token auth only, same
+  // as HEALTH) rather than the capability/tier system, since it is
+  // read-only metadata about route shape, not game or player data.
+  CATALOG: "/api/integrations/discord/catalog"
 });
 
 export const DISCORD_LIVE_ADAPTER_ROUTES = Object.freeze([
@@ -110,6 +119,13 @@ export function validateDiscordActor(actorPayload) {
   return normalizeDiscordActor(actorPayload);
 }
 
+// Bumped only when the command-catalog contract itself changes in a way
+// that could break an older bot's assumptions (e.g. a field is removed or
+// its meaning changes) -- NOT bumped for ordinary route additions, which
+// are additive and always safe for a bot that doesn't yet know about them.
+// See commandCatalog.js and docs/rfc-command-discovery.md §3.4.
+export const DISCORD_CATALOG_PROTOCOL_VERSION = 1;
+
 export async function discordAdapterHealth(config) {
   return {
     ok: true,
@@ -123,7 +139,8 @@ export async function discordAdapterHealth(config) {
     routes: DISCORD_LIVE_ADAPTER_ROUTES,
     liveRoutes: DISCORD_LIVE_ADAPTER_ROUTES,
     plannedRoutes: DISCORD_PLANNED_ADAPTER_ROUTES,
-    rolePolicy: discordRolePolicyHealth()
+    rolePolicy: discordRolePolicyHealth(),
+    protocolVersion: DISCORD_CATALOG_PROTOCOL_VERSION
   };
 }
 

--- a/console/api/src/integrations/discord/commandCatalog.js
+++ b/console/api/src/integrations/discord/commandCatalog.js
@@ -40,7 +40,18 @@
 import { DISCORD_ADAPTER_ROUTES, DISCORD_LIVE_ADAPTER_ROUTES } from "./adapter.js";
 import { DISCORD_CAPABILITIES, minTierForCapability } from "./policy.js";
 
-export const CATALOG_VERSION = 1;
+// Bumped from 1 to 2 for this revision: subcommand.route (a single string)
+// became subcommand.routes (an array) for every (group, subcommand) pair
+// that fans out to more than one backing adapter route -- a breaking shape
+// change for any future consumer that assumed one route per subcommand, per
+// this constant's own original design intent (see adapter.js's
+// DISCORD_CATALOG_PROTOCOL_VERSION comment: bump on "a field is removed or
+// its meaning changes", not on ordinary additions). No live consumer exists
+// yet (Phase 2/3 bot-side generator is still unimplemented -- confirmed via
+// grep across arrakis-control-panel's src/ for buildCommandCatalog/
+// DISCORD_CATALOG_PROTOCOL_VERSION, zero hits), so this bump is forward
+// hygiene, not a fix for an active breakage.
+export const CATALOG_VERSION = 2;
 
 // One entry per DISCORD_LIVE_ADAPTER_ROUTES member. Keys are route path
 // strings (DISCORD_ADAPTER_ROUTES.* values), not route constant names, so
@@ -51,7 +62,43 @@ export const CATALOG_VERSION = 1;
 // checks for this route (verified by direct reading of both files, not
 // inferred) -- diagnostic-mode STATUS uses LOGS_READ instead of
 // STATUS_READ; that distinction is preserved here via diagnosticCapability.
-const COMMAND_METADATA = Object.freeze({
+//
+// method: the exact HTTP method routes.js's real dispatch table checks for
+// this route (`req.method === "GET"|"POST"`) -- defaults to "POST" when
+// omitted (buildCommandCatalog() below), since all but 3 live routes
+// (HEALTH, VERSION, BACKUPS_LIST) are POST; those 3 set method: "GET"
+// explicitly rather than every other entry repeating "POST".
+//
+// params[].bodyField: the real JSON body field name routes.js actually
+// reads for this param (e.g. `body.characterName`), when it differs from
+// the param's own Discord-facing `name` (e.g. "character"). Defaults to
+// the param's own `name` when omitted -- most params match 1:1; only
+// PLAYERS_LINK ("character" -> "characterName") and
+// PLAYERS_INVENTORY_SEARCH ("search" -> "query") need an explicit
+// override today (found via upstream PR #171's review; see
+// discordCommandCatalog.test.js's cross-check against routes.js's real
+// body.<field> reads for the mechanism that keeps this from silently
+// drifting again).
+//
+// Three (group, subcommand) pairs intentionally fan out to two backing
+// routes each -- confirmed against the real, live Discord bot
+// (arrakis-control-panel/src/commands.js) that these are genuinely ONE
+// Discord subcommand each, not two: the bot registers a single "storage"/
+// "find"/"inventory" subcommand and picks which adapter route to call at
+// runtime based on a param value (scope=guild, or search being present).
+// Each fanned-out route entry below carries its own `selector` describing
+// which param/value picks it; the entry with `selector: null` is the
+// default used when no other selector in the pair matches. This is NOT a
+// naming collision to rename away -- inventing distinct subcommand names
+// (e.g. "guild-storage") would contradict this file's own design mandate
+// (see the module header) that catalog names must match what Discord users
+// actually see today, not a fresh naming scheme.
+// Exported (not just module-private) so discordCommandCatalog.test.js can
+// cross-check every declared field/bodyField against buildCommandCatalog()'s
+// real output and against routes.js's real body.<field> reads, without
+// re-deriving or hand-retyping this table a second time inside the test
+// (which would be tautological -- see that test file's own comments).
+export const COMMAND_METADATA = Object.freeze({
   [DISCORD_ADAPTER_ROUTES.HEALTH]: {
     group: "server", subcommand: "health",
     description: "Check the console Discord adapter.",
@@ -66,6 +113,7 @@ const COMMAND_METADATA = Object.freeze({
     // routes.js/adapter.js rather than trusting this table's own claims.
     capability: DISCORD_CAPABILITIES.STATUS_READ,
     routeEnforcesCapability: false,
+    method: "GET",
     params: []
   },
   [DISCORD_ADAPTER_ROUTES.STATUS]: {
@@ -135,6 +183,7 @@ const COMMAND_METADATA = Object.freeze({
     // rather than silently assumed.
     capability: DISCORD_CAPABILITIES.BACKUPS_READ,
     routeEnforcesCapability: false,
+    method: "GET",
     params: []
   },
   [DISCORD_ADAPTER_ROUTES.ANNOUNCEMENTS]: {
@@ -204,7 +253,9 @@ const COMMAND_METADATA = Object.freeze({
     description: "Link your Discord to your game character.",
     capability: DISCORD_CAPABILITIES.PLAYER_LINK_WRITE,
     params: [
-      { name: "character", type: "STRING", required: true, description: "Your character name." }
+      // routes.js:251 reads body.characterName, not body.character --
+      // found by upstream PR #171's review (Red-Blink).
+      { name: "character", bodyField: "characterName", type: "STRING", required: true, description: "Your character name." }
     ]
   },
   [DISCORD_ADAPTER_ROUTES.PLAYERS_LINK_VERIFY]: {
@@ -227,49 +278,84 @@ const COMMAND_METADATA = Object.freeze({
     capability: DISCORD_CAPABILITIES.INVENTORY_READ,
     params: []
   },
-  [DISCORD_ADAPTER_ROUTES.PLAYERS_INVENTORY]: {
-    group: "player", subcommand: "inventory",
-    description: "View your personal inventory.",
-    capability: DISCORD_CAPABILITIES.INVENTORY_READ,
-    params: []
-  },
+  // Fan-out pair 1 of 3 (upstream PR #171 review): the bot registers ONE
+  // real "storage" subcommand under group "player" (commands.js) with a
+  // scope choice ("owned"/"guild"); at runtime it calls PLAYERS_STORAGE for
+  // scope=owned (the default) or GUILD_STORAGE for scope=guild
+  // (commands.js's own comment: "guild scope has a dedicated guild-scoped
+  // route; do not silently fall back"). Two different capabilities/tiers
+  // are genuinely enforced depending on which route is selected --
+  // STORAGE_READ vs GUILD_READ -- so collapsing this into a single flat
+  // catalog entry with one capability would misreport the guild path's
+  // real authorization requirement. selector: null marks the default route
+  // used when no other selector in this (group, subcommand) pair matches.
   [DISCORD_ADAPTER_ROUTES.PLAYERS_STORAGE]: {
     group: "player", subcommand: "storage",
     description: "View your storage containers grouped by map.",
     capability: DISCORD_CAPABILITIES.STORAGE_READ,
+    selector: null,
     params: [
       { name: "scope", type: "STRING", required: false, description: 'Storage scope: "owned" (default) or "guild".', choices: ["owned", "guild"] }
-    ]
-  },
-  [DISCORD_ADAPTER_ROUTES.PLAYERS_FIND]: {
-    group: "player", subcommand: "find",
-    description: "Search for items across your containers.",
-    capability: DISCORD_CAPABILITIES.INVENTORY_READ,
-    params: [
-      { name: "query", type: "STRING", required: true, description: "Item name to search for." },
-      { name: "scope", type: "STRING", required: false, description: 'Search scope: "owned" (default) or "guild".', choices: ["owned", "guild"] }
-    ]
-  },
-  [DISCORD_ADAPTER_ROUTES.PLAYERS_INVENTORY_SEARCH]: {
-    group: "player", subcommand: "inventory",
-    description: "View your personal inventory, filtered by item name.",
-    capability: DISCORD_CAPABILITIES.INVENTORY_READ,
-    params: [
-      { name: "search", type: "STRING", required: false, description: "Filter by item name (optional)." }
     ]
   },
   [DISCORD_ADAPTER_ROUTES.GUILD_STORAGE]: {
     group: "player", subcommand: "storage",
     description: "View guild-scoped storage containers.",
     capability: DISCORD_CAPABILITIES.GUILD_READ,
+    selector: { param: "scope", equals: "guild" },
     params: []
+  },
+  // Fan-out pair 2 of 3: same pattern as storage above -- one real "find"
+  // subcommand, scope-selected between PLAYERS_FIND (owned, default) and
+  // GUILD_FIND (guild), with genuinely different capabilities
+  // (INVENTORY_READ vs GUILD_READ).
+  [DISCORD_ADAPTER_ROUTES.PLAYERS_FIND]: {
+    group: "player", subcommand: "find",
+    description: "Search for items across your containers.",
+    capability: DISCORD_CAPABILITIES.INVENTORY_READ,
+    selector: null,
+    params: [
+      { name: "query", type: "STRING", required: true, description: "Item name to search for." },
+      { name: "scope", type: "STRING", required: false, description: 'Search scope: "owned" (default) or "guild".', choices: ["owned", "guild"] }
+    ]
   },
   [DISCORD_ADAPTER_ROUTES.GUILD_FIND]: {
     group: "player", subcommand: "find",
     description: "Search for items across guild containers.",
     capability: DISCORD_CAPABILITIES.GUILD_READ,
+    selector: { param: "scope", equals: "guild" },
     params: [
       { name: "query", type: "STRING", required: true, description: "Item name to search for." }
+    ]
+  },
+  // Fan-out pair 3 of 3: one real "inventory" subcommand under group
+  // "player" with an optional "search" string option (commands.js). The
+  // bot calls PLAYERS_INVENTORY_SEARCH when search is present, else
+  // PLAYERS_INVENTORY -- selected by param PRESENCE, not a value match, so
+  // the selector shape differs from the two pairs above (`present: true`
+  // instead of `equals`). Same capability either way (INVENTORY_READ), so
+  // this pair is a real UX fan-out, not a security-relevant one like the
+  // two above -- still fixed the same way for structural consistency and
+  // because a future capability change to either route must not silently
+  // apply to only one side of a flattened entry.
+  [DISCORD_ADAPTER_ROUTES.PLAYERS_INVENTORY]: {
+    group: "player", subcommand: "inventory",
+    description: "View your personal inventory.",
+    capability: DISCORD_CAPABILITIES.INVENTORY_READ,
+    selector: null,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.PLAYERS_INVENTORY_SEARCH]: {
+    group: "player", subcommand: "inventory",
+    description: "View your personal inventory, filtered by item name.",
+    capability: DISCORD_CAPABILITIES.INVENTORY_READ,
+    selector: { param: "search", present: true },
+    params: [
+      // routes.js:339 reads body.query, not body.search -- found by
+      // upstream PR #171's review (Red-Blink). "search" is what the bot's
+      // own Discord-facing option is named (commands.js); "query" is the
+      // wire field the adapter route actually reads.
+      { name: "search", bodyField: "query", type: "STRING", required: false, description: "Filter by item name (optional)." }
     ]
   },
   [DISCORD_ADAPTER_ROUTES.VERSION]: {
@@ -280,6 +366,7 @@ const COMMAND_METADATA = Object.freeze({
     // recorded as null rather than guessing one.
     capability: null,
     routeEnforcesCapability: false,
+    method: "GET",
     params: []
   },
   [DISCORD_ADAPTER_ROUTES.SERVERS]: {
@@ -349,25 +436,56 @@ export function buildCommandCatalog(liveRoutes = DISCORD_LIVE_ADAPTER_ROUTES, me
     throw new Error(`commandCatalog.js: ${stale.length} catalog entry(ies) reference route(s) no longer in DISCORD_LIVE_ADAPTER_ROUTES: ${stale.join(", ")}`);
   }
 
+  // groups: group name -> (subcommand name -> array of route entries).
+  // A subcommand normally has exactly one route entry; the 3 documented
+  // fan-out pairs above (storage/find/inventory) produce two -- see this
+  // file's header comment for why that's a real, intentional shape and not
+  // a bug to flatten away.
   const groups = new Map();
   for (const route of liveRoutes) {
-    const meta = metadata[route];
-    if (!groups.has(meta.group)) groups.set(meta.group, []);
-    groups.get(meta.group).push({
-      name: meta.subcommand,
-      description: meta.description,
+    // Destructure-and-spread (not a hand-picked allowlist): every field
+    // NOT explicitly named below survives into the output route entry
+    // automatically via `...rest` -- this is the fix for the
+    // diagnosticCapability-silently-dropped bug (upstream PR #171 review):
+    // a future metadata field added to COMMAND_METADATA reaches the
+    // catalog's real JSON output without anyone having to remember to also
+    // edit this block a second time. Only fields that need renaming
+    // (group/subcommand, consumed into the Map keys below rather than
+    // copied verbatim) or type coercion (requiresWritesEnabled,
+    // routeEnforcesCapability -- both intentionally normalized to a real
+    // boolean, undefined -> false, not left as undefined) are named
+    // explicitly and excluded from `rest`.
+    const { group, subcommand, capability, requiresWritesEnabled, routeEnforcesCapability, method, params, ...rest } = metadata[route];
+    const routeEntry = {
+      ...rest,
       route,
-      capability: meta.capability,
-      minTier: resolveMinTier(meta.capability),
-      requiresWritesEnabled: Boolean(meta.requiresWritesEnabled),
-      routeEnforcesCapability: meta.routeEnforcesCapability !== false,
-      params: meta.params || []
-    });
+      capability,
+      minTier: resolveMinTier(capability),
+      method: method || "POST",
+      requiresWritesEnabled: Boolean(requiresWritesEnabled),
+      routeEnforcesCapability: routeEnforcesCapability !== false,
+      // bodyField defaults to the param's own Discord-facing name when not
+      // explicitly overridden -- most params match their real body field
+      // 1:1; PLAYERS_LINK and PLAYERS_INVENTORY_SEARCH are the two
+      // documented exceptions today (see their own entries above).
+      params: (params || []).map((param) => ({ ...param, bodyField: param.bodyField || param.name }))
+    };
+
+    if (!groups.has(group)) groups.set(group, new Map());
+    const subcommands = groups.get(group);
+    if (!subcommands.has(subcommand)) subcommands.set(subcommand, []);
+    subcommands.get(subcommand).push(routeEntry);
   }
 
   const result = {
     version: CATALOG_VERSION,
-    groups: [...groups.entries()].map(([name, subcommands]) => ({ name, subcommands }))
+    groups: [...groups.entries()].map(([groupName, subcommands]) => ({
+      name: groupName,
+      subcommands: [...subcommands.entries()].map(([subcommandName, routes]) => ({
+        name: subcommandName,
+        routes
+      }))
+    }))
   };
   if (isProductionCall) cachedProductionCatalog = result;
   return result;

--- a/console/api/src/integrations/discord/commandCatalog.js
+++ b/console/api/src/integrations/discord/commandCatalog.js
@@ -1,0 +1,364 @@
+// Discord command catalog -- Phase 1 of the automated command-discovery
+// design (docs/rfc-command-discovery.md, merged upstream as docs-only via
+// Red-Blink/dune-awakening-selfhost-docker#141).
+//
+// Purpose: give the Discord bot (arrakis-control-panel) a single,
+// mechanically verifiable source of truth for which read-only Discord
+// adapter routes are live, what capability/tier each one requires, and what
+// Discord-facing metadata (name, description, params) each one needs --
+// replacing the bot's own hand-maintained route classification, which has
+// required several separate manual reconciliations to date purely because
+// there was no automated way to detect drift between this file's real route
+// table and the bot's own copy.
+//
+// Deliberately Phase 1 only (see the RFC's own §4 migration path): this
+// file composes catalog entries from data that ALREADY exists as code
+// (DISCORD_LIVE_ADAPTER_ROUTES, DISCORD_CAPABILITIES, the per-route
+// capability checks in routes.js/adapter.js, and policy.js's
+// minTierForCapability() for the effective minimum tier per capability)
+// plus newly-authored Discord-facing metadata (group/subcommand name,
+// description, param shape) that does not exist as code anywhere today and
+// must be authored once per route.
+//
+// NOTE on scope of the drift-safety claim below: buildCommandCatalog()'s
+// coverage assertion (the missing/stale checks) makes ROUTE coverage
+// drift-proof -- it throws if a live route lacks a COMMAND_METADATA entry,
+// or if an entry references a route that's no longer live. It does NOT make
+// the hand-authored fields WITHIN each entry (like `description`) drift-
+// proof -- those still require a human to keep them accurate against the
+// real route behavior.
+//
+// Phases 2 (bot-side generator script), 3 (bot runtime loads from the
+// generated registry), and 4 (dynamic refresh, per-guild catalogs,
+// autocomplete) are explicitly out of scope here.
+//
+// Metadata sourced from the Discord bot's own real, currently-registered
+// command definitions (buildDuneCommand() in the bot repo's src/commands.js)
+// so this catalog describes what Discord users actually see today, not a
+// fresh, independently-invented naming scheme.
+
+import { DISCORD_ADAPTER_ROUTES, DISCORD_LIVE_ADAPTER_ROUTES } from "./adapter.js";
+import { DISCORD_CAPABILITIES, minTierForCapability } from "./policy.js";
+
+export const CATALOG_VERSION = 1;
+
+// One entry per DISCORD_LIVE_ADAPTER_ROUTES member. Keys are route path
+// strings (DISCORD_ADAPTER_ROUTES.* values), not route constant names, so
+// buildCommandCatalog() can validate coverage by iterating
+// DISCORD_LIVE_ADAPTER_ROUTES directly.
+//
+// capability: the exact capability string routes.js/adapter.js actually
+// checks for this route (verified by direct reading of both files, not
+// inferred) -- diagnostic-mode STATUS uses LOGS_READ instead of
+// STATUS_READ; that distinction is preserved here via diagnosticCapability.
+const COMMAND_METADATA = Object.freeze({
+  [DISCORD_ADAPTER_ROUTES.HEALTH]: {
+    group: "server", subcommand: "health",
+    description: "Check the console Discord adapter.",
+    capability: DISCORD_CAPABILITIES.STATUS_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.STATUS]: {
+    group: "server", subcommand: "status",
+    description: "Show high-level server status.",
+    capability: DISCORD_CAPABILITIES.STATUS_READ,
+    // diagnostic=true switches the required capability to LOGS_READ
+    // (admin-tier) -- see discordAdapterStatus() in adapter.js.
+    diagnosticCapability: DISCORD_CAPABILITIES.LOGS_READ,
+    params: [
+      { name: "diagnostic", type: "BOOLEAN", required: false, description: "Admin-only: full diagnostic with containers table." }
+    ]
+  },
+  [DISCORD_ADAPTER_ROUTES.READINESS]: {
+    group: "server", subcommand: "readiness",
+    description: "Show readiness and preflight state.",
+    capability: DISCORD_CAPABILITIES.READINESS_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.SERVICES]: {
+    group: "server", subcommand: "services",
+    description: "Show service container state.",
+    capability: DISCORD_CAPABILITIES.SERVICES_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.POPULATION]: {
+    group: "data", subcommand: "population",
+    description: "Show aggregate player count and server population.",
+    capability: DISCORD_CAPABILITIES.POPULATION_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.LOGS]: {
+    group: "logs", subcommand: "service",
+    description: "Show recent logs from a specific game service container.",
+    capability: DISCORD_CAPABILITIES.LOGS_READ,
+    params: [
+      { name: "service", type: "STRING", required: true, description: "Service/container name." }
+    ]
+  },
+  [DISCORD_ADAPTER_ROUTES.MAP_STATE]: {
+    group: "data", subcommand: "maps",
+    description: "Show active game maps with state and uptime.",
+    capability: DISCORD_CAPABILITIES.MAPS_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.MAINTENANCE]: {
+    group: "server", subcommand: "maintenance",
+    // The route handler (routes.js) runs `dune ready` -- the exact same
+    // underlying command READINESS already runs -- and returns raw
+    // readiness output. It does NOT read a maintenance note/window from
+    // anywhere. Recorded here as what the route ACTUALLY does, not what
+    // its name might otherwise imply.
+    description: "Show current maintenance/readiness state (runs the same check as /dune server readiness).",
+    capability: DISCORD_CAPABILITIES.READINESS_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.BACKUPS_LIST]: {
+    group: "data", subcommand: "backups",
+    description: "List recent backup metadata (read-only).",
+    // BACKUPS_LIST has no requireDiscordCapability() call in routes.js --
+    // it is unauthenticated at the route-handler level (relies on the
+    // adapter's bearer-token auth only, checked earlier in the dispatch
+    // pipeline via requireDiscordBotToken()). Recorded as BACKUPS_READ's
+    // tier (moderator) for catalog/UX purposes since that's the capability
+    // DISCORD_CAPABILITIES.BACKUPS_READ exists to describe, but this is NOT
+    // enforced per-actor by this specific route today -- flagged here
+    // rather than silently assumed.
+    capability: DISCORD_CAPABILITIES.BACKUPS_READ,
+    routeEnforcesCapability: false,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.ANNOUNCEMENTS]: {
+    group: "ops", subcommand: "announcements",
+    description: "Show recent in-game player announcements.",
+    // routes.js checks MAPS_READ for this route -- not a new
+    // ANNOUNCEMENTS-specific capability. Recorded as-is.
+    capability: DISCORD_CAPABILITIES.MAPS_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.OPS_ACTIVITY]: {
+    group: "ops", subcommand: "activity",
+    description: "Recent server activity summary.",
+    capability: DISCORD_CAPABILITIES.OPS_ACTIVITY_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.OPS_COMBAT]: {
+    group: "ops", subcommand: "combat",
+    description: "Recent combat statistics summary.",
+    capability: DISCORD_CAPABILITIES.OPS_COMBAT_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.OPS_RESOURCES]: {
+    group: "ops", subcommand: "resources",
+    description: "Deep Desert / Hagga Basin resource summary.",
+    capability: DISCORD_CAPABILITIES.OPS_RESOURCES_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.OPS_ECONOMY]: {
+    group: "ops", subcommand: "economy",
+    description: "Server economy summary.",
+    capability: DISCORD_CAPABILITIES.OPS_ECONOMY_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.OPS_INVENTORY]: {
+    group: "ops", subcommand: "armory",
+    description: "Aggregate armory/inventory summary.",
+    capability: DISCORD_CAPABILITIES.OPS_INVENTORY_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.OPS_SOC]: {
+    group: "ops", subcommand: "soc",
+    description: "Security operations center bridge-request summary.",
+    capability: DISCORD_CAPABILITIES.OPS_SOC_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.OPS_PROMETHEUS]: {
+    group: "ops", subcommand: "prometheus",
+    description: "Prometheus-backed metrics summary.",
+    capability: DISCORD_CAPABILITIES.OPS_PROMETHEUS_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.BROADCAST]: {
+    group: "admin", subcommand: "broadcast",
+    description: "Send a message to all in-game players.",
+    capability: DISCORD_CAPABILITIES.BROADCAST_SEND,
+    // Also gated behind DUNE_DISCORD_WRITES_ENABLED at the route level
+    // (discordWritesEnabled(config), routes.js) in addition to the
+    // capability check -- this is the bot's one non-read-only live route.
+    requiresWritesEnabled: true,
+    params: [
+      { name: "message", type: "STRING", required: true, description: "Message to broadcast.", maxLength: 500 }
+    ]
+  },
+  [DISCORD_ADAPTER_ROUTES.PLAYERS_LINK]: {
+    group: "player", subcommand: "link",
+    description: "Link your Discord to your game character.",
+    capability: DISCORD_CAPABILITIES.PLAYER_LINK_WRITE,
+    params: [
+      { name: "character", type: "STRING", required: true, description: "Your character name." }
+    ]
+  },
+  [DISCORD_ADAPTER_ROUTES.PLAYERS_LINK_VERIFY]: {
+    group: "player", subcommand: "verify",
+    description: "Verify a pending character link with a code.",
+    capability: DISCORD_CAPABILITIES.PLAYER_LINK_WRITE,
+    params: [
+      { name: "code", type: "STRING", required: true, description: "Verification code from in-game whisper." }
+    ]
+  },
+  [DISCORD_ADAPTER_ROUTES.PLAYERS_UNLINK]: {
+    group: "player", subcommand: "unlink",
+    description: "Unlink your character from your Discord.",
+    capability: DISCORD_CAPABILITIES.PLAYER_LINK_WRITE,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.PLAYERS_ME]: {
+    group: "player", subcommand: "whoami",
+    description: "Show your linked game character info.",
+    capability: DISCORD_CAPABILITIES.INVENTORY_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.PLAYERS_INVENTORY]: {
+    group: "player", subcommand: "inventory",
+    description: "View your personal inventory.",
+    capability: DISCORD_CAPABILITIES.INVENTORY_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.PLAYERS_STORAGE]: {
+    group: "player", subcommand: "storage",
+    description: "View your storage containers grouped by map.",
+    capability: DISCORD_CAPABILITIES.STORAGE_READ,
+    params: [
+      { name: "scope", type: "STRING", required: false, description: 'Storage scope: "owned" (default) or "guild".', choices: ["owned", "guild"] }
+    ]
+  },
+  [DISCORD_ADAPTER_ROUTES.PLAYERS_FIND]: {
+    group: "player", subcommand: "find",
+    description: "Search for items across your containers.",
+    capability: DISCORD_CAPABILITIES.INVENTORY_READ,
+    params: [
+      { name: "query", type: "STRING", required: true, description: "Item name to search for." },
+      { name: "scope", type: "STRING", required: false, description: 'Search scope: "owned" (default) or "guild".', choices: ["owned", "guild"] }
+    ]
+  },
+  [DISCORD_ADAPTER_ROUTES.PLAYERS_INVENTORY_SEARCH]: {
+    group: "player", subcommand: "inventory",
+    description: "View your personal inventory, filtered by item name.",
+    capability: DISCORD_CAPABILITIES.INVENTORY_READ,
+    params: [
+      { name: "search", type: "STRING", required: false, description: "Filter by item name (optional)." }
+    ]
+  },
+  [DISCORD_ADAPTER_ROUTES.GUILD_STORAGE]: {
+    group: "player", subcommand: "storage",
+    description: "View guild-scoped storage containers.",
+    capability: DISCORD_CAPABILITIES.GUILD_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.GUILD_FIND]: {
+    group: "player", subcommand: "find",
+    description: "Search for items across guild containers.",
+    capability: DISCORD_CAPABILITIES.GUILD_READ,
+    params: [
+      { name: "query", type: "STRING", required: true, description: "Item name to search for." }
+    ]
+  },
+  [DISCORD_ADAPTER_ROUTES.VERSION]: {
+    group: "infra", subcommand: "version",
+    description: "Show Dune stack version.",
+    // VERSION has no requireDiscordCapability() call -- GET-only, returns
+    // config.version unconditionally. No capability is actually checked;
+    // recorded as null rather than guessing one.
+    capability: null,
+    routeEnforcesCapability: false,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.SERVERS]: {
+    group: "infra", subcommand: "servers",
+    description: "List game servers.",
+    capability: DISCORD_CAPABILITIES.SERVICES_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.PORTS]: {
+    group: "infra", subcommand: "ports",
+    description: "Show network port and listener status.",
+    capability: DISCORD_CAPABILITIES.SERVICES_READ,
+    params: []
+  },
+  [DISCORD_ADAPTER_ROUTES.DB]: {
+    group: "infra", subcommand: "db",
+    description: "Show database status and health.",
+    capability: DISCORD_CAPABILITIES.SERVICES_READ,
+    params: []
+  }
+});
+
+function resolveMinTier(capability) {
+  if (!capability) return null;
+  return minTierForCapability(capability);
+}
+
+// Builds the catalog payload, asserting full, exact coverage against the
+// live-route list in both directions:
+//   1. every live route has a metadata entry (nothing silently missing
+//      from the catalog), and
+//   2. every metadata entry corresponds to a currently-live route (nothing
+//      stale left behind after a route is retired).
+// Throws synchronously on either violation -- this is the mechanism that
+// replaces manual reconciliation with a build-time/request-time failure
+// the test suite catches immediately.
+//
+// liveRoutes/metadata parameters default to the real, production data
+// (DISCORD_LIVE_ADAPTER_ROUTES, COMMAND_METADATA) and exist ONLY so
+// discordCommandCatalog.test.js can inject a deliberately mismatched pair
+// and assert the throw actually fires. No production call site should ever
+// pass these explicitly; the route handler in routes.js calls
+// buildCommandCatalog() with no arguments.
+//
+// The zero-argument (production) call path is memoized -- DISCORD_LIVE_
+// ADAPTER_ROUTES and COMMAND_METADATA are both frozen, load-time-constant
+// module data that never changes for the lifetime of a running process, so
+// recomputing the coverage assertion and group composition on every GET
+// /catalog request is pure wasted work. Memoization is skipped entirely
+// when either argument is explicitly passed (the test-injection path), so
+// injected test data is never cached across calls.
+let cachedProductionCatalog = null;
+export function buildCommandCatalog(liveRoutes = DISCORD_LIVE_ADAPTER_ROUTES, metadata = COMMAND_METADATA) {
+  const isProductionCall = liveRoutes === DISCORD_LIVE_ADAPTER_ROUTES && metadata === COMMAND_METADATA;
+  if (isProductionCall && cachedProductionCatalog) return cachedProductionCatalog;
+
+  const liveSet = new Set(liveRoutes);
+  const metadataRoutes = Object.keys(metadata);
+
+  const missing = liveRoutes.filter((route) => !(route in metadata));
+  if (missing.length > 0) {
+    throw new Error(`commandCatalog.js: ${missing.length} live route(s) missing catalog metadata: ${missing.join(", ")}`);
+  }
+
+  const stale = metadataRoutes.filter((route) => !liveSet.has(route));
+  if (stale.length > 0) {
+    throw new Error(`commandCatalog.js: ${stale.length} catalog entry(ies) reference route(s) no longer in DISCORD_LIVE_ADAPTER_ROUTES: ${stale.join(", ")}`);
+  }
+
+  const groups = new Map();
+  for (const route of liveRoutes) {
+    const meta = metadata[route];
+    if (!groups.has(meta.group)) groups.set(meta.group, []);
+    groups.get(meta.group).push({
+      name: meta.subcommand,
+      description: meta.description,
+      route,
+      capability: meta.capability,
+      minTier: resolveMinTier(meta.capability),
+      requiresWritesEnabled: Boolean(meta.requiresWritesEnabled),
+      routeEnforcesCapability: meta.routeEnforcesCapability !== false,
+      params: meta.params || []
+    });
+  }
+
+  const result = {
+    version: CATALOG_VERSION,
+    groups: [...groups.entries()].map(([name, subcommands]) => ({ name, subcommands }))
+  };
+  if (isProductionCall) cachedProductionCatalog = result;
+  return result;
+}

--- a/console/api/src/integrations/discord/commandCatalog.js
+++ b/console/api/src/integrations/discord/commandCatalog.js
@@ -461,6 +461,12 @@ export function buildCommandCatalog(liveRoutes = DISCORD_LIVE_ADAPTER_ROUTES, me
       route,
       capability,
       minTier: resolveMinTier(capability),
+      // Conditional capabilities need their own tier on the wire. A bot
+      // cannot derive this from diagnosticCapability alone because the
+      // Core policy table is not otherwise part of the catalog response.
+      ...(rest.diagnosticCapability
+        ? { diagnosticMinTier: resolveMinTier(rest.diagnosticCapability) }
+        : {}),
       method: method || "POST",
       requiresWritesEnabled: Boolean(requiresWritesEnabled),
       routeEnforcesCapability: routeEnforcesCapability !== false,

--- a/console/api/src/integrations/discord/commandCatalog.js
+++ b/console/api/src/integrations/discord/commandCatalog.js
@@ -55,7 +55,17 @@ const COMMAND_METADATA = Object.freeze({
   [DISCORD_ADAPTER_ROUTES.HEALTH]: {
     group: "server", subcommand: "health",
     description: "Check the console Discord adapter.",
+    // HEALTH has no requireDiscordCapability() call -- discordAdapterHealth()
+    // (adapter.js) never checks a capability, identical in enforcement
+    // posture to BACKUPS_LIST/VERSION below. Recorded as STATUS_READ for
+    // display purposes (matching the bot's own health command's stated
+    // minimum role), but routeEnforcesCapability: false makes clear that
+    // is not actually enforced by this specific route -- found by an L3
+    // integration audit (Red-Blink/dune-awakening-selfhost-docker#171)
+    // that independently re-derived every route's real enforcement from
+    // routes.js/adapter.js rather than trusting this table's own claims.
     capability: DISCORD_CAPABILITIES.STATUS_READ,
+    routeEnforcesCapability: false,
     params: []
   },
   [DISCORD_ADAPTER_ROUTES.STATUS]: {

--- a/console/api/src/integrations/discord/policy.js
+++ b/console/api/src/integrations/discord/policy.js
@@ -93,6 +93,24 @@ export function discordActorCan(actor, mapping, capability) {
   return CAPABILITY_BY_TIER[discordActorTier(actor, mapping)].has(normalizedCapability);
 }
 
+// Returns the lowest tier in DISCORD_ROLE_TIERS order that grants the given
+// capability per CAPABILITY_BY_TIER, or null if no tier grants it.
+//
+// Added so commandCatalog.js can derive its per-command minimum
+// tier directly from this file's real, single source of truth instead of
+// hand-maintaining a second, parallel table that could silently drift the
+// moment a capability is added or moved between tiers here. Any caller
+// needing "what's the minimum tier for capability X" should use this
+// function rather than re-deriving CAPABILITY_BY_TIER's shape elsewhere.
+export function minTierForCapability(capability) {
+  const normalizedCapability = requiredString(capability, "capability");
+  if (!Object.values(DISCORD_CAPABILITIES).includes(normalizedCapability)) throw policyError("invalid_capability", `Unsupported Discord capability: ${normalizedCapability}`);
+  for (const tier of DISCORD_ROLE_TIERS) {
+    if (CAPABILITY_BY_TIER[tier]?.has(normalizedCapability)) return tier;
+  }
+  return null;
+}
+
 export function requireDiscordCapability(actor, mapping, capability) {
   requireExperimentalReadOnlyCapability(capability);
   if (!discordActorCan(actor, mapping, capability)) {

--- a/console/api/src/integrations/discord/routes.js
+++ b/console/api/src/integrations/discord/routes.js
@@ -7,8 +7,9 @@ import {
   discordAdapterEnabled, discordAdapterErrorResponse, discordAdapterHealth,
   discordAdapterPopulation, discordAdapterReadiness, discordAdapterServices,
   discordAdapterStatus, discordWritesEnabled, DISCORD_ADAPTER_ROUTES, DISCORD_PLANNED_ADAPTER_ROUTES,
-  validateDiscordActor, discordRoleMappingFromEnv
+  DISCORD_CATALOG_PROTOCOL_VERSION, validateDiscordActor, discordRoleMappingFromEnv
 } from "./adapter.js";
+import { buildCommandCatalog } from "./commandCatalog.js";
 import { discordActorTier, policyError, requireDiscordCapability, DISCORD_CAPABILITIES } from "./policy.js";
 import { discordStatusProvider } from "./statusProvider.js";
 import { discordReadinessProvider, discordServicesProvider } from "./readOnlyProviders.js";
@@ -132,6 +133,16 @@ export async function handleDiscordAdapterRoute({
 
     if (path === DISCORD_ADAPTER_ROUTES.HEALTH && req.method === "GET") {
       return json(res, 200, await discordAdapterHealth(config));
+    }
+
+    // Command catalog (Phase 1 of docs/rfc-command-discovery.md).
+    // Bearer-token auth only (requireDiscordBotToken() above, matching
+    // HEALTH) -- no actor signature, no per-capability check: this is
+    // read-only metadata about route/command shape, not game or player
+    // data, so it does not need per-actor tier enforcement the way an
+    // actual data route does.
+    if (path === DISCORD_ADAPTER_ROUTES.CATALOG && req.method === "GET") {
+      return json(res, 200, { ok: true, protocolVersion: DISCORD_CATALOG_PROTOCOL_VERSION, catalog: buildCommandCatalog() });
     }
 
     if (path === DISCORD_ADAPTER_ROUTES.STATUS && req.method === "POST") {

--- a/console/api/test/discordAdapter.test.js
+++ b/console/api/test/discordAdapter.test.js
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { DISCORD_ADAPTER_ROUTES, discordAdapterErrorResponse, discordAdapterHealth, discordAdapterPopulation, discordAdapterReadiness, discordAdapterServices, discordAdapterStatus, discordWritesEnabled } from "../src/integrations/discord/adapter.js";
+import { DISCORD_ADAPTER_ROUTES, DISCORD_CATALOG_PROTOCOL_VERSION, discordAdapterErrorResponse, discordAdapterHealth, discordAdapterPopulation, discordAdapterReadiness, discordAdapterServices, discordAdapterStatus, discordWritesEnabled } from "../src/integrations/discord/adapter.js";
 
 const OLD_ENV = { ...process.env };
 
@@ -44,6 +44,18 @@ test("reports adapter health with isolated link-state writes", async () => {
   assert.equal(result.gameDataWritesEnabled, false);
   assert.deepEqual(result.adapterDataWrites, ["player-link"]);
   assert.equal(result.writesEnabled, false);
+  // RFC §3.4: /health must report the catalog protocol version so the
+  // bot can detect a contract-breaking change without needing to fetch
+  // the full catalog first.
+  assert.equal(typeof result.protocolVersion, "number");
+  assert.equal(result.protocolVersion, DISCORD_CATALOG_PROTOCOL_VERSION);
+  // Issue #245 fix: LOGS, MAP_STATE, and MAINTENANCE were promoted from
+  // planned -> live (see adapter.js's DISCORD_LIVE_ADAPTER_ROUTES,
+  // "fix(adapter): implement LOGS, MAP_STATE, MAINTENANCE handlers" --
+  // 8 bot slash commands were 404ing before this), but this hardcoded
+  // exact-match expected array was never updated to include them, so
+  // assert.deepEqual failed on the 3 missing entries even though the
+  // real, current behavior is correct and intentional.
   assert.deepEqual([...result.liveRoutes].sort(), [
     "/api/integrations/discord/announcements",
     "/api/integrations/discord/broadcast",
@@ -98,6 +110,12 @@ test("exposes only allowlisted adapter route names", () => {
     "/api/integrations/discord/announcements",
     "/api/integrations/discord/backups/list",
     "/api/integrations/discord/broadcast",
+    // catalog (Phase 1 of docs/rfc-command-discovery.md): read-only
+    // metadata describing the other routes' shape/capability/tier, not
+    // itself a data route -- deliberately excluded from
+    // DISCORD_LIVE_ADAPTER_ROUTES (see adapter.js's own comment) but still
+    // a real, allowlisted route constant here.
+    "/api/integrations/discord/catalog",
     "/api/integrations/discord/db",
     "/api/integrations/discord/guilds/find",
     "/api/integrations/discord/guilds/storage",
@@ -357,6 +375,15 @@ test("adapter routes respond through mounted HTTP server path", async () => {
           const version = await (await fetch(`${base}/api/integrations/discord/version`, { headers: auth })).json();
           assert.equal(version.ok, true);
           assert.equal(version.version, "dev");
+
+          // Command catalog (Phase 1 of docs/rfc-command-discovery.md) --
+          // bearer-token auth only, matching health.
+          const catalog = await (await fetch(`${base}/api/integrations/discord/catalog`, { headers: auth })).json();
+          assert.equal(catalog.ok, true);
+          assert.equal(typeof catalog.protocolVersion, "number");
+          assert.ok(Array.isArray(catalog.catalog.groups));
+          assert.ok(catalog.catalog.groups.length > 0);
+          assert.equal((await fetch(`${base}/api/integrations/discord/catalog`)).status, 401);
 
           // Auth: 401 without token
           assert.equal((await fetch(`${base}/api/integrations/discord/health`)).status, 401);

--- a/console/api/test/discordCommandCatalog.test.js
+++ b/console/api/test/discordCommandCatalog.test.js
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { DISCORD_ADAPTER_ROUTES, DISCORD_LIVE_ADAPTER_ROUTES } from "../src/integrations/discord/adapter.js";
+import { DISCORD_ROLE_TIERS } from "../src/integrations/discord/policy.js";
+import { buildCommandCatalog, CATALOG_VERSION } from "../src/integrations/discord/commandCatalog.js";
+
+test("catalog has an entry for every live route, and no entry for a non-live route", () => {
+  const catalog = buildCommandCatalog();
+  const routesInCatalog = new Set();
+  for (const group of catalog.groups) {
+    for (const subcommand of group.subcommands) {
+      assert.ok(subcommand.route, `subcommand ${group.name}.${subcommand.name} is missing a route`);
+      routesInCatalog.add(subcommand.route);
+    }
+  }
+
+  const liveSet = new Set(DISCORD_LIVE_ADAPTER_ROUTES);
+  assert.deepEqual([...routesInCatalog].sort(), [...liveSet].sort(),
+    "catalog route set must exactly match DISCORD_LIVE_ADAPTER_ROUTES -- this is the drift-detection assertion this file exists to add");
+});
+
+test("catalog throws when a live route is genuinely missing metadata (real simulated drift)", () => {
+  // Genuinely reproduces the drift scenario: a route that IS in the live
+  // list but has NO corresponding metadata entry. buildCommandCatalog()'s
+  // optional liveRoutes/metadata parameters exist specifically so this test
+  // can inject a deliberately mismatched pair without touching the real,
+  // frozen production data -- see buildCommandCatalog()'s own comment.
+  const fakeLiveRoutes = [DISCORD_ADAPTER_ROUTES.HEALTH, "/api/integrations/discord/not-a-real-route"];
+  const fakeMetadata = {
+    [DISCORD_ADAPTER_ROUTES.HEALTH]: { group: "server", subcommand: "health", description: "x", capability: null, params: [] }
+    // deliberately no entry for "/api/integrations/discord/not-a-real-route"
+  };
+  assert.throws(
+    () => buildCommandCatalog(fakeLiveRoutes, fakeMetadata),
+    /1 live route\(s\) missing catalog metadata: \/api\/integrations\/discord\/not-a-real-route/
+  );
+});
+
+test("catalog throws when a metadata entry references a route no longer live (real simulated staleness)", () => {
+  // The inverse drift scenario: a route was retired from the live list but
+  // its metadata entry was left behind. Also genuinely reproduced, not
+  // just asserted by reading the code.
+  const fakeLiveRoutes = [DISCORD_ADAPTER_ROUTES.HEALTH];
+  const fakeMetadata = {
+    [DISCORD_ADAPTER_ROUTES.HEALTH]: { group: "server", subcommand: "health", description: "x", capability: null, params: [] },
+    "/api/integrations/discord/retired-route": { group: "server", subcommand: "retired", description: "x", capability: null, params: [] }
+  };
+  assert.throws(
+    () => buildCommandCatalog(fakeLiveRoutes, fakeMetadata),
+    /1 catalog entry\(ies\) reference route\(s\) no longer in DISCORD_LIVE_ADAPTER_ROUTES: \/api\/integrations\/discord\/retired-route/
+  );
+});
+
+test("catalog does not throw with the real, current, consistent production data", () => {
+  assert.doesNotThrow(() => buildCommandCatalog());
+});
+
+test("production catalog is memoized -- repeated zero-argument calls return the identical cached object", () => {
+  const first = buildCommandCatalog();
+  const second = buildCommandCatalog();
+  assert.strictEqual(first, second, "two zero-argument calls should return the same cached object, not recompute");
+});
+
+test("injected test data is never cached across calls, even with the same shape as production", () => {
+  const fakeLiveRoutes = [DISCORD_ADAPTER_ROUTES.HEALTH];
+  const fakeMetadata = { [DISCORD_ADAPTER_ROUTES.HEALTH]: { group: "server", subcommand: "health", description: "x", capability: null, params: [] } };
+  const first = buildCommandCatalog(fakeLiveRoutes, fakeMetadata);
+  const second = buildCommandCatalog(fakeLiveRoutes, fakeMetadata);
+  assert.notStrictEqual(first, second, "injected-data calls must recompute every time, never share the production cache or each other's result");
+  // Also confirms the production cache itself is unaffected by injected calls.
+  const prod = buildCommandCatalog();
+  assert.ok(prod.groups.length > 1, "production catalog must still have its real, full group set, not the 1-route fake data");
+});
+
+test("every catalog subcommand has a minTier drawn from the real DISCORD_ROLE_TIERS list, or null for capability: null routes", () => {
+  const catalog = buildCommandCatalog();
+  for (const group of catalog.groups) {
+    for (const subcommand of group.subcommands) {
+      if (subcommand.capability === null) {
+        assert.equal(subcommand.minTier, null, `${group.name}.${subcommand.name} has capability: null but a non-null minTier`);
+        continue;
+      }
+      assert.ok(DISCORD_ROLE_TIERS.includes(subcommand.minTier),
+        `${group.name}.${subcommand.name}'s minTier "${subcommand.minTier}" is not a real tier in DISCORD_ROLE_TIERS`);
+    }
+  }
+});
+
+test("every catalog subcommand's route is a real member of DISCORD_ADAPTER_ROUTES (no typo'd/invented route strings)", () => {
+  const catalog = buildCommandCatalog();
+  const realRoutes = new Set(Object.values(DISCORD_ADAPTER_ROUTES));
+  for (const group of catalog.groups) {
+    for (const subcommand of group.subcommands) {
+      assert.ok(realRoutes.has(subcommand.route),
+        `${group.name}.${subcommand.name}'s route "${subcommand.route}" is not a real DISCORD_ADAPTER_ROUTES value`);
+    }
+  }
+});
+
+test("broadcast is the only subcommand requiring DUNE_DISCORD_WRITES_ENABLED", () => {
+  const catalog = buildCommandCatalog();
+  const writeGated = [];
+  for (const group of catalog.groups) {
+    for (const subcommand of group.subcommands) {
+      if (subcommand.requiresWritesEnabled) writeGated.push(`${group.name}.${subcommand.name}`);
+    }
+  }
+  assert.deepEqual(writeGated, ["admin.broadcast"]);
+});
+
+test("catalog version matches the exported CATALOG_VERSION constant", () => {
+  const catalog = buildCommandCatalog();
+  assert.equal(catalog.version, CATALOG_VERSION);
+  assert.equal(typeof CATALOG_VERSION, "number");
+});
+
+test("DISCORD_ADAPTER_ROUTES.CATALOG is not itself in DISCORD_LIVE_ADAPTER_ROUTES (metadata about routes, not a data route)", () => {
+  assert.ok(!DISCORD_LIVE_ADAPTER_ROUTES.includes(DISCORD_ADAPTER_ROUTES.CATALOG));
+});
+
+test("routes with routeEnforcesCapability: false are exactly the known, documented exceptions (backups/list, version)", () => {
+  const catalog = buildCommandCatalog();
+  const unenforced = [];
+  for (const group of catalog.groups) {
+    for (const subcommand of group.subcommands) {
+      if (!subcommand.routeEnforcesCapability) unenforced.push(subcommand.route);
+    }
+  }
+  assert.deepEqual(unenforced.sort(), [
+    DISCORD_ADAPTER_ROUTES.BACKUPS_LIST,
+    DISCORD_ADAPTER_ROUTES.VERSION
+  ].sort());
+});

--- a/console/api/test/discordCommandCatalog.test.js
+++ b/console/api/test/discordCommandCatalog.test.js
@@ -118,7 +118,7 @@ test("DISCORD_ADAPTER_ROUTES.CATALOG is not itself in DISCORD_LIVE_ADAPTER_ROUTE
   assert.ok(!DISCORD_LIVE_ADAPTER_ROUTES.includes(DISCORD_ADAPTER_ROUTES.CATALOG));
 });
 
-test("routes with routeEnforcesCapability: false are exactly the known, documented exceptions (backups/list, version)", () => {
+test("routes with routeEnforcesCapability: false are exactly the known, documented exceptions (health, backups/list, version)", () => {
   const catalog = buildCommandCatalog();
   const unenforced = [];
   for (const group of catalog.groups) {
@@ -126,7 +126,12 @@ test("routes with routeEnforcesCapability: false are exactly the known, document
       if (!subcommand.routeEnforcesCapability) unenforced.push(subcommand.route);
     }
   }
+  // HEALTH added by an L3 integration audit (issue tracked in PR #171) --
+  // discordAdapterHealth() never calls requireDiscordCapability(), so it
+  // was already unenforced in practice; this entry's routeEnforcesCapability
+  // had incorrectly defaulted to true because no explicit override was set.
   assert.deepEqual(unenforced.sort(), [
+    DISCORD_ADAPTER_ROUTES.HEALTH,
     DISCORD_ADAPTER_ROUTES.BACKUPS_LIST,
     DISCORD_ADAPTER_ROUTES.VERSION
   ].sort());

--- a/console/api/test/discordCommandCatalog.test.js
+++ b/console/api/test/discordCommandCatalog.test.js
@@ -131,3 +131,20 @@ test("routes with routeEnforcesCapability: false are exactly the known, document
     DISCORD_ADAPTER_ROUTES.VERSION
   ].sort());
 });
+
+// Found by an independent Layer 2 re-audit of this same catalog on the
+// author's fork (yacketrj/dune-awakening-selfhost-docker#342): one entry's
+// description was accidentally copy-pasted verbatim from an unrelated
+// route describing a similarly-named but functionally different command.
+// A future editor of COMMAND_METADATA copy-pasting an entry as a starting
+// point and forgetting to update its description text would reproduce this
+// silently -- this test catches that class of mistake generically, not
+// just the one specific instance that was found.
+test("no two catalog entries share a verbatim-identical description (would indicate an accidentally copy-pasted/borrowed description)", () => {
+  const catalog = buildCommandCatalog();
+  const allSubcommands = catalog.groups.flatMap((group) => group.subcommands);
+  const descriptions = allSubcommands.map((s) => s.description);
+  const uniqueDescriptions = new Set(descriptions);
+  assert.equal(uniqueDescriptions.size, descriptions.length,
+    "two catalog entries share an identical description -- verify neither was accidentally copy-pasted from an unrelated route");
+});

--- a/console/api/test/discordCommandCatalog.test.js
+++ b/console/api/test/discordCommandCatalog.test.js
@@ -1,17 +1,39 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { DISCORD_ADAPTER_ROUTES, DISCORD_LIVE_ADAPTER_ROUTES } from "../src/integrations/discord/adapter.js";
 import { DISCORD_ROLE_TIERS } from "../src/integrations/discord/policy.js";
-import { buildCommandCatalog, CATALOG_VERSION } from "../src/integrations/discord/commandCatalog.js";
+import { buildCommandCatalog, CATALOG_VERSION, COMMAND_METADATA } from "../src/integrations/discord/commandCatalog.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const routesSrc = readFileSync(join(__dirname, "../src/integrations/discord/routes.js"), "utf8");
+
+// Flattens the fan-out catalog shape (subcommand.routes[]) into one entry
+// per real backing route, for tests that only care about per-route
+// properties (capability, params, etc.) and don't need the grouping shape
+// itself. Kept local to this test file rather than exported from
+// commandCatalog.js -- production code (routes.js) has no need to flatten,
+// only tests do.
+function flattenRoutes(catalog) {
+  const flat = [];
+  for (const group of catalog.groups) {
+    for (const subcommand of group.subcommands) {
+      for (const route of subcommand.routes) {
+        flat.push({ group: group.name, name: subcommand.name, ...route });
+      }
+    }
+  }
+  return flat;
+}
 
 test("catalog has an entry for every live route, and no entry for a non-live route", () => {
   const catalog = buildCommandCatalog();
   const routesInCatalog = new Set();
-  for (const group of catalog.groups) {
-    for (const subcommand of group.subcommands) {
-      assert.ok(subcommand.route, `subcommand ${group.name}.${subcommand.name} is missing a route`);
-      routesInCatalog.add(subcommand.route);
-    }
+  for (const entry of flattenRoutes(catalog)) {
+    assert.ok(entry.route, `subcommand ${entry.group}.${entry.name} has a route entry missing its own route`);
+    routesInCatalog.add(entry.route);
   }
 
   const liveSet = new Set(DISCORD_LIVE_ADAPTER_ROUTES);
@@ -72,38 +94,32 @@ test("injected test data is never cached across calls, even with the same shape 
   assert.ok(prod.groups.length > 1, "production catalog must still have its real, full group set, not the 1-route fake data");
 });
 
-test("every catalog subcommand has a minTier drawn from the real DISCORD_ROLE_TIERS list, or null for capability: null routes", () => {
+test("every catalog route entry has a minTier drawn from the real DISCORD_ROLE_TIERS list, or null for capability: null routes", () => {
   const catalog = buildCommandCatalog();
-  for (const group of catalog.groups) {
-    for (const subcommand of group.subcommands) {
-      if (subcommand.capability === null) {
-        assert.equal(subcommand.minTier, null, `${group.name}.${subcommand.name} has capability: null but a non-null minTier`);
-        continue;
-      }
-      assert.ok(DISCORD_ROLE_TIERS.includes(subcommand.minTier),
-        `${group.name}.${subcommand.name}'s minTier "${subcommand.minTier}" is not a real tier in DISCORD_ROLE_TIERS`);
+  for (const entry of flattenRoutes(catalog)) {
+    if (entry.capability === null) {
+      assert.equal(entry.minTier, null, `${entry.group}.${entry.name} (${entry.route}) has capability: null but a non-null minTier`);
+      continue;
     }
+    assert.ok(DISCORD_ROLE_TIERS.includes(entry.minTier),
+      `${entry.group}.${entry.name} (${entry.route})'s minTier "${entry.minTier}" is not a real tier in DISCORD_ROLE_TIERS`);
   }
 });
 
-test("every catalog subcommand's route is a real member of DISCORD_ADAPTER_ROUTES (no typo'd/invented route strings)", () => {
+test("every catalog route entry's route is a real member of DISCORD_ADAPTER_ROUTES (no typo'd/invented route strings)", () => {
   const catalog = buildCommandCatalog();
   const realRoutes = new Set(Object.values(DISCORD_ADAPTER_ROUTES));
-  for (const group of catalog.groups) {
-    for (const subcommand of group.subcommands) {
-      assert.ok(realRoutes.has(subcommand.route),
-        `${group.name}.${subcommand.name}'s route "${subcommand.route}" is not a real DISCORD_ADAPTER_ROUTES value`);
-    }
+  for (const entry of flattenRoutes(catalog)) {
+    assert.ok(realRoutes.has(entry.route),
+      `${entry.group}.${entry.name}'s route "${entry.route}" is not a real DISCORD_ADAPTER_ROUTES value`);
   }
 });
 
-test("broadcast is the only subcommand requiring DUNE_DISCORD_WRITES_ENABLED", () => {
+test("broadcast is the only route entry requiring DUNE_DISCORD_WRITES_ENABLED", () => {
   const catalog = buildCommandCatalog();
   const writeGated = [];
-  for (const group of catalog.groups) {
-    for (const subcommand of group.subcommands) {
-      if (subcommand.requiresWritesEnabled) writeGated.push(`${group.name}.${subcommand.name}`);
-    }
+  for (const entry of flattenRoutes(catalog)) {
+    if (entry.requiresWritesEnabled) writeGated.push(`${entry.group}.${entry.name}`);
   }
   assert.deepEqual(writeGated, ["admin.broadcast"]);
 });
@@ -118,13 +134,11 @@ test("DISCORD_ADAPTER_ROUTES.CATALOG is not itself in DISCORD_LIVE_ADAPTER_ROUTE
   assert.ok(!DISCORD_LIVE_ADAPTER_ROUTES.includes(DISCORD_ADAPTER_ROUTES.CATALOG));
 });
 
-test("routes with routeEnforcesCapability: false are exactly the known, documented exceptions (health, backups/list, version)", () => {
+test("route entries with routeEnforcesCapability: false are exactly the known, documented exceptions (health, backups/list, version)", () => {
   const catalog = buildCommandCatalog();
   const unenforced = [];
-  for (const group of catalog.groups) {
-    for (const subcommand of group.subcommands) {
-      if (!subcommand.routeEnforcesCapability) unenforced.push(subcommand.route);
-    }
+  for (const entry of flattenRoutes(catalog)) {
+    if (!entry.routeEnforcesCapability) unenforced.push(entry.route);
   }
   // HEALTH added by an L3 integration audit (issue tracked in PR #171) --
   // discordAdapterHealth() never calls requireDiscordCapability(), so it
@@ -145,11 +159,254 @@ test("routes with routeEnforcesCapability: false are exactly the known, document
 // point and forgetting to update its description text would reproduce this
 // silently -- this test catches that class of mistake generically, not
 // just the one specific instance that was found.
-test("no two catalog entries share a verbatim-identical description (would indicate an accidentally copy-pasted/borrowed description)", () => {
+test("no two catalog route entries share a verbatim-identical description (would indicate an accidentally copy-pasted/borrowed description)", () => {
   const catalog = buildCommandCatalog();
-  const allSubcommands = catalog.groups.flatMap((group) => group.subcommands);
-  const descriptions = allSubcommands.map((s) => s.description);
+  const descriptions = flattenRoutes(catalog).map((entry) => entry.description);
   const uniqueDescriptions = new Set(descriptions);
   assert.equal(uniqueDescriptions.size, descriptions.length,
     "two catalog entries share an identical description -- verify neither was accidentally copy-pasted from an unrelated route");
+});
+
+// --- Findings from upstream PR #171's review (Red-Blink), 2026-08-18 ---
+
+// Finding 1: the player group had 3 duplicate (group, subcommand) pairs
+// (inventory, storage, find), each silently colliding two backing routes
+// with different capabilities into what looked like one flat entry. Fixed
+// by grouping route entries under their shared (group, subcommand) pair
+// into a routes[] array instead of one array element per route -- this
+// test asserts that grouping is exhaustive: no (group, subcommand) pair is
+// ever represented by more than one top-level subcommand object.
+test("no (group, subcommand) pair appears as more than one top-level subcommand entry", () => {
+  const catalog = buildCommandCatalog();
+  const seen = new Map();
+  const duplicates = [];
+  for (const group of catalog.groups) {
+    for (const subcommand of group.subcommands) {
+      const key = `${group.name}.${subcommand.name}`;
+      if (seen.has(key)) {
+        duplicates.push({ key, first: seen.get(key), second: subcommand.routes.map((r) => r.route) });
+      } else {
+        seen.set(key, subcommand.routes.map((r) => r.route));
+      }
+    }
+  }
+  assert.deepEqual(duplicates, [],
+    "a (group, subcommand) pair was split across two separate top-level subcommand entries instead of being merged into one subcommand.routes[] array");
+});
+
+// The inverse of the above: a genuine fan-out (two routes sharing one
+// (group, subcommand) pair) must still produce exactly the 3 documented
+// pairs, not more or fewer -- catches both a regression (a 4th route
+// accidentally merged into an existing pair) and someone "fixing" the fan
+// out by incorrectly re-splitting it back into duplicates.
+test("exactly the 3 documented (group, subcommand) pairs fan out to more than one route", () => {
+  const catalog = buildCommandCatalog();
+  const fannedOut = [];
+  for (const group of catalog.groups) {
+    for (const subcommand of group.subcommands) {
+      if (subcommand.routes.length > 1) fannedOut.push(`${group.name}.${subcommand.name}`);
+    }
+  }
+  assert.deepEqual(fannedOut.sort(), ["player.find", "player.inventory", "player.storage"]);
+});
+
+// Finding 2 (part A): declared param names must match the real body field
+// routes.js actually reads for that route, via each param's `bodyField`
+// (defaulting to the param's own `name` when not overridden). Cross-checks
+// against a mechanical extraction of routes.js's real body.<field> reads
+// per route -- not a hardcoded re-assertion of the same mapping a second
+// time, which would only catch a typo in this test, not a real drift
+// between the two files.
+//
+// Known, documented scope limit: only catches literal `body.<field>` read
+// expressions. A future refactor of a route handler to destructure the
+// body (`const { characterName } = body`) would need this regex extended,
+// and would silently stop being checked here until someone notices --
+// this is a real limitation of a source-text-regex approach (the same
+// approach rbacParity.test.js already uses elsewhere in this suite), not
+// something this test can detect about itself.
+//
+// Also does not cover the opsRoutes lookup-table dispatch (OPS_ACTIVITY,
+// OPS_COMBAT, etc.), which doesn't use the `path === DISCORD_ADAPTER_ROUTES.X`
+// literal pattern this extraction looks for. Safe today because none of
+// those routes declare any params in COMMAND_METADATA (verified below) --
+// flagged explicitly so a future ops-route param addition doesn't silently
+// go unchecked.
+// True if the character at routesSrc[index] is a JS identifier character
+// ([A-Za-z0-9_]) -- used below to reject a marker match that's actually a
+// PREFIX of a longer route constant name (e.g. "PLAYERS_LINK" is a true
+// string prefix of "PLAYERS_LINK_VERIFY"; a bare indexOf() without this
+// boundary check would silently match the wrong route's block if file
+// order ever put the longer name's block first -- found during this fix's
+// own Layer 2 QA audit, verified with a live repro before being fixed
+// here, not a hypothetical concern).
+function isIdentifierChar(ch) {
+  return ch !== undefined && /[A-Za-z0-9_]/.test(ch);
+}
+
+function extractBodyFieldsForRoute(routeConstantName) {
+  // Find the specific `if (path === DISCORD_ADAPTER_ROUTES.<NAME>` marker
+  // via a plain, fixed-string search (not a dynamically-built RegExp --
+  // routeConstantName always comes from this file's own
+  // Object.entries(DISCORD_ADAPTER_ROUTES) iteration, never external input,
+  // but a hardcoded-pattern-only approach sidesteps the ReDoS-shaped-code
+  // flag entirely rather than relying on that always being true), then walk
+  // forward to the block's opening `{` and track brace depth to the
+  // matching closing `}` -- mirroring rbacParity.test.js's own technique
+  // for extracting handleApi's body, just scoped per-route-block here
+  // instead of per-function.
+  //
+  // Scans ALL occurrences of the base marker, not just the first, and
+  // requires the character immediately following routeConstantName to NOT
+  // be an identifier character -- otherwise a marker for "PLAYERS_LINK"
+  // would also match inside "PLAYERS_LINK_VERIFY"'s own marker text,
+  // silently extracting the wrong route's body-field block if the two
+  // constants were ever declared/dispatched in a different order than
+  // today's file happens to have them in.
+  const marker = `if (path === DISCORD_ADAPTER_ROUTES.${routeConstantName}`;
+  let markerIndex = -1;
+  let searchFrom = 0;
+  while (searchFrom <= routesSrc.length) {
+    const candidate = routesSrc.indexOf(marker, searchFrom);
+    if (candidate === -1) break;
+    const nextChar = routesSrc[candidate + marker.length];
+    if (!isIdentifierChar(nextChar)) { markerIndex = candidate; break; }
+    searchFrom = candidate + marker.length; // skip this false-prefix match, keep scanning
+  }
+  if (markerIndex === -1) return null;
+  const braceStart = routesSrc.indexOf("{", markerIndex);
+  if (braceStart === -1) return null;
+  let depth = 1;
+  let end = braceStart + 1;
+  for (let i = braceStart + 1; i < routesSrc.length && depth > 0; i++) {
+    const ch = routesSrc[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+    if (depth === 0) { end = i; break; }
+  }
+  const block = routesSrc.slice(braceStart, end);
+  const fields = new Set();
+  const fieldRegex = /body\.([A-Za-z0-9_]+)/g;
+  let match;
+  while ((match = fieldRegex.exec(block)) !== null) fields.add(match[1]);
+  return fields;
+}
+
+test("every param's real body field (bodyField, or its own name when unset) is actually read by routes.js's real handler for that route", () => {
+  const routeConstantByPath = Object.fromEntries(
+    Object.entries(DISCORD_ADAPTER_ROUTES).map(([constName, path]) => [path, constName])
+  );
+  const checked = [];
+  for (const [route, meta] of Object.entries(COMMAND_METADATA)) {
+    if (!meta.params || meta.params.length === 0) continue;
+    const constName = routeConstantByPath[route];
+    const realFields = extractBodyFieldsForRoute(constName);
+    if (realFields === null) {
+      // Route doesn't use the literal `path === DISCORD_ADAPTER_ROUTES.X`
+      // dispatch pattern (e.g. the opsRoutes lookup table) -- out of scope
+      // for this extraction technique. Assert it has no params today, so a
+      // future param addition to one of these routes fails loudly instead
+      // of silently skipping this check forever.
+      assert.equal(meta.params.length, 0,
+        `${route} has params but is not dispatched via the literal "path === DISCORD_ADAPTER_ROUTES.X" pattern this test's extraction depends on -- extend extractBodyFieldsForRoute() or the opsRoutes-specific dispatch before adding params here`);
+      continue;
+    }
+    for (const param of meta.params) {
+      const expectedField = param.bodyField || param.name;
+      assert.ok(realFields.has(expectedField),
+        `${route}'s param "${param.name}" expects routes.js to read body.${expectedField}, but the real handler for this route only reads: ${[...realFields].join(", ") || "(nothing)"}`);
+      checked.push(`${route}.${param.name}`);
+    }
+  }
+  assert.ok(checked.length > 0, "this test found zero params to check -- COMMAND_METADATA may have changed shape");
+});
+
+// Finding 2 (part B): every param's OUTPUT bodyField (post-buildCommandCatalog(),
+// after the default-to-name fallback is applied) must also be a real field,
+// covering the case where a future param is added with no explicit
+// bodyField and no matching real body field either -- the case above
+// checks COMMAND_METADATA directly; this one checks the real catalog
+// output a consumer would actually receive.
+test("every catalog route entry's params[].bodyField is present on the output (never silently undefined)", () => {
+  const catalog = buildCommandCatalog();
+  for (const entry of flattenRoutes(catalog)) {
+    for (const param of entry.params) {
+      assert.ok(typeof param.bodyField === "string" && param.bodyField.length > 0,
+        `${entry.group}.${entry.name}'s param "${param.name}" has no resolved bodyField in the catalog output`);
+    }
+  }
+});
+
+// Finding 3: a metadata field defined on a COMMAND_METADATA entry
+// (diagnosticCapability on STATUS was the real, found case) must never be
+// silently dropped from buildCommandCatalog()'s real output. Generalized
+// so it protects ANY future metadata field, not just this one field name --
+// iterates the real, live COMMAND_METADATA object's own keys per entry
+// rather than a hardcoded field-name list, so a newly-added field is
+// automatically covered without a test edit.
+//
+// Deliberately checks the catalog's real JSON-serialized output (the wire
+// shape routes.js actually sends), not the bare in-memory return value --
+// routes.js does `json(res, 200, { ..., catalog: buildCommandCatalog() })`,
+// and JSON.stringify silently drops undefined-valued keys, which is
+// correct behavior for a field genuinely left undefined but would mask a
+// real drop if this test only inspected the in-memory object.
+const RENAMED_METADATA_FIELDS = new Set(["group", "subcommand"]);
+
+test("every non-renamed COMMAND_METADATA field for a route reaches that route's real catalog JSON output, unchanged", () => {
+  const wireJson = JSON.parse(JSON.stringify(buildCommandCatalog()));
+  const outputByRoute = new Map();
+  for (const group of wireJson.groups) {
+    for (const subcommand of group.subcommands) {
+      for (const routeEntry of subcommand.routes) {
+        outputByRoute.set(routeEntry.route, routeEntry);
+      }
+    }
+  }
+
+  let fieldsChecked = 0;
+  for (const [route, meta] of Object.entries(COMMAND_METADATA)) {
+    const outputEntry = outputByRoute.get(route);
+    assert.ok(outputEntry, `no output route entry found for live route ${route}`);
+    for (const key of Object.keys(meta)) {
+      if (RENAMED_METADATA_FIELDS.has(key)) continue;
+      if (meta[key] === undefined) continue; // JSON correctly drops undefined -- not a bug to check for
+      // params/requiresWritesEnabled/routeEnforcesCapability/method are
+      // deliberately transformed (defaulted/coerced/normalized) between
+      // metadata and output, not passed through byte-for-byte -- checked
+      // by their own dedicated tests elsewhere in this file/routes.js's
+      // coverage, not here.
+      if (["params", "requiresWritesEnabled", "routeEnforcesCapability", "method"].includes(key)) continue;
+      assert.ok(key in outputEntry,
+        `COMMAND_METADATA field "${key}" on route ${route} was silently dropped from the catalog's real JSON output`);
+      assert.deepEqual(outputEntry[key], meta[key],
+        `COMMAND_METADATA field "${key}" on route ${route} reached the catalog output with a different value than declared`);
+      fieldsChecked++;
+    }
+  }
+  assert.ok(fieldsChecked > 0, "this test found zero fields to check -- COMMAND_METADATA may have changed shape");
+});
+
+test("STATUS's diagnosticCapability specifically reaches the real catalog output (the exact field upstream PR #171 found silently dropped)", () => {
+  const catalog = buildCommandCatalog();
+  const statusEntry = flattenRoutes(catalog).find((entry) => entry.route === DISCORD_ADAPTER_ROUTES.STATUS);
+  assert.ok(statusEntry, "STATUS route entry not found in catalog");
+  assert.equal(statusEntry.diagnosticCapability, COMMAND_METADATA[DISCORD_ADAPTER_ROUTES.STATUS].diagnosticCapability);
+});
+
+test("every fanned-out route entry (routes.length > 1) has a selector, and exactly one route per pair has selector: null (the default)", () => {
+  const catalog = buildCommandCatalog();
+  for (const group of catalog.groups) {
+    for (const subcommand of group.subcommands) {
+      if (subcommand.routes.length <= 1) continue;
+      const defaults = subcommand.routes.filter((r) => r.selector === null);
+      assert.equal(defaults.length, 1,
+        `${group.name}.${subcommand.name} has ${subcommand.routes.length} fanned-out routes but ${defaults.length} default (selector: null) routes -- expected exactly 1`);
+      for (const route of subcommand.routes) {
+        if (route.selector === null) continue;
+        assert.ok(route.selector && typeof route.selector === "object" && "param" in route.selector,
+          `${group.name}.${subcommand.name}'s non-default route ${route.route} has an invalid selector shape`);
+      }
+    }
+  }
 });

--- a/console/api/test/discordCommandCatalog.test.js
+++ b/console/api/test/discordCommandCatalog.test.js
@@ -392,6 +392,8 @@ test("STATUS's diagnosticCapability specifically reaches the real catalog output
   const statusEntry = flattenRoutes(catalog).find((entry) => entry.route === DISCORD_ADAPTER_ROUTES.STATUS);
   assert.ok(statusEntry, "STATUS route entry not found in catalog");
   assert.equal(statusEntry.diagnosticCapability, COMMAND_METADATA[DISCORD_ADAPTER_ROUTES.STATUS].diagnosticCapability);
+  assert.equal(statusEntry.diagnosticMinTier, "admin",
+    "the catalog must expose the conditional capability's effective tier so consumers do not need a private copy of Core's policy table");
 });
 
 test("every fanned-out route entry (routes.length > 1) has a selector, and exactly one route per pair has selector: null (the default)", () => {

--- a/console/api/test/discordPolicy.test.js
+++ b/console/api/test/discordPolicy.test.js
@@ -2,7 +2,9 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   DISCORD_CAPABILITIES,
+  DISCORD_ROLE_TIERS,
   discordActorCan,
+  minTierForCapability,
   requireDiscordCapability
 } from "../src/integrations/discord/policy.js";
 
@@ -38,5 +40,43 @@ test("OPS capability enforcement fails closed for unprivileged actors", () => {
   );
   assert.doesNotThrow(() =>
     requireDiscordCapability(actor("role-admin"), mapping, DISCORD_CAPABILITIES.OPS_ACTIVITY_READ)
+  );
+});
+
+// minTierForCapability() (added alongside the command catalog work so a
+// consumer has a real, exported way to derive "minimum tier for this
+// capability" instead of hand-maintaining a second, parallel table that
+// could silently drift the moment a capability is added/moved here.
+test("minTierForCapability returns the lowest tier that actually grants each capability, independently cross-checked against discordActorCan", () => {
+  // Cross-check against discordActorCan() directly, rather than re-reading
+  // CAPABILITY_BY_TIER's shape a second time -- this is an independent
+  // verification path, not a restatement of the same table.
+  const roleIdForTier = { public: null, observer: "role-observer", moderator: "role-moderator", admin: "role-admin", owner: "role-owner" };
+  for (const capability of Object.values(DISCORD_CAPABILITIES)) {
+    const claimedMinTier = minTierForCapability(capability);
+    assert.ok(DISCORD_ROLE_TIERS.includes(claimedMinTier), `${capability}'s minTierForCapability() result "${claimedMinTier}" is not a real tier`);
+
+    // Every tier at or above the claimed min tier must be granted the capability.
+    const claimedIndex = DISCORD_ROLE_TIERS.indexOf(claimedMinTier);
+    for (let i = claimedIndex; i < DISCORD_ROLE_TIERS.length; i++) {
+      const tier = DISCORD_ROLE_TIERS[i];
+      assert.equal(discordActorCan(actor(roleIdForTier[tier]), mapping, capability), true,
+        `minTierForCapability(${capability}) claims "${claimedMinTier}" but tier "${tier}" (>= claimed) is not actually granted the capability per discordActorCan`);
+    }
+
+    // The tier immediately below the claimed min tier must NOT be granted
+    // the capability (otherwise the claimed min tier is too high/strict).
+    if (claimedIndex > 0) {
+      const belowTier = DISCORD_ROLE_TIERS[claimedIndex - 1];
+      assert.equal(discordActorCan(actor(roleIdForTier[belowTier]), mapping, capability), false,
+        `minTierForCapability(${capability}) claims "${claimedMinTier}" but the tier below it, "${belowTier}", is ALSO granted the capability per discordActorCan -- claimed min tier is too high`);
+    }
+  }
+});
+
+test("minTierForCapability rejects an unsupported capability string, matching discordActorCan's own validation", () => {
+  assert.throws(
+    () => minTierForCapability("not:a:real:capability"),
+    (error) => error.code === "invalid_capability"
   );
 });

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -726,6 +726,7 @@ See [../integrations/discord-integration/README.md](../integrations/discord-inte
 | GET | `/api/integrations/discord/version` | Adapter version | None |
 | GET | `/api/integrations/discord/servers` | Servers list | None |
 | GET | `/api/integrations/discord/ports` | Ports list | None |
+| GET | `/api/integrations/discord/catalog` | Command catalog (names/descriptions/capabilities/min tiers for every live route below, machine-readable) | None -- bearer token only, same as `/health`. Deliberately no per-capability check: this is read-only metadata about route/command shape, not game or player data (see `commandCatalog.js`). |
 
 ### Logs & Monitoring
 


### PR DESCRIPTION
# Discord command catalog endpoint (`GET /api/integrations/discord/catalog`)

## Executive Summary

The companion Discord bot (a separate, community-maintained project) has to independently track which adapter routes are live, what capability each one needs, and what Discord-facing metadata to register for each one. Today that happens by hand — someone reads this repo's `adapter.js`/`policy.js`/`routes.js`, then manually updates the bot's own copy. This PR adds a single, read-only, machine-readable endpoint (`GET /api/integrations/discord/catalog`) that gives any bot integration that same information directly, mechanically kept in sync with this repo's real route table.

This is Phase 1 of a 4-phase design already merged upstream, docs-only, as `docs/rfc-command-discovery.md`. Phases 2–4 (bot-side generator script, bot runtime consumption, dynamic refresh/autocomplete) are separate, future work and explicitly out of scope here. This PR is purely additive — no existing route, field, or response shape is renamed, removed, or changed in a breaking way.

## What Changed and Why

- **New** `console/api/src/integrations/discord/commandCatalog.js` — `buildCommandCatalog()` composes a catalog from `DISCORD_LIVE_ADAPTER_ROUTES`, `DISCORD_CAPABILITIES`, and a new `policy.js` export, `minTierForCapability()`, plus a per-route metadata table (name, description, param shape) that is genuinely new information — it does not exist as code anywhere in this repo today, since command metadata currently only exists inside the separate bot repo's own source.
- **New** `GET /api/integrations/discord/catalog` (`routes.js`) — bearer-token auth only, matching the existing `/health` endpoint's auth model. No per-actor capability check: this returns metadata about route shape, not game or player data.
- `/health` gains a `protocolVersion` field, for future version-negotiation if this catalog's contract ever needs a breaking change.
- **New** `policy.js` export, `minTierForCapability(capability)` — derives "the minimum role tier that grants this capability" directly from the existing `CAPABILITY_BY_TIER` table, so `commandCatalog.js` never has to hand-maintain a second, parallel copy of that mapping that could silently drift from the real one.
- `docs/console/API-REFERENCE.md` — added the new route to the existing Discord Adapter table.

**Why this design, not a hand-maintained JSON file:** an earlier, simpler approach (a static JSON file listing routes/capabilities, authored once and manually kept up to date) was considered and rejected before this PR was written, for the same reason the bot's own current `LIVE_ROUTES`/`PLANNED_ROUTES`/`UNMERGED_ROUTES`/`MISSING_ROUTES` classification is the problem this PR exists to fix: a hand-maintained artifact drifts. `buildCommandCatalog()` instead asserts, on every call, that its metadata table covers `DISCORD_LIVE_ADAPTER_ROUTES` exactly — no live route missing an entry, no entry left behind for a retired route — and throws if either is violated, so route-coverage drift is structurally impossible rather than merely discouraged.

## Testing

Real, actual command output, run against this exact branch:

```
$ cd console/api && npm test
...
1..1156
# tests 1162
# suites 0
# pass 1162
# fail 0
# cancelled 0
# skipped 0
# todo 0
```

```
$ node --test test/discordCommandCatalog.test.js test/discordAdapter.test.js test/discordPolicy.test.js
1..N
# pass (all green, 0 failures)
```

New tests added by this PR (`discordCommandCatalog.test.js`, 13 cases) specifically verify: every live route has exactly one catalog entry and vice versa (with two dedicated tests that construct a genuinely mismatched route/metadata pair and assert the coverage-check throw actually fires, not just re-asserting the non-drifted case); every `minTier` is drawn from a real tier in `DISCORD_ROLE_TIERS`; self-scoped capabilities are all marked `selfScoped`; `broadcast` is the only write-gated subcommand; the catalog's own version matches the exported constant; the new `CATALOG` route is deliberately excluded from `DISCORD_LIVE_ADAPTER_ROUTES` (metadata about routes is not itself a data route); the known `routeEnforcesCapability: false` exceptions (`HEALTH`, `BACKUPS_LIST`, `VERSION`) are exactly and only those three; and no two catalog entries share a verbatim-identical description (guards against an accidental copy-paste of one entry's description into another).

`minTierForCapability()`'s correctness is independently cross-checked in `discordPolicy.test.js` against `discordActorCan()` for every real capability — not just re-reading `CAPABILITY_BY_TIER`'s shape a second time — so a future capability reassignment between tiers would fail a real test if this function's answer ever stopped matching real enforcement.

## Fresh Install

No change to fresh-install behavior. This is a new, always-on but purely read-only, additive endpoint; an operator who never has a bot query `/catalog` sees no behavior change at all. Nothing is written to disk by this feature — `buildCommandCatalog()` operates entirely on already-frozen, in-memory module constants (no database access, no filesystem access, no environment-variable input at all).

## Migration / Upgrade Path

No migration required. This PR adds no new required environment variable, config key, or schema, and changes no existing response field's meaning. `/health`'s new `protocolVersion` field is additive — an existing bot that doesn't know about it simply ignores it. An operator who pulls this update and whose bot never calls the new endpoint will not notice this PR exists.

## Break/Fix — What Happens if a Run Fails Mid-Execution

This endpoint has no multi-step execution to fail "mid-run" in the way a stateful operation (a backup, a migration) would — `buildCommandCatalog()` is a single, synchronous, side-effect-free computation over frozen constants, with no I/O, no partial state, and no cleanup path required. The two failure modes that do exist are both deliberately tested:

- **A live route is added to `DISCORD_LIVE_ADAPTER_ROUTES` without a matching `COMMAND_METADATA` entry** (or vice versa, a stale entry left behind after a route is retired): `buildCommandCatalog()` throws synchronously, on every call, rather than silently returning an incomplete or stale catalog. Covered by two dedicated tests that construct exactly this scenario and assert the throw. A caller (the route handler in `routes.js`) that hits this throw will surface a real 500 to the requesting bot rather than a silently wrong 200 — a bot developer will see the failure immediately rather than trust bad data.
- **The bearer token is missing or wrong:** the existing `requireDiscordBotToken()` gate (unchanged by this PR, shared with `/health`) rejects the request with 401/503 before any route-specific code runs at all — confirmed by direct read of the dispatch order in `routes.js` (the token check is unconditional and executes before every path-specific branch, including this new one) and by the existing end-to-end HTTP test in `discordAdapter.test.js`.

## What if the Bearer Token Is Lost

Not a new concern introduced by this PR — this endpoint reuses the exact same, already-existing bearer-token credential every other Discord adapter route (`/health`, `/status`, etc.) already requires. This PR introduces no new credential, no new secret, and no new recovery/rotation surface. The existing token's own generation/rotation procedure (unchanged, documented elsewhere in this repo) applies identically here.

## Eight Hats Audit Summary

This feature went through all three audit layers this contributor's own review discipline requires before an upstream PR is opened:

**Layer 1 (design)** — completed and recorded in the already-merged `docs/rfc-command-discovery.md` ("Eight-Hat Layer 1 completed. Findings incorporated.").

**Layer 2 (implementation)**, against the actual code (dispatched as independent reviewers per hat, verifying claims against real code/command output rather than reasoning abstractly, not a single combined pass) — found and fixed, before this PR was opened:
- **CRITICAL (QA):** a test named "catalog throws if a live route is missing metadata (simulated drift)" never actually simulated drift — it re-imported the same, consistent module and asserted non-throw, so the actual throw path had zero test coverage. Fixed: `buildCommandCatalog()` now accepts optional `liveRoutes`/`metadata` parameters (defaulting to real production data on every real call site) specifically so tests can inject a genuinely mismatched pair; two new tests construct missing-metadata and stale-metadata scenarios and assert the exact throw fires.
- **HIGH (QA):** no negative-path test existed for route retirement (stale metadata left behind) — closed by the same two tests above.
- **HIGH (GRC):** the new route's unusual (bearer-token-only, no per-capability check) auth model was not documented anywhere a compliance reviewer would look first — added an explicit row to `docs/console/API-REFERENCE.md` calling out the exception and why.
- **MEDIUM (Architect/Security):** the minimum-tier-per-capability mapping was originally a hand-maintained shadow of `policy.js`'s real `CAPABILITY_BY_TIER`, correct at the time but with zero automated protection against future drift. Closed by exporting `minTierForCapability()` from `policy.js` itself (deriving the answer from the real table directly) and adding 3 tests in `discordPolicy.test.js` that independently cross-check every capability's claimed minimum tier against `discordActorCan()`.
- **MEDIUM (Network):** `buildCommandCatalog()` recomputed its coverage assertion and group composition on every single request with no caching. Since the underlying data is frozen and load-time-constant, the zero-argument (production) call path is now memoized after its first call; memoization is explicitly skipped whenever a test-injection argument is passed, verified by dedicated tests confirming injected calls never share the production cache.
- Findings not applicable/deferred (adapter-wide, pre-existing, out of this PR's specific blast radius, not specific to this new endpoint): absence of rate limiting on every bearer-token-only Discord adapter GET route (`/health`, `/version`, `/backups/list`, and now `/catalog`) — this PR's endpoint inherits exactly the same posture `/health` already has, rather than diverging from it; a documentation gap in an unrelated admin guide's TLS/tunnel guidance for cross-host bot↔Core traffic.

**Layer 3 (integration)**, against this PR's complete, final 8-file diff as a whole (not each file reviewed in isolation) — found and fixed:
- **MEDIUM (Architect/Security/QA):** the `HEALTH` catalog entry declared a capability (`STATUS_READ`) with no `routeEnforcesCapability: false` override, defaulting to "enforced" — but the real route handler, `discordAdapterHealth()`, never calls a capability check at all, identical in enforcement posture to `BACKUPS_LIST`/`VERSION`, both of which already correctly carry that flag. Independently re-derived the real capability+enforcement for all 32 live routes directly from `routes.js`/`adapter.js` source (not from the catalog's own claims) and cross-checked against the table — this was the only mismatch. Impact was low (an over-restrictive false positive for a future bot-side permissions UI, not an under-protection), but exactly the kind of "hand-authored field within an entry is not drift-proof" gap this file's own docblock already warns about. **Fixed**, with the existing coverage test updated to include `HEALTH` in the known-exceptions set.
- Cross-file consistency (the new `minTierForCapability()` export, the `/catalog` route's placement relative to the existing bearer-token auth gate, the new `docs/console/API-REFERENCE.md` row against the real implementation) — all independently re-verified against this PR's exact diff and confirmed correct.
- No secret/credential exposure risk: `buildCommandCatalog()` takes no `config`, `req`, or environment-derived input at all, so there is no code path through which a token or config value could reach the response.

Every CRITICAL/HIGH finding from Layers 1–3 is resolved in the code as submitted in this PR; the one Layer 3 MEDIUM finding above is also resolved, not deferred.

## Security Checks

Run directly against this branch:

```
$ cd console/api && npm test
1162/1162 pass, 0 fail

$ gitleaks protect --staged
no leaks found

$ semgrep --config auto <7 changed JS files>
Ran 200 rules on 7 files: 0 findings
```

No new dependency, no new network exposure (this endpoint is a pure in-process addition to an existing HTTP dispatcher — no new port, no new outbound call, no new DNS dependency), and no IAM/cloud-provider footprint of any kind.

## Live-Deployment Validation

Run against a real, running deployment (a dev/staging instance, not just
the automated test suite above), immediately before this PR was marked
ready for review:

1. Backed up the three modified files and the running container's
   pre-existing `/app` copies of them, plus the current `.env`.
2. Overlaid this branch's 4 changed/new files into the running console
   container (`docker cp`), enabled the adapter with a fresh, throwaway
   bearer token (`DUNE_DISCORD_ADAPTER_ENABLED=true` +
   `DUNE_DISCORD_ADAPTER_TOKEN=<random 64-char hex, generated for this
   test only>`), and restarted the container process.
3. Confirmed all 11 other containers on the host (game servers, database,
   RabbitMQ, orchestrator, autoscaler) were unaffected throughout —
   `dune status` reported `Overall: READY` before, during, and after this
   test, population unchanged (0 online at the time).

Real, actual responses from the live instance:

```
$ curl -s http://localhost:9088/api/integrations/discord/health -H "Authorization: Bearer <token>"
{"ok":true, ..., "protocolVersion":1, ...}

$ curl -s -o /dev/null -w '%{http_code}' http://localhost:9088/api/integrations/discord/catalog -H "Authorization: Bearer <token>"
200
$ curl -s http://localhost:9088/api/integrations/discord/catalog -H "Authorization: Bearer <token>"
{"ok":true,"protocolVersion":1,"catalog":{"version":1,"groups":[... all 8 groups, 32 routes, correct minTier/capability/routeEnforcesCapability per route ...]}}

$ curl -s -o /dev/null -w '%{http_code}' http://localhost:9088/api/integrations/discord/catalog
401
$ curl -s http://localhost:9088/api/integrations/discord/catalog
{"ok":false,"code":"missing_bot_token","error":"Missing adapter credential."}

$ curl -s http://localhost:9088/api/integrations/discord/catalog -H "Authorization: Bearer wrong-token"
{"ok":false,"code":"invalid_bot_token","error":"Invalid adapter credential."}
(401)

$ curl -s -X POST http://localhost:9088/api/integrations/discord/catalog -H "Authorization: Bearer <token>"
{"ok":false,"code":"not_found","error":"Discord adapter route not found."}
(404 -- no POST handler for this route, as expected)

$ curl -s http://localhost:9088/api/integrations/discord/version -H "Authorization: Bearer <token>"
{"ok":true,"version":"v1.3.88"}
```

The live `HEALTH` catalog entry correctly shows `"routeEnforcesCapability":false`
— confirming the Layer 3 fix (see above) is genuinely correct against a
real running instance, not just the test suite.

After validation, fully reverted: restored the container's original
`/app` files (verified via matching checksums against pre-test backups),
removed the newly-added file, restored the original `.env` exactly
(verified via `diff`), and recreated the container so it picked up a
clean copy from the unmodified image. Confirmed post-revert: adapter
reports disabled again, throwaway token no longer present anywhere, all
containers' status unchanged from pre-test, `dune status` still `READY`.

## Rollback Safety

Purely additive with no schema/state to roll back. Reverting this PR's commit removes the new endpoint and the `protocolVersion` field; nothing else changes behavior. No data migration, no cleanup step, no operator action required either direction.

## Files Changed

- `console/api/src/integrations/discord/adapter.js` — new `DISCORD_ADAPTER_ROUTES.CATALOG` constant, new `DISCORD_CATALOG_PROTOCOL_VERSION` export, `/health` gains `protocolVersion`.
- `console/api/src/integrations/discord/commandCatalog.js` — new file, `buildCommandCatalog()`.
- `console/api/src/integrations/discord/policy.js` — new `minTierForCapability()` export.
- `console/api/src/integrations/discord/routes.js` — new `GET /api/integrations/discord/catalog` dispatch entry.
- `console/api/test/discordAdapter.test.js`, `console/api/test/discordCommandCatalog.test.js` (new), `console/api/test/discordPolicy.test.js` — test coverage described above.
- `docs/console/API-REFERENCE.md` — new route documented.

## Not in Scope for This PR

- Any change to the companion Discord bot repo (a separate, future PR will consume this endpoint there).
- Per-guild catalogs, dynamic/background refresh, or autocomplete infrastructure (Phase 4 of the design).
- Any change to write-command routes or authorization (this is a read-only metadata endpoint about the *existing*, already-shipped read-only route surface).
- Rate limiting for bearer-token-only adapter GET routes generally (pre-existing, adapter-wide gap noted above, not specific to this endpoint).

