### PR TITLE
Market Bot: manual unseed, backup origin labeling, and 5-backup reten…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,6 +91,10 @@ ADMIN_MOCK_MODE=0
 # Maximum time allowed for rebuilding the Web Console during a stack update.
 DUNE_SELF_UPDATE_BUILD_TIMEOUT_SECONDS=1800
 
+# Number of unattended Market Bot backups retained across seed, buyback, and
+# unseed jobs. Manual, automatic, and safety backups are not counted.
+DUNE_MARKET_BOT_BACKUP_KEEP=5
+
 # Generator refill tuning.
 ADMIN_REFILL_FLUSH_INTERVAL_MS=5000
 ADMIN_REFILL_DOWN_DWELL_MS=30000

--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -172,6 +172,7 @@ export const ROUTE_ACTIONS = {
   "POST /api/exchange/market/seed/schedule":   "exchange:market-write",
   "POST /api/exchange/market/buyback/run":     "exchange:market-write",
   "POST /api/exchange/market/seed/run":        "exchange:market-write",
+  "POST /api/exchange/market/seed/clear":      "exchange:market-write",
 
   // --- Players (mutations) ---
   "POST /api/players/kick-all-online":         "players:kick-all",

--- a/console/api/src/addonJobs.js
+++ b/console/api/src/addonJobs.js
@@ -30,6 +30,7 @@ import {
   writeSeedSchedule,
   persistSeedRunCompletion,
   executeSeedRun,
+  executeUnseedRun,
   normalizeCategoryMultipliers,
   normalizeScheduleSource,
   normalizeAugmentPricing,
@@ -39,7 +40,7 @@ import {
   createListedMarketUnitPrice
 } from "./addonSeedJob.js";
 
-export { CATEGORY_MULTIPLIER_FIELDS, COMMODITY_STACK_CATALOG, COMMODITY_STACK_GROUPS, COMMODITY_STACK_MIN, COMMODITY_STACK_MAX, COMMODITY_STACK_DEFAULT, readSeedSchedule, normalizeSeedSchedule, saveSeedSchedule, normalizeCategoryMultipliers, normalizeCommodityStacks, normalizeScheduleSource, resolveMarketSeedPlanPath, legacySeedSchedulePath, seedSchedulePath, loadMarketSeedPlan, seedRowCategoryMultiplier, seedRowListingCount, createListedMarketUnitPrice, listedMarketUnitPrice, normalizeAugmentPricing } from "./addonSeedJob.js";
+export { CATEGORY_MULTIPLIER_FIELDS, COMMODITY_STACK_CATALOG, COMMODITY_STACK_GROUPS, COMMODITY_STACK_MIN, COMMODITY_STACK_MAX, COMMODITY_STACK_DEFAULT, readSeedSchedule, normalizeSeedSchedule, saveSeedSchedule, normalizeCategoryMultipliers, normalizeCommodityStacks, normalizeScheduleSource, resolveMarketSeedPlanPath, legacySeedSchedulePath, seedSchedulePath, loadMarketSeedPlan, seedRowCategoryMultiplier, seedRowListingCount, createListedMarketUnitPrice, listedMarketUnitPrice, normalizeAugmentPricing, buildMarketUnseedSql, buildBotListingCountSql, executeUnseedRun } from "./addonSeedJob.js";
 
 export const EDA_EXCHANGE_BOT_ADDON_ID = "eda-exchange-bot";
 export const ADDON_SCHEDULER_PERMISSION = "scheduler:server";
@@ -872,8 +873,36 @@ export function createAddonJobScheduler(config, options = {}) {
     }
   }
 
-  async function runNow({ trigger = "manual", job = "buyback" } = {}) {
+  async function runNow({ trigger = "manual", job = "buyback", exchangeId = "" } = {}) {
     if (running) throw new Error("An exchange scheduled job is already in progress.");
+    if (job === "unseed") {
+      // Manual-only clear of the bot's NPC listings (no reseed). Targets the
+      // explicitly requested exchange, falling back to the saved seed
+      // schedule's only when none was requested — a malformed id is an error,
+      // never a silent retarget. Shares the running lock so it can never race
+      // a sweep or reseed, and deliberately leaves the seed schedule
+      // untouched: an enabled reseed schedule will repopulate on its next run.
+      const requested = String(exchangeId ?? "").trim();
+      const targetExchangeId = requested ? normalizeExchangeId(requested) : readSeedSchedule(config).exchangeId;
+      if (requested && !targetExchangeId) throw new Error("Unseed exchangeId must be a positive whole number (PostgreSQL BIGINT).");
+      if (!targetExchangeId) throw new Error("Select an exchange (or save a seed schedule) before removing the bot's NPC listings.");
+      running = true;
+      try {
+        const outcome = await executeUnseedRun(config, getDb(), targetExchangeId, { runDuneImpl, buildDuneArgs, runSql });
+        auditJob("unseed", trigger, {
+          status: outcome.status,
+          removedListings: outcome.removedListings,
+          exchangeId: targetExchangeId,
+          ok: true
+        });
+        return outcome;
+      } catch (error) {
+        auditJob("unseed", trigger, { status: "error", exchangeId: targetExchangeId, ok: false, error: redact(String(error?.message || "Unexpected error.")) });
+        throw error;
+      } finally {
+        running = false;
+      }
+    }
     if (job === "seed") {
       const schedule = readSeedSchedule(config);
       if (!schedule.exchangeId) throw new Error("Save a seed schedule with an exchangeId before running a manual reseed.");

--- a/console/api/src/addonSeedJob.js
+++ b/console/api/src/addonSeedJob.js
@@ -372,6 +372,58 @@ function augmentStatRollCounts(config) {
   return counts;
 }
 
+// The bot's own listings for one exchange: every order owned by the bot's
+// 'Revy' actor. Player listings are never matched, and neither are seller
+// "Take Solari" payment entries — buyback writes those with the seller as
+// owner, so a clear can never destroy a pending payout.
+function botListingsClearSql(exchangeId, { countInto = "" } = {}) {
+  return `
+DO $$
+DECLARE
+    v_owner_id BIGINT;
+    v_exchange_id BIGINT;
+    v_item_ids BIGINT[];
+    v_removed BIGINT := 0;
+BEGIN
+    v_exchange_id := ${exchangeId};
+    SELECT id INTO v_owner_id FROM dune.actors WHERE class = 'Revy' LIMIT 1;
+    IF v_owner_id IS NOT NULL THEN
+        SELECT ARRAY_AGG(item_id) INTO v_item_ids
+        FROM dune.dune_exchange_orders
+        WHERE owner_id = v_owner_id AND exchange_id = v_exchange_id AND item_id IS NOT NULL;
+        DELETE FROM dune.dune_exchange_sell_orders WHERE order_id IN (SELECT id FROM dune.dune_exchange_orders WHERE owner_id = v_owner_id AND exchange_id = v_exchange_id);
+        DELETE FROM dune.dune_exchange_orders WHERE owner_id = v_owner_id AND exchange_id = v_exchange_id;
+        GET DIAGNOSTICS v_removed = ROW_COUNT;
+        IF v_item_ids IS NOT NULL THEN DELETE FROM dune.items WHERE id = ANY(v_item_ids); END IF;
+    END IF;
+${countInto ? `    INSERT INTO ${countInto} (removed_listings, removed_items, exchange_id) VALUES (v_removed, COALESCE(ARRAY_LENGTH(v_item_ids, 1), 0), v_exchange_id);` : "    -- Seed path: the removed count is not reported."}
+END $$;`;
+}
+
+// Read-only probe for the manual unseed: how many listings the bot currently
+// has on this exchange. Zero means the clear (and its backup) can be skipped.
+export function buildBotListingCountSql(exchangeId) {
+  const id = normalizeExchangeId(exchangeId);
+  if (!id) throw new Error("Unseed exchangeId must be a positive whole number (PostgreSQL BIGINT).");
+  return `SELECT COUNT(*)::bigint AS bot_listings
+FROM dune.dune_exchange_orders o
+JOIN dune.actors a ON a.id = o.owner_id
+WHERE a.class = 'Revy' AND o.exchange_id = ${id};`;
+}
+
+// Manual "unseed": the seed run's clear step alone, without reseeding.
+// Restores the EDA Exchange Bot's ability to empty the NPC market that was
+// lost when the bot became console-native (reseed always clears + seeds).
+export function buildMarketUnseedSql(exchangeId) {
+  const id = normalizeExchangeId(exchangeId);
+  if (!id) throw new Error("Unseed exchangeId must be a positive whole number (PostgreSQL BIGINT).");
+  // No outer BEGIN/COMMIT: executeUnseedRun wraps this in db.transaction(),
+  // matching buildMarketSeedSql.
+  return `CREATE TEMP TABLE market_unseed_result (removed_listings BIGINT NOT NULL, removed_items BIGINT NOT NULL, exchange_id BIGINT NOT NULL) ON COMMIT DROP;
+${botListingsClearSql(id, { countInto: "market_unseed_result" })}
+SELECT removed_listings, removed_items, exchange_id FROM market_unseed_result;`;
+}
+
 export function buildMarketSeedSql(plan, schedule) {
   const exchangeId = requireSeedExchangeId(schedule);
   const multiplier = schedule.priceMultiplier;
@@ -386,24 +438,7 @@ export function buildMarketSeedSql(plan, schedule) {
   }).join(",\n") || "(NULL,1,0,0,0,0,'equippable',0,'{}')";
 
   // Always clear the bot's own listings for this exchange before seeding.
-  const clearSql = `
-DO $$
-DECLARE
-    v_owner_id BIGINT;
-    v_exchange_id BIGINT;
-    v_item_ids BIGINT[];
-BEGIN
-    v_exchange_id := ${exchangeId};
-    SELECT id INTO v_owner_id FROM dune.actors WHERE class = 'Revy' LIMIT 1;
-    IF v_owner_id IS NOT NULL THEN
-        SELECT ARRAY_AGG(item_id) INTO v_item_ids
-        FROM dune.dune_exchange_orders
-        WHERE owner_id = v_owner_id AND exchange_id = v_exchange_id AND item_id IS NOT NULL;
-        DELETE FROM dune.dune_exchange_sell_orders WHERE order_id IN (SELECT id FROM dune.dune_exchange_orders WHERE owner_id = v_owner_id AND exchange_id = v_exchange_id);
-        DELETE FROM dune.dune_exchange_orders WHERE owner_id = v_owner_id AND exchange_id = v_exchange_id;
-        IF v_item_ids IS NOT NULL THEN DELETE FROM dune.items WHERE id = ANY(v_item_ids); END IF;
-    END IF;
-END $$;`;
+  const clearSql = botListingsClearSql(exchangeId);
 
   // No outer BEGIN/COMMIT: executeSeedRun wraps this in db.transaction(),
   // matching buildBuybackSql. Nested transaction delimiters end the outer txn
@@ -474,6 +509,40 @@ export async function executeSeedRun(config, db, schedule, { runDuneImpl, buildD
     priceMultiplier: schedule.priceMultiplier,
     exchangeId: schedule.exchangeId,
     detail: `Seeded ${listingCount} listings on exchange ${schedule.exchangeId} at ${schedule.priceMultiplier}x${describeCategoryMultipliers(schedule)}${describeCommodityStacks(schedule)} (bot listings cleared first).`
+  };
+}
+
+// Manual unseed run: probe read-only first and only back up + clear when the
+// bot actually has listings on the exchange, mirroring buyback's
+// probe-before-backup behavior. Never scheduled; runNow-only.
+export async function executeUnseedRun(config, db, exchangeId, { runDuneImpl, buildDuneArgs, runSql }) {
+  const id = normalizeExchangeId(exchangeId);
+  if (!id) throw new Error("An exchangeId is required to remove the bot's NPC listings.");
+  if (typeof db?.transaction !== "function") {
+    throw new Error("Exchange unseed requires database transaction support.");
+  }
+  const probe = await runSql(db, buildBotListingCountSql(id), false);
+  if (decimalString(probe?.rows?.[0]?.bot_listings) === "0") {
+    return {
+      status: "empty",
+      removedListings: "0",
+      removedItems: "0",
+      exchangeId: id,
+      detail: `No bot listings on exchange ${id}; nothing removed and no backup was taken.`
+    };
+  }
+  if (!config.mockMode) {
+    await runDuneImpl(config, buildDuneArgs("backupCreate"), { env: { DB_BACKUP_ORIGIN: "market-bot-unseed" } });
+  }
+  const result = await db.transaction((tx) => runSql(tx, buildMarketUnseedSql(id), true));
+  const row = result?.rows?.[0] || {};
+  const removedListings = decimalString(row.removed_listings);
+  return {
+    status: "unseeded",
+    removedListings,
+    removedItems: decimalString(row.removed_items),
+    exchangeId: id,
+    detail: `Removed ${removedListings} bot listing(s) from exchange ${id}. Player listings and pending seller payments were not touched.`
   };
 }
 

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -871,6 +871,7 @@ async function handleApi(req, res) {
   if (path === "/api/exchange/market/seed/schedule" && req.method === "POST") return marketScheduleSaveRoute(req, res, "seed");
   if (path === "/api/exchange/market/buyback/run" && req.method === "POST") return marketRunNowRoute(req, res, "buyback");
   if (path === "/api/exchange/market/seed/run" && req.method === "POST") return marketRunNowRoute(req, res, "seed");
+  if (path === "/api/exchange/market/seed/clear" && req.method === "POST") return marketUnseedRoute(req, res);
   if (path === "/api/maps/user-settings/schema") return userSettingsSchemaRoute(res);
   if (path === "/api/maps/user-settings/restart-pending") return json(res, 200, { pending: existsSync(resolve(config.repoRoot, "runtime/generated/landsraad-restart-required")) });
   if (path === "/api/maps/user-settings/deferred-pending") return json(res, 200, readDeferredRestartPending(config));
@@ -1427,6 +1428,24 @@ async function marketRunNowRoute(req, res, job) {
     return json(res, 200, result);
   } catch (error) {
     audit(config, req, "exchange.market", { op: `${job}-run`, ok: false, error: redact(error?.message || "Unexpected error.") });
+    const payload = apiErrorPayload(error, 400);
+    return json(res, payload.status, payload.body);
+  }
+}
+
+// Manual "unseed": remove the Market Bot's own NPC listings from one exchange
+// without reseeding — the clear-market ability the EDA addon had before the
+// bot became console-native. Probes read-only first and backs up only when
+// there is something to remove.
+async function marketUnseedRoute(req, res) {
+  const body = await readJson(req);
+  if (!applyMutationRateLimit(req, res, "exchange.market.seed.clear")) return;
+  try {
+    const result = await addonJobScheduler.runNow({ trigger: "console", job: "unseed", exchangeId: body?.exchangeId });
+    audit(config, req, "exchange.market", { op: "seed-clear", status: result.status, removedListings: result.removedListings, exchangeId: result.exchangeId, ok: true });
+    return json(res, 200, result);
+  } catch (error) {
+    audit(config, req, "exchange.market", { op: "seed-clear", ok: false, error: redact(error?.message || "Unexpected error.") });
     const payload = apiErrorPayload(error, 400);
     return json(res, payload.status, payload.body);
   }

--- a/console/api/src/services/backups.js
+++ b/console/api/src/services/backups.js
@@ -9,6 +9,7 @@ export function enrichBackupRows(config, rows) {
     const origin = String(metadata.backup_origin || metadata.origin || "").trim().toLowerCase();
     const battlegroupId = String(metadata.imported_from_battlegroup_id || metadata.battlegroup_id || "").trim();
     const enriched = { ...row, battlegroupId: battlegroupId || "Unknown", sizeBytes, size: formatBackupSize(sizeBytes) };
+    if (/^market[-_ ]?bot/.test(origin)) return { ...enriched, type: "Market Bot Backup" };
     if (/^(automatic|scheduled)$/.test(origin)) return { ...enriched, type: "Automatic Backup" };
     if (/^(restore-safety|restore_safety|restore safety)$/.test(origin)) return { ...enriched, type: "Restore Safety Backup" };
     if (/^(pre-update|pre_update|preupdate)$/.test(origin)) return { ...enriched, type: "Pre-update Backup" };

--- a/console/api/src/statusParsers.js
+++ b/console/api/src/statusParsers.js
@@ -178,6 +178,9 @@ function formatBackupTimestamp(value) {
 }
 
 function friendlyBackupType(name, line) {
+  // Before the generic checks: "market-bot-seed" must never fall through to
+  // the substring-based classifiers below.
+  if (/market[-_ ]?bot/i.test(name) || /market[-_ ]?bot/i.test(line)) return "Market Bot Backup";
   if (/auto|scheduled/i.test(name) || /auto|scheduled/i.test(line)) return "Automatic Backup";
   if (/restore[-_ ]?safety/i.test(name) || /restore[-_ ]?safety/i.test(line)) return "Restore Safety Backup";
   if (/pre[-_ ]?update/i.test(name) || /pre[-_ ]?update/i.test(line)) return "Pre-update Backup";

--- a/console/api/test/addonSeedJob.test.js
+++ b/console/api/test/addonSeedJob.test.js
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { EDA_EXCHANGE_BOT_ADDON_ID, buildMarketSeedSql, createListedMarketUnitPrice, loadMarketSeedPlan, normalizeSeedSchedule, seedRowCategoryMultiplier, seedRowListingCount, COMMODITY_STACK_CATALOG, COMMODITY_STACK_DEFAULT, COMMODITY_STACK_MAX } from "../src/addonSeedJob.js";
+import { EDA_EXCHANGE_BOT_ADDON_ID, buildBotListingCountSql, buildMarketSeedSql, buildMarketUnseedSql, createListedMarketUnitPrice, loadMarketSeedPlan, normalizeSeedSchedule, seedRowCategoryMultiplier, seedRowListingCount, COMMODITY_STACK_CATALOG, COMMODITY_STACK_DEFAULT, COMMODITY_STACK_MAX } from "../src/addonSeedJob.js";
 
 const REPO_ROOT = resolve(import.meta.dirname, "../../..");
 
@@ -92,6 +92,46 @@ test("rejects augment schematic grades with no matching augmentation item", () =
       () => loadMarketSeedPlan({ repoRoot }),
       /unsupported augment schematic grade: T6_Augment_Armor1_Schematic quality 1/
     );
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("unseed SQL clears only the bot's own orders and reports removal counts", () => {
+  const sql = buildMarketUnseedSql("42");
+  // Targets the bot's 'Revy' actor on the requested exchange only.
+  assert.match(sql, /SELECT id INTO v_owner_id FROM dune\.actors WHERE class = 'Revy' LIMIT 1;/);
+  assert.match(sql, /v_exchange_id := 42;/);
+  assert.match(sql, /DELETE FROM dune\.dune_exchange_orders WHERE owner_id = v_owner_id AND exchange_id = v_exchange_id;/);
+  // Counts what it removed for the run result.
+  assert.match(sql, /GET DIAGNOSTICS v_removed = ROW_COUNT;/);
+  assert.match(sql, /INSERT INTO market_unseed_result/);
+  assert.match(sql, /SELECT removed_listings, removed_items, exchange_id FROM market_unseed_result;/);
+  // Unseed never reseeds and never opens its own transaction (executeUnseedRun
+  // wraps it in db.transaction, like the seed run).
+  assert.doesNotMatch(sql, /INSERT INTO dune\.items/);
+  assert.doesNotMatch(sql, /INSERT INTO dune\.dune_exchange_orders/);
+  assert.doesNotMatch(sql, /^BEGIN;/m);
+  assert.doesNotMatch(sql, /^COMMIT;/m);
+});
+
+test("unseed SQL builders reject malformed exchange ids", () => {
+  for (const bad of ["", "0", "-1", "abc", "1; DROP TABLE dune.items", "9223372036854775808"]) {
+    assert.throws(() => buildMarketUnseedSql(bad), /positive whole number/);
+    assert.throws(() => buildBotListingCountSql(bad), /positive whole number/);
+  }
+  // BIGINT max is still accepted as a decimal string.
+  assert.match(buildBotListingCountSql("9223372036854775807"), /o\.exchange_id = 9223372036854775807/);
+});
+
+test("seed SQL still clears the bot's listings before seeding after the clear was shared with unseed", () => {
+  const repoRoot = makeRepoRoot();
+  try {
+    const plan = loadMarketSeedPlan({ repoRoot });
+    const sql = buildMarketSeedSql(plan, { enabled: true, exchangeId: "7", priceMultiplier: 5 });
+    assert.match(sql, /DELETE FROM dune\.dune_exchange_orders WHERE owner_id = v_owner_id AND exchange_id = v_exchange_id;/);
+    // The seed path's clear does not report counts into the unseed result table.
+    assert.doesNotMatch(sql, /market_unseed_result/);
   } finally {
     rmSync(repoRoot, { recursive: true, force: true });
   }

--- a/console/api/test/backupMetadata.test.js
+++ b/console/api/test/backupMetadata.test.js
@@ -38,6 +38,19 @@ test("imported official BattleGroup YAML is normalized with source battlegroup",
   assert.equal(metadata.backup_origin, "external");
 });
 
+test("backup rows type market-bot backups from the sidecar origin, covering unlabeled legacy names", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "dune-backup-marketbot-"));
+  const backupDir = join(repoRoot, "runtime/backups/db");
+  mkdirSync(backupDir, { recursive: true });
+  // A legacy name with no market-bot label: only the sidecar knows the origin.
+  writeFileSync(join(backupDir, "dune-db-all_maps-20260819-010203.backup"), Buffer.alloc(10));
+  writeFileSync(join(backupDir, "dune-db-all_maps-20260819-010203.backup.yaml"), "backup_origin: market-bot-buyback\n");
+
+  const rows = enrichBackupRows({ repoRoot }, [{ name: "dune-db-all_maps-20260819-010203.backup", backupName: "dune-db-all_maps-20260819-010203.backup", type: "Manual Backup" }]);
+
+  assert.equal(rows[0].type, "Market Bot Backup");
+});
+
 test("backup rows include human-readable file sizes", () => {
   const repoRoot = mkdtempSync(join(tmpdir(), "dune-backup-size-"));
   const backupDir = join(repoRoot, "runtime/backups/db");

--- a/console/api/test/exchangeMarket.test.js
+++ b/console/api/test/exchangeMarket.test.js
@@ -179,6 +179,107 @@ test("scheduled runs skip addon permission checks for console-sourced schedules 
   }
 });
 
+function fakeUnseedDb({ botListings = "12" } = {}) {
+  const db = {
+    counts: [],
+    clears: [],
+    transactions: 0,
+    query: async (sql) => {
+      const text = String(sql).trim();
+      if (/AS bot_listings/.test(text)) {
+        db.counts.push(text);
+        return { rows: [{ bot_listings: String(botListings) }], rowCount: 1, command: "SELECT" };
+      }
+      if (/^CREATE TEMP TABLE market_unseed_result/.test(text)) {
+        db.clears.push(text);
+        return { rows: [{ removed_listings: String(botListings), removed_items: String(botListings), exchange_id: "42" }], rowCount: 1, command: "SELECT" };
+      }
+      return { rows: [], rowCount: 0, command: "SELECT" };
+    },
+    transaction: async (fn) => {
+      db.transactions += 1;
+      return fn({ query: db.query });
+    }
+  };
+  return db;
+}
+
+function makeUnseedScheduler(config, db, { backups = [], audits = [] } = {}) {
+  return createAddonJobScheduler(config, {
+    getDb: () => db,
+    runDuneImpl: async (_cfg, _args, options) => {
+      backups.push(options?.env?.DB_BACKUP_ORIGIN);
+      return { code: 0 };
+    },
+    auditImpl: (_cfg, _req, category, detail) => audits.push({ category, ...detail }),
+    log: { error: () => {} }
+  });
+}
+
+test("manual unseed backs up, clears the bot's listings in a transaction, and audits the run", async () => {
+  const repoRoot = makeRepoRoot();
+  try {
+    const config = { repoRoot, mockMode: false };
+    const db = fakeUnseedDb();
+    const backups = [];
+    const audits = [];
+    const scheduler = makeUnseedScheduler(config, db, { backups, audits });
+
+    const result = await scheduler.runNow({ trigger: "console", job: "unseed", exchangeId: "42" });
+    assert.equal(result.status, "unseeded");
+    assert.equal(result.removedListings, "12");
+    assert.equal(result.exchangeId, "42");
+    assert.deepEqual(backups, ["market-bot-unseed"]);
+    assert.equal(db.counts.length, 1, "probes read-only before writing");
+    assert.equal(db.transactions, 1, "the clear runs inside a transaction");
+    assert.equal(audits.length, 1);
+    assert.equal(audits[0].job, "unseed");
+    assert.equal(audits[0].status, "unseeded");
+    assert.equal(audits[0].ok, true);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("manual unseed skips the backup and clear when the bot has no listings", async () => {
+  const repoRoot = makeRepoRoot();
+  try {
+    const config = { repoRoot, mockMode: false };
+    const db = fakeUnseedDb({ botListings: "0" });
+    const backups = [];
+    const scheduler = makeUnseedScheduler(config, db, { backups });
+
+    const result = await scheduler.runNow({ trigger: "console", job: "unseed", exchangeId: "42" });
+    assert.equal(result.status, "empty");
+    assert.equal(result.removedListings, "0");
+    assert.deepEqual(backups, [], "no backup without something to remove");
+    assert.equal(db.transactions, 0, "no write transaction on an empty market");
+    assert.equal(db.clears.length, 0);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test("manual unseed falls back to the saved seed exchange and rejects malformed ids", async () => {
+  const repoRoot = makeRepoRoot();
+  try {
+    const config = { repoRoot, mockMode: false };
+    const db = fakeUnseedDb();
+    const scheduler = makeUnseedScheduler(config, db);
+
+    // No requested exchange and no saved schedule: refuse to guess.
+    await assert.rejects(scheduler.runNow({ job: "unseed" }), /Select an exchange/);
+    // A malformed requested id is an error, never a silent fallback.
+    saveMarketSeedSchedule(config, { exchangeId: "7" });
+    await assert.rejects(scheduler.runNow({ job: "unseed", exchangeId: "abc" }), /positive whole number/);
+    // An omitted id falls back to the saved seed schedule's exchange.
+    const result = await scheduler.runNow({ job: "unseed" });
+    assert.equal(result.exchangeId, "7");
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
 const EXCHANGE_ROWS = [
   { exchange_id: "9007199254740993", is_global: false, access_point_count: "0", order_count: "12", bot_order_count: "12", player_order_count: "0" },
   { exchange_id: "7", is_global: false, access_point_count: "2", order_count: "40", bot_order_count: "30", player_order_count: "10" },

--- a/console/api/test/marketBotBackupPrune.test.js
+++ b/console/api/test/marketBotBackupPrune.test.js
@@ -1,0 +1,191 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+
+// A docker stub that answers exactly the calls backup_db() makes, so the real
+// runtime/scripts/db.sh backup path runs end to end without a database.
+const DOCKER_STUB = `#!/usr/bin/env bash
+cmd="\${1:-}"; shift || true
+case "$cmd" in
+  ps) echo "dune-postgres"; exit 0 ;;
+  cp)
+    src="\${1:-}"; dest="\${2:-}"
+    case "$src" in
+      dune-postgres:*) printf 'fake-pg-dump-archive' > "$dest" ;;
+    esac
+    exit 0
+    ;;
+  exec)
+    shift # container name
+    prog="\${1:-}"; shift || true
+    case "$prog" in
+      pg_dump|rm) exit 0 ;;
+      pg_restore)
+        echo "123; 2615 16385 SCHEMA - dune postgres"
+        echo "124; 1259 16386 TABLE dune world_partition postgres"
+        echo "125; 0 16386 TABLE DATA dune world_partition postgres"
+        exit 0
+        ;;
+      psql)
+        sql="$*"
+        case "$sql" in
+          *"select distinct map"*) echo "hagga_basin" ;;
+          *string_agg*) echo "hagga_basin" ;;
+          *"count(*) from dune.world_partition"*) echo "3" ;;
+          *) echo "" ;;
+        esac
+        exit 0
+        ;;
+    esac
+    exit 0
+    ;;
+esac
+exit 0
+`;
+
+function makeFixture() {
+  const fixture = mkdtempSync(join(tmpdir(), "dune-market-bot-backup-"));
+  const scripts = join(fixture, "runtime/scripts");
+  const bin = join(fixture, "bin");
+  mkdirSync(scripts, { recursive: true });
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(join(fixture, "runtime/backups/db"), { recursive: true });
+  cpSync(resolve(repoRoot, "runtime/scripts/db.sh"), join(scripts, "db.sh"));
+  cpSync(resolve(repoRoot, "runtime/scripts/env-file.sh"), join(scripts, "env-file.sh"));
+  writeFileSync(join(bin, "docker"), DOCKER_STUB);
+  chmodSync(join(bin, "docker"), 0o755);
+  return { fixture, bin, backupDir: join(fixture, "runtime/backups/db") };
+}
+
+function seedBackup(backupDir, name, origin) {
+  writeFileSync(join(backupDir, name), "fake-backup");
+  if (origin !== null) {
+    writeFileSync(join(backupDir, `${name}.yaml`), `artifact_id: test\nbackup_origin: ${origin}\ndatabase: dune\n`);
+  }
+}
+
+function backupNames(backupDir) {
+  return readdirSync(backupDir).filter((name) => name.endsWith(".backup")).sort();
+}
+
+function runDb(fixture, bin, args, env = {}) {
+  return spawnSync("bash", ["runtime/scripts/db.sh", ...args], {
+    cwd: fixture,
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH}`, ...env }
+  });
+}
+
+test("market bot backups carry their origin in the filename and prune to the newest five", () => {
+  const { fixture, bin, backupDir } = makeFixture();
+  try {
+    // Six pre-existing market-bot backups: four unlabeled names written by
+    // older releases and two labeled ones. With the new backup that makes
+    // seven; the oldest two must be pruned to hold the cap of five.
+    seedBackup(backupDir, "dune-db-all_maps-20260809-000001.backup", "market-bot-buyback");
+    seedBackup(backupDir, "dune-db-all_maps-20260810-000001.backup", "market-bot-seed");
+    seedBackup(backupDir, "dune-db-all_maps-20260811-000001.backup", "market-bot-buyback");
+    seedBackup(backupDir, "dune-db-all_maps-20260812-000001.backup", "market-bot-buyback");
+    seedBackup(backupDir, "dune-db-market-bot-seed-all_maps-20260813-000001.backup", "market-bot-seed");
+    seedBackup(backupDir, "dune-db-market-bot-buyback-all_maps-20260814-000001.backup", "market-bot-buyback");
+    // Never prune candidates, whatever their age or count.
+    seedBackup(backupDir, "dune-db-all_maps-20200101-000001.backup", "manual");
+    seedBackup(backupDir, "dune-db-all_maps-20200102-000001.backup", "automatic");
+    seedBackup(backupDir, "dune-db-all_maps-20200103-000001.backup", null); // no sidecar
+
+    const result = runDb(fixture, bin, ["backup"], { DB_BACKUP_ORIGIN: "market-bot-buyback" });
+    assert.equal(result.status, 0, `backup must succeed (stderr: ${result.stderr})`);
+
+    const names = backupNames(backupDir);
+    const created = names.find((name) => /^dune-db-market-bot-buyback-hagga_basin-\d{8}-\d{6}\.backup$/.test(name));
+    assert.ok(created, `new backup is labeled with its market-bot origin (got: ${names.join(", ")})`);
+    const sidecar = readFileSync(join(backupDir, `${created}.yaml`), "utf8");
+    assert.match(sidecar, /^backup_origin: market-bot-buyback$/m);
+
+    // Cap of five market-bot backups: the two oldest are gone, the newest
+    // four pre-existing ones plus the fresh backup remain.
+    assert.ok(!names.includes("dune-db-all_maps-20260809-000001.backup"), "oldest market-bot backup pruned");
+    assert.ok(!names.includes("dune-db-all_maps-20260810-000001.backup"), "second-oldest market-bot backup pruned");
+    assert.ok(!existsSync(join(backupDir, "dune-db-all_maps-20260810-000001.backup.yaml")), "pruned sidecar removed too");
+    assert.ok(names.includes("dune-db-all_maps-20260811-000001.backup"));
+    assert.ok(names.includes("dune-db-all_maps-20260812-000001.backup"));
+    assert.ok(names.includes("dune-db-market-bot-seed-all_maps-20260813-000001.backup"));
+    assert.ok(names.includes("dune-db-market-bot-buyback-all_maps-20260814-000001.backup"));
+    assert.equal(names.filter((name) => !/2020010\d/.test(name)).length, 5, "exactly five market-bot backups remain");
+
+    // Manual, automatic, and sidecar-less backups are untouched.
+    assert.ok(names.includes("dune-db-all_maps-20200101-000001.backup"));
+    assert.ok(names.includes("dune-db-all_maps-20200102-000001.backup"));
+    assert.ok(names.includes("dune-db-all_maps-20200103-000001.backup"));
+
+    assert.match(result.stdout, /Pruned 2 Market Bot backup\(s\); the newest 5 are kept\./);
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("manual and automatic backups keep their unlabeled names and trigger no market-bot prune", () => {
+  const { fixture, bin, backupDir } = makeFixture();
+  try {
+    for (let day = 1; day <= 7; day += 1) {
+      seedBackup(backupDir, `dune-db-all_maps-2026080${day}-000001.backup`, "market-bot-buyback");
+    }
+
+    const result = runDb(fixture, bin, ["backup"], { DB_BACKUP_ORIGIN: "manual" });
+    assert.equal(result.status, 0, `backup must succeed (stderr: ${result.stderr})`);
+
+    const names = backupNames(backupDir);
+    const created = names.find((name) => /^dune-db-hagga_basin-\d{8}-\d{6}\.backup$/.test(name));
+    assert.ok(created, `manual backup keeps the plain scope name (got: ${names.join(", ")})`);
+    // A manual backup never prunes market-bot backups, even past the cap.
+    assert.equal(names.length, 8, "all seven market-bot backups plus the manual one remain");
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("prune keeps the newest five by embedded timestamp across labeled and legacy names", () => {
+  const { fixture, bin, backupDir } = makeFixture();
+  try {
+    const wrapper = join(fixture, "runtime/scripts/prune-wrapper.sh");
+    writeFileSync(wrapper, `#!/usr/bin/env bash
+source "$(dirname "$0")/db.sh" help >/dev/null
+prune_market_bot_backups "$1" "$2"
+`);
+    chmodSync(wrapper, 0o755);
+
+    // Interleave labeled and legacy names so ordering must come from the
+    // embedded timestamp, not the name prefix.
+    seedBackup(backupDir, "dune-db-market-bot-unseed-all_maps-20260801-000001.backup", "market-bot-unseed");
+    seedBackup(backupDir, "dune-db-all_maps-20260802-000001.backup", "market-bot-seed");
+    seedBackup(backupDir, "dune-db-market-bot-seed-all_maps-20260803-000001.backup", "market-bot-seed");
+    seedBackup(backupDir, "dune-db-all_maps-20260804-000001.backup", "market-bot-buyback");
+    seedBackup(backupDir, "dune-db-market-bot-buyback-all_maps-20260805-000001.backup", "market-bot-buyback");
+    seedBackup(backupDir, "dune-db-all_maps-20260806-000001.backup", "market-bot-buyback");
+    seedBackup(backupDir, "dune-db-all_maps-20260807-000001.backup", "market-bot-seed");
+    seedBackup(backupDir, "dune-db-all_maps-20260931-000001.backup", "manual");
+
+    const result = spawnSync("bash", [wrapper, join(fixture, "runtime/backups/db"), "5"], {
+      cwd: fixture,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${join(fixture, "bin")}:${process.env.PATH}` }
+    });
+    assert.equal(result.status, 0, `prune must succeed (stderr: ${result.stderr})`);
+
+    const names = backupNames(backupDir);
+    assert.ok(!names.includes("dune-db-market-bot-unseed-all_maps-20260801-000001.backup"), "oldest pruned");
+    assert.ok(!names.includes("dune-db-all_maps-20260802-000001.backup"), "second-oldest pruned");
+    assert.ok(names.includes("dune-db-market-bot-seed-all_maps-20260803-000001.backup"));
+    assert.ok(names.includes("dune-db-all_maps-20260807-000001.backup"));
+    assert.ok(names.includes("dune-db-all_maps-20260931-000001.backup"), "manual backup untouched");
+    assert.equal(names.length, 6, "five market-bot backups plus the manual one remain");
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});

--- a/console/api/test/marketBotBackupPrune.test.js
+++ b/console/api/test/marketBotBackupPrune.test.js
@@ -189,3 +189,10 @@ prune_market_bot_backups "$1" "$2"
     rmSync(fixture, { recursive: true, force: true });
   }
 });
+
+test("the documented retention override is forwarded into the console container", () => {
+  const compose = readFileSync(resolve(repoRoot, "docker-compose.web.yml"), "utf8");
+  const envExample = readFileSync(resolve(repoRoot, ".env.example"), "utf8");
+  assert.match(compose, /^\s+DUNE_MARKET_BOT_BACKUP_KEEP:\s+"\$\{DUNE_MARKET_BOT_BACKUP_KEEP:-5\}"$/m);
+  assert.match(envExample, /^DUNE_MARKET_BOT_BACKUP_KEEP=5$/m);
+});

--- a/console/api/test/policy.test.js
+++ b/console/api/test/policy.test.js
@@ -126,6 +126,10 @@ test("persisting a refreshed buyback log requires market write permission", () =
   assert.equal(actionForRoute("/api/exchange/market/buyback/log", "POST"), "exchange:market-write");
 });
 
+test("removing the bot's NPC listings (unseed) requires market write permission", () => {
+  assert.equal(actionForRoute("/api/exchange/market/seed/clear", "POST"), "exchange:market-write");
+});
+
 // resolveAllowedActions has no caller yet (planned for a future policy-editor
 // UI), but it must already surface every action actionForRoute can resolve,
 // not just the ones with an exact ROUTE_ACTIONS entry -- bases:delete only

--- a/console/api/test/statusParsers.test.js
+++ b/console/api/test/statusParsers.test.js
@@ -328,6 +328,17 @@ dune-db-imported-20260531-010203.backup`);
   assert.equal(rows[3].source, "External");
 });
 
+test("backup list parser labels market-bot backups by their origin-carrying filename", () => {
+  const rows = parseBackupListRows(`dune-db-market-bot-buyback-hagga_basin-20260819-020000.backup
+dune-db-market-bot-seed-hagga_basin-20260819-010000.backup
+dune-db-market-bot-unseed-hagga_basin-20260819-000000.backup
+dune-db-hagga_basin-20260818-000000.backup`);
+  assert.equal(rows[0].type, "Market Bot Backup");
+  assert.equal(rows[1].type, "Market Bot Backup");
+  assert.equal(rows[2].type, "Market Bot Backup");
+  assert.equal(rows[3].type, "Manual Backup");
+});
+
 test("backup list parser prefers server-local file timestamps", () => {
   const rows = parseBackupListRows(`2026-06-06 18:06:33  runtime/backups/db/dune-db-overmap_and_survival_1-20260606-150633.backup`);
   assert.equal(rows[0].created, "2026-06-06 18:06:33");

--- a/console/web/src/api/marketBot.ts
+++ b/console/web/src/api/marketBot.ts
@@ -105,6 +105,9 @@ export type MarketRunResult = {
   totalSolari?: string;
   // seed run
   listingCount?: string;
+  // unseed run
+  removedListings?: string;
+  removedItems?: string;
   schedule?: MarketBuybackSchedule | MarketSeedSchedule;
 };
 
@@ -154,5 +157,7 @@ export const marketBotApi = {
   saveBuybackSchedule: (schedule: Partial<MarketBuybackSchedule>) => post<MarketBuybackSchedule>("/api/exchange/market/buyback/schedule", schedule),
   saveSeedSchedule: (schedule: Partial<MarketSeedSchedule>) => post<MarketSeedSchedule>("/api/exchange/market/seed/schedule", schedule),
   runBuyback: () => post<MarketRunResult>("/api/exchange/market/buyback/run", {}),
-  runSeed: () => post<MarketRunResult>("/api/exchange/market/seed/run", {})
+  runSeed: () => post<MarketRunResult>("/api/exchange/market/seed/run", {}),
+  // Remove the bot's NPC listings from one exchange without reseeding.
+  unseed: (payload: { exchangeId?: string } = {}) => post<MarketRunResult>("/api/exchange/market/seed/clear", payload)
 };

--- a/console/web/src/features/backups/BackupsPanel.tsx
+++ b/console/web/src/features/backups/BackupsPanel.tsx
@@ -430,6 +430,9 @@ function backupDisplayTimestampSort(value: string) {
 }
 
 function friendlyBackupType(name: string, line: string) {
+  // Keep in sync with statusParsers.js: market-bot names must not fall
+  // through to the substring-based classifiers below.
+  if (/market[-_ ]?bot/i.test(name) || /market[-_ ]?bot/i.test(line)) return "Market Bot Backup";
   if (/auto|scheduled/i.test(name) || /auto|scheduled/i.test(line)) return "Automatic Backup";
   if (/restore[-_ ]?safety/i.test(name) || /restore[-_ ]?safety/i.test(line)) return "Restore Safety Backup";
   if (/pre[-_ ]?update/i.test(name) || /pre[-_ ]?update/i.test(line)) return "Pre-update Backup";

--- a/console/web/src/features/exchange/MarketBotOverlay.test.tsx
+++ b/console/web/src/features/exchange/MarketBotOverlay.test.tsx
@@ -14,7 +14,8 @@ vi.mock("../../api/marketBot", () => ({
     saveBuybackSchedule: vi.fn(),
     saveSeedSchedule: vi.fn(),
     runBuyback: vi.fn(),
-    runSeed: vi.fn()
+    runSeed: vi.fn(),
+    unseed: vi.fn()
   }
 }));
 
@@ -253,6 +254,41 @@ describe("MarketBotOverlay", () => {
     const runSeed = await screen.findByRole("button", { name: "Run reseed now" });
     expect(runSeed).toBeDisabled();
     expect(await screen.findByRole("button", { name: "Run sweep now" })).toBeEnabled();
+  });
+
+  it("confirms before removing NPC listings and reports the removed count", async () => {
+    vi.mocked(marketBotApi.unseed).mockResolvedValue({ status: "unseeded", removedListings: "180", removedItems: "180", exchangeId: "42" });
+    const props = renderOverlay();
+
+    // Unlike Run reseed now, the unseed targets the exchange selected in the
+    // dropdown, so it works without a saved seed schedule.
+    fireEvent.click(await screen.findByRole("button", { name: "Remove NPC listings" }));
+
+    await waitFor(() => expect(props.confirmAction).toHaveBeenCalled());
+    await waitFor(() => expect(marketBotApi.unseed).toHaveBeenCalledWith({ exchangeId: "42" }));
+    expect(await screen.findByText(/removed 180 NPC listing\(s\) from exchange 42/)).toBeInTheDocument();
+  });
+
+  it("reports an empty market without claiming anything was removed", async () => {
+    vi.mocked(marketBotApi.unseed).mockResolvedValue({
+      status: "empty", removedListings: "0", removedItems: "0", exchangeId: "42",
+      detail: "No bot listings on exchange 42; nothing removed and no backup was taken."
+    });
+    renderOverlay();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Remove NPC listings" }));
+
+    expect(await screen.findByText(/No bot listings on exchange 42/)).toBeInTheDocument();
+  });
+
+  it("does not remove NPC listings when the confirmation is declined", async () => {
+    const props = renderOverlay();
+    props.confirmAction.mockResolvedValue(false);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Remove NPC listings" }));
+
+    await waitFor(() => expect(props.confirmAction).toHaveBeenCalled());
+    expect(marketBotApi.unseed).not.toHaveBeenCalled();
   });
 
   it("explains an unsupported schema instead of rendering controls", async () => {

--- a/console/web/src/features/exchange/MarketBotOverlay.tsx
+++ b/console/web/src/features/exchange/MarketBotOverlay.tsx
@@ -454,6 +454,24 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
     });
   }
 
+  async function runUnseedNow() {
+    const confirmed = await confirmAction(
+      "Remove all of the Market Bot's NPC sell listings from the selected exchange? The console checks read-only first and takes a database backup only when there is something to remove. Player listings and pending seller payments are never touched.",
+      {
+        title: "Remove NPC listings",
+        confirmLabel: "Remove listings",
+        danger: true,
+        warning: seedEnabled ? "The reseed schedule is enabled: the next scheduled run will repopulate this market. Disable the schedule to keep it unseeded." : undefined
+      }
+    );
+    if (!confirmed) return;
+    await run("unseed", async () => {
+      const result = await marketBotApi.unseed(exchangeId ? { exchangeId } : {});
+      if (result.status === "empty") return result.detail || "No NPC listings to remove; no backup was taken.";
+      return `Unseed finished: removed ${result.removedListings ?? "0"} NPC listing(s) from exchange ${result.exchangeId ?? "?"}.`;
+    });
+  }
+
   const supported = status?.capabilities.exchangeMarket !== false;
   const planReady = status?.plan.available === true;
   const savedBuybackExchange = status?.buyback.exchangeId || "";
@@ -573,7 +591,9 @@ export function MarketBotOverlay({ onClose, onError, confirmAction }: MarketBotO
               <div className="confirm-modal-actions market-bot-actions">
                 <button onClick={() => void saveSeed()} disabled={Boolean(busy)}>{busy === "save-seed" ? "Saving…" : "Save reseed schedule"}</button>
                 <button className="danger" onClick={() => void runSeedNow()} disabled={Boolean(busy) || !savedSeedExchange}>{busy === "run-seed" ? "Running…" : "Run reseed now"}</button>
+                <button className="danger" onClick={() => void runUnseedNow()} disabled={Boolean(busy) || !exchangeId}>{busy === "unseed" ? "Removing…" : "Remove NPC listings"}</button>
               </div>
+              <p className="action-help-note">Remove NPC listings empties the bot's own listings on the exchange selected above without reseeding — the market stays unseeded until the next reseed run (disable the schedule to keep it that way). Player listings and pending seller payments are never touched.</p>
             </div>
 
             {notice && <p className="market-bot-notice" role="status">{notice}</p>}

--- a/docker-compose.web.yml
+++ b/docker-compose.web.yml
@@ -64,6 +64,9 @@ services:
       DUNE_SELF_UPDATE_TOKEN: "${DUNE_SELF_UPDATE_TOKEN:-}"
       # Bound BuildKit/npm stalls so a console update cannot hang forever.
       DUNE_SELF_UPDATE_BUILD_TIMEOUT_SECONDS: "${DUNE_SELF_UPDATE_BUILD_TIMEOUT_SECONDS:-1800}"
+      # Forward the operator's Market Bot retention override to the console;
+      # its backup subprocess inherits this environment value.
+      DUNE_MARKET_BOT_BACKUP_KEEP: "${DUNE_MARKET_BOT_BACKUP_KEEP:-5}"
       DUNE_DISCORD_ADAPTER_ENABLED: "${DUNE_DISCORD_ADAPTER_ENABLED:-false}"
       DUNE_DISCORD_ADAPTER_TOKEN: "${DUNE_DISCORD_ADAPTER_TOKEN:-}"
       DUNE_BOT_API_TOKEN_FILE: "${DUNE_BOT_API_TOKEN_FILE:-}"

--- a/docs/addons/addon-scheduled-jobs.md
+++ b/docs/addons/addon-scheduled-jobs.md
@@ -23,7 +23,15 @@ The scheduler ticks with the console's other background tasks. A due buyback run
 
 A due reseed always takes a backup (`DB_BACKUP_ORIGIN=market-bot-seed`), clears
 only the bot's listings on the selected exchange, and writes the bundled seed
-plan. Seed and buyback share a running lock, so they cannot mutate the exchange
+plan.
+
+Market Bot backups (`market-bot-seed`, `market-bot-buyback`,
+`market-bot-unseed`) carry their origin in the backup filename and are capped
+by count, not age: after every successful Market Bot backup only the 5 newest
+remain (override with `DUNE_MARKET_BOT_BACKUP_KEEP`). Candidates are matched by
+the sidecar's `backup_origin`, so unlabeled Market Bot backups from earlier
+releases are pruned too. Manual, automatic, and safety backups are never
+touched. Seed and buyback share a running lock, so they cannot mutate the exchange
 at the same time. Player listings are never removed by reseeding.
 
 The SQL is built server-side from validated schedule parameters. SQL text from a

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -453,6 +453,7 @@ blacklist behaves.
 | POST | `/api/exchange/market/seed/schedule` | Save the market reseed schedule (audited, rate-limited) | body: `enabled`, `intervalMinutes`, `exchangeId`, `priceMultiplier`, `augmentMultiplier`, `rankedArmorMultiplier`, `rankedWeaponMultiplier`, `augmentPricing` (`discounted`\|`original`), `commodityStacks` (object of templateId → 1–20 listing counts for allowlisted commodities) |
 | POST | `/api/exchange/market/buyback/run` | Run a buyback sweep now with the saved schedule (probe → backup → sweep) | None |
 | POST | `/api/exchange/market/seed/run` | Run a market reseed now with the saved schedule (backup → clear bot listings → seed) | None |
+| POST | `/api/exchange/market/seed/clear` | Remove the bot's NPC listings from one exchange without reseeding (probe → backup → clear; no backup when the bot has none). Player listings and pending seller payments are never touched. Requires `exchange:market-write`. Rate-limited. | body: `exchangeId?` (defaults to the saved seed schedule's exchange) |
 
 The three category multipliers (`augmentMultiplier`, `rankedArmorMultiplier`,
 `rankedWeaponMultiplier`) accept 1–5 (up to two decimals, default 1 = no change)

--- a/docs/console/exchange.md
+++ b/docs/console/exchange.md
@@ -116,6 +116,14 @@ Exchange Bot addon drives through the scheduler bridge, now first-class):
   sand), refining ingots, building materials, schematic pattern fragments, and
   iodine pills. Everything else keeps the plan default. Buyback caps are
   per-unit and do not change.
+- **Remove NPC listings** (unseed) empties the bot's own listings on the selected
+  exchange without reseeding — the "clear market" ability the EDA bot had before
+  Market Bot became console-native. The console counts the bot's listings
+  read-only first and only takes a backup + clears when there is something to
+  remove. Player listings and pending seller "Take Solari" payments are never
+  touched (payments are owned by the seller, not the bot). The seed schedule is
+  left as-is, so an **enabled** reseed schedule repopulates the market on its
+  next run; disable the schedule to keep the market unseeded.
 - **Buyback sweeps** buy player sell listings whose per-unit ask is at or below the
   buyback percentage of the chosen **price basis** — seeded NPC price at that
   listing's grade (default), or the live player-market average / lowest ask with
@@ -146,6 +154,16 @@ Exchange Bot addon drives through the scheduler bridge, now first-class):
   `runtime/generated/market-bot/buyback-log.json` (20 most recent, dropped
   after 5 days). The scheduler prunes expired batches at most hourly even when
   buyback is disabled.
+- **Backup labeling and retention**: every Market Bot database write is preceded
+  by a backup whose filename carries the origin (for example
+  `dune-db-market-bot-buyback-<scope>-<timestamp>.backup`; the sidecar's
+  `backup_origin` records `market-bot-seed`, `market-bot-buyback`, or
+  `market-bot-unseed`), and the Backups page shows them as **Market Bot
+  Backup**. Because schedules mint backups unattended, only the **5 newest**
+  Market Bot backups are kept: after every successful Market Bot backup, older
+  ones are pruned by the sidecar origin — including unlabeled ones written by
+  earlier releases. Manual, automatic, and safety backups are never candidates.
+  Set `DUNE_MARKET_BOT_BACKUP_KEEP` to change the count.
 - **Schedules** run unattended inside the console API process (no browser page needs
   to stay open) and survive restarts. They are console-owned and authorized by RBAC
   at save time. Seed and buyback share one running lock, so they can never write the

--- a/runtime/scripts/db.sh
+++ b/runtime/scripts/db.sh
@@ -622,6 +622,15 @@ backup_db() {
   [ -n "$scope" ] || scope="all_maps"
   scope_maps="$(backup_scope_maps)"
   artifact_id="dune-db-$scope"
+  # Market Bot backups carry their origin in the filename so a plain ls of the
+  # backup directory shows what minted them (the sidecar's backup_origin is
+  # authoritative but not visible without opening it), e.g.
+  # dune-db-market-bot-buyback-hagga_basin-20260819-020000.backup
+  case "${DB_BACKUP_ORIGIN:-manual}" in
+    market-bot-*)
+      artifact_id="dune-db-$(printf '%s' "${DB_BACKUP_ORIGIN}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g; s/--*/-/g; s/^-//; s/-$//')-$scope"
+      ;;
+  esac
   backup_file="$out_dir/$artifact_id-$ts.backup"
   sidecar_file="$backup_file.yaml"
   staged_backup_file="$backup_file.partial.$$"
@@ -703,6 +712,15 @@ backup_db() {
   if [ "${DB_BACKUP_PRUNE_AFTER_SUCCESS:-0}" = "1" ]; then
     prune_old_db_backups "$out_dir" "${DB_AUTO_BACKUP_RETENTION_DAYS:-0}"
   fi
+
+  # Market Bot schedules mint backups unattended before every write, so they
+  # are capped by count after every successful Market Bot backup. Other
+  # origins (manual, automatic, safety) are never candidates.
+  case "${DB_BACKUP_ORIGIN:-manual}" in
+    market-bot-*)
+      prune_market_bot_backups "$out_dir"
+      ;;
+  esac
 }
 
 SYSTEM_BACKUP_DIR_DEFAULT="runtime/backups/system"
@@ -1183,6 +1201,65 @@ delete_all_backups() {
   done <<< "$names"
 
   echo "Deleted $deleted database backups."
+}
+
+# How many Market Bot backups survive a prune. Market Bot backups are matched
+# by the sidecar's backup_origin (market-bot-seed / market-bot-buyback /
+# market-bot-unseed), not the filename, so unlabeled backups written by older
+# releases are cleaned up too.
+MARKET_BOT_BACKUP_KEEP="${DUNE_MARKET_BOT_BACKUP_KEEP:-5}"
+
+backup_origin_value() {
+  local backup_file="$1"
+  local origin=""
+
+  origin="$(backup_metadata_value "$backup_file" backup_origin || true)"
+  [ -n "$origin" ] || origin="$(backup_metadata_value "$backup_file" origin || true)"
+  printf '%s' "$origin"
+}
+
+backup_is_market_bot() {
+  case "$(backup_origin_value "$1" | tr '[:upper:]' '[:lower:]')" in
+    market-bot-*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Keep only the newest $keep Market Bot backups (by the timestamp embedded in
+# the backup name, which is stable even if file mtimes were touched). Runs
+# after every successful Market Bot backup; count-based rather than age-based
+# because unattended seed/buyback schedules mint backups indefinitely.
+prune_market_bot_backups() {
+  local backup_dir="${1:-$BACKUP_DIR_DEFAULT}"
+  local keep="${2:-$MARKET_BOT_BACKUP_KEEP}"
+  local removed=0
+  local index=0
+  local name
+
+  validate_positive_integer "$keep" || return 0
+  [ -d "$backup_dir" ] || return 0
+
+  while IFS= read -r name; do
+    [ -n "$name" ] || continue
+    index=$((index + 1))
+    [ "$index" -gt "$keep" ] || continue
+    if delete_backup_files_for_name "$name" "$backup_dir" >/dev/null; then
+      removed=$((removed + 1))
+    fi
+  done < <(
+    iter_valid_backup_names "$backup_dir" \
+      | while IFS= read -r candidate; do
+          [ -n "$candidate" ] || continue
+          backup_is_market_bot "$(backup_path_for_name "$candidate" "$backup_dir")" || continue
+          printf '%s\t%s\n' "$(backup_timestamp_from_name "$candidate")" "$candidate"
+        done \
+      | sort -r \
+      | cut -f2-
+  )
+
+  if [ "$removed" -gt 0 ]; then
+    echo "Pruned $removed Market Bot backup(s); the newest $keep are kept."
+  fi
 }
 
 prune_old_db_backups() {


### PR DESCRIPTION
…tion (#9)

* Add manual unseed: remove Market Bot NPC listings without reseeding

Restores the EDA Exchange Bot's clear-market ability lost in the native migration. POST /api/exchange/market/seed/clear (exchange:market-write, rate-limited, audited) probes read-only and only backs up + clears when the bot has listings; player listings and pending seller payments are never touched. The Market Bot overlay gains a Remove NPC listings button targeting the selected exchange.



* Label Market Bot backups by origin and keep only the newest 5

Market Bot schedules mint pre-write backups unattended, sprawling the backup directory. Backups with DB_BACKUP_ORIGIN=market-bot-* now carry the origin in the filename (dune-db-market-bot-buyback-<scope>-<ts>), surface as 'Market Bot Backup' on the Backups page (sidecar- and filename-based), and are pruned to the newest 5 after every successful Market Bot backup. Pruning matches the sidecar's backup_origin, so unlabeled backups from older releases are cleaned up too; manual, automatic, and safety backups are never candidates.



---------