### PR TITLE
fix(console): buyback seeded caps honor reseed augment pricing; feat: commodity stack overrides

### DIFF
--- a/console/api/src/addonJobs.js
+++ b/console/api/src/addonJobs.js
@@ -32,13 +32,14 @@ import {
   executeSeedRun,
   normalizeCategoryMultipliers,
   normalizeScheduleSource,
+  normalizeAugmentPricing,
   resolveMarketSeedPlanPath,
   legacySeedSchedulePath,
   seedSchedulePath,
-  seedRowCategoryMultiplier
+  listedMarketUnitPrice
 } from "./addonSeedJob.js";
 
-export { CATEGORY_MULTIPLIER_FIELDS, readSeedSchedule, normalizeSeedSchedule, saveSeedSchedule, normalizeCategoryMultipliers, normalizeScheduleSource, resolveMarketSeedPlanPath, legacySeedSchedulePath, seedSchedulePath, loadMarketSeedPlan, seedRowCategoryMultiplier } from "./addonSeedJob.js";
+export { CATEGORY_MULTIPLIER_FIELDS, readSeedSchedule, normalizeSeedSchedule, saveSeedSchedule, normalizeCategoryMultipliers, normalizeScheduleSource, resolveMarketSeedPlanPath, legacySeedSchedulePath, seedSchedulePath, loadMarketSeedPlan, seedRowCategoryMultiplier, listedMarketUnitPrice, normalizeAugmentPricing } from "./addonSeedJob.js";
 
 export const EDA_EXCHANGE_BOT_ADDON_ID = "eda-exchange-bot";
 export const ADDON_SCHEDULER_PERMISSION = "scheduler:server";
@@ -210,7 +211,8 @@ export function loadBuybackSeedPlan(config, addonId = EDA_EXCHANGE_BOT_ADDON_ID)
       displayName: String(row?.display_name || "").trim(),
       price,
       qualityLevel: clampInteger(row?.quality_level, 0, 0, 5),
-      categoryMask: Math.trunc(Number(row?.category_mask) || 0)
+      categoryMask: Math.trunc(Number(row?.category_mask) || 0),
+      kind: String(row?.kind || "equippable").slice(0, 40)
     };
   });
   return { sourceMultiplier, rows };
@@ -298,12 +300,14 @@ const BUYBACK_PLAYER_SELL_SQL = "COALESCE(o.is_npc_order, FALSE) = FALSE AND (b.
 // seed row. Seed prices use stepped rounding, so reconstructing higher grades
 // from a grade-0 base can differ from the actual configured market price.
 // The schedule's category multipliers reprice each row the same way the seed
-// run does, so the "seeded" basis tracks the boosted market.
+// run does, so the "seeded" basis tracks the boosted market. Ready-made
+// augment items also use the reseed schedule's augmentPricing (discounted vs
+// original) so 60% of seeded means 60% of what the bot actually lists.
 export function buybackPlanValuesSql(plan, schedule) {
-  const { priceMultiplier, buybackPercent } = schedule;
+  const { buybackPercent } = schedule;
   const maxPrice = new Map();
   for (const row of plan.rows) {
-    const repriced = roundPrice((row.price / plan.sourceMultiplier) * priceMultiplier * seedRowCategoryMultiplier(row, schedule));
+    const repriced = listedMarketUnitPrice(plan, row, schedule);
     const key = `${row.templateId}\0${row.qualityLevel}`;
     maxPrice.set(key, Math.max(maxPrice.get(key) || 0, repriced));
   }
@@ -587,9 +591,16 @@ SELECT r.purchased, r.total_units, r.total_solari, r.threshold_percent, r.max_bu
 FROM market_buy_result r;`;
 }
 
+function withReseedAugmentPricing(config, schedule) {
+  return {
+    ...schedule,
+    augmentPricing: normalizeAugmentPricing(readSeedSchedule(config).augmentPricing)
+  };
+}
+
 export async function probeBuybackEligibility(config, db, overrides = {}) {
   const saved = readBuybackSchedule(config);
-  const schedule = normalizeBuybackSchedule({
+  const schedule = withReseedAugmentPricing(config, normalizeBuybackSchedule({
     exchangeId: overrides.exchangeId,
     priceMultiplier: overrides.priceMultiplier,
     augmentMultiplier: overrides.augmentMultiplier,
@@ -598,7 +609,7 @@ export async function probeBuybackEligibility(config, db, overrides = {}) {
     buybackPercent: overrides.buybackPercent,
     buybackPriceBasis: overrides.buybackPriceBasis,
     maxBuys: overrides.maxBuys
-  }, saved);
+  }, saved));
   if (!schedule.exchangeId) throw new Error("An exchangeId is required to probe buyback eligibility.");
   const plan = loadBuybackSeedPlan(config);
   const result = await runSql(db, buildBuybackEligibilitySql(plan, schedule), false);
@@ -631,7 +642,7 @@ function buybackScheduleOverrides(overrides = {}) {
 
 export async function classifyBuybackListings(config, db, overrides = {}) {
   const saved = readBuybackSchedule(config);
-  const schedule = normalizeBuybackSchedule(buybackScheduleOverrides(overrides), saved);
+  const schedule = withReseedAugmentPricing(config, normalizeBuybackSchedule(buybackScheduleOverrides(overrides), saved));
   if (!schedule.exchangeId) throw new Error("An exchangeId is required to classify buyback listings.");
   const plan = loadBuybackSeedPlan(config);
   const result = await runSql(db, buildBuybackClassifySql(plan, schedule), false);
@@ -921,11 +932,12 @@ async function executeBuybackRun(config, db, schedule, { runDuneImpl, trigger = 
   const plan = loadBuybackSeedPlan(config);
   const names = seedPlanDisplayNames(plan);
   const source = trigger === "schedule" ? "Scheduled buyback" : "Buyback sweep";
-  const probe = await runSql(db, buildBuybackEligibilitySql(plan, schedule), false);
+  const priced = withReseedAugmentPricing(config, schedule);
+  const probe = await runSql(db, buildBuybackEligibilitySql(plan, priced), false);
   const diagnostics = buybackDiagnostics(probe?.rows?.[0]);
   const eligible = diagnostics.eligible;
   if (eligible <= 0) {
-    await persistIdleBuybackLog(config, db, plan, schedule, names, source, diagnostics);
+    await persistIdleBuybackLog(config, db, plan, priced, names, source, diagnostics);
     return {
       status: "idle",
       eligible: 0,
@@ -944,7 +956,7 @@ async function executeBuybackRun(config, db, schedule, { runDuneImpl, trigger = 
   // Keep the entire sweep on one checked-out client. createDb.transaction()
   // guarantees ROLLBACK before releasing that client if any statement fails,
   // preventing an aborted transaction from being returned to the pool.
-  const sweep = await db.transaction((tx) => runSql(tx, buildBuybackSql(plan, schedule), true));
+  const sweep = await db.transaction((tx) => runSql(tx, buildBuybackSql(plan, priced), true));
   const row = sweep?.rows?.[0] || {};
   // purchased is a plain INTEGER bounded by maxBuys; the unit/solari totals
   // are BIGINT sums, so they stay decimal strings end-to-end like exchange
@@ -952,7 +964,7 @@ async function executeBuybackRun(config, db, schedule, { runDuneImpl, trigger = 
   const purchased = Number(row.purchased || 0);
   const totalUnits = decimalString(row.total_units);
   const totalSolari = decimalString(row.total_solari);
-  await persistSweepBuybackLog(config, db, plan, row, schedule, names, source);
+  await persistSweepBuybackLog(config, db, plan, row, priced, names, source);
   return {
     status: "swept",
     eligible,
@@ -1369,16 +1381,6 @@ function extractBuybackLogRows(row = {}) {
 
 function sqlLiteral(value) {
   return "'" + String(value ?? "").replaceAll("'", "''") + "'";
-}
-
-function roundPrice(value) {
-  const number = Math.max(1, Number(value) || 1);
-  let step = 1;
-  if (number >= 1000000) step = 10000;
-  else if (number >= 100000) step = 1000;
-  else if (number >= 10000) step = 100;
-  else if (number >= 1000) step = 10;
-  return Math.max(1, Math.round(number / step) * step);
 }
 
 function clampInteger(value, fallback, min, max) {

--- a/console/api/src/addonJobs.js
+++ b/console/api/src/addonJobs.js
@@ -36,10 +36,10 @@ import {
   resolveMarketSeedPlanPath,
   legacySeedSchedulePath,
   seedSchedulePath,
-  listedMarketUnitPrice
+  createListedMarketUnitPrice
 } from "./addonSeedJob.js";
 
-export { CATEGORY_MULTIPLIER_FIELDS, COMMODITY_STACK_CATALOG, COMMODITY_STACK_GROUPS, COMMODITY_STACK_MIN, COMMODITY_STACK_MAX, COMMODITY_STACK_DEFAULT, readSeedSchedule, normalizeSeedSchedule, saveSeedSchedule, normalizeCategoryMultipliers, normalizeCommodityStacks, normalizeScheduleSource, resolveMarketSeedPlanPath, legacySeedSchedulePath, seedSchedulePath, loadMarketSeedPlan, seedRowCategoryMultiplier, seedRowListingCount, listedMarketUnitPrice, normalizeAugmentPricing } from "./addonSeedJob.js";
+export { CATEGORY_MULTIPLIER_FIELDS, COMMODITY_STACK_CATALOG, COMMODITY_STACK_GROUPS, COMMODITY_STACK_MIN, COMMODITY_STACK_MAX, COMMODITY_STACK_DEFAULT, readSeedSchedule, normalizeSeedSchedule, saveSeedSchedule, normalizeCategoryMultipliers, normalizeCommodityStacks, normalizeScheduleSource, resolveMarketSeedPlanPath, legacySeedSchedulePath, seedSchedulePath, loadMarketSeedPlan, seedRowCategoryMultiplier, seedRowListingCount, createListedMarketUnitPrice, listedMarketUnitPrice, normalizeAugmentPricing } from "./addonSeedJob.js";
 
 export const EDA_EXCHANGE_BOT_ADDON_ID = "eda-exchange-bot";
 export const ADDON_SCHEDULER_PERMISSION = "scheduler:server";
@@ -306,8 +306,9 @@ const BUYBACK_PLAYER_SELL_SQL = "COALESCE(o.is_npc_order, FALSE) = FALSE AND (b.
 export function buybackPlanValuesSql(plan, schedule) {
   const { buybackPercent } = schedule;
   const maxPrice = new Map();
+  const listedUnitPrice = createListedMarketUnitPrice(plan, schedule);
   for (const row of plan.rows) {
-    const repriced = listedMarketUnitPrice(plan, row, schedule);
+    const repriced = listedUnitPrice(row);
     const key = `${row.templateId}\0${row.qualityLevel}`;
     maxPrice.set(key, Math.max(maxPrice.get(key) || 0, repriced));
   }

--- a/console/api/src/addonJobs.js
+++ b/console/api/src/addonJobs.js
@@ -39,7 +39,7 @@ import {
   listedMarketUnitPrice
 } from "./addonSeedJob.js";
 
-export { CATEGORY_MULTIPLIER_FIELDS, readSeedSchedule, normalizeSeedSchedule, saveSeedSchedule, normalizeCategoryMultipliers, normalizeScheduleSource, resolveMarketSeedPlanPath, legacySeedSchedulePath, seedSchedulePath, loadMarketSeedPlan, seedRowCategoryMultiplier, listedMarketUnitPrice, normalizeAugmentPricing } from "./addonSeedJob.js";
+export { CATEGORY_MULTIPLIER_FIELDS, COMMODITY_STACK_CATALOG, COMMODITY_STACK_GROUPS, COMMODITY_STACK_MIN, COMMODITY_STACK_MAX, COMMODITY_STACK_DEFAULT, readSeedSchedule, normalizeSeedSchedule, saveSeedSchedule, normalizeCategoryMultipliers, normalizeCommodityStacks, normalizeScheduleSource, resolveMarketSeedPlanPath, legacySeedSchedulePath, seedSchedulePath, loadMarketSeedPlan, seedRowCategoryMultiplier, seedRowListingCount, listedMarketUnitPrice, normalizeAugmentPricing } from "./addonSeedJob.js";
 
 export const EDA_EXCHANGE_BOT_ADDON_ID = "eda-exchange-bot";
 export const ADDON_SCHEDULER_PERMISSION = "scheduler:server";

--- a/console/api/src/addonSeedJob.js
+++ b/console/api/src/addonSeedJob.js
@@ -293,13 +293,11 @@ function augmentStatRollCounts(config) {
 export function buildMarketSeedSql(plan, schedule) {
   const exchangeId = requireSeedExchangeId(schedule);
   const multiplier = schedule.priceMultiplier;
-  const augmentPricing = normalizeAugmentPricing(schedule.augmentPricing);
-  const augmentSchematicPrices = augmentSchematicPriceMap(plan.rows);
   const valuesSql = plan.rows.map((row) => {
     // Price pipeline: plan price (with the augment pricing choice applied),
     // normalized back to the plan's own 1x scale, then the schedule's base
     // multiplier and the row's category multiplier, rounded to clean steps.
-    const price = roundPrice((seedRowBasePrice(row, augmentPricing, augmentSchematicPrices) / plan.sourceMultiplier) * multiplier * seedRowCategoryMultiplier(row, schedule));
+    const price = listedMarketUnitPrice(plan, row, schedule);
     return `(${sqlLiteral(row.templateId)},${row.stackSize},${price},${row.categoryMask},${row.categoryDepth},${row.qualityLevel},${sqlLiteral(row.kind)},${row.listings},${sqlLiteral(row.itemStats)})`;
   }).join(",\n") || "(NULL,1,0,0,0,0,'equippable',0,'{}')";
 
@@ -428,10 +426,14 @@ function requireSeedExchangeId(schedule) {
   return exchangeId;
 }
 
+function isAugmentSchematicRow(row) {
+  return row.kind === "schematic" || String(row.templateId || "").endsWith("_Schematic");
+}
+
 function augmentSchematicPriceMap(rows) {
   const prices = new Map();
   for (const row of rows) {
-    if (row.kind === "schematic" && AUGMENT_TEMPLATE_PATTERN.test(row.templateId)) {
+    if (isAugmentSchematicRow(row) && AUGMENT_TEMPLATE_PATTERN.test(row.templateId)) {
       prices.set(`${row.templateId}:${row.qualityLevel}`, row.price);
     }
   }
@@ -443,12 +445,23 @@ function augmentSchematicPriceMap(rows) {
 // the same grade, or 1/20 of the item's own plan price when no schematic is
 // listed — the plan's original augment item ladder (19M-37.5M) is 20x the
 // discounted one, so both paths land on the same scale.
-function seedRowBasePrice(row, augmentPricing, augmentSchematicPrices) {
-  if (augmentPricing !== "discounted" || row.kind === "schematic" || !AUGMENT_TEMPLATE_PATTERN.test(row.templateId)) {
+export function seedRowBasePrice(row, augmentPricing, augmentSchematicPrices) {
+  if (augmentPricing !== "discounted" || isAugmentSchematicRow(row) || !AUGMENT_TEMPLATE_PATTERN.test(row.templateId)) {
     return row.price;
   }
   const schematicPrice = augmentSchematicPrices.get(`${row.templateId}_Schematic:${row.qualityLevel}`);
   return schematicPrice ? schematicPrice / 2 : row.price / 20;
+}
+
+// Shared by reseed SQL and buyback's seeded price basis so "60% of seeded"
+// tracks what the bot actually lists after augmentPricing + multipliers.
+export function listedMarketUnitPrice(plan, row, schedule) {
+  const schematicPrices = augmentSchematicPriceMap(plan.rows || []);
+  const base = seedRowBasePrice(row, normalizeAugmentPricing(schedule?.augmentPricing), schematicPrices);
+  const source = Math.max(1, Number(plan.sourceMultiplier) || 1);
+  const multiplier = Number(schedule?.priceMultiplier);
+  const priceMultiplier = Number.isFinite(multiplier) && multiplier > 0 ? multiplier : 1;
+  return roundPrice((base / source) * priceMultiplier * seedRowCategoryMultiplier(row, schedule));
 }
 
 function itemStatsJson(durCur, durMax, statRolls = null) {

--- a/console/api/src/addonSeedJob.js
+++ b/console/api/src/addonSeedJob.js
@@ -65,6 +65,59 @@ const CATEGORY_MULTIPLIER_LABELS = {
   rankedWeaponMultiplier: "ranked weapons"
 };
 
+// Operator-tunable listing counts for base-useful commodities. Each listing is
+// one full stack_size sell order. The bundled plan uses 2 listings per row;
+// the reseed schedule may override that per template (1-20) without editing
+// the plan. Unknown template ids are dropped so a catalog shrink cannot wipe
+// a stored seed schedule on read.
+export const COMMODITY_STACK_MIN = 1;
+export const COMMODITY_STACK_MAX = 20;
+export const COMMODITY_STACK_DEFAULT = 2;
+export const COMMODITY_STACK_GROUPS = [
+  { id: "power", label: "Power" },
+  { id: "filters", label: "Windtrap filters" },
+  { id: "spice", label: "Spice" },
+  { id: "refining", label: "Refining" },
+  { id: "building", label: "Building" },
+  { id: "fragments", label: "Schematic fragments" },
+  { id: "survival", label: "Survival" }
+];
+export const COMMODITY_STACK_CATALOG = [
+  { templateId: "Oil", label: "Fuel Cell", group: "power", groupLabel: "Power", stackSize: 500 },
+  { templateId: "SpicedFuelCell", label: "Spice-infused Fuel Cell", group: "power", groupLabel: "Power", stackSize: 500 },
+  { templateId: "WindTurbineLubricant1", label: "Low-grade Lubricant", group: "power", groupLabel: "Power", stackSize: 100 },
+  { templateId: "WindTurbineLubricant2", label: "Industrial-grade Lubricant", group: "power", groupLabel: "Power", stackSize: 100 },
+  { templateId: "WindTrapFilter1", label: "Makeshift Filter", group: "filters", groupLabel: "Windtrap filters", stackSize: 5 },
+  { templateId: "WindTrapFilter2", label: "Standard Filter", group: "filters", groupLabel: "Windtrap filters", stackSize: 5 },
+  { templateId: "WindTrapFilter3", label: "Particulate Filter", group: "filters", groupLabel: "Windtrap filters", stackSize: 5 },
+  { templateId: "WindTrapFilter4", label: "Advanced Particulate Filter", group: "filters", groupLabel: "Windtrap filters", stackSize: 5 },
+  { templateId: "MelangeSpice", label: "Spice Melange", group: "spice", groupLabel: "Spice", stackSize: 500 },
+  { templateId: "SpiceResidue", label: "Spice Residue", group: "spice", groupLabel: "Spice", stackSize: 1000 },
+  { templateId: "FlourSand", label: "Flour Sand", group: "spice", groupLabel: "Spice", stackSize: 1000 },
+  { templateId: "SpiceSand", label: "Spice Sand", group: "spice", groupLabel: "Spice", stackSize: 2500 },
+  { templateId: "T6RefinedResourceA", label: "Plastanium Ingot", group: "refining", groupLabel: "Refining", stackSize: 500 },
+  { templateId: "DuraluminumRod", label: "Duraluminum Ingot", group: "refining", groupLabel: "Refining", stackSize: 500 },
+  { templateId: "AluminiumBar", label: "Aluminum Ingot", group: "refining", groupLabel: "Refining", stackSize: 500 },
+  { templateId: "SteelBar", label: "Steel Ingot", group: "refining", groupLabel: "Refining", stackSize: 500 },
+  { templateId: "IronBar", label: "Iron Ingot", group: "refining", groupLabel: "Refining", stackSize: 500 },
+  { templateId: "CopperBar", label: "Copper Ingot", group: "refining", groupLabel: "Refining", stackSize: 500 },
+  { templateId: "CobaltBar", label: "Cobalt Paste", group: "refining", groupLabel: "Refining", stackSize: 500 },
+  { templateId: "T6RefinedResourceB", label: "Stravidium Fiber", group: "refining", groupLabel: "Refining", stackSize: 500 },
+  { templateId: "T6ResourceB", label: "Stravidium Mass", group: "refining", groupLabel: "Refining", stackSize: 500 },
+  { templateId: "ScrapMetal", label: "Salvaged Metal", group: "building", groupLabel: "Building", stackSize: 500 },
+  { templateId: "Stone", label: "Granite Stone", group: "building", groupLabel: "Building", stackSize: 500 },
+  { templateId: "Plastone", label: "Plastone", group: "building", groupLabel: "Building", stackSize: 500 },
+  { templateId: "Silicone", label: "Silicone Block", group: "building", groupLabel: "Building", stackSize: 500 },
+  { templateId: "PlantFiber", label: "Plant Fiber", group: "building", groupLabel: "Building", stackSize: 500 },
+  { templateId: "T6SchematicFragmentQL1", label: "Schematic Pattern Grade 1", group: "fragments", groupLabel: "Schematic fragments", stackSize: 500 },
+  { templateId: "T6SchematicFragmentQL2", label: "Schematic Pattern Grade 2", group: "fragments", groupLabel: "Schematic fragments", stackSize: 500 },
+  { templateId: "T6SchematicFragmentQL3", label: "Schematic Pattern Grade 3", group: "fragments", groupLabel: "Schematic fragments", stackSize: 500 },
+  { templateId: "T6SchematicFragmentQL4", label: "Schematic Pattern Grade 4", group: "fragments", groupLabel: "Schematic fragments", stackSize: 500 },
+  { templateId: "T6SchematicFragmentQL5", label: "Schematic Pattern Grade 5", group: "fragments", groupLabel: "Schematic fragments", stackSize: 500 },
+  { templateId: "AntiRadiationPill", label: "Iodine Pill", group: "survival", groupLabel: "Survival", stackSize: 20 }
+];
+const COMMODITY_STACK_IDS = new Set(COMMODITY_STACK_CATALOG.map((item) => item.templateId));
+
 export function normalizeCategoryMultipliers(payload = {}, previous = {}, scheduleLabel = "Schedule") {
   const multipliers = {};
   for (const field of CATEGORY_MULTIPLIER_FIELDS) {
@@ -102,6 +155,34 @@ export function describeCategoryMultipliers(multipliers = {}) {
   return parts.length ? `, ${parts.join(", ")}` : "";
 }
 
+export function normalizeCommodityStacks(payload = {}, previous = {}) {
+  const raw = payload?.commodityStacks === undefined ? previous?.commodityStacks : payload.commodityStacks;
+  if (raw == null) return {};
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error("Seed schedule commodityStacks must be an object of templateId to stack count.");
+  }
+  const next = {};
+  for (const [templateId, value] of Object.entries(raw)) {
+    if (!COMMODITY_STACK_IDS.has(templateId)) continue;
+    next[templateId] = integerField(value, `commodityStacks.${templateId}`, COMMODITY_STACK_MIN, COMMODITY_STACK_MAX);
+  }
+  return next;
+}
+
+// Number of sell orders (full stacks) to list for this plan row. Catalog
+// overrides apply by template; every other row keeps the plan's listings.
+export function seedRowListingCount(row, schedule) {
+  const override = schedule?.commodityStacks?.[row.templateId];
+  return Number.isInteger(override) ? override : row.listings;
+}
+
+export function describeCommodityStacks(schedule = {}) {
+  const overridden = Object.entries(schedule.commodityStacks || {})
+    .filter(([, listings]) => listings !== COMMODITY_STACK_DEFAULT);
+  if (!overridden.length) return "";
+  return `, ${overridden.length} commodity stack override${overridden.length === 1 ? "" : "s"}`;
+}
+
 export function normalizeSeedSchedule(payload = {}, previous = {}) {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     throw new Error("Seed schedule must be a JSON object.");
@@ -126,7 +207,8 @@ export function normalizeSeedSchedule(payload = {}, previous = {}) {
     priceMultiplier: integerField(payload.priceMultiplier ?? previous.priceMultiplier ?? 5, "priceMultiplier", 1, 100),
     ...normalizeCategoryMultipliers(payload, previous, "Seed schedule"),
     augmentPricing: normalizeAugmentPricing(payload.augmentPricing ?? previous.augmentPricing),
-    // Who owns this schedule: "addon" (bridge-managed; scheduled runs re-verify
+    commodityStacks: normalizeCommodityStacks(payload, previous),
+    // Who owns this schedule: "addon" (bridge-managed; scheduled runs re-verify)
     // the addon's approved permissions) or "console" (first-class Market Bot;
     // authorized by RBAC at save time). Deliberately NOT read from the payload —
     // only the save-path options can set it, so an addon iframe cannot flip a
@@ -298,7 +380,8 @@ export function buildMarketSeedSql(plan, schedule) {
     // normalized back to the plan's own 1x scale, then the schedule's base
     // multiplier and the row's category multiplier, rounded to clean steps.
     const price = listedMarketUnitPrice(plan, row, schedule);
-    return `(${sqlLiteral(row.templateId)},${row.stackSize},${price},${row.categoryMask},${row.categoryDepth},${row.qualityLevel},${sqlLiteral(row.kind)},${row.listings},${sqlLiteral(row.itemStats)})`;
+    const listings = seedRowListingCount(row, schedule);
+    return `(${sqlLiteral(row.templateId)},${row.stackSize},${price},${row.categoryMask},${row.categoryDepth},${row.qualityLevel},${sqlLiteral(row.kind)},${listings},${sqlLiteral(row.itemStats)})`;
   }).join(",\n") || "(NULL,1,0,0,0,0,'equippable',0,'{}')";
 
   // Always clear the bot's own listings for this exchange before seeding.
@@ -389,7 +472,7 @@ export async function executeSeedRun(config, db, schedule, { runDuneImpl, buildD
     resourceListings: decimalString(row.resource_listings),
     priceMultiplier: schedule.priceMultiplier,
     exchangeId: schedule.exchangeId,
-    detail: `Seeded ${listingCount} listings on exchange ${schedule.exchangeId} at ${schedule.priceMultiplier}x${describeCategoryMultipliers(schedule)} (bot listings cleared first).`
+    detail: `Seeded ${listingCount} listings on exchange ${schedule.exchangeId} at ${schedule.priceMultiplier}x${describeCategoryMultipliers(schedule)}${describeCommodityStacks(schedule)} (bot listings cleared first).`
   };
 }
 

--- a/console/api/src/addonSeedJob.js
+++ b/console/api/src/addonSeedJob.js
@@ -375,11 +375,12 @@ function augmentStatRollCounts(config) {
 export function buildMarketSeedSql(plan, schedule) {
   const exchangeId = requireSeedExchangeId(schedule);
   const multiplier = schedule.priceMultiplier;
+  const listedUnitPrice = createListedMarketUnitPrice(plan, schedule);
   const valuesSql = plan.rows.map((row) => {
     // Price pipeline: plan price (with the augment pricing choice applied),
     // normalized back to the plan's own 1x scale, then the schedule's base
     // multiplier and the row's category multiplier, rounded to clean steps.
-    const price = listedMarketUnitPrice(plan, row, schedule);
+    const price = listedUnitPrice(row);
     const listings = seedRowListingCount(row, schedule);
     return `(${sqlLiteral(row.templateId)},${row.stackSize},${price},${row.categoryMask},${row.categoryDepth},${row.qualityLevel},${sqlLiteral(row.kind)},${listings},${sqlLiteral(row.itemStats)})`;
   }).join(",\n") || "(NULL,1,0,0,0,0,'equippable',0,'{}')";
@@ -536,15 +537,25 @@ export function seedRowBasePrice(row, augmentPricing, augmentSchematicPrices) {
   return schematicPrice ? schematicPrice / 2 : row.price / 20;
 }
 
-// Shared by reseed SQL and buyback's seeded price basis so "60% of seeded"
-// tracks what the bot actually lists after augmentPricing + multipliers.
-export function listedMarketUnitPrice(plan, row, schedule) {
+// Build the plan-wide schematic index once, then reuse it for every row. Both
+// reseed and buyback price thousands of rows at a time, so rebuilding the map
+// inside the row loop would turn SQL generation into quadratic work.
+export function createListedMarketUnitPrice(plan, schedule) {
   const schematicPrices = augmentSchematicPriceMap(plan.rows || []);
-  const base = seedRowBasePrice(row, normalizeAugmentPricing(schedule?.augmentPricing), schematicPrices);
+  const augmentPricing = normalizeAugmentPricing(schedule?.augmentPricing);
   const source = Math.max(1, Number(plan.sourceMultiplier) || 1);
   const multiplier = Number(schedule?.priceMultiplier);
   const priceMultiplier = Number.isFinite(multiplier) && multiplier > 0 ? multiplier : 1;
-  return roundPrice((base / source) * priceMultiplier * seedRowCategoryMultiplier(row, schedule));
+  return (row) => {
+    const base = seedRowBasePrice(row, augmentPricing, schematicPrices);
+    return roundPrice((base / source) * priceMultiplier * seedRowCategoryMultiplier(row, schedule));
+  };
+}
+
+// Shared single-row convenience helper. Bulk callers should create one
+// plan-scoped pricer with createListedMarketUnitPrice and reuse it.
+export function listedMarketUnitPrice(plan, row, schedule) {
+  return createListedMarketUnitPrice(plan, schedule)(row);
 }
 
 function itemStatsJson(durCur, durMax, statRolls = null) {

--- a/console/api/src/services/exchangeMarket.js
+++ b/console/api/src/services/exchangeMarket.js
@@ -5,7 +5,9 @@ import {
   saveBuybackSchedule,
   readSeedSchedule,
   saveSeedSchedule,
-  resolveMarketSeedPlanPath
+  resolveMarketSeedPlanPath,
+  COMMODITY_STACK_CATALOG,
+  COMMODITY_STACK_GROUPS
 } from "../addonJobs.js";
 
 // First-class Market Bot for the CHOAM exchange: the same seed/buyback engine
@@ -57,6 +59,8 @@ export async function marketBotStatus(config, db) {
     plan: marketSeedPlanSummary(config),
     buyback: readBuybackSchedule(config),
     seed: readSeedSchedule(config),
+    commodityStackCatalog: COMMODITY_STACK_CATALOG,
+    commodityStackGroups: COMMODITY_STACK_GROUPS,
     ...(supported ? {} : { reason: `Unsupported by detected schema. Missing required table(s): ${REQUIRED_TABLES.map((t) => `dune.${t}`).join(", ")}` })
   };
 }

--- a/console/api/test/addonJobs.test.js
+++ b/console/api/test/addonJobs.test.js
@@ -29,6 +29,7 @@ import {
   readBuybackSchedule,
   refreshBuybackLog,
   saveBuybackSchedule,
+  saveSeedSchedule,
   selectStoredBuybackLogEntries
 } from "../src/addonJobs.js";
 
@@ -474,16 +475,19 @@ test("buyback caps reprice ranked categories the same way the seed run does", ()
   const config = { repoRoot, mockMode: false };
   try {
     const loaded = loadBuybackSeedPlan(config);
-    const schedule = normalizeBuybackSchedule({
-      enabled: true,
-      exchangeId: "77",
-      priceMultiplier: 5,
-      augmentMultiplier: 2,
-      rankedArmorMultiplier: 3,
-      rankedWeaponMultiplier: 1.5,
-      buybackPercent: 50,
-      maxBuys: 100
-    });
+    const schedule = {
+      ...normalizeBuybackSchedule({
+        enabled: true,
+        exchangeId: "77",
+        priceMultiplier: 5,
+        augmentMultiplier: 2,
+        rankedArmorMultiplier: 3,
+        rankedWeaponMultiplier: 1.5,
+        buybackPercent: 50,
+        maxBuys: 100
+      }),
+      augmentPricing: "original"
+    };
     // Seeded basis per row: armor grade 3 8M -> 24M, grade 0 stays 5.5M,
     // weapon grade 4 9.6M -> 14.4M, augment 28M -> 56M, resource unchanged;
     // caps are 50% of that basis.
@@ -495,6 +499,64 @@ test("buyback caps reprice ranked categories the same way the seed run does", ()
       "('UniqueDualBlades_6',4,7200000),\n" +
       "('WaterBottle',0,500)"
     );
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("buyback seeded caps follow reseed discounted augment pricing", () => {
+  const plan = {
+    price_multiplier: 5,
+    rows: [
+      { template_id: "T6_Augment_Armor3", kind: "equippable", price: 37500000, category_mask: 67108864, quality_level: 5 },
+      { template_id: "T6_Augment_Armor3_Schematic", kind: "schematic", price: 3800000, category_mask: 67371008, quality_level: 5 },
+      { template_id: "WaterBottle", kind: "resource", price: 1000, category_mask: 1, quality_level: 0 }
+    ]
+  };
+  const repoRoot = makeRepoRoot(plan);
+  const config = { repoRoot, mockMode: false };
+  try {
+    const loaded = loadBuybackSeedPlan(config);
+    const base = normalizeBuybackSchedule({
+      exchangeId: "1",
+      priceMultiplier: 5,
+      augmentMultiplier: 1,
+      buybackPercent: 60
+    });
+    const discounted = { ...base, augmentPricing: "discounted" };
+    assert.match(buybackPlanValuesSql(loaded, discounted), /\('T6_Augment_Armor3',5,1140000\)/);
+    assert.match(buybackPlanValuesSql(loaded, discounted), /\('T6_Augment_Armor3_Schematic',5,2280000\)/);
+    assert.match(buybackPlanValuesSql(loaded, discounted), /\('WaterBottle',0,600\)/);
+
+    const original = { ...base, augmentPricing: "original" };
+    assert.match(buybackPlanValuesSql(loaded, original), /\('T6_Augment_Armor3',5,22500000\)/);
+    assert.match(buybackPlanValuesSql(loaded, original), /\('T6_Augment_Armor3_Schematic',5,2280000\)/);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("probe buyback SQL inherits reseed augmentPricing for seeded caps", async () => {
+  const plan = {
+    price_multiplier: 5,
+    rows: [
+      { template_id: "T6_Augment_Armor3", kind: "equippable", price: 37500000, category_mask: 67108864, quality_level: 5 },
+      { template_id: "T6_Augment_Armor3_Schematic", kind: "schematic", price: 3800000, category_mask: 67371008, quality_level: 5 }
+    ]
+  };
+  const repoRoot = makeRepoRoot(plan);
+  const config = { repoRoot, mockMode: false };
+  try {
+    saveBuybackSchedule(config, { exchangeId: "42", priceMultiplier: 5, augmentMultiplier: 1, buybackPercent: 60 });
+    saveSeedSchedule(config, { enabled: false, exchangeId: "42", augmentPricing: "original" });
+    const db = fakeDb({ eligible: "0" });
+    await probeBuybackEligibility(config, db, {});
+    assert.match(db.probes[0], /\('T6_Augment_Armor3',5,22500000\)/, "original reseed keeps the 37.5M item ladder");
+
+    saveSeedSchedule(config, { enabled: false, exchangeId: "42", augmentPricing: "discounted" });
+    await probeBuybackEligibility(config, db, {});
+    assert.match(db.probes[1], /\('T6_Augment_Armor3',5,1140000\)/, "discounted reseed uses half the schematic");
+    assert.match(db.probes[1], /\('T6_Augment_Armor3_Schematic',5,2280000\)/);
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
   }

--- a/console/api/test/addonSeedJob.test.js
+++ b/console/api/test/addonSeedJob.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { EDA_EXCHANGE_BOT_ADDON_ID, buildMarketSeedSql, loadMarketSeedPlan, normalizeSeedSchedule, seedRowCategoryMultiplier, seedRowListingCount, COMMODITY_STACK_CATALOG, COMMODITY_STACK_DEFAULT, COMMODITY_STACK_MAX } from "../src/addonSeedJob.js";
+import { EDA_EXCHANGE_BOT_ADDON_ID, buildMarketSeedSql, createListedMarketUnitPrice, loadMarketSeedPlan, normalizeSeedSchedule, seedRowCategoryMultiplier, seedRowListingCount, COMMODITY_STACK_CATALOG, COMMODITY_STACK_DEFAULT, COMMODITY_STACK_MAX } from "../src/addonSeedJob.js";
 
 const REPO_ROOT = resolve(import.meta.dirname, "../../..");
 
@@ -136,6 +136,24 @@ test("original augment pricing keeps the plan's augment item prices", () => {
     assert.match(sql, /'T6_Augment_Armor1_Schematic',1,2800000,/);
     // The stat roll pin is not a pricing choice: it applies in both modes.
     assert.match(sql, /"StatRolls":\[0\.2,0\.2\]/);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("plan-scoped market pricing reuses one schematic index across rows", () => {
+  const repoRoot = makeRepoRoot();
+  try {
+    const plan = loadMarketSeedPlan({ repoRoot });
+    const listedUnitPrice = createListedMarketUnitPrice(plan, {
+      priceMultiplier: 5,
+      augmentPricing: "discounted"
+    });
+    const byTemplate = new Map(plan.rows.map((row) => [row.templateId, row]));
+    assert.equal(listedUnitPrice(byTemplate.get("T6_Augment_Armor1")), 1400000);
+    assert.equal(listedUnitPrice(byTemplate.get("T6_Augment_Mystery1")), 950000);
+    assert.equal(listedUnitPrice(byTemplate.get("T6_Augment_Armor1_Schematic")), 2800000);
+    assert.equal(listedUnitPrice(byTemplate.get("Sword")), 2000);
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
   }

--- a/console/api/test/addonSeedJob.test.js
+++ b/console/api/test/addonSeedJob.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { EDA_EXCHANGE_BOT_ADDON_ID, buildMarketSeedSql, loadMarketSeedPlan, normalizeSeedSchedule, seedRowCategoryMultiplier } from "../src/addonSeedJob.js";
+import { EDA_EXCHANGE_BOT_ADDON_ID, buildMarketSeedSql, loadMarketSeedPlan, normalizeSeedSchedule, seedRowCategoryMultiplier, seedRowListingCount, COMMODITY_STACK_CATALOG, COMMODITY_STACK_DEFAULT, COMMODITY_STACK_MAX } from "../src/addonSeedJob.js";
 
 const REPO_ROOT = resolve(import.meta.dirname, "../../..");
 
@@ -273,6 +273,60 @@ test("seed schedule normalizes the augment pricing choice", () => {
   // Saves that omit the field (for example through the addon bridge) keep the stored choice.
   assert.equal(normalizeSeedSchedule({}, { augmentPricing: "original" }).augmentPricing, "original");
   assert.equal(normalizeSeedSchedule({ intervalMinutes: 20 }, { augmentPricing: "original" }).augmentPricing, "original");
+});
+
+test("seed schedule normalizes commodity stack overrides", () => {
+  assert.deepEqual(normalizeSeedSchedule({}).commodityStacks, {});
+  const set = normalizeSeedSchedule({ commodityStacks: { Oil: 10, SpicedFuelCell: 8 } });
+  assert.deepEqual(set.commodityStacks, { Oil: 10, SpicedFuelCell: 8 });
+  const kept = normalizeSeedSchedule({ intervalMinutes: 20 }, set);
+  assert.deepEqual(kept.commodityStacks, { Oil: 10, SpicedFuelCell: 8 });
+  const replaced = normalizeSeedSchedule({ commodityStacks: { Oil: 3 } }, set);
+  assert.deepEqual(replaced.commodityStacks, { Oil: 3 });
+  const dropped = normalizeSeedSchedule({ commodityStacks: { Oil: 10, NotARealItem: 9, Sword: 4 } });
+  assert.deepEqual(dropped.commodityStacks, { Oil: 10 });
+  assert.throws(() => normalizeSeedSchedule({ commodityStacks: { Oil: 0 } }), /commodityStacks.Oil must be an integer from 1 to 20/);
+  assert.throws(() => normalizeSeedSchedule({ commodityStacks: { Oil: COMMODITY_STACK_MAX + 1 } }), /commodityStacks.Oil/);
+  assert.throws(() => normalizeSeedSchedule({ commodityStacks: [] }), /commodityStacks must be an object/);
+});
+
+test("seed SQL lists overridden commodity stacks without changing other rows", () => {
+  const plan = {
+    panel_version: "test",
+    price_multiplier: 5,
+    rows: [
+      { template_id: "Oil", display_name: "Fuel Cell", kind: "resource", stack_size: 500, price: 250, category_mask: 1, category_depth: 1, quality_level: 0, listings: 2 },
+      { template_id: "WaterBottle", display_name: "Water Bottle", kind: "resource", stack_size: 10, price: 1000, category_mask: 1, category_depth: 1, quality_level: 0, listings: 2 }
+    ]
+  };
+  const repoRoot = makeRepoRoot({ plan });
+  try {
+    const loaded = loadMarketSeedPlan({ repoRoot });
+    assert.equal(seedRowListingCount(loaded.rows[0], {}), 2);
+    assert.equal(seedRowListingCount(loaded.rows[0], { commodityStacks: { Oil: 10 } }), 10);
+    assert.equal(seedRowListingCount(loaded.rows[1], { commodityStacks: { Oil: 10 } }), 2);
+    const sql = buildMarketSeedSql(loaded, { enabled: true, exchangeId: "7", priceMultiplier: 5, commodityStacks: { Oil: 10 } });
+    assert.match(sql, /'Oil',500,250,1,1,0,'resource',10,/);
+    assert.match(sql, /'WaterBottle',10,1000,1,1,0,'resource',2,/);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("commodity stack catalog matches the bundled plan", () => {
+  const plan = JSON.parse(readFileSync(resolve(REPO_ROOT, "runtime/data/market-seed-plan.json"), "utf8"));
+  const byTemplate = new Map(plan.rows.map((row) => [row.template_id, row]));
+  const seen = new Set();
+  for (const item of COMMODITY_STACK_CATALOG) {
+    assert.equal(seen.has(item.templateId), false, `duplicate catalog entry ${item.templateId}`);
+    seen.add(item.templateId);
+    const row = byTemplate.get(item.templateId);
+    assert.ok(row, `${item.templateId} (${item.label}) must exist in the bundled seed plan`);
+    assert.equal(row.stack_size, item.stackSize, `${item.templateId} stack_size`);
+    assert.equal(row.listings, COMMODITY_STACK_DEFAULT, `${item.templateId} default listings`);
+    assert.notEqual(row.kind, "equippable", `${item.templateId} should be a stacking commodity, not gear`);
+    assert.notEqual(row.kind, "schematic", `${item.templateId} should be a stacking commodity, not a schematic`);
+  }
 });
 
 test("bundled plan carries the original augment ladder with patterns to discount against", () => {

--- a/console/api/test/exchangeMarket.test.js
+++ b/console/api/test/exchangeMarket.test.js
@@ -233,6 +233,9 @@ test("market status carries both schedules with their sources", async () => {
     assert.equal(status.buyback.source, "console");
     assert.equal(status.seed.priceMultiplier, 7);
     assert.equal(status.seed.source, "console");
+    assert.deepEqual(status.seed.commodityStacks, {});
+    assert.ok(Array.isArray(status.commodityStackCatalog));
+    assert.ok(status.commodityStackCatalog.some((item) => item.templateId === "Oil"));
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
   }

--- a/console/web/src/api/marketBot.ts
+++ b/console/web/src/api/marketBot.ts
@@ -35,12 +35,25 @@ export type MarketBuybackSchedule = MarketCategoryMultipliers & {
   nextRunAt: string;
 };
 
+export type CommodityStackItem = {
+  templateId: string;
+  label: string;
+  group: string;
+  stackSize: number;
+};
+
+export type CommodityStackGroup = {
+  id: string;
+  label: string;
+};
+
 export type MarketSeedSchedule = MarketCategoryMultipliers & {
   enabled: boolean;
   intervalMinutes: number;
   exchangeId: string;
   priceMultiplier: number;
   augmentPricing: MarketAugmentPricing;
+  commodityStacks: Record<string, number>;
   source: "addon" | "console";
   lastRunAt: string;
   lastRunStatus: string;
@@ -53,6 +66,8 @@ export type MarketBotStatus = {
   plan: { available: boolean; source: "addon" | "bundled" | null; rows: number; panelVersion: string; generatedAt: string };
   buyback: MarketBuybackSchedule;
   seed: MarketSeedSchedule;
+  commodityStackCatalog?: CommodityStackItem[];
+  commodityStackGroups?: CommodityStackGroup[];
   reason?: string;
 };
 

--- a/console/web/src/features/exchange/ExchangePanel.test.tsx
+++ b/console/web/src/features/exchange/ExchangePanel.test.tsx
@@ -200,7 +200,7 @@ describe("ExchangePanel", () => {
       capabilities: { exchangeMarket: true },
       plan: { available: true, source: "bundled", rows: 10, panelVersion: "0.14.0", generatedAt: "" },
       buyback: { enabled: false, intervalMinutes: 30, exchangeId: "", priceMultiplier: 5, augmentMultiplier: 1, rankedArmorMultiplier: 1, rankedWeaponMultiplier: 1, buybackPercent: 60, buybackPriceBasis: "seeded", maxBuys: 500, source: "console", lastRunAt: "", lastRunStatus: "", lastRunDetail: "", nextRunAt: "" },
-      seed: { enabled: false, intervalMinutes: 15, exchangeId: "", priceMultiplier: 5, augmentMultiplier: 1, rankedArmorMultiplier: 1, rankedWeaponMultiplier: 1, augmentPricing: "discounted", source: "console", lastRunAt: "", lastRunStatus: "", lastRunDetail: "", nextRunAt: "" }
+      seed: { enabled: false, intervalMinutes: 15, exchangeId: "", priceMultiplier: 5, augmentMultiplier: 1, rankedArmorMultiplier: 1, rankedWeaponMultiplier: 1, augmentPricing: "discounted", source: "console", lastRunAt: "", lastRunStatus: "", lastRunDetail: "", nextRunAt: "", commodityStacks: {} }
     });
     renderPanel();
 

--- a/console/web/src/features/exchange/MarketBotOverlay.test.tsx
+++ b/console/web/src/features/exchange/MarketBotOverlay.test.tsx
@@ -32,6 +32,7 @@ function statusFixture(overrides: Partial<MarketBotStatus> = {}): MarketBotStatu
       enabled: false, intervalMinutes: 15, exchangeId: "", priceMultiplier: 5,
       augmentMultiplier: 1, rankedArmorMultiplier: 1, rankedWeaponMultiplier: 1,
       augmentPricing: "discounted", source: "console",
+      commodityStacks: {},
       lastRunAt: "", lastRunStatus: "", lastRunDetail: "", nextRunAt: ""
     },
     ...overrides
@@ -174,6 +175,7 @@ describe("MarketBotOverlay", () => {
       rankedArmorMultiplier: 1,
       rankedWeaponMultiplier: 1,
       augmentPricing: "original",
+      commodityStacks: {},
       exchangeId: "42"
     }));
     expect(await screen.findByText(/Reseed schedule saved \(disabled\)\./)).toBeInTheDocument();
@@ -203,6 +205,44 @@ describe("MarketBotOverlay", () => {
       rankedArmorMultiplier: 3,
       rankedWeaponMultiplier: 1.5,
       augmentPricing: "discounted",
+      commodityStacks: {},
+      exchangeId: "42"
+    }));
+  });
+
+  it("saves commodity stack counts from the reseed section", async () => {
+    vi.mocked(marketBotApi.status).mockResolvedValue(statusFixture({
+      commodityStackCatalog: [
+        { templateId: "Oil", label: "Fuel Cell", group: "power", stackSize: 500 },
+        { templateId: "AntiRadiationPill", label: "Iodine Pill", group: "survival", stackSize: 20 }
+      ],
+      commodityStackGroups: [
+        { id: "power", label: "Power" },
+        { id: "survival", label: "Survival" }
+      ],
+      seed: { ...statusFixture().seed, commodityStacks: { Oil: 2, AntiRadiationPill: 2 } }
+    }));
+    vi.mocked(marketBotApi.saveSeedSchedule).mockImplementation(async (schedule) => ({
+      ...statusFixture().seed, ...schedule, exchangeId: String(schedule.exchangeId || "42"), enabled: Boolean(schedule.enabled)
+    }));
+    renderOverlay();
+
+    const fuel = await screen.findByLabelText("Fuel Cell stacks");
+    expect(fuel).toHaveValue(2);
+    expect(screen.queryByText("10 × 500 = 5,000 units")).not.toBeInTheDocument();
+    fireEvent.change(fuel, { target: { value: "10" } });
+    expect(screen.getByText("10 × 500 = 5,000 units")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Save reseed schedule" }));
+
+    await waitFor(() => expect(marketBotApi.saveSeedSchedule).toHaveBeenCalledWith({
+      enabled: false,
+      intervalMinutes: 15,
+      priceMultiplier: 5,
+      augmentMultiplier: 1,
+      rankedArmorMultiplier: 1,
+      rankedWeaponMultiplier: 1,
+      augmentPricing: "discounted",
+      commodityStacks: { Oil: 10, AntiRadiationPill: 2 },
       exchangeId: "42"
     }));
   });

--- a/console/web/src/features/exchange/MarketBotOverlay.tsx
+++ b/console/web/src/features/exchange/MarketBotOverlay.tsx
@@ -417,7 +417,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
 
             <div className="market-bot-section">
               <strong>Buyback sweeps</strong>
-              <p className="action-help-note">Buys player sell listings whose per-unit ask is at or below the buyback percentage of the price basis (seeded NPC price at that grade, or live market average / lowest with seeded fallback). Whole listed stacks are bought in one pass. Every run probes eligibility read-only first and only backs up + sweeps when something qualifies. The category multipliers reprice the seeded basis the same way the reseed does — keep them matched with the reseed section so the buyback percentage tracks the real market prices.</p>
+              <p className="action-help-note">Buys player sell listings whose per-unit ask is at or below the buyback percentage of the price basis (seeded NPC price at that grade, or live market average / lowest with seeded fallback). Whole listed stacks are bought in one pass. Every run probes eligibility read-only first and only backs up + sweeps when something qualifies. The seeded basis uses this section's category multipliers and the reseed section's augment pricing (discounted vs original), so 60% of seeded tracks what the bot actually lists for ready-made augments. Category multipliers can still differ from reseed on purpose.</p>
               <div className="market-bot-grid">
                 <label>Interval (minutes)
                   <input aria-label="Buyback interval minutes" type="number" min={10} max={1440} value={buybackInterval} onChange={(event) => setBuybackInterval(Number(event.target.value))} />

--- a/console/web/src/features/exchange/MarketBotOverlay.tsx
+++ b/console/web/src/features/exchange/MarketBotOverlay.tsx
@@ -6,6 +6,8 @@ import {
   type MarketBotStatus,
   type MarketBuybackLogBatch,
   type MarketCategoryMultipliers,
+  type CommodityStackGroup,
+  type CommodityStackItem,
   type MarketExchange,
   type MarketPriceBasis,
   type MarketProbeResult
@@ -46,6 +48,72 @@ function categoryMultipliersFrom(schedule: Partial<MarketCategoryMultipliers>): 
     rankedArmorMultiplier: schedule.rankedArmorMultiplier ?? 1,
     rankedWeaponMultiplier: schedule.rankedWeaponMultiplier ?? 1
   };
+}
+
+const COMMODITY_STACK_MIN = 1;
+const COMMODITY_STACK_MAX = 20;
+const COMMODITY_STACK_DEFAULT = 2;
+
+function commodityStacksFrom(saved: Record<string, number> | undefined, catalog: CommodityStackItem[]): Record<string, number> {
+  const next: Record<string, number> = {};
+  for (const item of catalog) {
+    const value = saved?.[item.templateId];
+    next[item.templateId] = Number.isInteger(value) ? Number(value) : COMMODITY_STACK_DEFAULT;
+  }
+  return next;
+}
+
+function catalogGroups(catalog: CommodityStackItem[], groups: CommodityStackGroup[]): CommodityStackGroup[] {
+  if (groups.length) {
+    return groups.filter((group) => catalog.some((item) => item.group === group.id));
+  }
+  const seen = new Set<string>();
+  const derived: CommodityStackGroup[] = [];
+  for (const item of catalog) {
+    if (seen.has(item.group)) continue;
+    seen.add(item.group);
+    derived.push({ id: item.group, label: item.group });
+  }
+  return derived;
+}
+
+type CommodityStackInputsProps = {
+  catalog: CommodityStackItem[];
+  groups: CommodityStackGroup[];
+  values: Record<string, number>;
+  onChange: (next: Record<string, number>) => void;
+};
+
+function CommodityStackInputs({ catalog, groups, values, onChange }: CommodityStackInputsProps) {
+  if (!catalog.length) return null;
+  return (
+    <div className="market-bot-commodity-stacks">
+      {catalogGroups(catalog, groups).map((group) => (
+        <div key={group.id} className="market-bot-commodity-group">
+          <strong>{group.label}</strong>
+          <div className="market-bot-commodity-grid">
+            {catalog.filter((item) => item.group === group.id).map((item) => {
+              const stacks = values[item.templateId] ?? COMMODITY_STACK_DEFAULT;
+              const units = stacks * item.stackSize;
+              return (
+                <label key={item.templateId}>{item.label}
+                  <input
+                    aria-label={`${item.label} stacks`}
+                    type="number"
+                    min={COMMODITY_STACK_MIN}
+                    max={COMMODITY_STACK_MAX}
+                    value={stacks}
+                    onChange={(event) => onChange({ ...values, [item.templateId]: Number(event.target.value) })}
+                  />
+                  <span className="stack-hint">{stacks} × {item.stackSize.toLocaleString()} = {units.toLocaleString()} units</span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
 }
 
 type CategoryMultiplierInputsProps = {
@@ -203,9 +271,16 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
   const [seedMultiplier, setSeedMultiplier] = useState(5);
   const [seedCategoryMultipliers, setSeedCategoryMultipliers] = useState(defaultCategoryMultipliers);
   const [augmentPricing, setAugmentPricing] = useState<MarketAugmentPricing>("discounted");
+  const [commodityCatalog, setCommodityCatalog] = useState<CommodityStackItem[]>([]);
+  const [commodityGroups, setCommodityGroups] = useState<CommodityStackGroup[]>([]);
+  const [commodityStacks, setCommodityStacks] = useState<Record<string, number>>({});
 
   function applyStatus(next: MarketBotStatus, options: { populateForm?: boolean } = {}) {
     setStatus(next);
+    const catalog = next.commodityStackCatalog || [];
+    const groups = next.commodityStackGroups || [];
+    setCommodityCatalog(catalog);
+    setCommodityGroups(groups);
     if (options.populateForm) {
       setBuybackEnabled(Boolean(next.buyback.enabled));
       setBuybackInterval(next.buyback.intervalMinutes);
@@ -219,6 +294,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
       setSeedMultiplier(next.seed.priceMultiplier);
       setSeedCategoryMultipliers(categoryMultipliersFrom(next.seed));
       setAugmentPricing(next.seed.augmentPricing === "original" ? "original" : "discounted");
+      setCommodityStacks(commodityStacksFrom(next.seed.commodityStacks, catalog));
       setExchangeId((current) => current || next.buyback.exchangeId || next.seed.exchangeId || "");
     }
   }
@@ -318,6 +394,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
         priceMultiplier: seedMultiplier,
         ...seedCategoryMultipliers,
         augmentPricing,
+        commodityStacks,
         ...(exchangeId ? { exchangeId } : {})
       });
       return saved.enabled
@@ -471,6 +548,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
               <strong>Market reseed</strong>
               <p className="action-help-note">Replaces the bot's own NPC sell listings from the seed plan at the chosen price multiplier. Every run is backup, clear bot listings on that exchange, seed. Player listings are never touched. Augment items always seed as bottom-of-range rolls; the augment pricing option chooses whether they undercut their schematics (half the pattern's price) or keep the plan's original prices.</p>
               <p className="action-help-note">Category multipliers (1-5x, 1 = no change) additionally scale the seeded prices of augments &amp; augment schematics, ranked (grade 1-5) armor including stillsuits, and ranked weapons — on top of the base price multiplier. Grade-0 stock and everything else keeps the base multiplier alone.</p>
+              <p className="action-help-note">Number of stacks is how many full listings of that commodity each reseed writes. Units per stack stay at the plan maximum (so 10 fuel-cell stacks is 5,000 units). Unlisted commodities keep the plan default of 2 stacks.</p>
               <div className="market-bot-grid">
                 <label>Interval (minutes)
                   <input aria-label="Seed interval minutes" type="number" min={10} max={1440} value={seedInterval} onChange={(event) => setSeedInterval(Number(event.target.value))} />
@@ -486,6 +564,7 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
                   </select>
                 </label>
               </div>
+              <CommodityStackInputs catalog={commodityCatalog} groups={commodityGroups} values={commodityStacks} onChange={setCommodityStacks} />
               <label className="market-bot-toggle">
                 <input aria-label="Run reseed on a schedule" type="checkbox" checked={seedEnabled} onChange={(event) => setSeedEnabled(event.target.checked)} />
                 Run market reseed on a schedule (unattended)

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2213,6 +2213,13 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
 .market-bot-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px; }
 .market-bot-grid label { display: grid; gap: 4px; font-size: 12px; color: #cdbb95; }
 .market-bot-grid input, .market-bot-grid select { width: 100%; }
+.market-bot-commodity-stacks { display: grid; gap: 10px; margin-top: 4px; }
+.market-bot-commodity-group { display: grid; gap: 6px; }
+.market-bot-commodity-group > strong { font-size: 12px; color: #e8d4a8; }
+.market-bot-commodity-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 8px; }
+.market-bot-commodity-grid label { display: grid; gap: 4px; font-size: 12px; color: #cdbb95; }
+.market-bot-commodity-grid input { width: 100%; }
+.market-bot-commodity-grid .stack-hint { font-size: 11px; color: #9a8d74; font-weight: 400; }
 .market-bot-toggle { display: flex; align-items: center; gap: 8px; font-size: 13px; }
 .market-bot-toggle input { width: auto; }
 .market-bot-actions { justify-content: flex-start; }

--- a/docs/addons/addon-scheduled-jobs.md
+++ b/docs/addons/addon-scheduled-jobs.md
@@ -48,7 +48,8 @@ the database.
 Key buyback fields include `enabled`, `intervalMinutes`, `exchangeId`,
 `priceMultiplier`, category multipliers, `buybackPercent`, `buybackPriceBasis`,
 and `maxBuys`. Seed schedules include the same target, timing, and pricing fields
-plus augment pricing. Both record `lastRunAt`, `lastRunStatus`, `lastRunDetail`,
+plus augment pricing and optional `commodityStacks` (1–20 full listings for
+allowlisted base commodities). Both record `lastRunAt`, `lastRunStatus`, `lastRunDetail`,
 and `nextRunAt`.
 
 ## EDA Exchange Bot retirement

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -459,8 +459,10 @@ The three category multipliers (`augmentMultiplier`, `rankedArmorMultiplier`,
 and scale prices on top of the base `priceMultiplier` for augments & augment
 schematics, ranked (grade 1–5) armor including stillsuits, and ranked weapons
 respectively. On the seed schedule they raise the seeded sell prices; on the
-buyback schedule they reprice the reconstructed "seeded" price basis the same
-way, so `buybackPercent` keeps meaning a percentage of the real market price.
+buyback schedule they reprice the reconstructed "seeded" price basis. Ready-made
+augment item caps also follow the reseed schedule's `augmentPricing`
+(`discounted` vs `original`) so `buybackPercent` is a percentage of what the bot
+actually lists, even when the two schedules use different augment multipliers.
 
 Unlike the board above, these routes **do write the game database** through the
 native Market Bot engine (`addonJobs.js` / `addonSeedJob.js`). Reads, the probe, and

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -443,14 +443,14 @@ blacklist behaves.
 
 | Method | Route | Description | Parameters |
 |--------|-------|-------------|------------|
-| GET | `/api/exchange/market` | Market Bot status: seed-plan availability and both schedules | None |
+| GET | `/api/exchange/market` | Market Bot status: seed-plan availability, both schedules, and the commodity-stack catalog | None |
 | GET | `/api/exchange/market/exchanges` | Discover exchanges (BIGINT ids as strings; access-pointed exchanges first) | None |
 | POST | `/api/exchange/market/buyback/probe` | Read-only buyback diagnostics: total, recognized, eligible, above-threshold, unknown-template, and invalid price/stack listing counts (no backup taken) | body: `exchangeId?`, `priceMultiplier?`, `augmentMultiplier?`, `rankedArmorMultiplier?`, `rankedWeaponMultiplier?`, `buybackPercent?`, `buybackPriceBasis?`, `maxBuys?` |
 | GET | `/api/exchange/market/buyback/log` | Stored Buyback Sweep Log batches (purchased and skipped listings with reasons). Batches older than 5 days are omitted; the scheduler deletes them from disk at most hourly. | None |
 | POST | `/api/exchange/market/buyback/log` | Read-only dry-run classify of player sell listings (eligible first, then skip reasons; capped at 1000 stored rows with leftovers reserved); appends a log batch (no backup taken). Rate-limited. | body: same optional overrides as the probe |
 | POST | `/api/exchange/market/buyback/log/clear` | Clear stored Buyback Sweep Log batches. Requires `exchange:market-write`. Rate-limited. | None |
 | POST | `/api/exchange/market/buyback/schedule` | Save the buyback schedule (audited, rate-limited) | body: `enabled`, `intervalMinutes`, `exchangeId`, `priceMultiplier`, `augmentMultiplier`, `rankedArmorMultiplier`, `rankedWeaponMultiplier`, `buybackPercent`, `buybackPriceBasis`, `maxBuys` |
-| POST | `/api/exchange/market/seed/schedule` | Save the market reseed schedule (audited, rate-limited) | body: `enabled`, `intervalMinutes`, `exchangeId`, `priceMultiplier`, `augmentMultiplier`, `rankedArmorMultiplier`, `rankedWeaponMultiplier`, `augmentPricing` (`discounted`\|`original`) |
+| POST | `/api/exchange/market/seed/schedule` | Save the market reseed schedule (audited, rate-limited) | body: `enabled`, `intervalMinutes`, `exchangeId`, `priceMultiplier`, `augmentMultiplier`, `rankedArmorMultiplier`, `rankedWeaponMultiplier`, `augmentPricing` (`discounted`\|`original`), `commodityStacks` (object of templateId → 1–20 listing counts for allowlisted commodities) |
 | POST | `/api/exchange/market/buyback/run` | Run a buyback sweep now with the saved schedule (probe → backup → sweep) | None |
 | POST | `/api/exchange/market/seed/run` | Run a market reseed now with the saved schedule (backup → clear bot listings → seed) | None |
 
@@ -463,6 +463,12 @@ buyback schedule they reprice the reconstructed "seeded" price basis. Ready-made
 augment item caps also follow the reseed schedule's `augmentPricing`
 (`discounted` vs `original`) so `buybackPercent` is a percentage of what the bot
 actually lists, even when the two schedules use different augment multipliers.
+
+The seed schedule's `commodityStacks` map overrides how many full stacks of
+allowlisted commodities a reseed lists (1–20, default 2). Unknown template ids
+are ignored. Units per stack stay at the plan `stack_size`. The catalog of
+editable items is returned on `GET /api/exchange/market` as
+`commodityStackCatalog` / `commodityStackGroups`.
 
 Unlike the board above, these routes **do write the game database** through the
 native Market Bot engine (`addonJobs.js` / `addonSeedJob.js`). Reads, the probe, and

--- a/docs/console/exchange.md
+++ b/docs/console/exchange.md
@@ -108,6 +108,14 @@ Exchange Bot addon drives through the scheduler bridge, now first-class):
   multiplier is applied before the usual stepped price rounding, and relative
   pricing within a category is preserved (a discounted augment item stays at
   half its pattern's price when both are boosted).
+- **Commodity stacks** let the operator set how many full listings of selected
+  base-useful commodities each reseed writes (1–20, default 2 — the bundled
+  plan's `listings_per_grade`). Units per stack stay at the plan maximum, so
+  10 Fuel Cell stacks is 5,000 units. The allowlist is power fuels and
+  lubricants, windtrap filters, spice (melange, residue, flour sand, spice
+  sand), refining ingots, building materials, schematic pattern fragments, and
+  iodine pills. Everything else keeps the plan default. Buyback caps are
+  per-unit and do not change.
 - **Buyback sweeps** buy player sell listings whose per-unit ask is at or below the
   buyback percentage of the chosen **price basis** — seeded NPC price at that
   listing's grade (default), or the live player-market average / lowest ask with

--- a/docs/console/exchange.md
+++ b/docs/console/exchange.md
@@ -111,9 +111,10 @@ Exchange Bot addon drives through the scheduler bridge, now first-class):
 - **Buyback sweeps** buy player sell listings whose per-unit ask is at or below the
   buyback percentage of the chosen **price basis** — seeded NPC price at that
   listing's grade (default), or the live player-market average / lowest ask with
-  seeded fallback. The buyback schedule carries its own copy of the category
-  multipliers: keep them matched with the reseed schedule so the reconstructed
-  seeded basis tracks what the market actually sells at. Whole listed stacks are
+  seeded fallback. The buyback schedule carries its own category multipliers
+  (they may differ from reseed on purpose). The reconstructed seeded basis still
+  uses the **reseed** schedule's augment pricing (discounted vs original) so
+  ready-made augment caps track what the bot actually lists. Whole listed stacks are
   bought in one pass, sellers are paid through never-expiring "Take Solari"
   payment entries, and concurrent sweeps are safe at the database level
   (`FOR UPDATE ... SKIP LOCKED`). Every run probes eligibility with a read-only


### PR DESCRIPTION
## Summary

Two Market Bot changes for operators who run a CHOAM seed/buyback loop.

1. **Buyback seeded caps now follow reseed `augmentPricing`.**  
   Caps were scaled from raw plan prices. With **discounted** reseed, ready-made augments list at half the matching schematic (or 1/20 of the original item ladder), but buyback still used the fat 19–37.5M item prices. A 60% buyback of a grade-5 Woven Fiber used **22.5M** instead of **1.14M**.

2. **Reseed can list more than 2 stacks of selected base commodities.**  
   Operators set **Number of stacks** (1–20, default 2) in the reseed UI. Units per stack stay at the plan maximum (10 Fuel Cell stacks = 5,000 units).

Category multipliers (sell AM vs buyback AM) stay independent on purpose.

## Buyback / augment pricing

- Share `listedMarketUnitPrice()` between seed and buyback: same pipeline as a reseed (`seedRowBasePrice` for `augmentPricing`, then source / price / category multipliers, then stepped rounding).
- Copy the **reseed** schedule’s `augmentPricing` onto buyback probes, classify, and write sweeps. No new buyback UI field.
- Buyback seed-plan rows keep `kind` so schematic vs item discounting matches reseed.

Example (plan g5 Woven Fiber 37.5M / schematic 3.8M, plan and schedule `price_multiplier` 5 so they cancel, buyback AM=1, 60%):

| Reseed `augmentPricing` | Buyback cap (`T6_Augment_Armor3` g5) |
| --- | --- |
| `discounted` | **1,140,000** (half schematic × 60%) |
| `original` | **22,500,000** (37.5M × 60%) |

Schematic caps are unchanged in both modes (3.8M × 60% = 2,280,000).

## Commodity stacks

Allowlisted in the reseed section only. Unset items keep the bundled plan default of 2. Unknown template ids are dropped. Buyback is unchanged (per-unit caps).

**Power:** Fuel Cell, Spice-infused Fuel Cell, Low-grade / Industrial-grade Lubricant  
**Windtrap filters:** Makeshift, Standard, Particulate, Advanced Particulate  
**Spice:** Melange, Residue, Flour Sand, Spice Sand  
**Refining:** Plastanium, Duraluminum, Aluminum, Steel, Iron, Copper, Cobalt Paste, Stravidium Fiber / Mass  
**Building:** Salvaged Metal, Granite Stone, Plastone, Silicone Block, Plant Fiber  
**Schematic fragments:** Pattern grades 1–5  
**Survival:** Iodine Pill only  

Not included: vehicle fuel, healkits, welding wire, survey probes.

## Tests

- Ranked-category cap test pins `augmentPricing: "original"` so 28M × AM 2 × 50% still holds.
- Discounted vs original Woven g5 caps.
- Probe SQL inherits the saved reseed `augmentPricing`.
- Commodity stack normalize / seed SQL override / bundled-plan catalog match.
- Overlay save for stack counts.

## Operator notes

- Save the **reseed** schedule after changing stack counts, then run reseed (or wait for the interval). A reseed still clears bot listings first.
- If reseed is **original**, buyback behavior is unchanged for augment items.
- If reseed is **discounted**, existing buyback percents on ready-made augments will look much tighter (that is the fix).