### PR TITLE
feat: add items to base storage containers

### DIFF
--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -402,7 +402,15 @@ export const REGEX_ACTIONS_BY_METHOD_PATTERN = [
   // destruction — folding this into that bucket would silently widen every
   // existing narrow policy. The shipped owner/admin policies grant bases:*,
   // so default access is unchanged.
-  { method: "DELETE", pattern: /^\/api\/bases\/[^/]+\/containers\/[^/]+\/items\/[^/]+$/, action: "bases:delete-item" }
+  { method: "DELETE", pattern: /^\/api\/bases\/[^/]+\/containers\/[^/]+\/items\/[^/]+$/, action: "bases:delete-item" },
+  // POST /api/bases/{baseId}/containers/{placeableId}/items — creating one
+  // stored item. Own action for the same consent reason as bases:delete-item
+  // above, read in the other direction: a bases:mutate grant predates any
+  // ability to put items into a base at all, so it cannot be read as consent
+  // to fabricate them. Note this entry is also what keeps the route off the
+  // "POST /api/bases/" → bases:mutate prefix rule; without it the route would
+  // resolve to bases:mutate silently rather than failing closed.
+  { method: "POST", pattern: /^\/api\/bases\/[^/]+\/containers\/[^/]+\/items$/, action: "bases:add-item" }
 ];
 
 // ---- Action resolution ----

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -8004,7 +8004,17 @@ export async function baseContainerSlots(db, baseId, placeableId) {
              nullif((i.stats->'FItemStackAndDurabilityStats'->1->>'DecayedMaxDurability')::numeric, 0),
              null
            ) as max_durability`
-      : "null::numeric as max_durability"
+      : "null::numeric as max_durability",
+    // Same jsonb path buildAugmentedItemStats writes on the add side
+    // (AppliedAugments[].Name paired positionally with
+    // AppliedAugmentQualities) -- read back here rather than duplicated, so
+    // the two cannot disagree about where an item's augments live.
+    hasStats
+      ? "i.stats->'FAugmentedItemStats'->1->'AppliedAugments' as applied_augments"
+      : "null::jsonb as applied_augments",
+    hasStats
+      ? "i.stats->'FAugmentedItemStats'->1->'AppliedAugmentQualities' as applied_augment_qualities"
+      : "null::jsonb as applied_augment_qualities"
   ].join(",\n           ");
   const slotOrder = hasPositionIndex ? "i.position_index nulls last, i.id" : "i.id";
   const [groups, buildingTypes, typeNames] = baseInventoryTypeParams();
@@ -8078,6 +8088,24 @@ export async function baseContainerSlots(db, baseId, placeableId) {
     const templateId = String(row.template_id || "");
     if (!templateId) continue;
     inventory.usedSlots += 1;
+    // AppliedAugments and AppliedAugmentQualities are parallel arrays (see
+    // buildAugmentedItemStats, the write side); an item with none has both as
+    // null (missing key) rather than empty arrays, and a corrupt row could
+    // have mismatched lengths -- read positionally and simply stop pairing
+    // past whichever array is shorter, rather than throwing on a display path.
+    const appliedAugments = Array.isArray(row.applied_augments) ? row.applied_augments : [];
+    const appliedQualities = Array.isArray(row.applied_augment_qualities) ? row.applied_augment_qualities : [];
+    const augments = appliedAugments
+      .map((entry, index) => {
+        const augmentTemplateId = String(entry?.Name || "");
+        if (!augmentTemplateId) return null;
+        return {
+          templateId: augmentTemplateId,
+          name: itemMetadata.get(augmentTemplateId)?.name || augmentTemplateId,
+          qualityLevel: Number(appliedQualities[index]) || 0
+        };
+      })
+      .filter((augment) => augment !== null);
     inventory.slots.push({
       itemId: String(row.item_id),
       templateId,
@@ -8092,7 +8120,8 @@ export async function baseContainerSlots(db, baseId, placeableId) {
         : Number(row.current_durability),
       maxDurability: row.max_durability === null || row.max_durability === undefined
         ? null
-        : Number(row.max_durability)
+        : Number(row.max_durability),
+      augments
     });
   }
 
@@ -8295,6 +8324,181 @@ export async function deleteBaseContainerItem(db, baseId, placeableId, itemId, {
       partial: false,
       removed: { itemId: item.item_id, templateId: item.template_id, count: stackSize, remaining: 0, ...destroyedState },
       message: `${label} was deleted from the database.`
+    };
+  });
+}
+
+// The inverse of deleteBaseContainerItem, and deliberately its neighbour: the
+// two share an ownership proof, and keeping them adjacent is what makes a
+// drift between the copies visible in a diff.
+//
+// The parameter surface is giveItemToStorage's verbatim so resolveCatalogItem's
+// output drops straight in. What it does NOT take is a slot: placement is
+// always max(position_index)+1, and there is no merging into a matching stack,
+// so one add is always exactly one new row in one new slot. Both are contracts
+// the UI states out loud -- see the placement note in the add panel.
+//
+// No `set local search_path` here, unlike its sibling above. That line exists
+// there because the shipped dune.delete_item/dune.delete_inventory_item carry
+// no search_path of their own (pg_proc.proconfig is null for both). This path
+// calls no procedure -- it is a plain schema-qualified insert -- so the line
+// would be cargo-culted noise. Its absence is meaningful.
+export async function addBaseContainerItem(db, baseId, placeableId, {
+  itemName = "", itemId = "", templateId = "",
+  quantity = 1, quality = 0, augments = [], augmentQuality = 1
+} = {}) {
+  await requireCapability(
+    await supportsBaseContainerItemAdd(db),
+    "Container item add requires dune.buildings, dune.building_instances, dune.actor_fgl_entities, dune.placeables, dune.inventories and dune.items with insertable item columns."
+  );
+  const target = intParam(baseId, "base id", 1);
+  const container = intParam(placeableId, "container id", 1);
+  const resolvedTemplate = validateTemplateId(templateId || itemId || itemName);
+  const stackSize = intParam(quantity, "quantity", 1, 1000000);
+  // 0-5, not giveItemToStorage's 0-1000000. That range is an outlier -- every
+  // other path and the entire UI treat grade as 0-5 -- and widening it here
+  // would let the console write a grade the game has no meaning for.
+  const qualityLevel = normalizeStandaloneAugmentQuality(resolvedTemplate, intParam(quality, "grade", 0, 5));
+  const augmentIds = validateAugmentIds(augments);
+  const augmentQualityLevel = normalizeAugmentQuality(augmentQuality);
+  validateAugmentsForTemplate(resolvedTemplate, augmentIds);
+  const [groups, buildingTypes, typeNames] = baseInventoryTypeParams();
+
+  return db.transaction(async (tx) => {
+    // Ownership is re-proved from the base id, never trusted from the
+    // placeable id the caller sent. The inventory_types join is what keeps
+    // this off generator and windtrap fuel inventories, which the Power and
+    // Water tabs own.
+    //
+    // for update OF inv -- not a bare `for update`, since Postgres cannot lock
+    // a CTE reference. The outer query re-joins dune.inventories purely to
+    // have a lockable relation; the copy inside the containers CTE is not one.
+    // `select distinct` stays inside the CTE for the same reason: FOR UPDATE is
+    // rejected alongside DISTINCT at the locking query level.
+    //
+    // Taking this lock BEFORE the capacity and position reads below is the
+    // whole concurrency argument, not a style choice. See the comment there.
+    const found = await tx.query(`
+      with requested_claims as (
+        select distinct b.id, afe.actor_id
+        from dune.buildings b
+        join dune.building_instances bi on bi.building_id = b.id
+        join dune.actor_fgl_entities afe on afe.entity_id = bi.owner_entity_id
+        where b.id = $1
+      ), base_entities as (
+        select distinct rc.id, claim_afe.entity_id as owner_entity_id
+        from requested_claims rc
+        join dune.actor_fgl_entities claim_afe on claim_afe.actor_id = rc.actor_id
+      ), inventory_types as (
+        select * from unnest($2::text[], $3::text[], $4::text[]) as t(group_key, building_type, type_name)
+      ), containers as (
+        select distinct p.id as placeable_id, inv.id as inventory_id,
+               it.group_key, it.type_name
+        from base_entities be
+        join dune.placeables p on p.owner_entity_id = be.owner_entity_id
+        join inventory_types it on it.building_type = lower(p.building_type)
+        join dune.inventories inv on inv.actor_id = p.id and inv.max_item_count >= 0
+        where p.is_hologram = false and p.id = $5
+      )
+      select c.placeable_id::text as placeable_id, c.inventory_id,
+             c.group_key, c.type_name,
+             coalesce(inv.max_item_count, 0)::int as max_item_count
+      from containers c
+      join dune.inventories inv on inv.id = c.inventory_id
+      order by c.inventory_id
+      limit 1
+      for update of inv`, [target, groups, buildingTypes, typeNames, container]);
+
+    const containerRow = found.rows[0];
+    if (!containerRow) throw new Error("That container was not found at the selected base.");
+    if (containerRow.group_key !== "storage") {
+      throw new Error("Items can only be added to Storage containers. Crafting and Refining contents are read-only to protect active jobs.");
+    }
+
+    // One inventory, resolved deterministically rather than chosen by the
+    // caller. A placeable can back more than one surviving inventory, but the
+    // only shipped type that does is a refinery, which is off the storage
+    // allowlist above -- so `limit 1` cannot silently pick the wrong one here.
+    // An optional inventoryId parameter is the extension point if that ever
+    // changes; it would need its own membership check against `containers`.
+    const inventoryId = containerRow.inventory_id;
+    const maxItemCount = Number(containerRow.max_item_count) || 0;
+
+    // count(*) counts ROWS, not summed stack sizes -- correct precisely
+    // because this never merges, so one add always consumes exactly one slot.
+    // A max_item_count of 0 means uncapped, matching giveItemToStorage and
+    // giveItemToPlayer; inventing a third convention for it would be worse
+    // than the unreachable edge it leaves open.
+    const count = await tx.query("select count(*)::int as count from dune.items where inventory_id = $1", [inventoryId]);
+    const currentCount = Number(count.rows[0]?.count || 0);
+    if (maxItemCount > 0 && currentCount >= maxItemCount) {
+      throw new Error(`This container is full: ${currentCount} of ${maxItemCount} slots are used. Delete an item to make room.`);
+    }
+
+    // Safe against a concurrent add despite there being no unique constraint
+    // on (inventory_id, position_index): db.transaction issues a bare `begin`,
+    // so this runs at READ COMMITTED, where the FOR UPDATE above makes a second
+    // adder block until the first commits and then re-evaluate rather than
+    // abort. These two reads are separate statements taking fresh snapshots, so
+    // the waiter sees the committed insert and computes max+1, not the stale
+    // value. The delete's `for update of i, inv` -- specifically the inv -- is
+    // what serializes a concurrent delete against this; trimming it there would
+    // silently break the guarantee here.
+    //
+    // Worst case if that reasoning ever fails: layoutSlots routes a duplicate
+    // index to the overflow list, which still renders with a working delete.
+    // Degraded display, never a lost or unreachable row.
+    const position = await tx.query("select coalesce(max(position_index), -1)::int + 1 as position_index from dune.items where inventory_id = $1", [inventoryId]);
+    const positionIndex = Number(position.rows[0]?.position_index || 0);
+
+    // No explicit durability, deliberately. buildItemStats already gives
+    // clothing and weapons a 100/100 fallback, while ore, spice and salvage get
+    // an empty stat block -- which is what real resource rows actually look
+    // like. Passing giveItemToPlayer's {current:100,max:100} here would stamp
+    // MaxDurability onto a stack of ScrapMetal, inventing state the game never
+    // wrote and that the read path would then render as a durability bar.
+    const standaloneAugment = isStandaloneAugmentTemplate(resolvedTemplate);
+    const rollPayloads = await loadAugmentRollPayloads(
+      tx,
+      standaloneAugment ? [resolvedTemplate] : augmentIds,
+      standaloneAugment ? qualityLevel : augmentQualityLevel,
+      { sourceTemplateId: resolvedTemplate }
+    );
+    const stats = buildItemStats({ templateId: resolvedTemplate, augments: augmentIds, rollPayloads });
+    const itemColumns = await columnsFor(tx, "items");
+    const insert = itemInsertShape(
+      ["inventory_id", "template_id", "stack_size", "quality_level", "position_index", "stats"],
+      [inventoryId, resolvedTemplate, stackSize, qualityLevel, positionIndex, JSON.stringify(stats)],
+      itemColumns
+    );
+    const inserted = await tx.query(`
+      insert into dune.items (${insert.columns.join(", ")})
+      values (${insert.values.map((_, index) => index === 5 ? `$${index + 1}::jsonb` : `$${index + 1}`).join(", ")})
+      returning id, template_id, stack_size, quality_level, position_index, inventory_id`, insert.values);
+    const row = inserted.rows[0];
+    if (!row) throw new Error("Stored item add did not insert the item into the database.");
+
+    const label = resolvedTemplate || "Item";
+    return {
+      ok: true,
+      baseId: target,
+      placeableId: containerRow.placeable_id,
+      inventoryId: String(inventoryId),
+      typeName: containerRow.type_name,
+      group: containerRow.group_key,
+      // Stringified because dune.items.id is bigint and every other id on this
+      // API surface is a decimal string. Reporting the slot after the fact is
+      // fine; promising one beforehand is what the UI must not do.
+      added: {
+        itemId: String(row.id),
+        templateId: row.template_id,
+        quantity: Number(row.stack_size),
+        qualityLevel: Number(row.quality_level),
+        positionIndex: Number(row.position_index),
+        augments: augmentIds.length > 0 ? augmentIds : undefined
+      },
+      capacity: { usedSlots: currentCount + 1, maxSlots: maxItemCount },
+      message: `${label} x${stackSize} was added to ${containerRow.type_name} in slot #${positionIndex}.`
     };
   });
 }
@@ -9016,6 +9220,33 @@ async function supportsBaseContainerItemDelete(db) {
 
 async function supportsPartialStackDelete(db) {
   return functionExists(db, "dune.delete_inventory_item(bigint,bigint)");
+}
+
+// Same six relations as the delete probe above, and for the same reason: the
+// add's ownership query names every one of them, and Postgres resolves a
+// relation at parse time, so a partial probe reports the capability as present
+// and then fails on use.
+//
+// No functionExists check -- the add invokes no shipped procedure, which is
+// also why it needs no search_path. Two column notes worth keeping:
+// placeables.is_hologram is probed because the query filters on it (the delete
+// probe does not, a small pre-existing gap left alone here), and
+// max_item_volume is deliberately absent -- supportsStorageGiveItem probes for
+// it but never reads it, and probing a column this path never selects would
+// make the capability narrower than the feature.
+async function supportsBaseContainerItemAdd(db) {
+  const required = [
+    "buildings", "building_instances", "actor_fgl_entities",
+    "placeables", "inventories", "items"
+  ];
+  const present = await Promise.all(required.map((table) => tableExists(db, table)));
+  if (present.some((exists) => !exists)) return false;
+  const placeableColumns = await columnsFor(db, "placeables");
+  const inventoryColumns = await columnsFor(db, "inventories");
+  const itemColumns = await columnsFor(db, "items");
+  return ["id", "owner_entity_id", "building_type", "is_hologram"].every((column) => placeableColumns.has(column)) &&
+    ["id", "actor_id", "max_item_count"].every((column) => inventoryColumns.has(column)) &&
+    ["inventory_id", "template_id", "stack_size", "quality_level", "position_index", "stats"].every((column) => itemColumns.has(column));
 }
 
 async function supportsStorageGiveItem(db) {

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -631,6 +631,7 @@ async function handleApi(req, res) {
   if (path.match(/^\/api\/bases\/[^/]+\/inventory$/) && req.method === "GET") return baseInventoryRoute(res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/containers\/[^/]+$/) && req.method === "GET") return baseContainerSlotsRoute(res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/containers\/[^/]+\/items\/[^/]+$/) && req.method === "DELETE") return baseContainerItemDeleteRoute(req, res, path);
+  if (path.match(/^\/api\/bases\/[^/]+\/containers\/[^/]+\/items$/) && req.method === "POST") return baseContainerItemAddRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/refill-water$/) && req.method === "POST") return baseRefillWaterRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/queued-water-refill$/) && req.method === "DELETE") return baseCancelQueuedWaterRefillRoute(req, res, path);
   if (path.match(/^\/api\/bases\/[^/]+\/auto-refill-water$/) && req.method === "POST") return baseAutoRefillWaterToggleRoute(req, res, path);
@@ -3067,59 +3068,93 @@ async function baseContainerSlotsRoute(res, path) {
   }
   try {
     const slots = await duneDb.baseContainerSlots(db, baseId, placeableId);
-    return json(res, 200, { ...slots, deleteSafety: await baseContainerDeleteSafety(baseId, slots.group) });
+    // Both gates on one resolve. deleteSafety keeps its name rather than being
+    // generalised: it is read across the API client, the tab, four test files
+    // and two docs pages, and an additive twin buys everything a rename would
+    // without needing a lockstep frontend/backend deploy.
+    const resolved = await resolveBaseContainerWriteSafety(baseId, slots.group);
+    return json(res, 200, {
+      ...slots,
+      deleteSafety: baseContainerWriteSafetyFor(resolved, "delete"),
+      addSafety: baseContainerWriteSafetyFor(resolved, "add")
+    });
   } catch (error) {
     return json(res, 500, { supported: false, error: redact(error?.message || "Unexpected error."), reason: redact(error?.message || "Unexpected error.") });
   }
 }
 
-async function baseContainerDeleteSafety(baseId, group = "storage") {
-  if (group && group !== "storage") {
-    return {
-      safe: false,
-      known: true,
-      map: "",
-      partitionId: 0,
-      reason: "Item deletion is available only for Storage containers. Crafting and Refining contents are read-only to protect active jobs."
-    };
+// Adds and deletes are gated on exactly the same four conditions, so the
+// decision tree is written once and only the wording varies per action. A
+// second hand-maintained copy would be worse than the small indirection: the
+// failure mode of a copy that drifts is an add permitted in a state where a
+// delete is refused, which is precisely the boundary this enforces.
+const BASE_CONTAINER_WRITE_WORDING = {
+  delete: {
+    group: "Item deletion is available only for Storage containers. Crafting and Refining contents are read-only to protect active jobs.",
+    unsupported: "The console cannot verify that this base's map is safely stopped, so item deletion is disabled.",
+    running: "deleting stored items",
+    failed: "The console could not verify that this base's map is safely stopped, so item deletion is disabled."
+  },
+  add: {
+    group: "Adding items is available only for Storage containers. Crafting and Refining contents are read-only to protect active jobs.",
+    unsupported: "The console cannot verify that this base's map is safely stopped, so adding items is disabled.",
+    running: "adding stored items",
+    failed: "The console could not verify that this base's map is safely stopped, so adding items is disabled."
   }
+};
+
+// Resolves the live-map state once. Split from the wording below so the slots
+// route can answer for both actions without paying for two baseRefillTarget
+// round-trips -- it runs observeRefillPartitions plus baseMapLocation, which is
+// not free on a request made every time the contents modal opens.
+async function resolveBaseContainerWriteSafety(baseId, group = "storage") {
+  if (group && group !== "storage") return { groupOk: false };
   try {
     const target = await duneDb.baseRefillTarget(db, baseId);
-    if (!target.queueSupported) {
-      return {
-        safe: false,
-        known: false,
-        map: target.map || "",
-        partitionId: target.partitionId || 0,
-        reason: "The console cannot verify that this base's map is safely stopped, so item deletion is disabled."
-      };
-    }
-    if (!target.writeSafeNow) {
-      const location = `${target.map || "This base's map"}${target.partitionId ? ` · Partition ${target.partitionId}` : ""}`;
-      return {
-        safe: false,
-        known: true,
-        map: target.map || "",
-        partitionId: target.partitionId || 0,
-        reason: `${location} is running. Stop that map before deleting stored items.`
-      };
-    }
     return {
-      safe: true,
-      known: true,
+      groupOk: true,
+      known: Boolean(target.queueSupported),
+      writeSafeNow: Boolean(target.queueSupported) && Boolean(target.writeSafeNow),
       map: target.map || "",
       partitionId: target.partitionId || 0,
-      reason: ""
+      threw: false
     };
   } catch {
+    return { groupOk: true, known: false, writeSafeNow: false, map: "", partitionId: 0, threw: true };
+  }
+}
+
+// Pure. `action` is "delete" or "add" and selects wording only -- never which
+// states count as safe.
+function baseContainerWriteSafetyFor(resolved, action) {
+  const wording = BASE_CONTAINER_WRITE_WORDING[action] || BASE_CONTAINER_WRITE_WORDING.delete;
+  if (!resolved.groupOk) {
+    return { safe: false, known: true, map: "", partitionId: 0, reason: wording.group };
+  }
+  const map = resolved.map || "";
+  const partitionId = resolved.partitionId || 0;
+  if (!resolved.known) {
     return {
       safe: false,
       known: false,
-      map: "",
-      partitionId: 0,
-      reason: "The console could not verify that this base's map is safely stopped, so item deletion is disabled."
+      map: resolved.threw ? "" : map,
+      partitionId: resolved.threw ? 0 : partitionId,
+      reason: resolved.threw ? wording.failed : wording.unsupported
     };
   }
+  if (!resolved.writeSafeNow) {
+    const location = `${map || "This base's map"}${partitionId ? ` · Partition ${partitionId}` : ""}`;
+    return { safe: false, known: true, map, partitionId, reason: `${location} is running. Stop that map before ${wording.running}.` };
+  }
+  return { safe: true, known: true, map, partitionId, reason: "" };
+}
+
+async function baseContainerDeleteSafety(baseId, group = "storage") {
+  return baseContainerWriteSafetyFor(await resolveBaseContainerWriteSafety(baseId, group), "delete");
+}
+
+async function baseContainerAddSafety(baseId, group = "storage") {
+  return baseContainerWriteSafetyFor(await resolveBaseContainerWriteSafety(baseId, group), "add");
 }
 
 // Phrase-gated, unlike the refills above: this destroys a player's stored item
@@ -3151,6 +3186,37 @@ async function baseContainerItemDeleteRoute(req, res, path) {
     const result = await duneDb.deleteBaseContainerItem(db, baseId, placeableId, itemId, { count });
     return { ...result, deleteSafety: safety };
   }, { baseId, placeableId, itemId });
+}
+
+// Phrase-gated despite being additive, unlike the refills below. An item that
+// lands in a player's storage is an economy write with no in-game undo, and
+// storage.give-item already sets the precedent that item creation carries a
+// phrase. The phrase is deliberately distinct from "GIVE ITEM TO STORAGE" so a
+// client replaying a give-item body cannot satisfy this gate.
+//
+// Same stopped-map rule as the delete above, re-checked inside the mutation
+// immediately before the write for the same reason: disabling the UI alone is
+// never a security or consistency boundary.
+async function baseContainerItemAddRoute(req, res, path) {
+  const parts = path.split("/");
+  const baseId = Number(decodeURIComponent(parts[3]));
+  const placeableId = Number(decodeURIComponent(parts[5]));
+  for (const id of [baseId, placeableId]) {
+    if (!Number.isInteger(id) || id < 1 || id > Number.MAX_SAFE_INTEGER) {
+      return json(res, 400, { error: "Invalid base or container ID" });
+    }
+  }
+  if (baseDeletePending(baseId)) return json(res, 409, { error: BASE_DELETE_PENDING_MESSAGE });
+  if (await baseBackedUp(baseId)) return json(res, 409, { error: BASE_BACKED_UP_MESSAGE });
+  return directDbMutation(req, res, "bases.container-item-add", "ADD ITEM TO CONTAINER", async (body) => {
+    const safety = await baseContainerAddSafety(baseId);
+    if (!safety.safe) throw new Error(safety.reason);
+    // Spread order matters: the catalog-resolved id must win over whatever
+    // templateId the client sent alongside an itemName.
+    const resolved = resolveCatalogItem(config.repoRoot, body);
+    const result = await duneDb.addBaseContainerItem(db, baseId, placeableId, { ...body, templateId: resolved.itemId });
+    return { ...result, addSafety: safety };
+  }, { baseId, placeableId });
 }
 
 // Mirrors baseRefillGeneratorsRoute: no confirmation phrase (additive and

--- a/console/api/test-support/baseContainerFixture.js
+++ b/console/api/test-support/baseContainerFixture.js
@@ -1,0 +1,248 @@
+import { withIsolatedDatabase } from "./pgIntegrationDb.js";
+
+// Shared by baseContainerItemDelete.integration.test.js and
+// baseContainerItemAdd.integration.test.js. Extracted rather than copied
+// because the SCHEMA below is the honest part of these tests: it was corrected
+// once already against .claude/dune_backup.sql (an invented `stats` default,
+// two missing actor_fgl_entities UNIQUE constraints, a NOT NULL that is not
+// real), and a second copy would silently drift on the next such correction --
+// taking the ownership-isolation guarantees with it.
+//
+// The procedures are transcribed from the shipped schema, not reinvented.
+// delete_inventory_item returning the REMAINING stack size -- and NULL only
+// when the count exceeds it -- is load-bearing: a remaining size of 0 is a
+// success, so any check treating the return as plain truthy would be wrong.
+export const CLAIM_ACTOR = 8001;
+export const BUILDING_ACTOR = 8002;
+export const ENTITY_ID = 701;
+export const CHEST = 8003;          // storagecontainer_placeable, on the allowlist
+export const GENERATOR = 8004;      // oilgenerator_placeable, NOT on the allowlist
+
+export const OTHER_CLAIM_ACTOR = 8101;
+export const OTHER_BUILDING_ACTOR = 8102;
+export const OTHER_ENTITY_ID = 801;
+export const OTHER_CHEST = 8103;
+
+// A refinery at the SAME base as CHEST. On the inventory-types allowlist but in
+// the "refining" group, so it is the fixture that proves the group check fires
+// against real data rather than only against a mocked group_key.
+export const REFINERY = 8005;
+
+// A placeable that belongs to no base at all -- no building_instances row ties
+// its entity back to a claim.
+export const ORPHAN_PLACEABLE = 8006;
+export const ORPHAN_ENTITY_ID = 702;
+
+export const SCHEMA = `
+  create schema dune;
+
+  create table dune.actors (id bigint primary key, map text, partition_id bigint, owner_account_id bigint);
+  create table dune.buildings (id bigint primary key references dune.actors(id) on delete cascade);
+  create table dune.building_instances (
+    building_id bigint not null references dune.actors(id) on delete cascade,
+    instance_id integer not null,
+    owner_entity_id bigint
+  );
+  -- Both columns are nullable in production and carry a third NOT NULL column,
+  -- plus two UNIQUE constraints. The uniques matter here: entity_id being
+  -- unique is what makes the placeables -> base_entities join single-valued,
+  -- so declaring them keeps the ownership-isolation tests honest rather than
+  -- passing because the fixture happens not to contain a duplicate.
+  create table dune.actor_fgl_entities (
+    entity_id bigint,
+    actor_id bigint references dune.actors(id) on delete cascade,
+    slot_name text not null default '',
+    constraint actor_fgl_entities_entity_id_key unique (entity_id),
+    constraint actor_fgl_no_slot_duplication unique (actor_id, slot_name)
+  );
+  create table dune.placeables (
+    id bigint primary key references dune.actors(id) on delete cascade,
+    owner_entity_id bigint,
+    building_type text,
+    is_hologram boolean not null default false
+  );
+  create table dune.permission_actor (
+    actor_id bigint primary key references dune.actors(id) on delete cascade,
+    actor_name text
+  );
+  -- actor_id is nullable in production, guarded by a CHECK that at least one
+  -- of the four owner columns is set: an inventory can belong to an exchange,
+  -- an item or a vehicle module instead of an actor. max_item_count is
+  -- nullable with no default. Declaring the loose production shape is what
+  -- lets the max_item_count >= 0 filter be exercised against a NULL.
+  create table dune.inventories (
+    id bigint primary key,
+    actor_id bigint references dune.actors(id) on delete cascade,
+    exchange_id bigint,
+    item_id bigint,
+    vehicle_module_id bigint,
+    max_item_count integer,
+    constraint valid_fkey check (actor_id is not null or exchange_id is not null
+      or item_id is not null or vehicle_module_id is not null)
+  );
+  -- The production constraints, not a convenient subset: position_index is NOT
+  -- NULL with a >= 0 check and has NO unique constraint against
+  -- (inventory_id, position_index), which is exactly why the grid has to cope
+  -- with duplicates -- and why the add's next-free-slot computation is guarded
+  -- by a row lock rather than by the database.
+  -- stats has NO default in production, so every insert must supply it; a
+  -- default here would let a seed omit it and pass a test production would
+  -- reject. id uses a sequence default rather than GENERATED ALWAYS, which
+  -- would refuse the explicit ids production accepts.
+  create sequence dune.items_id_seq;
+  create table dune.items (
+    id bigint primary key default nextval('dune.items_id_seq'),
+    inventory_id bigint references dune.inventories(id) on delete cascade,
+    stack_size bigint not null,
+    position_index bigint not null,
+    template_id text not null,
+    stats jsonb not null,
+    quality_level bigint not null default 0,
+    constraint items_position_index_check check (position_index >= 0),
+    constraint items_stack_size_check check (stack_size > 0)
+  );
+
+  -- delete_item's item-tracking log. Early-returns in production unless
+  -- dune.item_tracking_enabled is set; stubbed to a no-op so the signature and
+  -- call shape match without needing the setting.
+  create function dune._add_item_delete_log(in_item_id bigint, in_inventory_id bigint, in_template_id text)
+  returns void language plpgsql as $$ begin return; end $$;
+
+  create function dune.delete_item(in_id bigint) returns void
+  language sql as $$
+    delete from dune.items i
+    using dune.inventories inv
+    where i.inventory_id = inv.id
+      and i.id = in_id
+    returning dune._add_item_delete_log(i.id, inv.id, i.template_id);
+  $$;
+
+  create function dune.delete_inventory_item(in_item_id bigint, in_count bigint) returns bigint
+  language plpgsql as $$
+  declare
+    remaining_stack_size bigint;
+  begin
+    select into strict remaining_stack_size stack_size from dune.items where id = in_item_id;
+    remaining_stack_size := remaining_stack_size - in_count;
+    if remaining_stack_size < 0 then
+      return null;
+    end if;
+    if remaining_stack_size > 0 then
+      update dune.items set stack_size = remaining_stack_size where id = in_item_id;
+    else
+      perform dune.delete_item(in_item_id);
+    end if;
+    return remaining_stack_size;
+  end $$;
+`;
+
+export function seedBase(claimActor, buildingActor, entityId, chestId, extraPlaceables = "") {
+  return `
+    insert into dune.actors (id, map, partition_id) values (${claimActor}, 'HaggaBasin', 3);
+    insert into dune.actor_fgl_entities (entity_id, actor_id) values (${entityId}, ${claimActor});
+    insert into dune.permission_actor (actor_id, actor_name) values (${claimActor}, 'Base ${claimActor}');
+
+    insert into dune.actors (id, map, partition_id) values (${buildingActor}, 'HaggaBasin', 3);
+    insert into dune.buildings (id) values (${buildingActor});
+    insert into dune.building_instances (building_id, instance_id, owner_entity_id) values (${buildingActor}, 0, ${entityId});
+
+    insert into dune.actors (id, map, partition_id) values (${chestId}, 'HaggaBasin', 3);
+    insert into dune.placeables (id, owner_entity_id, building_type) values (${chestId}, ${entityId}, 'storagecontainer_placeable');
+    insert into dune.inventories (id, actor_id, max_item_count) values (${chestId} * 10, ${chestId}, 45);
+    ${extraPlaceables}
+  `;
+}
+
+// Two stacks of ONE template, plus a second template. The duplicate template is
+// the case the merged items[] collapses and the per-slot view must keep apart.
+export const SEED = `
+  ${seedBase(CLAIM_ACTOR, BUILDING_ACTOR, ENTITY_ID, CHEST, `
+    insert into dune.actors (id, map, partition_id) values (${GENERATOR}, 'HaggaBasin', 3);
+    insert into dune.placeables (id, owner_entity_id, building_type) values (${GENERATOR}, ${ENTITY_ID}, 'oilgenerator_placeable');
+    insert into dune.inventories (id, actor_id, max_item_count) values (${GENERATOR} * 10, ${GENERATOR}, 4);
+
+    insert into dune.actors (id, map, partition_id) values (${REFINERY}, 'HaggaBasin', 3);
+    insert into dune.placeables (id, owner_entity_id, building_type) values (${REFINERY}, ${ENTITY_ID}, 'smallorerefinery_placeable');
+    insert into dune.inventories (id, actor_id, max_item_count) values (${REFINERY} * 10, ${REFINERY}, 10);
+
+    insert into dune.actors (id, map, partition_id) values (${ORPHAN_PLACEABLE}, 'HaggaBasin', 3);
+    insert into dune.actor_fgl_entities (entity_id, actor_id) values (${ORPHAN_ENTITY_ID}, ${ORPHAN_PLACEABLE});
+    insert into dune.placeables (id, owner_entity_id, building_type) values (${ORPHAN_PLACEABLE}, ${ORPHAN_ENTITY_ID}, 'storagecontainer_placeable');
+    insert into dune.inventories (id, actor_id, max_item_count) values (${ORPHAN_PLACEABLE} * 10, ${ORPHAN_PLACEABLE}, 20);
+  `)}
+  insert into dune.items (inventory_id, template_id, stack_size, position_index, stats) values
+    (${CHEST} * 10, 'ScrapMetal', 500, 0, '{}'::jsonb),
+    (${CHEST} * 10, 'MagnetiteOre', 200, 1, '{}'::jsonb),
+    (${CHEST} * 10, 'ScrapMetal', 400, 2, '{}'::jsonb);
+  insert into dune.items (inventory_id, template_id, stack_size, position_index, stats) values
+    (${GENERATOR} * 10, 'Oil', 900, 0, '{}'::jsonb);
+
+  ${seedBase(OTHER_CLAIM_ACTOR, OTHER_BUILDING_ACTOR, OTHER_ENTITY_ID, OTHER_CHEST)}
+  insert into dune.items (inventory_id, template_id, stack_size, position_index, stats) values
+    (${OTHER_CHEST} * 10, 'Spice', 77, 0, '{}'::jsonb);
+`;
+
+// namePrefix must be unique per calling test file -- it is the first line of
+// defence against two suites colliding on a database name, independent of the
+// advisory lock withIsolatedDatabase adds.
+export function withBaseContainerDatabase(t, { namePrefix, unavailableLabel }, run) {
+  return withIsolatedDatabase(t, { namePrefix, unavailableLabel }, async (pool) => {
+    await pool.query(SCHEMA);
+    await pool.query(SEED);
+    return run(pool);
+  });
+}
+
+export async function itemsIn(pool, inventoryId) {
+  const result = await pool.query(
+    "select id, template_id, stack_size, position_index from dune.items where inventory_id = $1 order by position_index",
+    [inventoryId]);
+  return result.rows;
+}
+
+export async function itemAt(pool, inventoryId, positionIndex) {
+  const rows = await itemsIn(pool, inventoryId);
+  return rows.find((row) => Number(row.position_index) === positionIndex);
+}
+
+// Confirms a transaction is genuinely blocked on a held row lock via
+// Postgres's own wait-state, instead of inferring "still waiting" from a fixed
+// timer -- a timer proves nothing about WHY a promise has not settled, and the
+// fixed 1200ms hold this replaced was the most likely reason this file was the
+// one seen hitting the teardown race documented in pgIntegrationDb.js.
+//
+// `requested_claims` is the CTE name shared by both ownership queries. Both
+// deleteBaseContainerItem and addBaseContainerItem take FOR UPDATE there;
+// baseContainerSlots names it too but never locks, so it can never be the
+// blocked one.
+export async function waitUntilBlockedOnLock(pool, { timeoutMs = 3000, pollMs = 50, queryPattern = "%requested_claims%" } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const { rows } = await pool.query(`
+      select 1 from pg_stat_activity
+      where datname = current_database()
+        and wait_event_type = 'Lock'
+        and query ilike $1
+      limit 1`, [queryPattern]);
+    if (rows.length) return true;
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+  return false;
+}
+
+// pgIntegrationDb.js's own header documents a confirmed, external race: its
+// teardown issues a best-effort pg_terminate_backend against any connection
+// its pool.end() missed, and under load that can hit a connection a test
+// still needed, surfacing as this exact server-generated error text. A
+// single retry re-runs the WHOLE test body against a brand-new isolated
+// database and a brand-new lock scenario, so it cannot mask a real locking
+// bug -- if the locking were actually broken, the retry would fail
+// identically, not intermittently.
+export async function retryOnTransientDisconnect(fn) {
+  try {
+    return await fn();
+  } catch (error) {
+    if (!/terminating connection due to administrator command/.test(error?.message || "")) throw error;
+    return await fn();
+  }
+}

--- a/console/api/test/baseContainerItemAdd.integration.test.js
+++ b/console/api/test/baseContainerItemAdd.integration.test.js
@@ -1,0 +1,290 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { addBaseContainerItem, deleteBaseContainerItem } from "../src/duneDb.js";
+import { pgConnectionConfig, pgTransactionalDb } from "../test-support/pgIntegrationDb.js";
+import pg from "pg";
+import {
+  BUILDING_ACTOR,
+  CHEST,
+  GENERATOR,
+  ORPHAN_PLACEABLE,
+  OTHER_CHEST,
+  REFINERY,
+  itemsIn,
+  retryOnTransientDisconnect,
+  waitUntilBlockedOnLock,
+  withBaseContainerDatabase
+} from "../test-support/baseContainerFixture.js";
+
+// Real PostgreSQL rather than a mocked db. Three of the guarantees this feature
+// rests on cannot be proved by string-matching SQL: that the ownership query
+// actually isolates one base's containers from another's and from the fuel
+// inventories the Power tab owns, that `for update of inv` actually serializes
+// two adds onto distinct slots when the schema has no unique constraint to
+// catch a collision, and that an add genuinely blocks on the lock a delete
+// holds rather than racing past it.
+//
+// The schema and seed are shared with the delete suite; see
+// test-support/baseContainerFixture.js.
+const CHEST_INVENTORY = CHEST * 10;
+const GENERATOR_INVENTORY = GENERATOR * 10;
+const OTHER_CHEST_INVENTORY = OTHER_CHEST * 10;
+const REFINERY_INVENTORY = REFINERY * 10;
+const ORPHAN_INVENTORY = ORPHAN_PLACEABLE * 10;
+
+function withDatabase(t, run) {
+  return withBaseContainerDatabase(t, {
+    namePrefix: "dune_container_item_add",
+    unavailableLabel: "the base container item add integration test"
+  }, run);
+}
+
+const SCRAP = { itemId: "ScrapMetal", quantity: 25 };
+
+test("real PostgreSQL: an add lands in the next free slot and leaves every existing row untouched", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const before = await itemsIn(pool, CHEST_INVENTORY);
+    assert.deepEqual(before.map((row) => Number(row.position_index)), [0, 1, 2]);
+
+    const result = await addBaseContainerItem(db, BUILDING_ACTOR, CHEST, SCRAP);
+    assert.equal(result.ok, true);
+    assert.equal(result.added.positionIndex, 3);
+    assert.equal(result.group, "storage");
+
+    const after = await itemsIn(pool, CHEST_INVENTORY);
+    assert.equal(after.length, 4);
+    // The three pre-existing rows are byte-identical -- an add must not
+    // renumber, reorder or restack anything already in the box.
+    assert.deepEqual(after.slice(0, 3), before);
+    assert.equal(Number(after[3].position_index), 3);
+    assert.equal(Number(after[3].stack_size), 25);
+  });
+});
+
+test("real PostgreSQL: an add to an empty container starts at slot zero", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    // The orphan chest has an inventory but no items -- coalesce(max(...), -1)+1
+    // is the branch that has to produce 0 rather than NULL or 1.
+    await pool.query("delete from dune.items where inventory_id = $1", [CHEST_INVENTORY]);
+    const result = await addBaseContainerItem(db, BUILDING_ACTOR, CHEST, SCRAP);
+    assert.equal(result.added.positionIndex, 0);
+    const rows = await itemsIn(pool, CHEST_INVENTORY);
+    assert.equal(rows.length, 1);
+    assert.equal(Number(rows[0].position_index), 0);
+  });
+});
+
+test("real PostgreSQL: another base's container cannot be reached through this base", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    // A real placeable with a real inventory -- just not one whose entity chain
+    // resolves to BUILDING_ACTOR's claim.
+    await assert.rejects(
+      () => addBaseContainerItem(db, BUILDING_ACTOR, OTHER_CHEST, SCRAP),
+      /not found at the selected base/
+    );
+    const rows = await itemsIn(pool, OTHER_CHEST_INVENTORY);
+    assert.equal(rows.length, 1, "the other base's chest is unchanged");
+    assert.equal(rows[0].template_id, "Spice");
+  });
+});
+
+test("real PostgreSQL: a generator's fuel inventory cannot be reached", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    // Same base, same entity, real inventory -- excluded only by the
+    // inventory_types allowlist join. This is the case that join buys, and the
+    // Power tab owns this inventory.
+    await assert.rejects(
+      () => addBaseContainerItem(db, BUILDING_ACTOR, GENERATOR, SCRAP),
+      /not found at the selected base/
+    );
+    const rows = await itemsIn(pool, GENERATOR_INVENTORY);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].template_id, "Oil");
+    assert.equal(Number(rows[0].stack_size), 900);
+  });
+});
+
+test("real PostgreSQL: a refinery at the same base is refused as a non-storage group", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    // On the allowlist, so the ownership query resolves it -- and then the
+    // group check is what refuses it. A refining slot can be referenced by an
+    // active job, so it stays read-only even with the map stopped.
+    await assert.rejects(
+      () => addBaseContainerItem(db, BUILDING_ACTOR, REFINERY, SCRAP),
+      /only be added to Storage containers/
+    );
+    assert.equal((await itemsIn(pool, REFINERY_INVENTORY)).length, 0);
+  });
+});
+
+test("real PostgreSQL: a placeable that belongs to no base is refused", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    await assert.rejects(
+      () => addBaseContainerItem(db, BUILDING_ACTOR, ORPHAN_PLACEABLE, SCRAP),
+      /not found at the selected base/
+    );
+    assert.equal((await itemsIn(pool, ORPHAN_INVENTORY)).length, 0);
+  });
+});
+
+test("real PostgreSQL: a full container refuses the add and inserts nothing", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    // Fill the 45-slot chest exactly. count(*) counts rows, so this is full at
+    // 45 regardless of how large the stacks are.
+    await pool.query(`
+      insert into dune.items (inventory_id, template_id, stack_size, position_index, stats)
+      select $1, 'Filler', 1, generate_series(3, 44), '{}'::jsonb`, [CHEST_INVENTORY]);
+    assert.equal((await itemsIn(pool, CHEST_INVENTORY)).length, 45);
+
+    await assert.rejects(
+      () => addBaseContainerItem(db, BUILDING_ACTOR, CHEST, SCRAP),
+      /full: 45 of 45/
+    );
+    assert.equal((await itemsIn(pool, CHEST_INVENTORY)).length, 45, "nothing was inserted");
+  });
+});
+
+test("real PostgreSQL: an add never merges into an existing stack of the same template", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    // Slot 0 already holds 500 ScrapMetal. Adding more must be a new row, not a
+    // top-up -- the add panel states this contract to the operator out loud.
+    const result = await addBaseContainerItem(db, BUILDING_ACTOR, CHEST, { itemId: "ScrapMetal", quantity: 300 });
+    assert.equal(result.added.positionIndex, 3);
+
+    const rows = await itemsIn(pool, CHEST_INVENTORY);
+    const scrap = rows.filter((row) => row.template_id === "ScrapMetal");
+    assert.equal(scrap.length, 3, "three separate ScrapMetal rows, not two");
+    assert.equal(Number(rows[0].stack_size), 500, "slot 0 is untouched");
+    assert.deepEqual(scrap.map((row) => Number(row.stack_size)).sort((a, b) => a - b), [300, 400, 500]);
+  });
+});
+
+test("real PostgreSQL: the inserted row always carries non-null stats", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    // dune.items.stats is NOT NULL with NO default in production, so an insert
+    // that omitted it would raise rather than default -- this pins that the
+    // column is always in the insert list.
+    const result = await addBaseContainerItem(db, BUILDING_ACTOR, CHEST, SCRAP);
+    const { rows } = await pool.query("select stats from dune.items where id = $1", [result.added.itemId]);
+    assert.equal(rows.length, 1);
+    assert.notEqual(rows[0].stats, null);
+    // A resource gets an empty stat block, not invented durability.
+    assert.deepEqual(rows[0].stats.FItemStackAndDurabilityStats, [[], {}]);
+  });
+});
+
+test("real PostgreSQL: an item id above Number.MAX_SAFE_INTEGER survives as a string", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    await pool.query("select setval('dune.items_id_seq', 9007199254740993)");
+    const result = await addBaseContainerItem(db, BUILDING_ACTOR, CHEST, SCRAP);
+    assert.equal(typeof result.added.itemId, "string");
+    // Round-trips exactly: a Number cast anywhere in the path would have
+    // rounded this to an id that does not exist.
+    const { rows } = await pool.query("select id::text as id from dune.items where id = $1", [result.added.itemId]);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].id, result.added.itemId);
+    assert.ok(Number(result.added.itemId) > Number.MAX_SAFE_INTEGER);
+  });
+});
+
+// The two locking tests below open a second connection deliberately, so they
+// cannot use the shared pool's transactional wrapper for both sides.
+async function withSecondConnection(database, run) {
+  const client = new pg.Client(pgConnectionConfig(database));
+  await client.connect();
+  try {
+    return await run(client);
+  } finally {
+    await client.end().catch(() => {});
+  }
+}
+
+test("real PostgreSQL: two concurrent adds serialize onto distinct slots", async (t) => {
+  await retryOnTransientDisconnect(() => withDatabase(t, async (pool) => {
+    return withSecondConnection(await currentDatabase(pool), async (client) => {
+      // A holds the inventory row. B's ownership query must block on it rather
+      // than racing ahead to read the same max(position_index).
+      await client.query("begin");
+      await client.query("select id from dune.inventories where id = $1 for update", [CHEST_INVENTORY]);
+
+      const db = pgTransactionalDb(pool);
+      const pending = addBaseContainerItem(db, BUILDING_ACTOR, CHEST, SCRAP);
+      assert.equal(await waitUntilBlockedOnLock(pool), true, "the add must block on the held row lock");
+
+      // A inserts at slot 3 and commits. B then re-evaluates under READ
+      // COMMITTED, sees the committed row, and must compute 4 -- not 3.
+      await client.query(`
+        insert into dune.items (inventory_id, template_id, stack_size, position_index, stats)
+        values ($1, 'Water', 10, 3, '{}'::jsonb)`, [CHEST_INVENTORY]);
+      await client.query("commit");
+
+      const result = await pending;
+      assert.equal(result.added.positionIndex, 4, "the waiter must not reuse the slot taken while it blocked");
+
+      const rows = await itemsIn(pool, CHEST_INVENTORY);
+      const indices = rows.map((row) => Number(row.position_index));
+      assert.deepEqual(indices, [0, 1, 2, 3, 4]);
+      assert.equal(new Set(indices).size, indices.length, "no two rows share a slot");
+    });
+  }));
+});
+
+test("real PostgreSQL: an add blocks while a delete holds its item and inventory lock", async (t) => {
+  await retryOnTransientDisconnect(() => withDatabase(t, async (pool) => {
+    return withSecondConnection(await currentDatabase(pool), async (client) => {
+      // What this proves, precisely: WHEN a transaction holds the lock
+      // deleteBaseContainerItem takes, an add blocks on it and then reads
+      // max(position_index) fresh. That is a statement about the ADD's
+      // locking, and it was verified by mutation -- removing the add's
+      // `for update of inv` makes this test fail.
+      //
+      // What it does NOT prove: that the delete still takes `inv` in its lock
+      // list. The lock below is this test's own SQL, so trimming production's
+      // to `for update of i` leaves this green -- also confirmed by mutation.
+      // The guard for that is the unit assertion in db.test.js, "container
+      // item delete locks the item and its inventory rather than the CTE".
+      // Both are needed; neither covers the other.
+      const target = (await itemsIn(pool, CHEST_INVENTORY)).find((row) => Number(row.position_index) === 2);
+      await client.query("begin");
+      await client.query(
+        "select i.id from dune.items i join dune.inventories inv on inv.id = i.inventory_id where i.id = $1 for update of i, inv",
+        [target.id]);
+
+      const db = pgTransactionalDb(pool);
+      const pending = addBaseContainerItem(db, BUILDING_ACTOR, CHEST, SCRAP);
+      assert.equal(await waitUntilBlockedOnLock(pool), true, "the add must block on the delete's inventory lock");
+
+      // Release by deleting the top slot, exactly as the real delete would.
+      await client.query("delete from dune.items where id = $1", [target.id]);
+      await client.query("commit");
+
+      const result = await pending;
+      // Slot 2 is free again, so the next free index is 2, not 3 -- the add
+      // read max(position_index) AFTER the delete committed, which is the
+      // whole point of having waited.
+      assert.equal(result.added.positionIndex, 2);
+      const indices = (await itemsIn(pool, CHEST_INVENTORY)).map((row) => Number(row.position_index));
+      assert.deepEqual(indices, [0, 1, 2]);
+      assert.equal(new Set(indices).size, indices.length);
+    });
+  }));
+});
+
+// The delete is imported so the suite fails to load if the two functions ever
+// drift apart in signature; it is exercised for real by its own suite.
+assert.equal(typeof deleteBaseContainerItem, "function");
+
+async function currentDatabase(pool) {
+  const { rows } = await pool.query("select current_database() as name");
+  return rows[0].name;
+}

--- a/console/api/test/baseContainerItemDelete.integration.test.js
+++ b/console/api/test/baseContainerItemDelete.integration.test.js
@@ -1,7 +1,19 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { baseContainerSlots, deleteBaseContainerItem } from "../src/duneDb.js";
-import { pgTransactionalDb, withIsolatedDatabase } from "../test-support/pgIntegrationDb.js";
+import { pgTransactionalDb } from "../test-support/pgIntegrationDb.js";
+import {
+  BUILDING_ACTOR,
+  CHEST,
+  GENERATOR,
+  OTHER_BUILDING_ACTOR,
+  OTHER_CHEST,
+  itemAt,
+  itemsIn,
+  retryOnTransientDisconnect,
+  waitUntilBlockedOnLock,
+  withBaseContainerDatabase
+} from "../test-support/baseContainerFixture.js";
 
 // Real PostgreSQL rather than a mocked db, for the same reason
 // baseDelete.integration.test.js uses it: the guarantees that matter here are
@@ -10,227 +22,14 @@ import { pgTransactionalDb, withIsolatedDatabase } from "../test-support/pgInteg
 // row lock, that a failed verification actually rolls back the write, and that
 // the shipped procedures behave as the code assumes.
 //
-// The procedures below are transcribed from the shipped schema
-// (.claude/dune_backup.sql), not reinvented. delete_inventory_item returning
-// the REMAINING stack size -- and NULL only when the count exceeds it -- is
-// load-bearing: a remaining size of 0 is a success, so any check that treats
-// the return as a plain truthy value would be wrong.
-const CLAIM_ACTOR = 8001;
-const BUILDING_ACTOR = 8002;
-const ENTITY_ID = 701;
-const CHEST = 8003;          // storagecontainer_placeable, on the allowlist
-const GENERATOR = 8004;      // oilgenerator_placeable, NOT on the allowlist
-
-const OTHER_CLAIM_ACTOR = 8101;
-const OTHER_BUILDING_ACTOR = 8102;
-const OTHER_ENTITY_ID = 801;
-const OTHER_CHEST = 8103;
-
-const SCHEMA = `
-  create schema dune;
-
-  create table dune.actors (id bigint primary key, map text, partition_id bigint, owner_account_id bigint);
-  create table dune.buildings (id bigint primary key references dune.actors(id) on delete cascade);
-  create table dune.building_instances (
-    building_id bigint not null references dune.actors(id) on delete cascade,
-    instance_id integer not null,
-    owner_entity_id bigint
-  );
-  -- Both columns are nullable in production and carry a third NOT NULL column,
-  -- plus two UNIQUE constraints. The uniques matter here: entity_id being
-  -- unique is what makes the placeables -> base_entities join single-valued,
-  -- so declaring them keeps the ownership-isolation tests honest rather than
-  -- passing because the fixture happens not to contain a duplicate.
-  create table dune.actor_fgl_entities (
-    entity_id bigint,
-    actor_id bigint references dune.actors(id) on delete cascade,
-    slot_name text not null default '',
-    constraint actor_fgl_entities_entity_id_key unique (entity_id),
-    constraint actor_fgl_no_slot_duplication unique (actor_id, slot_name)
-  );
-  create table dune.placeables (
-    id bigint primary key references dune.actors(id) on delete cascade,
-    owner_entity_id bigint,
-    building_type text,
-    is_hologram boolean not null default false
-  );
-  create table dune.permission_actor (
-    actor_id bigint primary key references dune.actors(id) on delete cascade,
-    actor_name text
-  );
-  -- actor_id is nullable in production, guarded by a CHECK that at least one
-  -- of the four owner columns is set: an inventory can belong to an exchange,
-  -- an item or a vehicle module instead of an actor. max_item_count is
-  -- nullable with no default. Declaring the loose production shape is what
-  -- lets the max_item_count >= 0 filter be exercised against a NULL.
-  create table dune.inventories (
-    id bigint primary key,
-    actor_id bigint references dune.actors(id) on delete cascade,
-    exchange_id bigint,
-    item_id bigint,
-    vehicle_module_id bigint,
-    max_item_count integer,
-    constraint valid_fkey check (actor_id is not null or exchange_id is not null
-      or item_id is not null or vehicle_module_id is not null)
-  );
-  -- The production constraints, not a convenient subset: position_index is NOT
-  -- NULL with a >= 0 check and has NO unique constraint against
-  -- (inventory_id, position_index), which is exactly why the grid has to cope
-  -- with duplicates. stack_size > 0 is why a partial removal to zero must go
-  -- through delete_item rather than an UPDATE.
-  -- stats has NO default in production, so every insert must supply it; a
-  -- default here would let a seed omit it and pass a test production would
-  -- reject. id uses a sequence default rather than GENERATED ALWAYS, which
-  -- would refuse the explicit ids production accepts.
-  create sequence dune.items_id_seq;
-  create table dune.items (
-    id bigint primary key default nextval('dune.items_id_seq'),
-    inventory_id bigint references dune.inventories(id) on delete cascade,
-    stack_size bigint not null,
-    position_index bigint not null,
-    template_id text not null,
-    stats jsonb not null,
-    quality_level bigint not null default 0,
-    constraint items_position_index_check check (position_index >= 0),
-    constraint items_stack_size_check check (stack_size > 0)
-  );
-
-  -- delete_item's item-tracking log. Early-returns in production unless
-  -- dune.item_tracking_enabled is set; stubbed to a no-op so the signature and
-  -- call shape match without needing the setting.
-  create function dune._add_item_delete_log(in_item_id bigint, in_inventory_id bigint, in_template_id text)
-  returns void language plpgsql as $$ begin return; end $$;
-
-  create function dune.delete_item(in_id bigint) returns void
-  language sql as $$
-    delete from dune.items i
-    using dune.inventories inv
-    where i.inventory_id = inv.id
-      and i.id = in_id
-    returning dune._add_item_delete_log(i.id, inv.id, i.template_id);
-  $$;
-
-  create function dune.delete_inventory_item(in_item_id bigint, in_count bigint) returns bigint
-  language plpgsql as $$
-  declare
-    remaining_stack_size bigint;
-  begin
-    select into strict remaining_stack_size stack_size from dune.items where id = in_item_id;
-    remaining_stack_size := remaining_stack_size - in_count;
-    if remaining_stack_size < 0 then
-      return null;
-    end if;
-    if remaining_stack_size > 0 then
-      update dune.items set stack_size = remaining_stack_size where id = in_item_id;
-    else
-      perform dune.delete_item(in_item_id);
-    end if;
-    return remaining_stack_size;
-  end $$;
-`;
-
-function seedBase(claimActor, buildingActor, entityId, chestId, extraPlaceables = "") {
-  return `
-    insert into dune.actors (id, map, partition_id) values (${claimActor}, 'HaggaBasin', 3);
-    insert into dune.actor_fgl_entities (entity_id, actor_id) values (${entityId}, ${claimActor});
-    insert into dune.permission_actor (actor_id, actor_name) values (${claimActor}, 'Base ${claimActor}');
-
-    insert into dune.actors (id, map, partition_id) values (${buildingActor}, 'HaggaBasin', 3);
-    insert into dune.buildings (id) values (${buildingActor});
-    insert into dune.building_instances (building_id, instance_id, owner_entity_id) values (${buildingActor}, 0, ${entityId});
-
-    insert into dune.actors (id, map, partition_id) values (${chestId}, 'HaggaBasin', 3);
-    insert into dune.placeables (id, owner_entity_id, building_type) values (${chestId}, ${entityId}, 'storagecontainer_placeable');
-    insert into dune.inventories (id, actor_id, max_item_count) values (${chestId} * 10, ${chestId}, 45);
-    ${extraPlaceables}
-  `;
-}
-
-// Two stacks of ONE template, plus a second template. The duplicate template is
-// the case the merged items[] collapses and the per-slot view must keep apart.
-const SEED = `
-  ${seedBase(CLAIM_ACTOR, BUILDING_ACTOR, ENTITY_ID, CHEST, `
-    insert into dune.actors (id, map, partition_id) values (${GENERATOR}, 'HaggaBasin', 3);
-    insert into dune.placeables (id, owner_entity_id, building_type) values (${GENERATOR}, ${ENTITY_ID}, 'oilgenerator_placeable');
-    insert into dune.inventories (id, actor_id, max_item_count) values (${GENERATOR} * 10, ${GENERATOR}, 4);
-  `)}
-  insert into dune.items (inventory_id, template_id, stack_size, position_index, stats) values
-    (${CHEST} * 10, 'ScrapMetal', 500, 0, '{}'::jsonb),
-    (${CHEST} * 10, 'MagnetiteOre', 200, 1, '{}'::jsonb),
-    (${CHEST} * 10, 'ScrapMetal', 400, 2, '{}'::jsonb);
-  insert into dune.items (inventory_id, template_id, stack_size, position_index, stats) values
-    (${GENERATOR} * 10, 'Oil', 900, 0, '{}'::jsonb);
-
-  ${seedBase(OTHER_CLAIM_ACTOR, OTHER_BUILDING_ACTOR, OTHER_ENTITY_ID, OTHER_CHEST)}
-  insert into dune.items (inventory_id, template_id, stack_size, position_index, stats) values
-    (${OTHER_CHEST} * 10, 'Spice', 77, 0, '{}'::jsonb);
-`;
-
-async function withDatabase(t, run) {
-  return withIsolatedDatabase(t, {
+// The schema, seed and helpers live in test-support/baseContainerFixture.js so
+// the add suite exercises byte-identical production constraints -- see that
+// file's header for why a second copy would be a liability.
+function withDatabase(t, run) {
+  return withBaseContainerDatabase(t, {
     namePrefix: "dune_container_item_delete",
     unavailableLabel: "the base container item delete integration test"
-  }, async (pool) => {
-    await pool.query(SCHEMA);
-    await pool.query(SEED);
-    return run(pool);
-  });
-}
-
-async function itemsIn(pool, inventoryId) {
-  const result = await pool.query(
-    "select id, template_id, stack_size, position_index from dune.items where inventory_id = $1 order by position_index",
-    [inventoryId]);
-  return result.rows;
-}
-
-async function itemAt(pool, inventoryId, positionIndex) {
-  const rows = await itemsIn(pool, inventoryId);
-  return rows.find((row) => Number(row.position_index) === positionIndex);
-}
-
-// Confirms the delete's ownership query is genuinely blocked on the held row
-// lock via Postgres's own wait-state, instead of inferring "still waiting"
-// from a fixed timer. `requested_claims` is the CTE name unique to
-// deleteBaseContainerItem's ownership query -- baseContainerSlots names it
-// too, but that query never takes FOR UPDATE, so it can't be the blocked one.
-// A timer proves nothing about WHY a promise hasn't settled, and this test
-// used to be the only one in the file that held two connections open for a
-// fixed 1200ms regardless of how quickly the block was real -- the most
-// likely reason it was the one seen to hit the teardown race documented in
-// pgIntegrationDb.js's header (see retryOnTransientDisconnect below). Polling
-// removes that fixed hold time: the common case resolves in well under
-// 100ms, same as every other test in this file.
-async function waitUntilBlockedOnLock(pool, { timeoutMs = 3000, pollMs = 50 } = {}) {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const { rows } = await pool.query(`
-      select 1 from pg_stat_activity
-      where datname = current_database()
-        and wait_event_type = 'Lock'
-        and query ilike '%requested_claims%'
-      limit 1`);
-    if (rows.length) return true;
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
-  }
-  return false;
-}
-
-// pgIntegrationDb.js's own header documents a confirmed, external race: its
-// teardown issues a best-effort pg_terminate_backend against any connection
-// its pool.end() missed, and under load that can hit a connection a test
-// still needed, surfacing as this exact server-generated error text. A
-// single retry re-runs the WHOLE test body against a brand-new isolated
-// database and a brand-new lock scenario, so it cannot mask a real locking
-// bug -- if deleteBaseContainerItem's locking were actually broken, the
-// retry would fail identically, not intermittently.
-async function retryOnTransientDisconnect(fn) {
-  try {
-    return await fn();
-  } catch (error) {
-    if (!/terminating connection due to administrator command/.test(error?.message || "")) throw error;
-    return await fn();
-  }
+  }, run);
 }
 
 test("real PostgreSQL: baseContainerSlots returns one entry per slot, keeping two stacks of one template apart", async (t) => {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -17,7 +17,7 @@ import {
   queueGeneratorRefill,
   supportsGeneratorRefillQueue
 } from "../src/duneDb.js";
-import { addCurrency, addFactionReputation, addGuildMember, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, addSpecializationXp, applyLandsraadMilestonePreset, augmentInventoryItem, augmentNewestPlayerItem, baseContainerSlots, baseGeneratorFuelLevels, baseGenerators, baseIsBackedUp, changeDunePassword, completeJourneyNode, completeTutorial, dbStatus, deleteBaseContainerItem, deleteInventoryItem, demoteGuildMember, disbandGuild, exportBaseAsBlueprint, generatorUptimePolicy, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listBases, listGuilds, listPlayers, listRoutines, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerBuildingUnlockState, playerCraftingRecipes, playerCurrency, playerFactions, playerIntel, playerInventory, playerInventoryAll, playerJourney, playerPortalSnapshots, playerPosition, playerProfile, playerProgression, playerResearchItems, playerSolarisCoinTotal, playerVitals, portalGeneratorFuel, portalVehicles, promoteGuildMember, refillBaseGenerators, removeGuildMember, repairFactionReputation, repairVehicleDecay, resetJourneyNode, resetTutorial, routineDefinition, runSql, setLandsraadPlayerContribution, setPlayerFaction, supportsGeneratorRefill, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError, _resetPlayerTargetCacheForTests } from "../src/duneDb.js";
+import { addBaseContainerItem, addCurrency, addFactionReputation, addGuildMember, addIntel, addonLeadershipPlayers, addonOpsHealthFarms, addonOpsHealthPlayers, addonOpsHealthSummary, addonOpsHealthSummaryV2, addSpecializationXp, applyLandsraadMilestonePreset, augmentInventoryItem, augmentNewestPlayerItem, baseContainerSlots, baseGeneratorFuelLevels, baseGenerators, baseIsBackedUp, changeDunePassword, completeJourneyNode, completeTutorial, dbStatus, deleteBaseContainerItem, deleteInventoryItem, demoteGuildMember, disbandGuild, exportBaseAsBlueprint, generatorUptimePolicy, giveItemToPlayer, giveItemToStorage, guildMembers, landsraadOverview, listBases, listGuilds, listPlayers, listRoutines, listSpicefieldTypes, listTables, liveMapPlayers, liveMapServices, playerBuildingUnlockState, playerCraftingRecipes, playerCurrency, playerFactions, playerIntel, playerInventory, playerInventoryAll, playerJourney, playerPortalSnapshots, playerPosition, playerProfile, playerProgression, playerResearchItems, playerSolarisCoinTotal, playerVitals, portalGeneratorFuel, portalVehicles, promoteGuildMember, refillBaseGenerators, removeGuildMember, repairFactionReputation, repairVehicleDecay, resetJourneyNode, resetTutorial, routineDefinition, runSql, setLandsraadPlayerContribution, setPlayerFaction, supportsGeneratorRefill, tablePreview, teleportOfflinePlayerToCoords, unlockCraftingRecipe, unlockResearchItem, updateInventoryItem, updateLandsraadRewardTier, updateLandsraadTaskGoal, updateLandsraadTermTaskGoals, updateSpicefieldType, updateTableRow, UnsupportedCapabilityError, _resetPlayerTargetCacheForTests } from "../src/duneDb.js";
 import { listStorage, liveMapBases, liveMapStorage, trackPlayerPlaytime } from "../src/duneDb.js";
 
 beforeEach(() => {
@@ -3787,6 +3787,324 @@ test("container item delete degrades to null state fields on a schema without th
   assert.ok(!query.text.includes("i.position_index"), "must not select a column this schema lacks");
 });
 
+// Container-item add. The inverse of the delete above and, like it, mostly a
+// story about the ownership query -- plus two contracts the UI states out loud
+// and the backend has to actually keep: never merge into an existing stack, and
+// always append to the next free slot.
+function fakeContainerAddDb(calls, fixtures = {}) {
+  const {
+    containerRows = [],
+    count = 0,
+    maxPositionIndex = -1,
+    augmentRollRows = [],
+    insertedRows = null,
+    itemColumns = ["id", "inventory_id", "stack_size", "position_index", "template_id", "stats", "quality_level"],
+    tables = null
+  } = fixtures;
+  const run = async (text, values = []) => {
+    calls.push({ text, values });
+    if (text.includes("to_regclass")) {
+      if (!tables) return { rows: [{ exists: true }] };
+      const name = String(values[0] || "");
+      return { rows: [{ exists: tables.some((table) => name.includes(table)) }] };
+    }
+    if (text.includes("to_regprocedure")) return { rows: [{ exists: true }] };
+    if (text.includes("information_schema.columns")) {
+      // columnsFor passes [schema, table], so the table name is values[1].
+      const table = String(values[1] || "");
+      if (table === "items") return { rows: itemColumns.map((column_name) => ({ column_name })) };
+      if (table === "inventories") {
+        return { rows: ["id", "actor_id", "max_item_count", "max_item_volume"].map((column_name) => ({ column_name })) };
+      }
+      if (table === "placeables") {
+        return { rows: (fixtures.placeableColumns
+          || ["id", "owner_entity_id", "building_type", "is_hologram"]).map((column_name) => ({ column_name })) };
+      }
+      return { rows: itemColumns.map((column_name) => ({ column_name })) };
+    }
+    if (text.includes("requested_claims")) return { rows: containerRows };
+    if (text.includes("count(*)::int as count")) return { rows: [{ count }] };
+    if (text.includes("max(position_index)")) return { rows: [{ position_index: maxPositionIndex + 1 }] };
+    if (text.includes("FAugmentItemStats")) return { rows: augmentRollRows };
+    if (text.includes("FAugmentedItemStats")) return { rows: [] };
+    if (text.includes("insert into dune.items")) {
+      return {
+        rows: insertedRows || [{
+          id: "9007199254740999", template_id: values[1], stack_size: values[2],
+          quality_level: values[3], position_index: values[4], inventory_id: values[0]
+        }]
+      };
+    }
+    return { rows: [] };
+  };
+  return { query: run, transaction: async (fn) => fn({ query: run }) };
+}
+
+const CONTAINER_ADD_ROW = {
+  placeable_id: "42", inventory_id: 7, group_key: "storage",
+  type_name: "Small Storage Container", max_item_count: 45
+};
+
+const insertCalls = (calls) => calls.filter((call) => call.text.includes("insert into dune.items"));
+
+test("container item add resolves ownership through the base before inserting", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW] });
+  const result = await addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 5 });
+  assert.equal(result.ok, true);
+  const ownership = calls.find((call) => call.text.includes("requested_claims"));
+  assert.ok(ownership, "ownership query ran");
+  // The base constrains the lookup; a placeable id alone must never reach a row.
+  assert.equal(ownership.values[0], 16836);
+  assert.equal(ownership.values[4], 42);
+  const insert = insertCalls(calls)[0];
+  assert.equal(insert.values[0], 7);
+  assert.equal(insert.values[1], "ScrapMetal");
+  assert.equal(insert.values[2], 5);
+});
+
+test("container item add locks the inventory row rather than the CTE", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW] });
+  await addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 });
+  const ownership = calls.find((call) => call.text.includes("requested_claims"));
+  // Postgres cannot lock a CTE reference, so the outer query re-joins the real
+  // relation purely to have something lockable.
+  assert.match(ownership.text, /for update of inv/);
+  assert.ok(!/for update\s*$/.test(ownership.text.trim().replace(/for update of inv/, "")),
+    "must not also take a bare for update");
+});
+
+test("container item add takes the inventory lock before reading capacity and position", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW] });
+  await addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 });
+  // Ordering is the entire concurrency argument: reading capacity or max slot
+  // before the lock would let two adders compute the same next index.
+  const lockAt = calls.findIndex((call) => call.text.includes("for update of inv"));
+  const countAt = calls.findIndex((call) => call.text.includes("count(*)::int as count"));
+  const positionAt = calls.findIndex((call) => call.text.includes("max(position_index)"));
+  assert.ok(lockAt >= 0 && countAt > lockAt, "capacity read must follow the lock");
+  assert.ok(positionAt > lockAt, "position read must follow the lock");
+});
+
+test("container item add refuses a container that is not at the requested base", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [] });
+  await assert.rejects(
+    () => addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 }),
+    /not found at the selected base/
+  );
+  assert.equal(insertCalls(calls).length, 0);
+});
+
+test("container item add refuses a non-storage container", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, {
+    containerRows: [{ ...CONTAINER_ADD_ROW, group_key: "refining", type_name: "Ore Refinery" }]
+  });
+  await assert.rejects(
+    () => addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 }),
+    /only be added to Storage containers/
+  );
+  assert.equal(insertCalls(calls).length, 0);
+});
+
+test("container item add refuses a full container", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW], count: 45 });
+  await assert.rejects(
+    () => addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 }),
+    /full: 45 of 45/
+  );
+  assert.equal(insertCalls(calls).length, 0);
+});
+
+test("container item add treats a max_item_count of zero as uncapped", async () => {
+  const calls = [];
+  // Matches giveItemToStorage and giveItemToPlayer. No shipped storage type has
+  // 0, but inventing a third convention for it would be worse than the edge.
+  const db = fakeContainerAddDb(calls, {
+    containerRows: [{ ...CONTAINER_ADD_ROW, max_item_count: 0 }],
+    count: 9999
+  });
+  const result = await addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 });
+  assert.equal(result.ok, true);
+  assert.equal(insertCalls(calls).length, 1);
+});
+
+test("container item add appends to the next free slot", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW], count: 8, maxPositionIndex: 7 });
+  const result = await addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 });
+  assert.equal(insertCalls(calls)[0].values[4], 8);
+  assert.equal(result.added.positionIndex, 8);
+});
+
+test("container item add starts an empty container at slot zero", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW], count: 0, maxPositionIndex: -1 });
+  await addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 });
+  assert.equal(insertCalls(calls)[0].values[4], 0);
+});
+
+test("container item add never merges into an existing stack of the same template", async () => {
+  const calls = [];
+  // The container already holds ScrapMetal. Adding more must still be one new
+  // row in one new slot -- this is a contract the add panel states out loud.
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW], count: 1, maxPositionIndex: 0 });
+  await addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 300 });
+  assert.equal(insertCalls(calls).length, 1);
+  assert.equal(calls.some((call) => /update\s+dune\.items/i.test(call.text)), false,
+    "must not update an existing row");
+  assert.equal(insertCalls(calls)[0].values[4], 1);
+});
+
+test("container item add leaves a resource stack without invented durability", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW] });
+  await addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 300 });
+  const stats = JSON.parse(insertCalls(calls)[0].values[5]);
+  // Real ore rows carry an empty stat block. Stamping MaxDurability onto scrap
+  // would invent state the game never wrote, and the read path would then
+  // render a durability bar for it.
+  assert.deepEqual(stats.FItemStackAndDurabilityStats, [[], {}]);
+});
+
+test("container item add gives a weapon full durability without being asked", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, {
+    containerRows: [CONTAINER_ADD_ROW],
+    augmentRollRows: [{ template_id: "T6_Augment_Melee1", stats: { FAugmentItemStats: [[], { StatRolls: [1], AppliedEffectIndices: [] }] } }]
+  });
+  await addBaseContainerItem(db, 16836, 42, {
+    itemId: "UniqueSword_05", quantity: 1, quality: 0, augments: ["T6_Augment_Melee1"]
+  });
+  const stats = JSON.parse(insertCalls(calls)[0].values[5]);
+  // Comes from buildItemStats' own fallback, not from an explicit durability
+  // argument -- which is exactly why resources above stay empty.
+  assert.equal(stats.FItemStackAndDurabilityStats[1].CurrentDurability, 100);
+});
+
+test("container item add rejects augments on an item that cannot take them", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW] });
+  await assert.rejects(
+    () => addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1, augments: ["T6_Augment_Melee1"] }),
+    /Only clothing and weapons support augments/
+  );
+  assert.equal(insertCalls(calls).length, 0);
+});
+
+test("container item add rejects more augments than the item allows", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW] });
+  await assert.rejects(
+    () => addBaseContainerItem(db, 16836, 42, {
+      itemId: "UniqueSword_05",
+      quantity: 1,
+      augments: ["T6_Augment_Melee1", "T6_Augment_Melee2", "T6_Augment_Melee3", "T6_Augment_Melee4"]
+    }),
+    /supports up to 3 augment/
+  );
+  assert.equal(insertCalls(calls).length, 0);
+});
+
+test("container item add rejects an out-of-range quantity", async () => {
+  for (const quantity of [0, -1, 1.5, 1000001]) {
+    const calls = [];
+    const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW] });
+    await assert.rejects(
+      () => addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity }),
+      /quantity/i,
+      `quantity ${quantity} must be refused`
+    );
+    assert.equal(insertCalls(calls).length, 0);
+  }
+});
+
+test("container item add rejects a grade outside 0-5", async () => {
+  const calls = [];
+  // giveItemToStorage allows 0-1000000, which is an outlier -- every other path
+  // and the whole UI treat grade as 0-5, and this must not widen that.
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW] });
+  await assert.rejects(
+    () => addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1, quality: 6 }),
+    /grade/i
+  );
+  assert.equal(insertCalls(calls).length, 0);
+});
+
+test("container item add is unsupported when any relation its query names is missing", async () => {
+  const all = ["buildings", "building_instances", "actor_fgl_entities", "placeables", "inventories", "items"];
+  for (const missing of all) {
+    const calls = [];
+    // Postgres resolves relations at parse time, so a missing buildings raises
+    // exactly as hard as a missing items -- a partial probe would report the
+    // capability present and then fail on use.
+    const db = fakeContainerAddDb(calls, {
+      containerRows: [CONTAINER_ADD_ROW],
+      tables: all.filter((table) => table !== missing)
+    });
+    await assert.rejects(
+      () => addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 }),
+      /Container item add requires/,
+      `a schema without ${missing} must report unsupported`
+    );
+    assert.equal(insertCalls(calls).length, 0);
+  }
+});
+
+test("container item add is unsupported when placeables lacks is_hologram", async () => {
+  const calls = [];
+  // The ownership query filters on it, so its absence is a parse error, not a
+  // null -- the delete's probe misses this, which is why this one checks.
+  const db = fakeContainerAddDb(calls, {
+    containerRows: [CONTAINER_ADD_ROW],
+    placeableColumns: ["id", "owner_entity_id", "building_type"]
+  });
+  await assert.rejects(
+    () => addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 }),
+    /Container item add requires/
+  );
+  assert.equal(insertCalls(calls).length, 0);
+});
+
+test("container item add calls no shipped procedure and sets no search_path", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW] });
+  await addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 });
+  // The delete needs `set local search_path` because dune.delete_item carries
+  // none of its own. This path invokes no procedure, so the line would be
+  // cargo-culted noise -- its absence is deliberate and worth pinning.
+  assert.equal(calls.some((call) => /set local search_path/.test(call.text)), false);
+  assert.equal(calls.some((call) => /dune\.delete_/.test(call.text)), false);
+});
+
+test("container item add returns the new item id as a string", async () => {
+  const calls = [];
+  // dune.items.id is bigint; a Number cast is silent precision loss above 2^53.
+  const db = fakeContainerAddDb(calls, {
+    containerRows: [CONTAINER_ADD_ROW],
+    insertedRows: [{
+      id: "9007199254741001", template_id: "ScrapMetal", stack_size: 1,
+      quality_level: 0, position_index: 0, inventory_id: 7
+    }]
+  });
+  const result = await addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 });
+  assert.equal(typeof result.added.itemId, "string");
+  assert.equal(result.added.itemId, "9007199254741001");
+});
+
+test("container item add reports capacity after the insert", async () => {
+  const calls = [];
+  const db = fakeContainerAddDb(calls, { containerRows: [CONTAINER_ADD_ROW], count: 8, maxPositionIndex: 7 });
+  const result = await addBaseContainerItem(db, 16836, 42, { itemId: "ScrapMetal", quantity: 1 });
+  assert.deepEqual(result.capacity, { usedSlots: 9, maxSlots: 45 });
+  assert.equal(result.group, "storage");
+  assert.equal(result.inventoryId, "7");
+});
+
 // baseContainerSlots: the per-slot read the contents overlay and its delete
 // both rest on. Deliberately separate from baseInventory, whose items[] stays
 // template-merged.
@@ -3893,6 +4211,67 @@ test("baseContainerSlots degrades rather than failing when dune.items lacks the 
   assert.match(query.text, /null::bigint as position_index/);
   assert.ok(!query.text.includes("i.position_index"), "must not select a column this schema lacks");
   assert.match(query.text, /null::numeric as max_durability/);
+});
+
+test("baseContainerSlots extracts an item's applied augments with their own per-augment grade", async () => {
+  const calls = [];
+  // Same jsonb shape buildAugmentedItemStats writes on the add side:
+  // AppliedAugments[].Name paired positionally with AppliedAugmentQualities.
+  // An id unlikely to be in the real catalog, so the assertion doesn't depend
+  // on what the catalog happens to contain -- it must fall back to the id.
+  const db = fakeContainerSlotsDb(calls, {
+    rows: [{
+      ...SLOT_ROW, item_id: "1", template_id: "UniqueSword_05", stack_size: 1, position_index: 0,
+      applied_augments: [{ Name: "T6_Augment_UnitTestFixture1" }, { Name: "T6_Augment_UnitTestFixture2" }],
+      applied_augment_qualities: [2, 3]
+    }]
+  });
+  const result = await baseContainerSlots(db, 16836, 40001);
+  assert.deepEqual(result.inventories[0].slots[0].augments, [
+    { templateId: "T6_Augment_UnitTestFixture1", name: "T6_Augment_UnitTestFixture1", qualityLevel: 2 },
+    { templateId: "T6_Augment_UnitTestFixture2", name: "T6_Augment_UnitTestFixture2", qualityLevel: 3 }
+  ]);
+});
+
+test("baseContainerSlots reports an empty augments array for an item with none", async () => {
+  const calls = [];
+  const db = fakeContainerSlotsDb(calls, {
+    rows: [{ ...SLOT_ROW, item_id: "1", template_id: "ScrapMetal", stack_size: 500, position_index: 0 }]
+  });
+  const result = await baseContainerSlots(db, 16836, 40001);
+  // Not undefined, not null -- the frontend's `.length > 0` check needs a
+  // real array on every slot, augmented or not.
+  assert.deepEqual(result.inventories[0].slots[0].augments, []);
+});
+
+test("baseContainerSlots does not throw on a shorter qualities array than augments", async () => {
+  const calls = [];
+  // A corrupt or hand-edited row; the display path should degrade, not 500.
+  const db = fakeContainerSlotsDb(calls, {
+    rows: [{
+      ...SLOT_ROW, item_id: "1", template_id: "UniqueSword_05", stack_size: 1, position_index: 0,
+      applied_augments: [{ Name: "T6_Augment_UnitTestFixture1" }, { Name: "T6_Augment_UnitTestFixture2" }],
+      applied_augment_qualities: [2]
+    }]
+  });
+  const result = await baseContainerSlots(db, 16836, 40001);
+  assert.deepEqual(
+    result.inventories[0].slots[0].augments.map((augment) => augment.qualityLevel),
+    [2, 0]
+  );
+});
+
+test("baseContainerSlots degrades augments to an empty array on a schema without stats", async () => {
+  const calls = [];
+  const db = fakeContainerSlotsDb(calls, {
+    itemColumns: ["id", "inventory_id", "stack_size", "template_id"],
+    rows: [{ ...SLOT_ROW, item_id: "1", template_id: "ScrapMetal", stack_size: 500, position_index: null }]
+  });
+  const result = await baseContainerSlots(db, 16836, 40001);
+  assert.deepEqual(result.inventories[0].slots[0].augments, []);
+  const query = calls.find((call) => call.text.includes("requested_claims"));
+  assert.match(query.text, /null::jsonb as applied_augments/);
+  assert.match(query.text, /null::jsonb as applied_augment_qualities/);
 });
 
 test("baseContainerSlots scopes to the base and keeps the container allowlist filters", async () => {

--- a/console/api/test/policy.test.js
+++ b/console/api/test/policy.test.js
@@ -73,6 +73,43 @@ test("bases:delete-item can be withheld independently of bases:mutate", () => {
   assert.equal(evaluate({ tier: "admin" }, "bases:delete-item", policies), true);
 });
 
+// Same argument as the delete above, read in the other direction: a
+// bases:mutate grant predates any ability to put items into a base at all, so
+// it cannot be read as consent to fabricate them.
+test("bases:add-item can be withheld independently of bases:mutate", () => {
+  const policies = {
+    owner: { version: 1, tier: "owner", statements: [{ Effect: "Allow", Action: "*" }] },
+    moderator: {
+      version: 1,
+      tier: "moderator",
+      statements: [{ Effect: "Allow", Action: ["bases:read", "bases:mutate", "bases:delete-item"] }]
+    },
+    admin: { version: 1, tier: "admin", statements: [{ Effect: "Allow", Action: "bases:*" }] }
+  };
+  assert.equal(setPolicies(policies).ok, true);
+  // Even a policy that already grants the sibling destructive action does not
+  // carry creation with it -- the two are independently grantable.
+  assert.equal(evaluate({ tier: "moderator" }, "bases:delete-item", policies), true);
+  assert.equal(evaluate({ tier: "moderator" }, "bases:add-item", policies), false);
+  assert.equal(evaluate({ tier: "admin" }, "bases:add-item", policies), true);
+});
+
+// This assertion is the only real gate on the new route's IAM entry.
+// rbacParity's extractRoutes cannot see a `path.match(...) && req.method`
+// route, and an unmatched POST under /api/bases/ falls through to the
+// bases:mutate prefix rule -- so a missing pattern entry would be silently
+// permissive rather than failing closed.
+test("the container item add route resolves to bases:add-item without shadowing its neighbours", () => {
+  assert.equal(actionForRoute("/api/bases/5/containers/9/items", "POST"), "bases:add-item");
+  // Every other base POST keeps the shared mutate bucket.
+  assert.equal(actionForRoute("/api/bases/5/refill-generators", "POST"), "bases:mutate");
+  assert.equal(actionForRoute("/api/bases/5/refill-water", "POST"), "bases:mutate");
+  assert.equal(actionForRoute("/api/bases/5/permissions", "PUT"), "bases:mutate");
+  // The sibling delete is unaffected: its path carries a trailing item id, so
+  // the two patterns cannot match the same request.
+  assert.equal(actionForRoute("/api/bases/5/containers/9/items/77", "DELETE"), "bases:delete-item");
+});
+
 test("the container item delete route resolves to bases:delete-item without shadowing its neighbours", () => {
   assert.equal(actionForRoute("/api/bases/5/containers/9/items/77", "DELETE"), "bases:delete-item");
   // The base delete and the cancellation routes must keep their own actions --

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -160,6 +160,9 @@ export type BaseInventorySlot = {
   qualityLevel: number;
   currentDurability: number | null;
   maxDurability: number | null;
+  // Always an array, empty for an item with none -- never undefined, so a
+  // plain `.length > 0` check is enough to decide whether to render a line.
+  augments: { templateId: string; name: string; qualityLevel: number }[];
 };
 
 // Slots hang off an inventory rather than the container because a placeable can
@@ -190,6 +193,7 @@ export type BaseContainerSlots = {
   inventories: BaseContainerInventory[];
   reason?: string;
   deleteSafety?: BaseContainerDeleteSafety;
+  addSafety?: BaseContainerAddSafety;
 };
 
 // Item deletion is deliberately fail-closed: only plain storage on a map that
@@ -200,6 +204,24 @@ export type BaseContainerDeleteSafety = {
   map: string;
   partitionId: number;
   reason: string;
+};
+
+// Structurally identical to the delete gate, and gated on the same four
+// conditions -- only the wording of `reason` differs, so the operator reads a
+// sentence about the thing they actually tried to do. Aliased rather than
+// reused so that if the two ever need to diverge (adds queueable while a
+// running map holds, say) doing so does not silently retype the other one.
+export type BaseContainerAddSafety = BaseContainerDeleteSafety;
+
+// Mirrors giveItemToStorage's parameter surface. `quality` is the item grade
+// (0-5); `augmentQuality` is the grade rolled onto each selected augment.
+export type AddContainerItemRequest = {
+  itemId?: string;
+  itemName?: string;
+  quantity: number;
+  quality?: number;
+  augments?: string[];
+  augmentQuality?: number;
 };
 
 // How much of one item a single container holds. `name` is the container's,
@@ -414,6 +436,34 @@ export const basesApi = {
       reason?: string;
     }>(`/api/bases/${encodeURIComponent(baseId)}/containers/${encodeURIComponent(placeableId)}/items/${encodeURIComponent(itemId)}`,
       { method: "DELETE", body: JSON.stringify(count === undefined ? { confirmation } : { confirmation, count }) }),
+  // Creates a stored item. Always inserts a NEW row -- it never tops up a
+  // matching stack -- and always appends to the next free slot. There is no
+  // slot parameter by design: clicking an empty cell in the grid is a shortcut
+  // to the form, not a placement target, so nothing in the UI may promise one.
+  addContainerItem: (baseId: string, placeableId: string, item: AddContainerItemRequest, confirmation: string) =>
+    post<{
+      supported: boolean;
+      result?: {
+        ok: boolean;
+        inventoryId: string;
+        typeName: string;
+        group: BaseInventoryGroupKey;
+        added: {
+          itemId: string;
+          templateId: string;
+          quantity: number;
+          qualityLevel: number;
+          positionIndex: number;
+          augments?: string[];
+        };
+        capacity: { usedSlots: number; maxSlots: number };
+        message: string;
+        addSafety: BaseContainerAddSafety;
+      };
+      error?: string;
+      reason?: string;
+    }>(`/api/bases/${encodeURIComponent(baseId)}/containers/${encodeURIComponent(placeableId)}/items`,
+      { ...item, confirmation }),
   // A refill for a map that is currently running comes back as
   // `result.queued`: the write is deferred to the next time that map is down.
   refillWater: (baseId: string) =>

--- a/console/web/src/components/common/ItemCatalog.tsx
+++ b/console/web/src/components/common/ItemCatalog.tsx
@@ -67,7 +67,7 @@ export function ItemCatalogSelector({ label = "Select Item", selected, onSelect,
         <tbody>{filteredItems.map((item) => {
           const active = selected?.id === item.id && selected?.name === item.name;
           const fullName = catalogItemName(item);
-          return <tr className={active ? "active" : ""} key={`${item.id}-${item.name}-${item.source}`} title={fullName} onClick={() => onSelect(item)}>
+          return <tr className={active ? "active" : ""} key={`${item.id}-${item.name}-${item.source}`} title={fullName} onClick={() => onSelect(active ? null : item)}>
             <td><CatalogItemThumb item={item} small /></td>
             <td className="catalog-item-name-cell">{fullName}</td>
             <td>{item.id}</td>
@@ -78,7 +78,7 @@ export function ItemCatalogSelector({ label = "Select Item", selected, onSelect,
       </table> : filteredItems.map((item) => {
         const active = selected?.id === item.id && selected?.name === item.name;
         const fullName = catalogItemName(item);
-        return <button type="button" className={`catalog-item-option ${active ? "active" : ""}`} key={`${item.id}-${item.name}-${item.source}`} title={fullName} onClick={() => onSelect(item)}>
+        return <button type="button" className={`catalog-item-option ${active ? "active" : ""}`} key={`${item.id}-${item.name}-${item.source}`} title={fullName} onClick={() => onSelect(active ? null : item)}>
           <CatalogItemThumb item={item} />
           <span>
             <strong>{fullName}</strong>
@@ -151,8 +151,17 @@ export function ItemGradeSelect({ value, onChange, minGrade = 0, disabled = fals
   </select>;
 }
 
-export function catalogItemName(item: { itemName?: string; itemId?: string }) {
+// Polymorphic over two different item shapes on purpose: a queued/given
+// package item, which carries `itemName` (checked first, unchanged), and a
+// CatalogItem from ItemCatalogSelector's own loaded list, which carries
+// `name` instead -- that field was never checked here, so every catalog
+// picker (grid title and list view's "Item Name" column alike) fell through
+// to prettifying the raw id and looked like the id shown twice, once
+// formatted and once raw. Package items never carry `name`, so this addition
+// cannot change their behavior.
+export function catalogItemName(item: { itemName?: string; name?: string; itemId?: string }) {
   if (item.itemName) return item.itemName;
+  if (item.name) return item.name;
   if (item.itemId) return friendlyCatalogName(item.itemId);
   return "Unknown";
 }

--- a/console/web/src/components/common/ItemCatalogSelector.test.tsx
+++ b/console/web/src/components/common/ItemCatalogSelector.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ItemCatalogSelector, type CatalogItem } from "./ItemCatalog";
+
+vi.mock("../../api/admin", () => ({
+  adminApi: {
+    itemCatalog: vi.fn(async () => ({
+      rows: [
+        { itemId: "ScrapMetal", id: "ScrapMetal", name: "Scrap Metal", category: "resource", source: "Resources" },
+        { itemId: "PlantFiber", id: "PlantFiber", name: "Plant Fiber", category: "resource", source: "Resources" }
+      ]
+    }))
+  }
+}));
+
+// This is the one place the shared click-to-deselect behavior actually
+// lives (BaseInventoryTab's add panel just consumes it), so it's tested here
+// directly rather than only indirectly through one of the three panels that
+// embed this component.
+function Harness() {
+  const [selected, setSelected] = useState<CatalogItem | null>(null);
+  return <ItemCatalogSelector selected={selected} onSelect={setSelected} />;
+}
+
+describe("ItemCatalogSelector click-to-select", () => {
+  it("selects on grid click, then clears on a second click of the same tile", async () => {
+    render(<Harness />);
+    await waitFor(() => expect(screen.getAllByRole("button", { name: /Scrap Metal/ }).length).toBeGreaterThan(0));
+
+    const tile = screen.getByRole("button", { name: /Scrap Metal/ });
+    fireEvent.click(tile);
+    await waitFor(() => expect(tile.className).toMatch(/active/));
+    expect(screen.getByText("Item Name")).toBeTruthy();
+
+    fireEvent.click(tile);
+    await waitFor(() => expect(tile.className).not.toMatch(/active/));
+    expect(screen.queryByText("Item Name")).toBeNull();
+  });
+
+  it("selecting a different tile switches selection rather than toggling the first off", async () => {
+    render(<Harness />);
+    await waitFor(() => expect(screen.getAllByRole("button", { name: /Scrap Metal/ }).length).toBeGreaterThan(0));
+
+    const scrap = screen.getByRole("button", { name: /Scrap Metal/ });
+    const fiber = screen.getByRole("button", { name: /Plant Fiber/ });
+    fireEvent.click(scrap);
+    await waitFor(() => expect(scrap.className).toMatch(/active/));
+
+    fireEvent.click(fiber);
+    await waitFor(() => expect(fiber.className).toMatch(/active/));
+    expect(scrap.className).not.toMatch(/active/);
+  });
+
+  it("selects on list-row click, then clears on a second click of the same row", async () => {
+    render(<Harness />);
+    await waitFor(() => expect(screen.getAllByRole("button", { name: /Scrap Metal/ }).length).toBeGreaterThan(0));
+    fireEvent.click(screen.getByRole("button", { name: "List view" }));
+    await waitFor(() => expect(screen.getByRole("table")).toBeTruthy());
+
+    const row = screen.getByText("Scrap Metal").closest("tr")!;
+    fireEvent.click(row);
+    await waitFor(() => expect(row.className).toMatch(/active/));
+
+    fireEvent.click(row);
+    await waitFor(() => expect(row.className).not.toMatch(/active/));
+  });
+});

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -8,7 +8,23 @@ vi.mock("../../api/bases", () => ({
   basesApi: {
     inventory: vi.fn(),
     containerSlots: vi.fn(),
-    deleteContainerItem: vi.fn()
+    deleteContainerItem: vi.fn(),
+    addContainerItem: vi.fn()
+  }
+}));
+
+// The add panel mounts ItemCatalogSelector, which fetches the full item
+// catalog, and separately loads the augment subset. Neither is what these
+// tests are about, so both resolve empty -- the item is selected by driving
+// the selector's own input instead.
+vi.mock("../../api/admin", () => ({
+  adminApi: {
+    itemCatalog: vi.fn(async () => ({
+      rows: [
+        { itemId: "ScrapMetal", id: "ScrapMetal", name: "Scrap Metal", category: "resource", source: "Resources" },
+        { itemId: "UniqueSword_05", id: "UniqueSword_05", name: "Karpov 38", category: "weapon", source: "Weapons" }
+      ]
+    }))
   }
 }));
 
@@ -82,15 +98,16 @@ const SLOTS: BaseContainerSlots = {
   maxSlots: 45,
   usedSlots: 3,
   deleteSafety: { safe: true, known: true, map: "HaggaBasin", partitionId: 1, reason: "" },
+  addSafety: { safe: true, known: true, map: "HaggaBasin", partitionId: 1, reason: "" },
   inventories: [
     {
       inventoryId: "9001",
       maxSlots: 45,
       usedSlots: 3,
       slots: [
-        { itemId: "501", templateId: "Stone", name: "Granite Stone", positionIndex: 0, quantity: 600, qualityLevel: 0, currentDurability: null, maxDurability: null },
-        { itemId: "502", templateId: "MagnetiteOre", name: "Iron Ore", positionIndex: 1, quantity: 200, qualityLevel: 0, currentDurability: null, maxDurability: null },
-        { itemId: "503", templateId: "Stone", name: "Granite Stone", positionIndex: 2, quantity: 400, qualityLevel: 0, currentDurability: null, maxDurability: null }
+        { itemId: "501", templateId: "Stone", name: "Granite Stone", positionIndex: 0, quantity: 600, qualityLevel: 0, currentDurability: null, maxDurability: null, augments: [] },
+        { itemId: "502", templateId: "MagnetiteOre", name: "Iron Ore", positionIndex: 1, quantity: 200, qualityLevel: 0, currentDurability: null, maxDurability: null, augments: [] },
+        { itemId: "503", templateId: "Stone", name: "Granite Stone", positionIndex: 2, quantity: 400, qualityLevel: 0, currentDurability: null, maxDurability: null, augments: [] }
       ]
     }
   ]
@@ -135,6 +152,14 @@ async function openVaultContents({ stayOnGrid = false } = {}) {
   await waitFor(() => expect(screen.getByRole("dialog")).toBeTruthy());
   await waitFor(() => expect(document.querySelectorAll(".bases-inventory-slot-cell").length).toBeGreaterThan(0));
   if (stayOnGrid) return;
+  fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: /List/ }));
+  await waitFor(() => expect(document.querySelectorAll(".bases-inventory-contents-row:not(.head)").length).toBeGreaterThan(0));
+}
+
+// Add Item lives only in list view (grid's empty cells are its own
+// affordance there), so a test asserting on the button from a grid-view start
+// has to switch first.
+async function switchToList() {
   fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: /List/ }));
   await waitFor(() => expect(document.querySelectorAll(".bases-inventory-contents-row:not(.head)").length).toBeGreaterThan(0));
 }
@@ -537,9 +562,9 @@ describe("BaseInventoryTab", () => {
       inventories: [{
         inventoryId: "9001", maxSlots: 4, usedSlots: 3,
         slots: [
-          { itemId: "601", templateId: "Stone", name: "Granite Stone", positionIndex: 1, quantity: 10, qualityLevel: 0, currentDurability: null, maxDurability: null },
-          { itemId: "602", templateId: "MagnetiteOre", name: "Iron Ore", positionIndex: 1, quantity: 20, qualityLevel: 0, currentDurability: null, maxDurability: null },
-          { itemId: "603", templateId: "SpiceSand", name: "Spice Sand", positionIndex: 99, quantity: 30, qualityLevel: 0, currentDurability: null, maxDurability: null }
+          { itemId: "601", templateId: "Stone", name: "Granite Stone", positionIndex: 1, quantity: 10, qualityLevel: 0, currentDurability: null, maxDurability: null, augments: [] },
+          { itemId: "602", templateId: "MagnetiteOre", name: "Iron Ore", positionIndex: 1, quantity: 20, qualityLevel: 0, currentDurability: null, maxDurability: null, augments: [] },
+          { itemId: "603", templateId: "SpiceSand", name: "Spice Sand", positionIndex: 99, quantity: 30, qualityLevel: 0, currentDurability: null, maxDurability: null, augments: [] }
         ]
       }]
     });
@@ -602,6 +627,12 @@ describe("BaseInventoryTab", () => {
       deleteSafety: {
         safe: false, known: true, map: "HaggaBasin", partitionId: 68,
         reason: "HaggaBasin · Partition 68 is running. Stop that map before deleting stored items."
+      },
+      // Both gates resolve from one liveness probe, so in practice they always
+      // arrive together -- only the wording differs.
+      addSafety: {
+        safe: false, known: true, map: "HaggaBasin", partitionId: 68,
+        reason: "HaggaBasin · Partition 68 is running. Stop that map before adding stored items."
       }
     });
     renderTab();
@@ -645,6 +676,41 @@ describe("BaseInventoryTab", () => {
     await waitFor(() => expect(input.value).toBe("450"));
   });
 
+  it("shows grade on every slot, and an augments line only on a slot that has any", async () => {
+    mockInventory();
+    mockSlots({
+      ...SLOTS,
+      inventories: [{
+        inventoryId: "9001",
+        maxSlots: 45,
+        usedSlots: 2,
+        slots: [
+          { itemId: "501", templateId: "Stone", name: "Granite Stone", positionIndex: 0, quantity: 600, qualityLevel: 0, currentDurability: null, maxDurability: null, augments: [] },
+          {
+            itemId: "504", templateId: "UniqueSword_05", name: "Replica Pulse-sword", positionIndex: 1, quantity: 1,
+            qualityLevel: 3, currentDurability: 100, maxDurability: 100,
+            augments: [{ templateId: "T6_Augment_Melee1", name: "Blade Sharpener", qualityLevel: 2 }]
+          }
+        ]
+      }]
+    });
+    renderTab();
+    await loaded();
+    await openVaultContents();
+
+    fireEvent.click(screen.getByRole("button", { name: "Granite Stone" }));
+    await waitFor(() => expect(document.querySelector(".bases-inventory-slot-detail")).toBeTruthy());
+    const stoneDetail = document.querySelector(".bases-inventory-slot-detail-body") as HTMLElement;
+    expect(within(stoneDetail).getByText(/Grade 0/)).toBeTruthy();
+    expect(within(stoneDetail).queryByText(/Augments:/)).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Replica Pulse-sword" }));
+    await waitFor(() => expect(screen.getByText(/Grade 3/)).toBeTruthy());
+    const swordDetail = document.querySelector(".bases-inventory-slot-detail-body") as HTMLElement;
+    expect(within(swordDetail).getByText(/100% durability/)).toBeTruthy();
+    expect(within(swordDetail).getByText("Augments: Blade Sharpener (Grade 2)")).toBeTruthy();
+  });
+
   it("keeps crafting and refining contents read-only", async () => {
     mockInventory();
     // The game's own crafting routine consumes allocated ingredients from
@@ -658,7 +724,7 @@ describe("BaseInventoryTab", () => {
       group: "refining",
       inventories: [{
         inventoryId: "9003", maxSlots: 5, usedSlots: 1,
-        slots: [{ itemId: "701", templateId: "MagnetiteOre", name: "Iron Ore", positionIndex: 0, quantity: 420, qualityLevel: 0, currentDurability: null, maxDurability: null }]
+        slots: [{ itemId: "701", templateId: "MagnetiteOre", name: "Iron Ore", positionIndex: 0, quantity: 420, qualityLevel: 0, currentDurability: null, maxDurability: null, augments: [] }]
       }]
     });
     renderTab();
@@ -734,5 +800,341 @@ describe("BaseInventoryTab", () => {
 
     const vault = cards().find((card) => card.textContent?.includes("Vault"));
     expect(within(vault as HTMLElement).getByText("2 / 45")).toBeTruthy();
+  });
+
+  // ---- Adding an item ----
+
+  const addButton = () => screen.getByRole("button", { name: /Add Item/ }) as HTMLButtonElement;
+  const addPanel = () => document.querySelector(".bases-inventory-add-panel");
+  const emptyCells = () => [...document.querySelectorAll(".bases-inventory-slot-cell.empty")] as HTMLButtonElement[];
+
+  // Picks a catalog option by template id. Not by index: the selector sorts on
+  // the rendered name, so "Karpov 38" precedes "Scrap Metal" and an index
+  // would silently select the wrong item. Not by accessible name either --
+  // that comes from catalogItemName, which is not what this file is testing.
+  async function pickCatalogItem(templateId = "ScrapMetal") {
+    await waitFor(() => expect(document.querySelectorAll(".catalog-item-option").length).toBeGreaterThan(0));
+    const option = [...document.querySelectorAll(".catalog-item-option")]
+      .find((element) => element.textContent?.includes(templateId));
+    expect(option).toBeTruthy();
+    fireEvent.click(option as Element);
+  }
+
+  async function openAddPanel() {
+    fireEvent.click(addButton());
+    await waitFor(() => expect(addPanel()).toBeTruthy());
+  }
+
+  function mockAddSuccess() {
+    vi.mocked(basesApi.addContainerItem).mockResolvedValue({
+      supported: true,
+      result: {
+        ok: true, inventoryId: "9001", typeName: "Storage Container", group: "storage",
+        added: { itemId: "999", templateId: "ScrapMetal", quantity: 25, qualityLevel: 0, positionIndex: 3 },
+        capacity: { usedSlots: 4, maxSlots: 45 },
+        message: "ScrapMetal x25 was added to Storage Container in slot #3.",
+        addSafety: { safe: true, known: true, map: "HaggaBasin", partitionId: 1, reason: "" }
+      }
+    } as never);
+  }
+
+  it("opens the add panel from the list-view footer button", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    // List view enumerates occupied slots only, so it has no empty cell to
+    // click -- the footer button is the only add affordance here, which is
+    // precisely why it exists (and why it is absent from grid view).
+    await openVaultContents();
+    expect(emptyCells().length).toBe(0);
+    await openAddPanel();
+    expect(addPanel()).toBeTruthy();
+  });
+
+  it("does not offer Add Item in grid view", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    // Grid's own empty cells already open the panel; a second, redundant
+    // control in the footer would just be noise there.
+    await openVaultContents({ stayOnGrid: true });
+    expect(screen.queryByRole("button", { name: /Add Item/ })).toBeNull();
+    await switchToList();
+    expect(screen.getByRole("button", { name: /Add Item/ })).toBeTruthy();
+  });
+
+  it("has no Back to slots button, and hides the footer's Add Item and Close while the add panel is open", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+
+    // Both live in the footer already, via Cancel and the header's X --
+    // repeating either at the top of the panel would be redundant.
+    await openAddPanel();
+    expect(screen.queryByRole("button", { name: /Back to slots/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Close" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /^Add Item/ })).toBeNull();
+    // The overlay itself must still be closable from this state.
+    expect(screen.getByRole("button", { name: "Close contents" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Close" })).toBeTruthy());
+    expect(screen.getByRole("button", { name: /^Add Item/ })).toBeTruthy();
+  });
+
+  it("opens the add panel from an empty grid cell without claiming a slot number", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    await openVaultContents({ stayOnGrid: true });
+
+    const cell = emptyCells()[0];
+    expect(cell).toBeTruthy();
+    // Placement is not chooseable: the server always appends to the next free
+    // index, so nothing on this control may promise a specific slot.
+    const label = cell.getAttribute("aria-label") || "";
+    expect(label).toBe("Add an item to this container");
+    expect(label).not.toMatch(/slot\s*#?\d/i);
+    expect(cell.getAttribute("title") || "").not.toMatch(/slot\s*#?\d/i);
+    // Kept out of the tab order -- 42 empty cells would otherwise sit between
+    // the grid and the controls below it.
+    expect(cell.tabIndex).toBe(-1);
+
+    fireEvent.click(cell);
+    await waitFor(() => expect(addPanel()).toBeTruthy());
+  });
+
+  it("states the placement rule in the add panel", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+    await openAddPanel();
+    // Regression guard on both contracts the backend keeps.
+    expect(addPanel()!.textContent).toMatch(/next free slot/i);
+    expect(addPanel()!.textContent).toMatch(/never topped up/i);
+  });
+
+  it("disables adding when the map is running or its state cannot be verified", async () => {
+    mockInventory();
+    mockSlots({
+      ...SLOTS,
+      addSafety: {
+        safe: false, known: false, map: "", partitionId: 0,
+        reason: "The console cannot verify that this base's map is safely stopped, so adding items is disabled."
+      }
+    });
+    renderTab();
+    await loaded();
+    await openVaultContents({ stayOnGrid: true });
+
+    expect(emptyCells().every((cell) => cell.disabled)).toBe(true);
+    expect(screen.getByText(/cannot verify that this base's map is safely stopped, so adding items is disabled/i)).toBeTruthy();
+    await switchToList();
+    expect(addButton().disabled).toBe(true);
+    expect(basesApi.addContainerItem).not.toHaveBeenCalled();
+  });
+
+  it("keeps crafting and refining contents read-only for adding too", async () => {
+    mockInventory();
+    mockSlots({
+      ...SLOTS,
+      group: "refining",
+      typeName: "Ore Refinery",
+      // The server refuses on the group before it ever looks at the map.
+      addSafety: {
+        safe: false, known: true, map: "", partitionId: 0,
+        reason: "Adding items is available only for Storage containers. Crafting and Refining contents are read-only to protect active jobs."
+      }
+    });
+    renderTab();
+    await loaded();
+    await openVaultContents({ stayOnGrid: true });
+
+    expect(screen.getByText(/only for Storage containers/i)).toBeTruthy();
+    await switchToList();
+    expect(addButton().disabled).toBe(true);
+  });
+
+  it("refuses to add to a container with no free slots", async () => {
+    // Capacity comes from the container, not from the safety gate: a stopped
+    // map and a plain storage box can still be full.
+    mockInventory({
+      ...PAYLOAD,
+      containers: PAYLOAD.containers.map((container) =>
+        container.placeableId === "40001" ? { ...container, usedSlots: 45, maxSlots: 45 } : container)
+    });
+    renderTab();
+    await loaded();
+    await openVaultContents({ stayOnGrid: true });
+
+    expect(emptyCells().every((cell) => cell.disabled)).toBe(true);
+    await switchToList();
+    expect(addButton().disabled).toBe(true);
+    expect(addButton().title).toMatch(/full \(45 \/ 45 slots\)/i);
+    expect(basesApi.addContainerItem).not.toHaveBeenCalled();
+  });
+
+  it("adds an item and refetches both the slots and the tab", async () => {
+    mockInventory();
+    mockAddSuccess();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+    const slotLoads = vi.mocked(basesApi.containerSlots).mock.calls.length;
+    const tabLoads = vi.mocked(basesApi.inventory).mock.calls.length;
+
+    await openAddPanel();
+    await pickCatalogItem();
+    fireEvent.change(screen.getByLabelText(/Quantity to add/i), { target: { value: "25" } });
+    fireEvent.click(screen.getByRole("button", { name: /Add to container/i }));
+
+    await waitFor(() => expect(basesApi.addContainerItem).toHaveBeenCalled());
+    const call = vi.mocked(basesApi.addContainerItem).mock.calls[0];
+    expect(call[0]).toBe("1006");
+    expect(call[1]).toBe("40001");
+    expect(call[2]).toMatchObject({ itemId: "ScrapMetal", quantity: 25, quality: 0 });
+    // The phrase is deliberately distinct from GIVE ITEM TO STORAGE.
+    expect(call[3]).toBe("ADD ITEM TO CONTAINER");
+
+    // Both are invalidated by an add: this container's slots, and the tab's
+    // totals, group counts and rollup.
+    await waitFor(() => expect(vi.mocked(basesApi.containerSlots).mock.calls.length).toBeGreaterThan(slotLoads));
+    await waitFor(() => expect(vi.mocked(basesApi.inventory).mock.calls.length).toBeGreaterThan(tabLoads));
+  });
+
+  it("tells the operator the slot was not chosen when confirming", async () => {
+    mockInventory();
+    mockAddSuccess();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+    await openAddPanel();
+    await pickCatalogItem();
+    fireEvent.click(screen.getByRole("button", { name: /Add to container/i }));
+
+    await waitFor(() => expect(confirmAction).toHaveBeenCalled());
+    const details = confirmAction.mock.calls.at(-1)?.[1]?.details || [];
+    const slot = details.find((detail) => detail.label === "Slot");
+    // The last place the placement promise is made, and it has to stay honest.
+    expect(slot?.value).toBe("Next free slot");
+    expect(slot?.value).not.toMatch(/#\d/);
+  });
+
+  it("does not call the add API when the confirmation is declined", async () => {
+    mockInventory();
+    confirmAction.mockResolvedValue(false);
+    renderTab();
+    await loaded();
+    await openVaultContents();
+    await openAddPanel();
+    await pickCatalogItem();
+    fireEvent.click(screen.getByRole("button", { name: /Add to container/i }));
+
+    await waitFor(() => expect(confirmAction).toHaveBeenCalled());
+    expect(basesApi.addContainerItem).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an add failure without blanking the slot list", async () => {
+    mockInventory();
+    vi.mocked(basesApi.addContainerItem).mockRejectedValue(new Error("This container is full: 45 of 45 slots are used."));
+    renderTab();
+    await loaded();
+    await openVaultContents();
+    await openAddPanel();
+    await pickCatalogItem();
+    fireEvent.click(screen.getByRole("button", { name: /Add to container/i }));
+
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(expect.stringMatching(/45 of 45/)));
+    // The panel closes back to the slots, which are still intact -- a failed
+    // add must not hide them behind a Retry the way a failed load does.
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    expect(screen.getByText(/45 of 45/)).toBeTruthy();
+  });
+
+  it("rejects a quantity outside the server's own bounds before calling the API", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+    await openAddPanel();
+    await pickCatalogItem();
+    const input = screen.getByLabelText(/Quantity to add/i);
+
+    for (const value of ["0", "1000001", "1.5"]) {
+      fireEvent.change(input, { target: { value } });
+      await waitFor(() => expect(document.querySelector(".bases-inventory-amount-error")).toBeTruthy());
+      expect((screen.getByRole("button", { name: /Add to container/i }) as HTMLButtonElement).disabled).toBe(true);
+    }
+    fireEvent.change(input, { target: { value: "25" } });
+    await waitFor(() => expect((screen.getByRole("button", { name: /Add to container/i }) as HTMLButtonElement).disabled).toBe(false));
+    expect(basesApi.addContainerItem).not.toHaveBeenCalled();
+  });
+
+  it("offers augments only for an item that can take them", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+    await openAddPanel();
+
+    // A resource cannot be augmented, so the control is absent entirely rather
+    // than present and empty.
+    await pickCatalogItem("ScrapMetal");
+    expect(addPanel()!.textContent).not.toMatch(/Aug\. Grade/);
+  });
+
+  it("keeps the add panel and the slot-detail strip mutually exclusive", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+
+    // Selecting a slot arms the delete strip.
+    fireEvent.click(screen.getAllByRole("button", { name: "Granite Stone" })[0]);
+    await waitFor(() => expect(document.querySelector(".bases-inventory-slot-detail")).toBeTruthy());
+
+    // Opening the add panel replaces the slot region and clears that strip --
+    // two modes of one dialog, not two panels stacked in it. The strip is keyed
+    // to an existing occupied slot and cannot represent an add.
+    await openAddPanel();
+    expect(document.querySelector(".bases-inventory-slot-detail")).toBeNull();
+    expect(document.querySelector(".bases-inventory-contents-scroll")).toBeNull();
+
+    // Cancel restores the slots with nothing selected. No separate "back"
+    // control -- it would just duplicate what Cancel already does.
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(addPanel()).toBeNull());
+    expect(document.querySelector(".bases-inventory-contents-scroll")).toBeTruthy();
+    expect(document.querySelector(".bases-inventory-slot-detail")).toBeNull();
+  });
+
+  it("clears the add panel when the overlay is reopened", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+    await openAddPanel();
+    await pickCatalogItem();
+
+    // The footer's Close is hidden while the add panel is open (see the
+    // "does not show Close or the footer Add Item while the add panel is
+    // open" test); the header's X is what still closes the whole overlay
+    // from this state.
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Close contents" }));
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+
+    // Reopened directly rather than via openVaultContents: contentsView is
+    // sticky, so the overlay comes back in list mode and has no grid cells for
+    // that helper to wait on.
+    const vault = [...document.querySelectorAll(".bases-inventory-cards .bases-card")]
+      .find((card) => card.textContent?.includes("Vault")) as HTMLElement;
+    fireEvent.click(within(vault).getByRole("button", { name: /View Contents/ }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeTruthy());
+
+    // A half-filled form must not carry over: the capacity, the gate and the
+    // confirm dialog's Container line all change with the container.
+    expect(addPanel()).toBeNull();
   });
 });

--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -3,6 +3,14 @@ import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { basesApi, type BaseContainerSlots, type BaseInventory } from "../../api/bases";
 import { BaseInventoryTab } from "./BaseInventoryTab";
+// Only this file needs the real cascade: jsdom applies no CSS at all unless a
+// stylesheet is actually imported, so the column-hiding, header/body-split
+// and control-sizing assertions below would otherwise silently check nothing
+// against real rules. jsdom has no layout engine, so this only reaches
+// declared computed-style facts (display, position, explicit height/padding/
+// colour) -- not actual pixel geometry (rendered widths, "does the header
+// visually stay put while scrolling"), which stays a live-browser check.
+import "../../styles.css";
 
 vi.mock("../../api/bases", () => ({
   basesApi: {
@@ -1083,6 +1091,106 @@ describe("BaseInventoryTab", () => {
     // than present and empty.
     await pickCatalogItem("ScrapMetal");
     expect(addPanel()!.textContent).not.toMatch(/Aug\. Grade/);
+  });
+
+  // This repo has repeatedly shipped CSS-cascade regressions in exactly this
+  // shape (fixed-width columns not accounting for a narrower container,
+  // position: sticky silently failing inside another sticky ancestor) --
+  // each was only caught by a live-browser check, with nothing in CI to
+  // reproduce it. jsdom has no layout engine, so these assertions reach
+  // computed-style FACTS (display, position, explicit height/padding/colour)
+  // that the real styles.css rule declares -- not actual rendered pixel
+  // geometry (does a column really fit, does the header really stay put
+  // while scrolling), which stays a live-browser check; see the CSS
+  // comments this pins for the reasoning and the live measurements taken
+  // when each was written.
+  it("keeps the CSS-cascade fixes for this panel's narrow catalog table intact", async () => {
+    mockInventory();
+    renderTab();
+    await loaded();
+    await openVaultContents();
+    await openAddPanel();
+    const panel = addPanel()!;
+    const toggle = panel.querySelector(".catalog-view-toggle")!;
+    fireEvent.click(within(toggle as HTMLElement).getByRole("button", { name: /List view/i }));
+    await waitFor(() => expect(panel.querySelector(".catalog-item-table")).toBeTruthy());
+
+    // Item ID and Source dropped to fit this panel's ~500px width; Item Name
+    // and Category stay. Regresses to crushed, character-wrapped columns if
+    // this display:none is ever lost.
+    const headers = [...panel.querySelectorAll(".catalog-item-table thead th")];
+    const byText = (text: string) => headers.find((th) => th.textContent?.trim() === text)!;
+    expect(getComputedStyle(byText("Item ID")).display).toBe("none");
+    expect(getComputedStyle(byText("Source")).display).toBe("none");
+    expect(getComputedStyle(byText("Item Name")).display).not.toBe("none");
+    expect(getComputedStyle(byText("Category")).display).toBe("table-cell");
+
+    // The header/body split that replaced position: sticky (which measurably
+    // did not hold in this nesting -- see the CSS comment above these rules).
+    // thead as a non-growing flex item and tbody as the sole scrolling region
+    // is the mechanism that keeps the header out of the scrolled content
+    // altogether; regressing any one of these reopens the drifting-header bug.
+    const picker = panel.querySelector(".catalog-item-picker")!;
+    const table = panel.querySelector(".catalog-item-table")!;
+    const thead = panel.querySelector(".catalog-item-table thead")!;
+    const tbody = panel.querySelector(".catalog-item-table tbody")!;
+    expect(getComputedStyle(picker).display).toBe("flex");
+    expect(getComputedStyle(table).display).toBe("flex");
+    expect(getComputedStyle(thead).display).toBe("block");
+    expect(getComputedStyle(thead).flexGrow).toBe("0");
+    expect(getComputedStyle(tbody).display).toBe("block");
+    expect(getComputedStyle(tbody).flexGrow).toBe("1");
+    expect(getComputedStyle(tbody).overflowY).toBe("auto");
+
+    // Grade -- a native <select> -- needs an explicit height to match the
+    // <input> siblings; a browser rendering quirk means identical padding
+    // alone leaves it 2px taller (measured live: 41px vs 43px).
+    const grade = panel.querySelector(".bases-inventory-add-field .package-item-durability-input")!;
+    expect(getComputedStyle(grade).height).toBe("41px");
+  });
+
+  it("scopes the augment dropdown's control styling to this panel, not other panels using the same component", async () => {
+    // AugmentDropdown ships its own padding/border/background that only
+    // matches this panel's plain inputs once overridden here -- and only
+    // here, not in Player give-items, which still uses the component's
+    // stock styling. Exercised as a standalone fixture rather than through
+    // the full add flow: the mocked catalog in this file has no
+    // augment-category item, so the real interactive path never mounts
+    // AugmentDropdown -- this instead pins the CSS selector itself
+    // (specificity and scoping), independent of that mock gap.
+    const scoped = document.createElement("div");
+    scoped.className = "bases-inventory-add-panel";
+    scoped.innerHTML = '<div class="augment-dropdown-control"></div>';
+    document.body.appendChild(scoped);
+
+    const unscoped = document.createElement("div");
+    unscoped.innerHTML = '<div class="augment-dropdown-control"></div>';
+    document.body.appendChild(unscoped);
+
+    try {
+      const inPanel = getComputedStyle(scoped.querySelector(".augment-dropdown-control")!);
+      const outsidePanel = getComputedStyle(unscoped.querySelector(".augment-dropdown-control")!);
+
+      // border-color isn't asserted here: the rule sets it via var(--border-
+      // strong), and jsdom's getComputedStyle does not resolve CSS custom
+      // properties (confirmed empirically -- a literal value on the same rule
+      // applies correctly, but the var() one silently falls through to the
+      // unscoped default). Real-browser border-color was measured live by the
+      // reviewer at rgb(77, 64, 50), matching --border-strong.
+      expect(inPanel.padding).toBe("10px 12px");
+      expect(inPanel.backgroundColor).toBe("rgb(21, 23, 25)");
+
+      // Same class, no .bases-inventory-add-panel ancestor: must fall back to
+      // the component's own stock styling, proving the override cannot leak.
+      expect(outsidePanel.padding).not.toBe("10px 12px");
+      expect(outsidePanel.backgroundColor).not.toBe("rgb(21, 23, 25)");
+    } finally {
+      // Raw DOM nodes, not React-rendered -- the file's afterEach(cleanup())
+      // only unmounts React trees, so these would otherwise leak into every
+      // later test's queries for the rest of the file.
+      scoped.remove();
+      unscoped.remove();
+    }
   });
 
   it("keeps the add panel and the slot-detail strip mutually exclusive", async () => {

--- a/console/web/src/features/bases/BaseInventoryTab.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.tsx
@@ -1,6 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Boxes, ChevronDown, ChevronRight, LayoutGrid, List, Trash2, TriangleAlert, X } from "lucide-react";
-import { CatalogItemThumb } from "../../components/common/ItemCatalog";
+import { Boxes, ChevronDown, ChevronRight, LayoutGrid, List, Plus, Trash2, TriangleAlert, X } from "lucide-react";
+import {
+  CatalogItemThumb,
+  ItemCatalogSelector,
+  ItemGradeSelect,
+  catalogItemMinimumGrade,
+  type CatalogItem
+} from "../../components/common/ItemCatalog";
+import { AugmentDropdown } from "../../components/common/AugmentDropdown";
+import { augmentLimitForItem, filterAugmentsForItem, formatAugmentOptions, itemCanUseAugments } from "../../lib/augmentEligibility";
+import { adminApi } from "../../api/admin";
 import {
   basesApi,
   type BaseContainerSlots,
@@ -102,6 +111,24 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
   const [selectedSlotId, setSelectedSlotId] = useState("");
   const [amount, setAmount] = useState("");
   const slotsRequestIdRef = useRef(0);
+
+  // Add-item panel. It replaces the slot region rather than stacking under it:
+  // ItemCatalogSelector brings its own ~300px of category select, filter and
+  // scrolling grid, and hanging that below an already-scrolling slot list is
+  // what pushed the modal's own actions off screen once before.
+  const [addOpen, setAddOpen] = useState(false);
+  const [addItem, setAddItem] = useState<CatalogItem | null>(null);
+  const [addQuantity, setAddQuantity] = useState("1");
+  const [addGrade, setAddGrade] = useState("0");
+  const [addAugments, setAddAugments] = useState<string[]>([]);
+  const [addAugmentGrade, setAddAugmentGrade] = useState("1");
+  const [augmentCatalog, setAugmentCatalog] = useState<{ id: string; name: string }[]>([]);
+  // Its own triad, for the same reason the delete's is separate from
+  // slotsError: a failed add leaves the slot list perfectly valid, and hiding
+  // it behind a Retry would lose the operator's place over one form's error.
+  const [adding, setAdding] = useState(false);
+  const [addNotice, setAddNotice] = useState("");
+  const [addError, setAddError] = useState("");
 
   // Only the newest request may write state. StrictMode double-invokes this
   // effect, so two requests really are open at once here, and whichever settles
@@ -213,6 +240,75 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
       : slots.deleteSafety?.reason || "Item deletion is unavailable for this container."
     : "";
 
+  // Same shape and the same fail-closed default as the delete gate above. The
+  // server re-checks this immediately before the write regardless.
+  const addAllowed = slots?.group === "storage" && slots?.addSafety?.safe === true;
+  const addUnavailableReason = slots?.found && !addAllowed
+    ? slots.group !== "storage"
+      ? "Adding items is available only for Storage containers. Crafting and Refining contents are read-only to protect active jobs."
+      : slots.addSafety?.reason || "Adding items is unavailable for this container."
+    : "";
+  // Read off the open container rather than the safety object -- capacity is a
+  // property of the box, not of whether its map is stopped.
+  const containerFull = Boolean(openContainer) && openContainer!.maxSlots > 0
+    && openContainer!.usedSlots >= openContainer!.maxSlots;
+  const containerFullReason = containerFull && openContainer
+    ? `This container is full (${openContainer.usedSlots.toLocaleString()} / ${openContainer.maxSlots.toLocaleString()} slots). Delete an item to make room.`
+    : "";
+
+  const addItemMeta = addItem
+    ? { templateId: addItem.itemId || addItem.id, category: addItem.category || "", source: addItem.source || "" }
+    : null;
+  const addAugmentLimit = addItemMeta ? augmentLimitForItem(addItemMeta) : 0;
+  const addAugmentOptions = addItemMeta && itemCanUseAugments(addItemMeta)
+    ? formatAugmentOptions(filterAugmentsForItem(addItemMeta, augmentCatalog), addAugmentGrade)
+    : [];
+  const addQuantityNumber = Number(addQuantity);
+  const addQuantityValid = Number.isInteger(addQuantityNumber)
+    && addQuantityNumber >= 1
+    && addQuantityNumber <= 1000000;
+
+  // Only paid for by an operator who actually opens the add panel -- the
+  // catalog fetch is the full 10k-row list.
+  useEffect(() => {
+    if (!addOpen || augmentCatalog.length > 0) return;
+    let cancelled = false;
+    adminApi.itemCatalog("", 10000).then((result) => {
+      if (cancelled) return;
+      setAugmentCatalog((result.rows || []).filter((item) =>
+        (item.category || "").toLowerCase().includes("augment") ||
+        (item.source || "").toLowerCase() === "augments"
+      ).map((item) => ({ id: item.itemId || item.id, name: item.name })));
+    }).catch(() => { if (!cancelled) setAugmentCatalog([]); });
+    return () => { cancelled = true; };
+  }, [addOpen, augmentCatalog.length]);
+
+  function resetAddForm() {
+    setAddItem(null);
+    setAddQuantity("1");
+    setAddGrade("0");
+    setAddAugments([]);
+    setAddAugmentGrade("1");
+    setAddError("");
+  }
+
+  // The add panel and the slot-detail strip are two modes of one dialog, not
+  // two panels: the strip is keyed to an existing occupied slot and cannot
+  // represent an add, so opening either closes the other.
+  function openAddPanel() {
+    setSelectedSlotId("");
+    setAmount("");
+    setAddNotice("");
+    setAddError("");
+    setAddOpen(true);
+  }
+
+  function selectSlot(slot: BaseInventorySlot) {
+    setAddOpen(false);
+    setSelectedSlotId(slot.itemId);
+    setAmount(String(slot.quantity));
+  }
+
   // A slot that vanished (deleted, or moved by a player between refetches)
   // must not leave a stale strip pointing at an id the server no longer has.
   useEffect(() => {
@@ -253,11 +349,19 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
       setDeleteError("");
       setSelectedSlotId("");
       setAmount("");
+      setAddOpen(false);
+      setAddNotice("");
+      resetAddForm();
       return;
     }
     setSelectedSlotId("");
     setAmount("");
     setDeleteError("");
+    // A half-filled form must not carry over to a different container: the
+    // capacity, the gate and the confirm dialog's "Container" line all change.
+    setAddOpen(false);
+    setAddNotice("");
+    resetAddForm();
     void loadSlots(contentsFor);
   }, [contentsFor, loadSlots]);
 
@@ -344,6 +448,61 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
     }
   }
 
+  async function addToContainer(containerName: string) {
+    if (!addAllowed) {
+      const text = addUnavailableReason || "Adding items is unavailable for this container.";
+      setAddError(text);
+      onError(text);
+      return;
+    }
+    if (!addItem || !addQuantityValid) return;
+    const augmentNames = addAugments
+      .map((id) => augmentCatalog.find((entry) => entry.id === id)?.name || id);
+    const confirmed = await confirmAction("Add this item to the container?", {
+      title: "Add Item to Container",
+      confirmLabel: "Add",
+      details: [
+        { label: "Base", value: baseName },
+        { label: "Container", value: containerName, tone: "accent" },
+        { label: "Item", value: `${addItem.name} ×${addQuantityNumber.toLocaleString()}`, tone: "success" },
+        { label: "Grade", value: addGrade },
+        ...(augmentNames.length > 0 ? [{ label: "Augments", value: augmentNames.join(", ") }] : []),
+        // The last place the operator sees the placement rule, and it has to
+        // stay honest: the server appends, and no slot was ever reserved.
+        { label: "Slot", value: "Next free slot" }
+      ]
+    });
+    if (!confirmed) return;
+    setAdding(true);
+    setAddNotice("");
+    setAddError("");
+    try {
+      const response = await basesApi.addContainerItem(baseId, contentsFor, {
+        itemId: addItem.itemId || addItem.id,
+        quantity: addQuantityNumber,
+        quality: Number(addGrade) || 0,
+        augments: addAugments,
+        augmentQuality: Number(addAugmentGrade) || 1
+      }, "ADD ITEM TO CONTAINER");
+      const result = response.result;
+      if (!response.supported || !result?.ok) {
+        throw new Error(response.error || response.reason || "The item could not be added.");
+      }
+      setAddNotice(result.message);
+      setAddOpen(false);
+      resetAddForm();
+      // Same pair the delete refetches: this container's slots, and the tab's
+      // totals, group counts and rollup, all of which the add invalidated.
+      await Promise.all([loadSlots(contentsFor), load()]);
+    } catch (error) {
+      const text = errorText(error);
+      setAddError(text);
+      onError(text);
+    } finally {
+      setAdding(false);
+    }
+  }
+
   if (loading) {
     return <p className="muted" role="status">Loading base inventory…</p>;
   }
@@ -377,7 +536,7 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
             destructive controls remain disabled until the backend verifies a
             safe stopped-map window. */}
         <p className="bases-inventory-note muted">
-          A database snapshot, not a live view. Stored items can be deleted only while their map is safely stopped.
+          A database snapshot, not a live view. Stored items can be added or deleted only while their map is safely stopped.
         </p>
 
         {/* summary-stats/summary-stat are the app's stat tiles, shared with
@@ -630,6 +789,14 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
           {deleteUnavailableReason && <p className="bases-inventory-amount-error" role="status">
             {deleteUnavailableReason}
           </p>}
+          {addNotice && <p className="bases-inventory-delete-notice" role="status">{addNotice}</p>}
+          {addError && <p className="bases-inventory-amount-error" role="alert">{addError}</p>}
+          {/* Suppressed when the delete gate already said the same thing --
+              both fire on a running map, and two near-identical sentences read
+              as a stutter rather than as two independent gates. */}
+          {addUnavailableReason && !deleteUnavailableReason && <p className="bases-inventory-amount-error" role="status">
+            {addUnavailableReason}
+          </p>}
 
           {!slotsLoading && !slotsError && slots && slots.found === false && <p className="muted" role="status">
             {slots.reason || "That container is no longer at this base."}
@@ -640,7 +807,7 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
               the scrolling: an intermediate block with no height of its own
               breaks the constraint chain, and the list inside then renders at
               its full natural height straight over the controls beneath it. */}
-          <div className="bases-inventory-contents-scroll">
+          {!addOpen && <div className="bases-inventory-contents-scroll">
           {!slotsLoading && !slotsError && slots?.found && slots.inventories.map((inventory) => {
             const { cells, overflow } = layoutSlots(inventory);
             // Grid needs real slot positions and a sane capacity; without
@@ -672,12 +839,30 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
                         // never applied.
                         aria-label={`${slot.name} ×${slot.quantity.toLocaleString()}, slot ${index}`}
                         title={`${slot.name} ×${slot.quantity.toLocaleString()} (slot ${index})`}
-                        onClick={() => { setSelectedSlotId(slot.itemId); setAmount(String(slot.quantity)); }}
+                        onClick={() => selectSlot(slot)}
                       >
                         <CatalogItemThumb item={{ id: slot.templateId, itemId: slot.templateId, name: slot.name, image: itemImage(slot.templateId) }} small />
                         {slot.quantity > 1 && <span className="bases-inventory-slot-qty">{slot.quantity.toLocaleString()}</span>}
                       </button>
-                    : <span className="bases-inventory-slot-cell empty" key={`empty-${index}`} aria-hidden="true" />)}
+                    // Deliberately says nothing about which slot: the click is a
+                    // shortcut to the add form, not a placement target, and the
+                    // server always appends to the next free index. tabIndex=-1
+                    // because a 45-slot container holding three items would
+                    // otherwise wedge 42 tab stops between the grid and the
+                    // controls below it -- the header button is the keyboard
+                    // route to the identical action.
+                    : <button
+                        className="bases-inventory-slot-cell empty"
+                        key={`empty-${index}`}
+                        type="button"
+                        tabIndex={-1}
+                        disabled={!addAllowed || containerFull}
+                        aria-label="Add an item to this container"
+                        title={addAllowed
+                          ? (containerFull ? containerFullReason : "Add an item to this container")
+                          : (addUnavailableReason || "Adding items is unavailable for this container.")}
+                        onClick={() => openAddPanel()}
+                      />)}
                 </div>}
 
                 {showGrid && overflow.length > 0 && <p className="muted bases-inventory-slot-overflow-note">
@@ -701,7 +886,7 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
                         className="bases-inventory-contents-name"
                         title={slot.templateId}
                         aria-pressed={selectedSlotId === slot.itemId}
-                        onClick={() => { setSelectedSlotId(slot.itemId); setAmount(String(slot.quantity)); }}
+                        onClick={() => selectSlot(slot)}
                       >{slot.name}</button>
                       <span className="bases-inventory-contents-slot muted">
                         {slot.positionIndex === null ? "—" : `#${slot.positionIndex}`}
@@ -721,7 +906,81 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
             );
           })}
 
-          </div>
+          </div>}
+
+          {addOpen && <div className="bases-inventory-add-panel">
+            <div className="bases-inventory-add-head">
+              <h4>Add Item</h4>
+              <span className="muted">
+                {openContainer.usedSlots.toLocaleString()} / {openContainer.maxSlots.toLocaleString()} slots used
+              </span>
+            </div>
+            {/* The one sentence that states both contracts the backend
+                enforces. It stays visible for the whole form, not just at
+                submit time. */}
+            <p className="muted bases-inventory-add-note">
+              Appends to the next free slot. Existing stacks are never topped up — this always creates a new slot.
+            </p>
+
+            <ItemCatalogSelector label="Select item to add" selected={addItem} onSelect={setAddItem} />
+
+            <div className="bases-inventory-add-controls">
+              <label className="bases-inventory-add-field">
+                <span>Quantity</span>
+                <input
+                  type="number"
+                  min={1}
+                  max={1000000}
+                  value={addQuantity}
+                  aria-label="Quantity to add"
+                  onChange={(event) => setAddQuantity(event.target.value)}
+                />
+              </label>
+              <label className="bases-inventory-add-field">
+                <span>Grade</span>
+                <ItemGradeSelect
+                  value={addGrade}
+                  minGrade={catalogItemMinimumGrade(addItem)}
+                  onChange={setAddGrade}
+                />
+              </label>
+              {addAugmentOptions.length > 0 && <>
+                <div className="bases-inventory-add-field bases-inventory-add-augments">
+                  <span>Augments</span>
+                  <AugmentDropdown
+                    options={addAugmentOptions}
+                    value={addAugments}
+                    maxSelected={addAugmentLimit}
+                    onChange={(selected) => setAddAugments(selected.slice(0, addAugmentLimit))}
+                  />
+                </div>
+                <label className="bases-inventory-add-field">
+                  <span>Aug. Grade</span>
+                  <ItemGradeSelect
+                    value={addAugmentGrade}
+                    minGrade={1}
+                    disabled={addAugments.length === 0}
+                    emptyWhenDisabled
+                    onChange={setAddAugmentGrade}
+                  />
+                </label>
+              </>}
+            </div>
+
+            {addItem && !addQuantityValid && <p className="bases-inventory-amount-error" role="alert">
+              Enter a quantity between 1 and 1,000,000.
+            </p>}
+            {containerFull && <p className="bases-inventory-amount-error" role="status">{containerFullReason}</p>}
+
+            <div className="bases-inventory-add-actions">
+              <button
+                className="primary"
+                disabled={!addAllowed || containerFull || !addItem || !addQuantityValid || adding}
+                onClick={() => void addToContainer(containerLabel(openContainer))}
+              >{adding ? "Adding…" : "Add to container"}</button>
+              <button onClick={() => { setAddOpen(false); resetAddForm(); }}>Cancel</button>
+            </div>
+          </div>}
 
           {selectedSlot && <div className="bases-inventory-slot-detail">
             <CatalogItemThumb item={{ id: selectedSlot.templateId, itemId: selectedSlot.templateId, name: selectedSlot.name, image: itemImage(selectedSlot.templateId) }} />
@@ -730,10 +989,16 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
               <span className="muted">
                 {selectedSlot.positionIndex === null ? "Unplaced" : `Slot #${selectedSlot.positionIndex}`}
                 {" · "}{selectedSlot.quantity.toLocaleString()} held
+                {" · "}Grade {selectedSlot.qualityLevel}
                 {selectedSlot.currentDurability !== null && selectedSlot.maxDurability
                   ? ` · ${Math.round((selectedSlot.currentDurability / selectedSlot.maxDurability) * 100)}% durability`
                   : ""}
               </span>
+              {/* Its own line, and only when the item actually has any -- a
+                  raw resource or an unaugmented item never carries this. */}
+              {selectedSlot.augments.length > 0 && <span className="muted">
+                Augments: {selectedSlot.augments.map((augment) => `${augment.name} (Grade ${augment.qualityLevel})`).join(", ")}
+              </span>}
             </div>
             <label className="bases-inventory-slot-amount">
               <span>Remove</span>
@@ -756,9 +1021,29 @@ export function BaseInventoryTab({ baseId, baseName, onError, confirmAction }: B
             Enter an amount between 1 and {selectedSlot.quantity.toLocaleString()}.
           </p>}
 
-          <div className="confirm-modal-actions">
+          {/* Hidden entirely while the add panel is open, not just disabled:
+              its own action row (Add to container / Cancel) is the footer in
+              that state, and Cancel already returns here -- a second Close
+              next to it would be a redundant way to leave. The X in the
+              header and Escape both still close the whole overlay. */}
+          {!addOpen && <div className="confirm-modal-actions confirm-modal-actions-grouped">
+            {/* List-view only: grid's own empty cells already open this panel,
+                so a second, redundant control there would just be noise. List
+                enumerates occupied slots only and has no empty cell to click,
+                which is why it needs an explicit affordance. */}
+            {contentsView === "list"
+              ? <button
+                  className="bases-inventory-add-item"
+                  aria-expanded={addOpen}
+                  disabled={!addAllowed || containerFull}
+                  title={addAllowed
+                    ? (containerFull ? containerFullReason : "Add an item to this container")
+                    : (addUnavailableReason || "Adding items is unavailable for this container.")}
+                  onClick={() => openAddPanel()}
+                ><Plus size={14} aria-hidden="true" /> Add Item</button>
+              : <span />}
             <button onClick={() => setContentsFor("")}>Close</button>
-          </div>
+          </div>}
         </section>
       </div>}
     </div>

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -28,7 +28,8 @@ vi.mock("../../api/bases", () => ({
     setAutoRefillWater: vi.fn(),
     inventory: vi.fn(),
     containerSlots: vi.fn(),
-    deleteContainerItem: vi.fn()
+    deleteContainerItem: vi.fn(),
+    addContainerItem: vi.fn()
   }
 }));
 
@@ -971,6 +972,7 @@ describe("BasesPanel permissions editing", () => {
       supported: true, found: true, baseId: 1006, placeableId: "40001",
       typeName: "Storage Container", group: "storage", maxSlots: 45, usedSlots: 1,
       deleteSafety: { safe: true, known: true, map: "HaggaBasin", partitionId: 1, reason: "" },
+      addSafety: { safe: true, known: true, map: "HaggaBasin", partitionId: 1, reason: "" },
       inventories: [{
         inventoryId: "9001", maxSlots: 45, usedSlots: 1,
         slots: [{ itemId: "501", templateId: "Stone", name: "Granite Stone", positionIndex: 0, quantity: 500, qualityLevel: 0, currentDurability: null, maxDurability: null }]

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2655,8 +2655,12 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
    table into its rounded border. Give the table's four outer cells matching
    inner radii instead, and let the wrapper own the final bottom border. */
 .bases-table-wrap .bases-table { border-collapse: separate; border-spacing: 0; }
-.bases-table-wrap .bases-table thead > tr:first-child > th:first-child { border-top-left-radius: 7px; }
-.bases-table-wrap .bases-table thead > tr:first-child > th:last-child { border-top-right-radius: 7px; }
+/* > thead, not a bare descendant space, for the same reason as the sticky-top
+   fix above: this must only round the corners of the bases-table's own
+   header, not a nested table's (e.g. an expanded row rendering another table
+   with its own thead). */
+.bases-table-wrap .bases-table > thead > tr:first-child > th:first-child { border-top-left-radius: 7px; }
+.bases-table-wrap .bases-table > thead > tr:first-child > th:last-child { border-top-right-radius: 7px; }
 .bases-table-wrap .bases-table tbody > tr:last-child > td { border-bottom: 0; }
 .bases-table-wrap .bases-table tbody > tr:last-child > td:first-child { border-bottom-left-radius: 7px; }
 .bases-table-wrap .bases-table tbody > tr:last-child > td:last-child { border-bottom-right-radius: 7px; }
@@ -2700,9 +2704,16 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   background: var(--panel);
 }
 /* 67px = the search row's 43px of content plus its 24px of padding, so the
-   header parks directly beneath the search bar rather than under it. */
+   header parks directly beneath the search bar rather than under it.
+   `> thead > tr > th`, not a bare descendant `th`: a plain `.bases-table th`
+   matches every th anywhere inside the table's DOM subtree, including one
+   belonging to an unrelated table rendered inside an expanded row's cell
+   (e.g. the item catalog picker in the base-inventory add panel) -- which
+   then inherited this table's 67px offset and rendered mid-list instead of
+   at its own container's top. The child-combinator chain only matches a th
+   that is this table's own direct header cell. */
 .table-wrap.bases-table-wrap { margin-top: 0; }
-.bases-table-wrap .bases-table th { top: 67px; z-index: 3; }
+.bases-table-wrap .bases-table > thead > tr > th { top: 67px; z-index: 3; }
 /* Below 900px the sidebar stops being a column and becomes a sticky header at
    top:0 with z-index:100, so a search bar pinned to the same edge sits behind
    it. Offsetting by the sidebar's height would break the moment the hamburger
@@ -2939,8 +2950,182 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   scrollbar-gutter: stable;
   padding-right: 10px;
 }
+/* Replaces .bases-inventory-contents-scroll rather than stacking under it, so
+   the dialog's height envelope is identical in both modes and the actions at
+   its foot stay on screen. ItemCatalogSelector brings its own ~300px of
+   chrome; below a 400px slot region that sum is what pushed them off. Same
+   flex-item rule as the scroll region above: min-height 0, or the catalog's
+   own list renders at full natural height and overflows the modal. */
+.bases-inventory-add-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  /* The panel itself must NOT scroll. Its one tall child, the catalog picker,
+     already scrolls internally; letting the panel scroll too nests two regions
+     and -- because the picker holds a fixed 520px that exceeds the space the
+     dialog can give it -- pushes the Add button below the fold, reachable only
+     after scrolling past ~2,300 catalog options. Measured: actions landed at
+     y=1001 in a 720px viewport before this. */
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-right: 10px;
+}
+/* Let the picker shrink to whatever is left instead of insisting on its
+   standalone 520px. min-height keeps it usable rather than collapsing to a
+   sliver on a short viewport; the surrounding rows are fixed-height, so the
+   arithmetic always resolves. */
+.bases-inventory-add-panel .catalog-selector {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.bases-inventory-add-panel .catalog-item-picker {
+  flex: 1 1 auto;
+  min-height: 120px;
+  max-height: none;
+}
+/* The category select's default column is a fixed 360px -- fine in the
+   full-width panels ItemCatalogSelector was built for, but this add panel
+   lives inside a ~560px dialog, where 360px is most of the row and crushes
+   the filter input into a sliver. Same stacked, full-width treatment the app
+   already gives this same selector at narrow VIEWPORT widths (see the
+   max-width: 1024px block below) -- applied here unconditionally, since this
+   panel is narrow regardless of viewport. */
+.bases-inventory-add-panel .catalog-filter-row { grid-template-columns: 1fr; }
+.bases-inventory-add-panel .catalog-search-tools { grid-template-columns: minmax(0, 1fr) auto; }
+/* The list-view table's ID/Category/Source columns are percentage-widthed for
+   the full-page panels ItemCatalogSelector was built for. At this panel's
+   ~500px, table-layout: fixed still honours those percentages, so the four
+   non-preview columns each end up tens of pixels wide and every cell's text
+   wraps character-by-character. Dropping ID and Source is enough -- Category
+   is worth keeping visible (it's how an operator scans for "is this the
+   resource or the schematic"), and the full id/source still show in
+   .catalog-selected-item once an item is chosen, so nothing here is only
+   available in a dropped column. display: none on nth-child is applied
+   identically to every row, so table-layout: fixed's column algorithm simply
+   drops those two columns instead of misaligning anything. */
+.bases-inventory-add-panel .catalog-item-table th:nth-child(3),
+.bases-inventory-add-panel .catalog-item-table td:nth-child(3),
+.bases-inventory-add-panel .catalog-item-table th:nth-child(5),
+.bases-inventory-add-panel .catalog-item-table td:nth-child(5) {
+  display: none;
+}
+/* No explicit width on Item Name: in a fixed-layout table that's what lets it
+   claim whatever space the two dropped columns and Category's own fixed
+   width leave behind. Category gets a fixed width rather than also going
+   auto -- two auto columns in a fixed-layout table split the remaining space
+   evenly between them, which would give a one-word category ("Weapons") the
+   same room as a much longer item name. */
+.bases-inventory-add-panel .catalog-item-table th:nth-child(2),
+.bases-inventory-add-panel .catalog-item-table td:nth-child(2) {
+  width: auto;
+}
+.bases-inventory-add-panel .catalog-item-table th:nth-child(4),
+.bases-inventory-add-panel .catalog-item-table td:nth-child(4) {
+  width: 100px;
+}
+/* Not position: sticky. Verified live it does not hold in this nesting --
+   scrolling the picker moved the header 1:1 with the content instead of
+   pinning it, even after the top:67px leak above was fixed and top read
+   correctly as 0. Most likely cause: this table sits inside another table's
+   own sticky-positioned cell (.bases-table td.expanded-row-cell is itself
+   position: sticky, since BaseInventoryTab renders inside an expanded
+   bases-table row), and sticky-within-sticky-within-nested-table is a known
+   rough edge across browsers.
+   Fixed instead with the standard header/body split: thead and tbody become
+   independent flex items in a column, each row-group laid out with its own
+   `display: table` so th/td widths still align between them (both use the
+   same nth-child width rules, so they compute identically). The header is
+   then structurally outside the one scrolling region (tbody) -- it cannot
+   float, drift, or fail to pin, because it was never part of the scrolled
+   content to begin with. */
+.bases-inventory-add-panel .catalog-item-picker.list-view {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.bases-inventory-add-panel .catalog-item-table {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+}
+.bases-inventory-add-panel .catalog-item-table thead {
+  display: block;
+  flex: 0 0 auto;
+}
+.bases-inventory-add-panel .catalog-item-table tbody {
+  display: block;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  width: 100%;
+}
+.bases-inventory-add-panel .catalog-item-table thead tr,
+.bases-inventory-add-panel .catalog-item-table tbody tr {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+}
+/* 56px, not the shared .small (42px) or default (72px) variant -- picked from
+   three rendered mockups. The 92px Preview column already has room (56px
+   icon + 20px cell padding = 76px), so only the icon itself changes. */
+.bases-inventory-add-panel .catalog-item-table .catalog-item-preview.small {
+  width: 56px;
+  height: 56px;
+  flex-basis: 56px;
+}
+.bases-inventory-add-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.bases-inventory-add-head h4 { margin: 0; font-size: 15px; }
+.bases-inventory-add-note { margin: 0; font-size: 12px; }
+.bases-inventory-add-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 10px;
+}
+.bases-inventory-add-field { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.bases-inventory-add-field > span { color: var(--muted-warm); font-size: 11.5px; }
+.bases-inventory-add-field input { width: 120px; }
+/* A native <select> with identical padding/border/font still renders 2px
+   taller than an <input> in this row (41px vs 43px, measured) -- a browser
+   rendering quirk in how it sizes around its own dropdown arrow, not
+   anything padding/border can fix. Pinning the height directly is what
+   actually lines Grade and Aug. Grade up with Quantity and Augments. */
+.bases-inventory-add-field .package-item-durability-input { height: 41px; }
+/* The dropdown is the widest control by far, so it takes the remaining track
+   instead of forcing the grade selects onto their own row at every width. */
+.bases-inventory-add-augments { flex: 1 1 240px; }
+/* AugmentDropdown ships its own control styling (8px 10px padding, its own
+   near-but-not-quite border/background hex), so next to the plain <input>/
+   <select> siblings here (10px 12px padding, --border-strong, #151719) it
+   reads a couple px shorter and a shade off. Matched to those exact computed
+   values rather than the shared augment-dropdown-control rule, which other
+   panels (player give-items) still use unchanged. */
+.bases-inventory-add-panel .augment-dropdown-control {
+  padding: 10px 12px;
+  border-color: var(--border-strong);
+  background: #151719;
+}
+.bases-inventory-add-actions { display: flex; gap: 8px; flex-wrap: wrap; }
+
 .bases-inventory-contents-modal .confirm-modal-title { align-items: start; }
 .bases-inventory-contents-modal .confirm-modal-title > div { min-width: 0; }
+/* Lives in the footer, not the header: List-view only (grid's empty cells are
+   the add affordance there), and the footer's confirm-modal-actions-grouped
+   space-between puts it at the trailing edge of the LEFT side, opposite Close.
+   Plain styling rather than a danger tone or the view-toggle's segmented
+   look -- adding is additive, not a destructive control or a view mode. */
+.bases-inventory-add-item { display: inline-flex; align-items: center; gap: 6px; white-space: nowrap; }
 .bases-inventory-contents-summary {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
@@ -3045,11 +3230,14 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
 }
 /* Dashed and dimmer so an empty slot reads as absence at a glance rather than
    as an item that failed to load. */
-.bases-inventory-slot-cell.empty { background: #1b1610; border-style: dashed; cursor: default; }
-/* Purely decorative, matching the game's own empty slot. Pseudo-elements
-   rather than markup: the cell is already aria-hidden and non-interactive, so
-   nothing should announce a "+" to a screen reader or suggest it can be
-   clicked -- there is no add-item action here yet.
+.bases-inventory-slot-cell.empty { background: #1b1610; border-style: dashed; }
+.bases-inventory-slot-cell.empty:hover:not(:disabled) { border-color: var(--accent); background: #241d14; }
+/* Disabled whenever the map is running, the group is not storage, or the box
+   is full -- the same three gates the header's Add Item button reads. */
+.bases-inventory-slot-cell.empty:disabled { cursor: not-allowed; opacity: .45; }
+/* Decorative, matching the game's own empty slot. Pseudo-elements rather than
+   markup because the cell is now a real button carrying its own aria-label --
+   the bars must not add a second thing for a screen reader to announce.
    Drawn as two bars rather than typed as a "+" glyph. A glyph is centred by
    its line box, not by its ink, and the plus in this font sits above that
    centre -- it read as noticeably high in the slot. Two absolutely positioned

--- a/console/web/vitest.config.ts
+++ b/console/web/vitest.config.ts
@@ -5,6 +5,13 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: "jsdom",
+    // Off by default (no test currently imports a stylesheet). Needed so
+    // BaseInventoryTab.test.tsx can import the real styles.css and assert
+    // computed-style facts about it -- jsdom has no CSS engine to reflect
+    // without this, so those assertions would otherwise silently check
+    // nothing. Scoped in effect to whichever test files actually import CSS;
+    // does not change behavior for the rest of the suite.
+    css: true,
     setupFiles: ["src/test/setup.ts"],
     globals: true,
     include: ["src/**/*.test.{ts,tsx}"],

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -263,8 +263,9 @@ Player rows include `total_playtime_seconds`. The console samples `player_state.
 | GET | `/api/bases/auto-refill-water` | Get per-base water auto-refill enrollment state | None |
 | POST | `/api/bases/{baseId}/auto-refill-water` | Enable/disable water auto-refill for a base | `baseId`, `enabled` |
 | GET | `/api/bases/{baseId}/inventory` | Get a base's stored items, rolled up by item template and by container (storage, refining, crafting, other). Merged per template, not per slot | `baseId` |
-| GET | `/api/bases/{baseId}/containers/{placeableId}` | Get one container's inventories and their individual slots (item id, slot number, quantity, quality, durability), plus `deleteSafety`. Answers `found: false` when that container is not at the base | `baseId`, `placeableId` |
+| GET | `/api/bases/{baseId}/containers/{placeableId}` | Get one container's inventories and their individual slots (item id, slot number, quantity, quality, durability, applied augments with their own per-augment quality), plus `deleteSafety` and `addSafety`. Answers `found: false` when that container is not at the base | `baseId`, `placeableId` |
 | DELETE | `/api/bases/{baseId}/containers/{placeableId}/items/{itemId}` | Delete an item from a plain Storage container, or part of its stack with `count`. Refused unless the owning map is verifiably and safely stopped; Crafting and Refining contents are read-only. Requires `{ confirmation: "DELETE ITEM" }` | `baseId`, `placeableId`, `itemId`, `count?` |
+| POST | `/api/bases/{baseId}/containers/{placeableId}/items` | Add a new item to a plain Storage container. Always creates a new row at the next free slot — never merges into an existing stack, and the slot cannot be chosen. Refused unless the owning map is verifiably and safely stopped; Crafting and Refining contents are read-only. Requires `{ confirmation: "ADD ITEM TO CONTAINER" }` | `baseId`, `placeableId`, `itemId`\|`itemName`, `quantity`, `quality?`, `augments?`, `augmentQuality?` |
 | GET | `/api/bases/{baseId}/permissions` | Get a base's permission roster (Owner, Co-Owners, Associates) | `baseId` |
 | POST | `/api/bases/{baseId}/system-custodian` | Transfer ownership to the Server or detected GM system custodian while preserving the roster; provisions Server when no custodian exists | `baseId` |
 | PUT | `/api/bases/{baseId}/permissions` | Replace a base's permission roster | `baseId`, `entries[]` (`playerId`, `rank`) |
@@ -320,13 +321,17 @@ routes above. Its `containers[].items[]` is merged per item template, not per
 slot — `GET /api/bases/{baseId}/containers/{placeableId}` is the per-slot view,
 fetched one container at a time because slots roughly triple the response.
 
-`DELETE /api/bases/{baseId}/containers/{placeableId}/items/{itemId}` is refused
-unless `baseRefillTarget` can verify that the owning map is safely stopped. An
-unknown state fails closed, and the route repeats the check immediately before
-the write. Only plain Storage contents are mutable; Crafting and Refining remain
+`DELETE …/containers/{placeableId}/items/{itemId}` and
+`POST …/containers/{placeableId}/items` are both refused unless
+`baseRefillTarget` can verify that the owning map is safely stopped. An unknown
+state fails closed, and each route repeats the check immediately before the
+write. Only plain Storage contents are mutable; Crafting and Refining remain
 read-only because active jobs can reference their item rows. The same allowlist
-that keeps fuel inventories out of the read keeps them out of the delete. It
-needs `bases:delete-item`, not `bases:mutate`. See
+that keeps fuel inventories out of the read keeps them out of both writes. They
+need `bases:delete-item` and `bases:add-item` respectively, not `bases:mutate` —
+this tab shipped read-only, so a `bases:mutate` grant cannot be read as consent
+to destroy or fabricate items. The add never merges into an existing stack and
+always appends to `max(position_index) + 1`; the caller cannot pick a slot. See
 [base-inventory.md](base-inventory.md).
 
 Both `GET /api/bases/{baseId}/water` and `GET /api/bases/{baseId}/inventory`

--- a/docs/console/base-inventory.md
+++ b/docs/console/base-inventory.md
@@ -264,6 +264,11 @@ It offers two views, and **opens on Grid**:
   repeat it: its empty cells are already the add affordance, and a second control doing the same thing
   would be redundant.
 
+**The footer's Add Item and Close are both hidden while the add panel is open**, not merely disabled — the
+panel's own "Add to container" / Cancel row is the effective footer in that state, and repeating Close next
+to Cancel (which already returns to the slot view) would be a second, redundant way to leave. The overlay
+itself is still closable from here: the header's `×` and Escape both work throughout.
+
 Selecting a slot — a grid cell or an item name in the list — moves its controls into a strip below,
 carrying the item, its slot, grade and durability, an amount field defaulting to the whole stack, and the
 delete button. A second line lists the item's augments with their own per-augment grade, present only on a
@@ -277,6 +282,17 @@ pushed the dialog's own actions off screen. Swapping keeps the height envelope i
 add panel and the slot-detail strip are therefore two modes of one dialog, not two panels: opening either
 closes the other, and the strip is keyed to an existing occupied slot so it could not represent an add
 anyway. Both are cleared when the overlay is closed or a different container is opened.
+
+The panel itself: a header (title, live "N / M slots used" count), a permanent note stating the two
+contracts the backend enforces ("appends to the next free slot… never topped up"), the catalog picker, then
+a controls row of Quantity, Grade, and — only for an item category that can carry them — Augments plus its
+own Aug. Grade, all sized to match (the shared `AugmentDropdown` component ships its own slightly different
+padding/border/background by default, overridden here to line up; a native `<select>` also renders a couple
+px taller than a plain `<input>` at identical padding, a browser quirk fixed with an explicit height rather
+than chased through padding). The catalog picker's own list view is narrower here than in its full-page
+uses elsewhere (Care Package, Player give-items): Item ID and Source are dropped to fit, leaving Preview,
+Item Name and Category — the dropped fields are still shown once an item is picked, in the panel's own
+selected-item summary.
 
 Every inventory shares a single scroll region, so a placeable backing two inventories does not get two
 independent scrollbars.

--- a/docs/console/base-inventory.md
+++ b/docs/console/base-inventory.md
@@ -104,25 +104,80 @@ The shipped `owner`/`admin` policies grant `bases:*`, so default access is uncha
 Both of the usual base preconditions apply: a base with a queued delete, or one picked up via the game's
 base-backup tool, rejects this with `409`.
 
-## Why deletion requires a stopped map
+## Adding a stored item
 
-An item delete is **not** queued: a specific inventory row may move, merge, or disappear before a deferred
-operation runs. Instead, the route refuses the write until it can verify that the owning map is safely down.
+The same overlay can put an item into a plain Storage container. Backed by
+`POST /api/bases/{baseId}/containers/{placeableId}/items` → `duneDb.addBaseContainerItem()`, body
+`{ confirmation: "ADD ITEM TO CONTAINER", itemId | itemName, quantity, quality?, augments?, augmentQuality? }`.
+The parameter surface is `giveItemToStorage`'s, so a catalog-resolved item drops straight in — except that
+`quality` is bounded 0–5 here. `giveItemToStorage` allows 0–1000000, which is an outlier: every other path
+and the whole UI treat grade as 0–5.
+
+**Every add creates a new row. It never tops up a matching stack.** Adding 300 ScrapMetal to a container
+that already holds 500 leaves two rows, not one of 800. Merging would have to pick a stack to grow, and the
+game's own stack limits are not modelled here.
+
+**The slot is not chooseable.** The row lands at `max(position_index) + 1` within the resolved inventory —
+0 for an empty container. Clicking an empty grid cell is a shortcut to the form, not a placement target, and
+nothing in the UI may promise a specific slot: the empty cell's accessible name is "Add an item to this
+container", and the confirm dialog's Slot line reads "Next free slot". The response reports where it
+actually landed, which is a statement of fact rather than a promise.
+
+**Capacity is refused at `count(*) >= max_item_count`.** Rows, not summed stack sizes — correct precisely
+because nothing merges, so one add always consumes exactly one slot. A `max_item_count` of 0 is treated as
+uncapped, matching `giveItemToStorage` and `giveItemToPlayer`; no shipped storage type has one.
+
+**Durability is left alone.** The insert calls `buildItemStats` without a durability argument, so clothing
+and weapons get the usual 100/100 fallback while ore, spice and salvage get an empty stat block — which is
+what real resource rows look like. Stamping `MaxDurability` onto a stack of ScrapMetal would invent state
+the game never wrote, and the read path would then render a durability bar for it.
+
+Ownership is re-resolved from the base id through the same CTE chain the delete uses, with the same
+`inventory_types` allowlist, `is_hologram = false` and `max_item_count >= 0` filters — so a generator's fuel
+inventory answers "not found" here too.
+
+The row lock is `for update of inv`, taken **before** the capacity and next-slot reads. That ordering is the
+whole concurrency argument: `db.transaction` issues a bare `begin`, so this runs at READ COMMITTED, where a
+second adder blocks on the lock and then re-evaluates rather than aborting — its `count(*)` and
+`max(position_index)` are fresh statements that see the first insert. There is no unique constraint on
+`(inventory_id, position_index)`, so this reasoning is the only guard; every console path that inserts into
+`dune.items` takes this same lock first, and the delete's `for update of i, inv` is what serializes a delete
+against an add.
+
+Unlike the delete, this path sets **no** `search_path`. That line exists there because the shipped
+`dune.delete_item`/`dune.delete_inventory_item` carry none of their own; the add invokes no procedure at
+all, so its absence is deliberate.
+
+`POST …/items` requires its own IAM action, **`bases:add-item`**, for the same consent reason as
+`bases:delete-item` read in the other direction: a `bases:mutate` grant predates any ability to put items
+into a base at all, so it cannot be read as consent to fabricate them. The same two base preconditions
+apply — a queued delete or a backed-up base rejects with `409`.
+
+## Why item writes require a stopped map
+
+Neither an add nor a delete is queued: a specific inventory row may move, merge, or disappear before a
+deferred operation runs. Instead, both routes refuse the write until they can verify the owning map is
+safely down.
 
 The reason a queue exists at all still holds here:
 
 - No `pg_notify` routine covers inventory or buildings. The game's 8 notify channels are guild, landsraad, party, permission, taxation, faction, vehicle_recovery, player_info.
 - There are zero triggers on `dune.items`, `dune.inventories`, `dune.buildings`, `dune.placeables`.
-- The RMQ command bus has no per-item edit or delete. `AddItemToInventory` addresses items by *template name*; every id here is a row id.
+- The RMQ command bus has no per-item edit or delete. `AddItemToInventory` addresses items by *template
+  name*, and it addresses a **player**, not a base container — so it is not an escape hatch for the add
+  either. Every id here is a row id.
 
-So a running map can neither miss the delete nor resurrect the row on its next autosave. The container GET
-returns `deleteSafety`; the overlay disables deletion and explains why when the map is running or its state
-cannot be verified. The DELETE route then repeats the check immediately before changing the database, so a
-stale or hand-built request cannot bypass the UI.
+So a running map can neither miss the write nor resurrect the row on its next autosave. The container GET
+returns both `deleteSafety` and `addSafety` — structurally identical, resolved from one liveness probe, and
+differing only in wording so the operator reads a sentence about what they actually tried to do. The overlay
+disables the matching control and explains why when the map is running or its state cannot be verified. Each
+route then repeats its check immediately before changing the database, so a stale or hand-built request
+cannot bypass the UI.
 
-Deletion is limited to plain **Storage** containers. Refinery and fabricator inventories are visible but
+Both writes are limited to plain **Storage** containers. Refinery and fabricator inventories are visible but
 read-only because the game's crafting state can reference their item rows; removing a reserved ingredient
-can leave an active job pointing at an item that no longer exists.
+can leave an active job pointing at an item that no longer exists, and adding a row into a job's inventory
+is no safer.
 
 Item identifiers remain decimal strings from the URL through the PostgreSQL query. They are `bigint` values,
 and converting one to JavaScript `Number` could round an id above `Number.MAX_SAFE_INTEGER` into a different
@@ -156,7 +211,10 @@ GET /api/bases/{baseId}/containers/{placeableId}
 { supported, found, baseId, placeableId, typeName, group, maxSlots, usedSlots,
   inventories: [{ inventoryId, maxSlots, usedSlots,
                   slots: [{ itemId, templateId, name, positionIndex, quantity,
-                            qualityLevel, currentDurability, maxDurability }] }] }
+                            qualityLevel, currentDurability, maxDurability,
+                            augments: [{ templateId, name, qualityLevel }] }] }],
+  deleteSafety: { safe, known, map, partitionId, reason },
+  addSafety:    { safe, known, map, partitionId, reason } }
 ```
 
 **Fetched per container, not with the tab.** Folding slots into `baseInventory` tripled that response —
@@ -176,6 +234,14 @@ a container. `currentDurability`/`maxDurability` come out of the `stats` jsonb u
 column is a parse-time error rather than a null, so a schema without them would 500 a container that used
 to open. They come back null instead, and the grid view is withheld.
 
+`augments` reads the same `FAugmentedItemStats` jsonb shape the add path writes
+(`AppliedAugments[].Name` paired positionally with `AppliedAugmentQualities`), resolving each augment's
+template id through the same item-name catalog as everything else. Always an array — empty for an
+unaugmented item, never null or missing — so the frontend's "does this item have any" check is a plain
+length test. A row with more augment names than qualities (or the reverse) pairs positionally and stops at
+the shorter array rather than throwing; a display path degrades, it does not 500 a container that used to
+open over one corrupt row.
+
 ### The contents overlay
 
 Opened by **View Contents**, either on a container card or on any container listed under an expanded
@@ -185,15 +251,32 @@ It offers two views, and **opens on Grid**:
 
 - **Grid** lays the container out at its real capacity, one cell per slot, with empty slots marked by a
   plus. It is the closest thing to the in-game container and answers "what is in this box" at a glance.
-  Empty cells are `aria-hidden` and non-interactive; the plus is decorative, drawn as two positioned
-  bars rather than a `+` glyph, since a glyph centres on its line box rather than its ink.
+  Each empty cell is a button that opens the add panel, labelled "Add an item to this container" — never
+  naming a slot, because clicking it does not choose one. The plus itself is decorative, drawn as two
+  positioned bars rather than a `+` glyph, since a glyph centres on its line box rather than its ink.
+  Empty cells carry `tabIndex={-1}`: a 45-slot container holding three items would otherwise wedge 42 tab
+  stops between the grid and the controls below it. Grid has no standalone Add Item control — the
+  keyboard route there is the **List** toggle, then the footer button below.
 - **List** is one row per slot with its slot number, quantity and a delete button. It sorts and scans
   better on a full 100-slot container, and is the automatic fallback whenever the grid is withheld.
+  It enumerates *occupied* slots only, so it has no empty cell to click — which is why **Add Item**
+  appears at the bottom-left of the dialog's footer, opposite Close, in this view only. Grid does not
+  repeat it: its empty cells are already the add affordance, and a second control doing the same thing
+  would be redundant.
 
 Selecting a slot — a grid cell or an item name in the list — moves its controls into a strip below,
-carrying the item, its slot, an amount field defaulting to the whole stack, and the delete button.
+carrying the item, its slot, grade and durability, an amount field defaulting to the whole stack, and the
+delete button. A second line lists the item's augments with their own per-augment grade, present only on a
+slot that actually has any — most items are unaugmented, so most selections show no second line at all.
 One strip rather than a control per row: a packed 100-slot container would otherwise render a hundred
 quantity inputs.
+
+**Add Item replaces the slot region rather than stacking under it.** `ItemCatalogSelector` brings roughly
+300px of its own category select, filter and scrolling grid; below an already-scrolling slot list that sum
+pushed the dialog's own actions off screen. Swapping keeps the height envelope identical in both modes. The
+add panel and the slot-detail strip are therefore two modes of one dialog, not two panels: opening either
+closes the other, and the strip is keyed to an existing occupied slot so it could not represent an add
+anyway. Both are cleared when the overlay is closed or a different container is opened.
 
 Every inventory shares a single scroll region, so a placeable backing two inventories does not get two
 independent scrollbars.


### PR DESCRIPTION
Adds the inverse of the existing container delete: a Storage container's contents overlay can now create a new item, under the same ownership proof and stopped-map gate.

- Never merges into a matching stack; always appends to `max(position_index)+1` — the slot is never chooseable, and the UI never implies otherwise
- `addSafety` twin of `deleteSafety` off one shared liveness probe; own IAM action `bases:add-item`
- Shared integration schema/seed extracted so the add and delete suites can't drift apart
- Slot-detail strip now also shows grade and (when present) augments with their own per-augment grade

Also fixes a few UI issues surfaced while building this: a header layout wrap bug, a sticky-header-in-a-nested-table bug (replaced with a header/body split), and the catalog picker showing a formatted item ID instead of the real item name.

**Verified**: 372/372 backend, 435/435 frontend, clean typecheck, live end-to-end against a restored production dump (add/delete round-trips, concurrent-add locking, write-safety gate).
