### PR TITLE
Add Bot items tab for per-item Market Bot catalog overrides

### DIFF
--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -173,6 +173,9 @@ export const ROUTE_ACTIONS = {
   "POST /api/exchange/market/buyback/run":     "exchange:market-write",
   "POST /api/exchange/market/seed/run":        "exchange:market-write",
   "POST /api/exchange/market/seed/clear":      "exchange:market-write",
+  "GET /api/exchange/market/items":            "exchange:market",
+  "GET /api/exchange/market/items/catalog":    "exchange:market",
+  "POST /api/exchange/market/items":           "exchange:market-write",
 
   // --- Players (mutations) ---
   "POST /api/players/kick-all-online":         "players:kick-all",

--- a/console/api/src/addonJobs.js
+++ b/console/api/src/addonJobs.js
@@ -39,6 +39,17 @@ import {
   seedSchedulePath,
   createListedMarketUnitPrice
 } from "./addonSeedJob.js";
+import { readMarketItemOverrides, mergeBuybackSeedPlanWithOverrides, readUnsafeTemplateIds } from "./services/marketItemOverrides.js";
+
+// Applies the same admin-editable per-item overrides (enable/disable, price)
+// used by the reseed job, so a disabled/repriced item's buyback cap agrees
+// with what the bot actually lists rather than the bundled plan alone.
+function loadMergedBuybackSeedPlan(config, addonId) {
+  const plan = loadBuybackSeedPlan(config, addonId);
+  const overrides = readMarketItemOverrides(config.repoRoot);
+  const unsafeIds = readUnsafeTemplateIds(config.repoRoot);
+  return mergeBuybackSeedPlanWithOverrides(plan, overrides, unsafeIds);
+}
 
 export { CATEGORY_MULTIPLIER_FIELDS, COMMODITY_STACK_CATALOG, COMMODITY_STACK_GROUPS, COMMODITY_STACK_MIN, COMMODITY_STACK_MAX, COMMODITY_STACK_DEFAULT, readSeedSchedule, normalizeSeedSchedule, saveSeedSchedule, normalizeCategoryMultipliers, normalizeCommodityStacks, normalizeScheduleSource, resolveMarketSeedPlanPath, legacySeedSchedulePath, seedSchedulePath, loadMarketSeedPlan, seedRowCategoryMultiplier, seedRowListingCount, createListedMarketUnitPrice, listedMarketUnitPrice, normalizeAugmentPricing, buildMarketUnseedSql, buildBotListingCountSql, executeUnseedRun } from "./addonSeedJob.js";
 
@@ -613,7 +624,7 @@ export async function probeBuybackEligibility(config, db, overrides = {}) {
     maxBuys: overrides.maxBuys
   }, saved));
   if (!schedule.exchangeId) throw new Error("An exchangeId is required to probe buyback eligibility.");
-  const plan = loadBuybackSeedPlan(config);
+  const plan = loadMergedBuybackSeedPlan(config);
   const result = await runSql(db, buildBuybackEligibilitySql(plan, schedule), false);
   const diagnostics = buybackDiagnostics(result?.rows?.[0]);
   return {
@@ -646,7 +657,7 @@ export async function classifyBuybackListings(config, db, overrides = {}) {
   const saved = readBuybackSchedule(config);
   const schedule = withReseedAugmentPricing(config, normalizeBuybackSchedule(buybackScheduleOverrides(overrides), saved));
   if (!schedule.exchangeId) throw new Error("An exchangeId is required to classify buyback listings.");
-  const plan = loadBuybackSeedPlan(config);
+  const plan = loadMergedBuybackSeedPlan(config);
   const result = await runSql(db, buildBuybackClassifySql(plan, schedule), false);
   const names = seedPlanDisplayNames(plan);
   const entries = applyDryRunMaxBuysRanking(
@@ -959,7 +970,7 @@ export function createAddonJobScheduler(config, options = {}) {
 }
 
 async function executeBuybackRun(config, db, schedule, { runDuneImpl, trigger = "manual" } = {}) {
-  const plan = loadBuybackSeedPlan(config);
+  const plan = loadMergedBuybackSeedPlan(config);
   const names = seedPlanDisplayNames(plan);
   const source = trigger === "schedule" ? "Scheduled buyback" : "Buyback sweep";
   const priced = withReseedAugmentPricing(config, schedule);

--- a/console/api/src/addonSeedJob.js
+++ b/console/api/src/addonSeedJob.js
@@ -11,6 +11,7 @@
 
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
+import { readMarketItemOverrides, mergeMarketSeedPlanWithOverrides, readUnsafeTemplateIds } from "./services/marketItemOverrides.js";
 
 // Keep identity helpers local so this module does not circular-import addonJobs.js.
 export const EDA_EXCHANGE_BOT_ADDON_ID = "eda-exchange-bot";
@@ -490,7 +491,10 @@ SELECT r.status, r.exchange_id, r.access_point_id, r.owner_id, r.inventory_id, S
 }
 
 export async function executeSeedRun(config, db, schedule, { runDuneImpl, buildDuneArgs, runSql }) {
-  const plan = loadMarketSeedPlan(config);
+  const basePlan = loadMarketSeedPlan(config);
+  const overrides = readMarketItemOverrides(config.repoRoot);
+  const unsafeIds = readUnsafeTemplateIds(config.repoRoot);
+  const plan = mergeMarketSeedPlanWithOverrides(basePlan, overrides, unsafeIds);
   if (typeof db?.transaction !== "function") {
     throw new Error("Exchange seed requires database transaction support.");
   }

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -52,6 +52,8 @@ import { createPublicDirectoryReporter, normalizeDiscordInvite, readDirectorySet
 import { choamTerminalOverview, installChoamTerminals, removeChoamTerminals } from "./services/choamTerminals.js";
 import { exchangeStats, listExchangeItems, listExchangeListings, readExchangeConfig, saveExchangeConfig } from "./services/exchange.js";
 import { listMarketExchanges, marketBotStatus, saveMarketBuybackSchedule, saveMarketSeedSchedule } from "./services/exchangeMarket.js";
+import { loadMarketSeedPlan } from "./addonSeedJob.js";
+import { readMarketItemOverrides, saveMarketItemOverrides, readUnsafeTemplateIds, listBotItemCatalogPickerItems, getOverrideRow } from "./services/marketItemOverrides.js";
 import { autoRefillPublicState, createAutoRefillScheduler, setBaseAutoRefill } from "./services/autoRefill.js";
 import { autoRefillWaterPublicState, createAutoRefillWaterScheduler, setBaseAutoRefillWater } from "./services/autoRefillWater.js";
 import { calculateAlwaysOnHostMemorySafety } from "./services/hostMemorySafety.js";
@@ -872,6 +874,9 @@ async function handleApi(req, res) {
   if (path === "/api/exchange/market/buyback/run" && req.method === "POST") return marketRunNowRoute(req, res, "buyback");
   if (path === "/api/exchange/market/seed/run" && req.method === "POST") return marketRunNowRoute(req, res, "seed");
   if (path === "/api/exchange/market/seed/clear" && req.method === "POST") return marketUnseedRoute(req, res);
+  if (path === "/api/exchange/market/items" && req.method === "GET") return marketItemsListRoute(res);
+  if (path === "/api/exchange/market/items" && req.method === "POST") return marketItemsSaveRoute(req, res);
+  if (path === "/api/exchange/market/items/catalog" && req.method === "GET") return marketItemsCatalogRoute(res, url);
   if (path === "/api/maps/user-settings/schema") return userSettingsSchemaRoute(res);
   if (path === "/api/maps/user-settings/restart-pending") return json(res, 200, { pending: existsSync(resolve(config.repoRoot, "runtime/generated/landsraad-restart-required")) });
   if (path === "/api/maps/user-settings/deferred-pending") return json(res, 200, readDeferredRestartPending(config));
@@ -1446,6 +1451,93 @@ async function marketUnseedRoute(req, res) {
     return json(res, 200, result);
   } catch (error) {
     audit(config, req, "exchange.market", { op: "seed-clear", ok: false, error: redact(error?.message || "Unexpected error.") });
+    const payload = apiErrorPayload(error, 400);
+    return json(res, payload.status, payload.body);
+  }
+}
+
+// Merged, display-ready view of the bot's item catalog: the bundled plan's
+// rows plus any admin-added newItems, annotated with override/unsafe state.
+// Unlike the seed/buyback merge (which drops unsafe/disabled rows so the bot
+// never lists them), this view keeps every row visible so an admin can see
+// and re-enable a disabled item.
+function buildBotItemRows(plan, overrides, unsafeIds, metadata) {
+  const overrideMap = overrides.overrides || {};
+  const unsafeSet = new Set(unsafeIds);
+  const rows = plan.rows.map((row) => {
+    const o = getOverrideRow(overrideMap, row.templateId, row.qualityLevel);
+    const meta = metadata.get(row.templateId);
+    return {
+      templateId: row.templateId,
+      displayName: meta?.name || row.templateId,
+      category: meta?.category || "",
+      qualityLevel: row.qualityLevel,
+      price: o?.price ?? row.price,
+      listings: o?.listings ?? row.listings,
+      enabled: o?.enabled !== false,
+      overridden: Boolean(o),
+      isNew: false,
+      unsafe: unsafeSet.has(row.templateId)
+    };
+  });
+  for (const [templateId, item] of Object.entries(overrides.newItems || {})) {
+    rows.push({
+      templateId,
+      displayName: item.name,
+      category: item.category,
+      qualityLevel: item.qualityLevel,
+      price: item.price,
+      listings: item.listings,
+      enabled: item.enabled !== false,
+      overridden: false,
+      isNew: true,
+      unsafe: unsafeSet.has(templateId)
+    });
+  }
+  return rows.sort((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
+async function marketItemsListRoute(res) {
+  try {
+    const status = await marketBotStatus(config, db);
+    if (!status.capabilities.exchangeMarket) {
+      return json(res, 200, { capabilities: { exchangeMarket: false }, rows: [], reason: status.reason });
+    }
+    const plan = loadMarketSeedPlan(config);
+    const overrides = readMarketItemOverrides(config.repoRoot);
+    const unsafeIds = readUnsafeTemplateIds(config.repoRoot);
+    const rows = buildBotItemRows(plan, overrides, unsafeIds, duneDb.adminItemMetadata());
+    return json(res, 200, { capabilities: { exchangeMarket: true }, rows });
+  } catch (error) {
+    const payload = apiErrorPayload(error, 400);
+    return json(res, payload.status, payload.body);
+  }
+}
+
+function marketItemsCatalogRoute(res, url) {
+  try {
+    const rows = listBotItemCatalogPickerItems(config.repoRoot, {
+      q: url.searchParams.get("q") || "",
+      category: url.searchParams.get("category") || ""
+    });
+    return json(res, 200, { rows });
+  } catch (error) {
+    const payload = apiErrorPayload(error, 400);
+    return json(res, payload.status, payload.body);
+  }
+}
+
+async function marketItemsSaveRoute(req, res) {
+  const body = await readJson(req);
+  if (!applyMutationRateLimit(req, res, "exchange.market.items")) return;
+  const overrideCount = Object.keys(body?.overrides || {}).length;
+  const newItemCount = Object.keys(body?.newItems || {}).length;
+  try {
+    const result = saveMarketItemOverrides(config.repoRoot, body && typeof body === "object" ? body : {});
+    audit(config, req, "exchange.market", { op: "items-save", overrideCount, newItemCount, ok: true });
+    return json(res, 200, result);
+  } catch (error) {
+    audit(config, req, "exchange.market", { op: "items-save", ok: false, error: redact(error?.message || "Unexpected error.") });
     const payload = apiErrorPayload(error, 400);
     return json(res, payload.status, payload.body);
   }

--- a/console/api/src/services/marketItemOverrides.js
+++ b/console/api/src/services/marketItemOverrides.js
@@ -1,0 +1,288 @@
+// Per-item Market Bot catalog overrides: an admin-editable layer on top of the
+// bundled, read-only runtime/data/market-seed-plan.json. Overrides can disable
+// a bundled row, reprice it, or change its listing count; newItems adds a row
+// the bundled plan does not have at all, sourced only from
+// runtime/data/admin-items.json (never free text) so the bot can never be
+// pointed at a template id that does not exist anywhere in the catalog.
+//
+// This module intentionally has no dependency on addonSeedJob.js/addonJobs.js
+// (only server.js and those two modules import it) so loadMarketSeedPlan's
+// merge call and this module's own file I/O never form an import cycle. The
+// unsafe-ids lookup below duplicates the few lines of plan-path resolution
+// addonSeedJob.js already duplicates into addonJobs.js for the same reason.
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { writeJsonAtomic, clampInt } from "../jsonStore.js";
+import { validateTemplateId } from "../duneDb/presentation.js";
+import { listCatalogItems } from "../adminCatalog.js";
+
+const OVERRIDES_PATH = "runtime/generated/market-bot/items.json";
+
+// Categories from admin-items.json that must never appear in the "add item"
+// picker: not sellable market items (buildings/contracts) or not physical
+// items at all (emotes).
+export const EXCLUDED_NEW_ITEM_CATEGORIES = new Set(["buildings", "contracts", "emotes"]);
+
+const PRICE_MIN = 1;
+const PRICE_MAX = 999999999;
+const LISTINGS_MIN = 1;
+const LISTINGS_MAX = 99;
+
+function overridesFile(repoRoot) {
+  return resolve(repoRoot, OVERRIDES_PATH);
+}
+
+function emptyState() {
+  return { overrides: {}, newItems: {} };
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+// overrides is nested { templateId: { qualityLevel: {enabled?, price?, listings?} } }
+// -- the same template id can carry a different price at every grade (Q0..Q5
+// each have their own row in the bundled plan), so a template-only key would
+// silently apply one edit to every grade of that item at once.
+export function readMarketItemOverrides(repoRoot) {
+  const file = overridesFile(repoRoot);
+  if (!existsSync(file)) return emptyState();
+  try {
+    const raw = JSON.parse(readFileSync(file, "utf8"));
+    const overrides = {};
+    if (isPlainObject(raw?.overrides)) {
+      for (const [templateId, byQuality] of Object.entries(raw.overrides)) {
+        if (!isPlainObject(byQuality)) continue;
+        overrides[templateId] = { ...byQuality };
+      }
+    }
+    const newItems = isPlainObject(raw?.newItems) ? raw.newItems : {};
+    return { overrides, newItems };
+  } catch {
+    return emptyState();
+  }
+}
+
+export function getOverrideRow(overrideMap, templateId, qualityLevel) {
+  return overrideMap?.[templateId]?.[String(qualityLevel)];
+}
+
+function resolveSeedPlanFile(repoRoot) {
+  const bundled = resolve(repoRoot, "runtime/data/market-seed-plan.json");
+  if (existsSync(bundled)) return bundled;
+  const addonFallback = resolve(repoRoot, "runtime/addons/installed/eda-exchange-bot/web/market-seed-plan.json");
+  return existsSync(addonFallback) ? addonFallback : null;
+}
+
+// The upstream generator's own blocklist (NPC-only weapon variants,
+// story-unique items, etc.) — used here as a hard block, not a warning.
+export function readUnsafeTemplateIds(repoRoot) {
+  const path = resolveSeedPlanFile(repoRoot);
+  if (!path) return [];
+  try {
+    const plan = JSON.parse(readFileSync(path, "utf8"));
+    return Array.isArray(plan?.unsafe_template_ids) ? plan.unsafe_template_ids.map(String) : [];
+  } catch {
+    return [];
+  }
+}
+
+function findCatalogEntry(repoRoot, templateId) {
+  let items;
+  try {
+    items = JSON.parse(readFileSync(resolve(repoRoot, "runtime/data/admin-items.json"), "utf8"));
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(items)) return null;
+  return items.find((item) => String(item?.id || "") === templateId) || null;
+}
+
+function normalizeOverrideRow(raw) {
+  const out = {};
+  if (raw?.enabled !== undefined) {
+    if (typeof raw.enabled !== "boolean") throw new Error("Item override 'enabled' must be true or false.");
+    out.enabled = raw.enabled;
+  }
+  if (raw?.price !== undefined) {
+    const price = Number(raw.price);
+    if (!Number.isFinite(price) || price < PRICE_MIN || price > PRICE_MAX) throw new Error("Item override price must be a positive number.");
+    out.price = Math.trunc(price);
+  }
+  if (raw?.listings !== undefined) {
+    const listings = Number(raw.listings);
+    if (!Number.isInteger(listings) || listings < LISTINGS_MIN || listings > LISTINGS_MAX) {
+      throw new Error(`Item override listings must be an integer from ${LISTINGS_MIN} to ${LISTINGS_MAX}.`);
+    }
+    out.listings = listings;
+  }
+  return out;
+}
+
+function normalizeNewItemRow(raw, templateId, catalogEntry) {
+  const price = Number(raw?.price);
+  if (!Number.isFinite(price) || price < PRICE_MIN || price > PRICE_MAX) throw new Error(`New item ${templateId} price must be a positive number.`);
+  const listings = Number(raw?.listings);
+  if (!Number.isInteger(listings) || listings < LISTINGS_MIN || listings > LISTINGS_MAX) {
+    throw new Error(`New item ${templateId} listings must be an integer from ${LISTINGS_MIN} to ${LISTINGS_MAX}.`);
+  }
+  const durabilityMax = clampInt(raw?.durabilityMax, 100, 100, 200);
+  return {
+    name: String(raw?.name || catalogEntry.name || templateId).slice(0, 200),
+    category: String(catalogEntry.category || "misc").toLowerCase(),
+    qualityLevel: clampInt(raw?.qualityLevel, 0, 0, 5),
+    categoryDepth: clampInt(raw?.categoryDepth, 1, 0, 4),
+    categoryMask: Math.trunc(Number(raw?.categoryMask) || 0),
+    kind: String(raw?.kind || "equippable").slice(0, 40),
+    stackSize: Math.max(1, Math.trunc(Number(raw?.stackSize) || 1)),
+    price: Math.trunc(price),
+    listings,
+    enabled: raw?.enabled !== false,
+    durabilityMax,
+    durabilityCur: Math.min(clampInt(raw?.durabilityCur ?? durabilityMax, durabilityMax, 100, 200), durabilityMax),
+    addedAt: new Date().toISOString()
+  };
+}
+
+export function saveMarketItemOverrides(repoRoot, payload = {}) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Bot item overrides payload must be a JSON object.");
+  }
+  const unsafeSet = new Set(readUnsafeTemplateIds(repoRoot));
+  const previous = readMarketItemOverrides(repoRoot);
+  const nextOverrides = {};
+  for (const [templateId, byQuality] of Object.entries(previous.overrides)) nextOverrides[templateId] = { ...byQuality };
+  const nextNewItems = { ...previous.newItems };
+
+  if (payload.overrides !== undefined && !isPlainObject(payload.overrides)) {
+    throw new Error("overrides must be an object of templateId to {qualityLevel: patch}.");
+  }
+  for (const [rawId, byQuality] of Object.entries(payload.overrides || {})) {
+    const templateId = validateTemplateId(rawId);
+    if (unsafeSet.has(templateId)) throw new Error(`${templateId} is flagged unsafe and cannot be edited.`);
+    if (!isPlainObject(byQuality)) throw new Error(`Item override for ${templateId} must be an object keyed by quality level.`);
+    for (const [rawQuality, rawRow] of Object.entries(byQuality)) {
+      const qualityLevel = clampInt(rawQuality, -1, -1, 5);
+      if (qualityLevel < 0 || String(qualityLevel) !== String(rawQuality).trim()) {
+        throw new Error(`${templateId} has an invalid quality level override key: ${rawQuality}.`);
+      }
+      const normalized = normalizeOverrideRow(rawRow);
+      const key = String(qualityLevel);
+      if (Object.keys(normalized).length === 0) {
+        if (nextOverrides[templateId]) {
+          delete nextOverrides[templateId][key];
+          if (Object.keys(nextOverrides[templateId]).length === 0) delete nextOverrides[templateId];
+        }
+      } else {
+        nextOverrides[templateId] = { ...nextOverrides[templateId], [key]: { ...nextOverrides[templateId]?.[key], ...normalized } };
+      }
+    }
+  }
+
+  for (const [rawId, rawRow] of Object.entries(payload.newItems || {})) {
+    const templateId = validateTemplateId(rawId);
+    if (unsafeSet.has(templateId)) throw new Error(`${templateId} is flagged unsafe and cannot be added.`);
+    if (nextOverrides[templateId]) throw new Error(`${templateId} is already in the base catalog; edit it there instead of adding it as new.`);
+    const catalogEntry = findCatalogEntry(repoRoot, templateId);
+    if (!catalogEntry) throw new Error(`${templateId} was not found in the item catalog.`);
+    const category = String(catalogEntry.category || "").toLowerCase();
+    if (EXCLUDED_NEW_ITEM_CATEGORIES.has(category)) {
+      throw new Error(`${templateId} is in an excluded category (${category}) and cannot be added.`);
+    }
+    nextNewItems[templateId] = normalizeNewItemRow(rawRow, templateId, catalogEntry);
+  }
+
+  for (const rawId of Array.isArray(payload.removedNewItems) ? payload.removedNewItems : []) {
+    delete nextNewItems[validateTemplateId(rawId)];
+  }
+
+  const next = { overrides: nextOverrides, newItems: nextNewItems };
+  writeJsonAtomic(overridesFile(repoRoot), next, 0o600);
+  return next;
+}
+
+function newItemStatsJson(durCur, durMax) {
+  return JSON.stringify({
+    FItemStackAndDurabilityStats: [[], {
+      CurrentDurability: durCur,
+      MaxDurability: durMax,
+      DecayedMaxDurability: durMax
+    }]
+  });
+}
+
+// Applies overrides to the full seed-run row shape from addonSeedJob.js's
+// loadMarketSeedPlan (templateId/stackSize/price/categoryMask/categoryDepth/
+// qualityLevel/kind/listings/itemStats). A disabled row (explicit override or
+// unsafe id) is dropped entirely, matching what the old commodityStacks-only
+// override could never do for anything outside its ~30-item allowlist.
+export function mergeMarketSeedPlanWithOverrides(plan, overrides, unsafeIds = []) {
+  const unsafeSet = new Set(unsafeIds);
+  const overrideMap = overrides?.overrides || {};
+  const newItems = overrides?.newItems || {};
+  const rows = (plan.rows || [])
+    .filter((row) => !unsafeSet.has(row.templateId))
+    .filter((row) => getOverrideRow(overrideMap, row.templateId, row.qualityLevel)?.enabled !== false)
+    .map((row) => {
+      const o = getOverrideRow(overrideMap, row.templateId, row.qualityLevel);
+      if (!o) return row;
+      return { ...row, price: o.price ?? row.price, listings: o.listings ?? row.listings };
+    });
+  for (const [templateId, item] of Object.entries(newItems)) {
+    if (unsafeSet.has(templateId) || item.enabled === false) continue;
+    rows.push({
+      templateId,
+      stackSize: item.stackSize,
+      price: item.price,
+      categoryMask: item.categoryMask,
+      categoryDepth: item.categoryDepth,
+      qualityLevel: item.qualityLevel,
+      kind: item.kind,
+      listings: item.listings,
+      itemStats: newItemStatsJson(item.durabilityCur, item.durabilityMax)
+    });
+  }
+  return { ...plan, rows };
+}
+
+// Same idea for addonJobs.js's loadBuybackSeedPlan, whose rows are a smaller
+// shape (no stackSize/listings/itemStats — buyback only needs a reference
+// price per template+grade). Listings overrides don't apply here; only price
+// and enabled/disable matter for a buyback cap.
+export function mergeBuybackSeedPlanWithOverrides(plan, overrides, unsafeIds = []) {
+  const unsafeSet = new Set(unsafeIds);
+  const overrideMap = overrides?.overrides || {};
+  const newItems = overrides?.newItems || {};
+  const rows = (plan.rows || [])
+    .filter((row) => !unsafeSet.has(row.templateId))
+    .filter((row) => getOverrideRow(overrideMap, row.templateId, row.qualityLevel)?.enabled !== false)
+    .map((row) => {
+      const o = getOverrideRow(overrideMap, row.templateId, row.qualityLevel);
+      if (!o || o.price === undefined) return row;
+      return { ...row, price: o.price };
+    });
+  for (const [templateId, item] of Object.entries(newItems)) {
+    if (unsafeSet.has(templateId) || item.enabled === false) continue;
+    rows.push({
+      templateId,
+      displayName: item.name,
+      price: item.price,
+      qualityLevel: item.qualityLevel,
+      categoryMask: item.categoryMask,
+      kind: item.kind
+    });
+  }
+  return { ...plan, rows };
+}
+
+// Picker results for the "add item" flow: the admin-items.json catalog minus
+// excluded categories and anything the upstream generator flagged unsafe.
+export function listBotItemCatalogPickerItems(repoRoot, { q = "", category = "" } = {}) {
+  const unsafe = new Set(readUnsafeTemplateIds(repoRoot));
+  const safeCategory = String(category || "").trim().toLowerCase();
+  return listCatalogItems(repoRoot, { q, limit: 3000 })
+    .filter((item) => !EXCLUDED_NEW_ITEM_CATEGORIES.has(String(item.category || "").toLowerCase()))
+    .filter((item) => !unsafe.has(item.id))
+    .filter((item) => !safeCategory || String(item.category || "").toLowerCase() === safeCategory);
+}

--- a/console/api/src/services/marketItemOverrides.js
+++ b/console/api/src/services/marketItemOverrides.js
@@ -88,6 +88,22 @@ export function readUnsafeTemplateIds(repoRoot) {
   }
 }
 
+// New items are additions to the bundled plan, not another way to edit an
+// existing row. Keep this check on the server: the picker is only a convenience
+// and API clients can submit save payloads directly.
+export function readBaseMarketTemplateIds(repoRoot) {
+  const path = resolveSeedPlanFile(repoRoot);
+  if (!path) return [];
+  try {
+    const plan = JSON.parse(readFileSync(path, "utf8"));
+    return [...new Set((Array.isArray(plan?.rows) ? plan.rows : [])
+      .map((row) => String(row?.template_id ?? row?.templateId ?? "").trim())
+      .filter(Boolean))];
+  } catch {
+    return [];
+  }
+}
+
 function findCatalogEntry(repoRoot, templateId) {
   let items;
   try {
@@ -150,6 +166,7 @@ export function saveMarketItemOverrides(repoRoot, payload = {}) {
     throw new Error("Bot item overrides payload must be a JSON object.");
   }
   const unsafeSet = new Set(readUnsafeTemplateIds(repoRoot));
+  const baseTemplateIds = new Set(readBaseMarketTemplateIds(repoRoot));
   const previous = readMarketItemOverrides(repoRoot);
   const nextOverrides = {};
   for (const [templateId, byQuality] of Object.entries(previous.overrides)) nextOverrides[templateId] = { ...byQuality };
@@ -183,7 +200,7 @@ export function saveMarketItemOverrides(repoRoot, payload = {}) {
   for (const [rawId, rawRow] of Object.entries(payload.newItems || {})) {
     const templateId = validateTemplateId(rawId);
     if (unsafeSet.has(templateId)) throw new Error(`${templateId} is flagged unsafe and cannot be added.`);
-    if (nextOverrides[templateId]) throw new Error(`${templateId} is already in the base catalog; edit it there instead of adding it as new.`);
+    if (baseTemplateIds.has(templateId)) throw new Error(`${templateId} is already in the base catalog; edit it there instead of adding it as new.`);
     const catalogEntry = findCatalogEntry(repoRoot, templateId);
     if (!catalogEntry) throw new Error(`${templateId} was not found in the item catalog.`);
     const category = String(catalogEntry.category || "").toLowerCase();
@@ -280,9 +297,11 @@ export function mergeBuybackSeedPlanWithOverrides(plan, overrides, unsafeIds = [
 // excluded categories and anything the upstream generator flagged unsafe.
 export function listBotItemCatalogPickerItems(repoRoot, { q = "", category = "" } = {}) {
   const unsafe = new Set(readUnsafeTemplateIds(repoRoot));
+  const baseTemplateIds = new Set(readBaseMarketTemplateIds(repoRoot));
   const safeCategory = String(category || "").trim().toLowerCase();
   return listCatalogItems(repoRoot, { q, limit: 3000 })
     .filter((item) => !EXCLUDED_NEW_ITEM_CATEGORIES.has(String(item.category || "").toLowerCase()))
     .filter((item) => !unsafe.has(item.id))
+    .filter((item) => !baseTemplateIds.has(item.id))
     .filter((item) => !safeCategory || String(item.category || "").toLowerCase() === safeCategory);
 }

--- a/console/api/test/marketItemOverrides.test.js
+++ b/console/api/test/marketItemOverrides.test.js
@@ -7,6 +7,7 @@ import {
   readMarketItemOverrides,
   saveMarketItemOverrides,
   readUnsafeTemplateIds,
+  readBaseMarketTemplateIds,
   mergeMarketSeedPlanWithOverrides,
   mergeBuybackSeedPlanWithOverrides,
   listBotItemCatalogPickerItems
@@ -46,6 +47,13 @@ test("readUnsafeTemplateIds returns [] when no plan file exists, and the plan's 
     assert.deepEqual(readUnsafeTemplateIds(repo), []);
     seedPlanFile(repo, { unsafeTemplateIds: ["BadItem1"] });
     assert.deepEqual(readUnsafeTemplateIds(repo), ["BadItem1"]);
+  });
+});
+
+test("readBaseMarketTemplateIds reads both bundled and normalized row keys", () => {
+  withRepo((repo) => {
+    seedPlanFile(repo);
+    assert.deepEqual(readBaseMarketTemplateIds(repo), ["Existing1"]);
   });
 });
 
@@ -109,6 +117,16 @@ test("saveMarketItemOverrides only accepts new items that resolve in admin-items
   });
 });
 
+test("saveMarketItemOverrides rejects a base-plan item even when it has no existing override", () => {
+  withRepo((repo) => {
+    seedPlanFile(repo);
+    seedAdminItems(repo, [{ id: "Existing1", name: "Existing One", category: "weapons", source: "Weapons" }]);
+    assert.throws(
+      () => saveMarketItemOverrides(repo, { newItems: { Existing1: { price: 250, listings: 2 } } }),
+      /already in the base catalog/);
+  });
+});
+
 test("saveMarketItemOverrides removes a single grade's override when its patch normalizes empty, and supports removedNewItems", () => {
   withRepo((repo) => {
     seedPlanFile(repo);
@@ -164,11 +182,12 @@ test("mergeBuybackSeedPlanWithOverrides applies price overrides per grade and ap
   assert.equal(merged.rows.find((row) => row.templateId === "NewOne").price, 88);
 });
 
-test("listBotItemCatalogPickerItems excludes buildings/contracts/emotes and unsafe ids", () => {
+test("listBotItemCatalogPickerItems excludes base-plan, buildings/contracts/emotes, and unsafe ids", () => {
   withRepo((repo) => {
     seedPlanFile(repo, { unsafeTemplateIds: ["UnsafeWeapon"] });
     seedAdminItems(repo, [
       { id: "GoodWeapon", name: "Good Weapon", category: "weapons", source: "Weapons" },
+      { id: "Existing1", name: "Existing Weapon", category: "weapons", source: "Weapons" },
       { id: "UnsafeWeapon", name: "Unsafe Weapon", category: "weapons", source: "Weapons" },
       { id: "SomeBuilding", name: "Some Building", category: "buildings", source: "BuildingSets" },
       { id: "SomeContract", name: "Some Contract", category: "contracts", source: "Contracts" },

--- a/console/api/test/marketItemOverrides.test.js
+++ b/console/api/test/marketItemOverrides.test.js
@@ -1,0 +1,181 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readMarketItemOverrides,
+  saveMarketItemOverrides,
+  readUnsafeTemplateIds,
+  mergeMarketSeedPlanWithOverrides,
+  mergeBuybackSeedPlanWithOverrides,
+  listBotItemCatalogPickerItems
+} from "../src/services/marketItemOverrides.js";
+
+function withRepo(run) {
+  const repo = mkdtempSync(join(tmpdir(), "market-item-overrides-"));
+  try {
+    return run(repo);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+}
+
+function seedAdminItems(repo, items) {
+  mkdirSync(join(repo, "runtime/data"), { recursive: true });
+  writeFileSync(join(repo, "runtime/data/admin-items.json"), JSON.stringify(items));
+}
+
+function seedPlanFile(repo, { unsafeTemplateIds = [] } = {}) {
+  mkdirSync(join(repo, "runtime/data"), { recursive: true });
+  writeFileSync(join(repo, "runtime/data/market-seed-plan.json"), JSON.stringify({
+    price_multiplier: 1,
+    rows: [{ template_id: "Existing1", price: 10, quality_level: 0 }],
+    unsafe_template_ids: unsafeTemplateIds
+  }));
+}
+
+test("readMarketItemOverrides returns empty defaults when no file exists", () => {
+  withRepo((repo) => {
+    assert.deepEqual(readMarketItemOverrides(repo), { overrides: {}, newItems: {} });
+  });
+});
+
+test("readUnsafeTemplateIds returns [] when no plan file exists, and the plan's list when present", () => {
+  withRepo((repo) => {
+    assert.deepEqual(readUnsafeTemplateIds(repo), []);
+    seedPlanFile(repo, { unsafeTemplateIds: ["BadItem1"] });
+    assert.deepEqual(readUnsafeTemplateIds(repo), ["BadItem1"]);
+  });
+});
+
+test("saveMarketItemOverrides validates and persists an override keyed by quality level, round-tripping through readMarketItemOverrides", () => {
+  withRepo((repo) => {
+    seedPlanFile(repo);
+    const saved = saveMarketItemOverrides(repo, { overrides: { Existing1: { 0: { price: 500, listings: 3, enabled: true } } } });
+    assert.deepEqual(saved.overrides.Existing1["0"], { price: 500, listings: 3, enabled: true });
+    assert.deepEqual(readMarketItemOverrides(repo).overrides.Existing1["0"], { price: 500, listings: 3, enabled: true });
+    const raw = JSON.parse(readFileSync(join(repo, "runtime/generated/market-bot/items.json"), "utf8"));
+    assert.equal(raw.overrides.Existing1["0"].price, 500);
+  });
+});
+
+test("saveMarketItemOverrides keeps separate grades of the same template independent", () => {
+  withRepo((repo) => {
+    seedPlanFile(repo);
+    saveMarketItemOverrides(repo, { overrides: { Existing1: { 0: { price: 500 } } } });
+    const saved = saveMarketItemOverrides(repo, { overrides: { Existing1: { 3: { price: 900 } } } });
+    assert.equal(saved.overrides.Existing1["0"].price, 500);
+    assert.equal(saved.overrides.Existing1["3"].price, 900);
+  });
+});
+
+test("saveMarketItemOverrides rejects an out-of-range price and listings count, and an invalid quality level key", () => {
+  withRepo((repo) => {
+    seedPlanFile(repo);
+    assert.throws(() => saveMarketItemOverrides(repo, { overrides: { Existing1: { 0: { price: -5 } } } }), /price/);
+    assert.throws(() => saveMarketItemOverrides(repo, { overrides: { Existing1: { 0: { listings: 0 } } } }), /listings/);
+    assert.throws(() => saveMarketItemOverrides(repo, { overrides: { Existing1: { 0: { listings: 100 } } } }), /listings/);
+    assert.throws(() => saveMarketItemOverrides(repo, { overrides: { Existing1: { 9: { price: 10 } } } }), /quality level/);
+  });
+});
+
+test("saveMarketItemOverrides hard-blocks unsafe template ids from being edited or added", () => {
+  withRepo((repo) => {
+    seedPlanFile(repo, { unsafeTemplateIds: ["Existing1"] });
+    assert.throws(() => saveMarketItemOverrides(repo, { overrides: { Existing1: { 0: { enabled: false } } } }), /unsafe/);
+    seedAdminItems(repo, [{ id: "Unsafe2", name: "Unsafe Two", category: "weapons", source: "Weapons" }]);
+    const plan = JSON.parse(readFileSync(join(repo, "runtime/data/market-seed-plan.json"), "utf8"));
+    plan.unsafe_template_ids.push("Unsafe2");
+    writeFileSync(join(repo, "runtime/data/market-seed-plan.json"), JSON.stringify(plan));
+    assert.throws(() => saveMarketItemOverrides(repo, { newItems: { Unsafe2: { price: 10, listings: 1 } } }), /unsafe/);
+  });
+});
+
+test("saveMarketItemOverrides only accepts new items that resolve in admin-items.json, and blocks excluded categories", () => {
+  withRepo((repo) => {
+    seedPlanFile(repo);
+    seedAdminItems(repo, [
+      { id: "GoodWeapon", name: "Good Weapon", category: "weapons", source: "Weapons" },
+      { id: "SomeBuilding", name: "Some Building", category: "buildings", source: "BuildingSets" }
+    ]);
+    assert.throws(() => saveMarketItemOverrides(repo, { newItems: { NotInCatalog: { price: 10, listings: 1 } } }), /not found/);
+    assert.throws(() => saveMarketItemOverrides(repo, { newItems: { SomeBuilding: { price: 10, listings: 1 } } }), /excluded category/);
+    const saved = saveMarketItemOverrides(repo, { newItems: { GoodWeapon: { price: 250, listings: 2, qualityLevel: 3 } } });
+    assert.equal(saved.newItems.GoodWeapon.name, "Good Weapon");
+    assert.equal(saved.newItems.GoodWeapon.category, "weapons");
+    assert.equal(saved.newItems.GoodWeapon.price, 250);
+    assert.equal(saved.newItems.GoodWeapon.qualityLevel, 3);
+  });
+});
+
+test("saveMarketItemOverrides removes a single grade's override when its patch normalizes empty, and supports removedNewItems", () => {
+  withRepo((repo) => {
+    seedPlanFile(repo);
+    seedAdminItems(repo, [{ id: "GoodWeapon", name: "Good Weapon", category: "weapons", source: "Weapons" }]);
+    saveMarketItemOverrides(repo, { overrides: { Existing1: { 0: { price: 500 }, 3: { price: 900 } } } });
+    const cleared = saveMarketItemOverrides(repo, { overrides: { Existing1: { 0: {} } } });
+    assert.equal(cleared.overrides.Existing1["0"], undefined);
+    assert.equal(cleared.overrides.Existing1["3"].price, 900);
+
+    saveMarketItemOverrides(repo, { newItems: { GoodWeapon: { price: 100, listings: 1 } } });
+    const afterRemoval = saveMarketItemOverrides(repo, { removedNewItems: ["GoodWeapon"] });
+    assert.equal(afterRemoval.newItems.GoodWeapon, undefined);
+  });
+});
+
+test("mergeMarketSeedPlanWithOverrides applies overrides per grade, not per template, drops disabled and unsafe rows, and appends new items", () => {
+  const plan = {
+    sourceMultiplier: 1,
+    rows: [
+      { templateId: "A", price: 10, listings: 1, stackSize: 1, categoryMask: 0, categoryDepth: 0, qualityLevel: 0, kind: "equippable" },
+      { templateId: "A", price: 20, listings: 1, stackSize: 1, categoryMask: 0, categoryDepth: 0, qualityLevel: 3, kind: "equippable" },
+      { templateId: "B", price: 20, listings: 2, stackSize: 1, categoryMask: 0, categoryDepth: 0, qualityLevel: 0, kind: "equippable" },
+      { templateId: "Unsafe", price: 30, listings: 1, stackSize: 1, categoryMask: 0, categoryDepth: 0, qualityLevel: 0, kind: "equippable" }
+    ]
+  };
+  const overrides = {
+    overrides: { A: { 0: { price: 999 } }, B: { 0: { enabled: false } } },
+    newItems: { NewOne: { price: 55, listings: 4, stackSize: 1, categoryMask: 0, categoryDepth: 0, qualityLevel: 1, kind: "equippable", enabled: true, durabilityCur: 100, durabilityMax: 100 } }
+  };
+  const merged = mergeMarketSeedPlanWithOverrides(plan, overrides, ["Unsafe"]);
+  const aRows = merged.rows.filter((row) => row.templateId === "A");
+  assert.equal(aRows.find((row) => row.qualityLevel === 0).price, 999);
+  assert.equal(aRows.find((row) => row.qualityLevel === 3).price, 20, "grade 3 must be untouched by the grade-0 override");
+  assert.deepEqual(merged.rows.map((row) => row.templateId).sort(), ["A", "A", "NewOne"]);
+  assert.equal(merged.rows.find((row) => row.templateId === "NewOne").listings, 4);
+});
+
+test("mergeBuybackSeedPlanWithOverrides applies price overrides per grade and appends new items without a listings field", () => {
+  const plan = {
+    sourceMultiplier: 1,
+    rows: [
+      { templateId: "A", displayName: "A", price: 10, qualityLevel: 0, categoryMask: 0, kind: "equippable" },
+      { templateId: "A", displayName: "A", price: 20, qualityLevel: 2, categoryMask: 0, kind: "equippable" }
+    ]
+  };
+  const overrides = {
+    overrides: { A: { 0: { price: 777 } } },
+    newItems: { NewOne: { name: "New One", price: 88, qualityLevel: 0, categoryMask: 0, kind: "equippable", enabled: true } }
+  };
+  const merged = mergeBuybackSeedPlanWithOverrides(plan, overrides, []);
+  assert.equal(merged.rows.find((row) => row.templateId === "A" && row.qualityLevel === 0).price, 777);
+  assert.equal(merged.rows.find((row) => row.templateId === "A" && row.qualityLevel === 2).price, 20);
+  assert.equal(merged.rows.find((row) => row.templateId === "NewOne").price, 88);
+});
+
+test("listBotItemCatalogPickerItems excludes buildings/contracts/emotes and unsafe ids", () => {
+  withRepo((repo) => {
+    seedPlanFile(repo, { unsafeTemplateIds: ["UnsafeWeapon"] });
+    seedAdminItems(repo, [
+      { id: "GoodWeapon", name: "Good Weapon", category: "weapons", source: "Weapons" },
+      { id: "UnsafeWeapon", name: "Unsafe Weapon", category: "weapons", source: "Weapons" },
+      { id: "SomeBuilding", name: "Some Building", category: "buildings", source: "BuildingSets" },
+      { id: "SomeContract", name: "Some Contract", category: "contracts", source: "Contracts" },
+      { id: "SomeEmote", name: "Some Emote", category: "emotes", source: "Emotes" }
+    ]);
+    const rows = listBotItemCatalogPickerItems(repo, {});
+    const ids = rows.map((row) => row.itemId).sort();
+    assert.deepEqual(ids, ["GoodWeapon"]);
+  });
+});

--- a/console/web/src/api/marketBotItems.ts
+++ b/console/web/src/api/marketBotItems.ts
@@ -1,0 +1,62 @@
+import { api, post } from "./client";
+
+// Per-item Market Bot catalog overrides — an admin-editable layer on top of
+// the bundled, read-only market seed plan. See console/api/src/services/marketItemOverrides.js.
+
+export type MarketBotItemRow = {
+  templateId: string;
+  displayName: string;
+  category: string;
+  qualityLevel: number;
+  price: number;
+  listings: number;
+  enabled: boolean;
+  overridden: boolean;
+  isNew: boolean;
+  unsafe: boolean;
+};
+
+export type MarketBotItemsResponse = {
+  capabilities: { exchangeMarket?: boolean } & Record<string, unknown>;
+  rows: MarketBotItemRow[];
+  reason?: string;
+};
+
+export type MarketItemOverridePatch = { enabled?: boolean; price?: number; listings?: number };
+
+export type MarketNewItemPayload = {
+  name?: string;
+  price: number;
+  listings: number;
+  enabled?: boolean;
+  qualityLevel?: number;
+  stackSize?: number;
+};
+
+// overrides is nested templateId -> qualityLevel (as a string key) -> patch,
+// since the same template id has a distinct row (and price) per grade.
+export type MarketItemsSavePayload = {
+  overrides?: Record<string, Record<string, MarketItemOverridePatch>>;
+  newItems?: Record<string, MarketNewItemPayload>;
+  removedNewItems?: string[];
+};
+
+export type MarketCatalogPickItem = {
+  id: string;
+  itemId: string;
+  name: string;
+  category: string;
+  image: string;
+};
+
+export const marketBotItemsApi = {
+  list: () => api<MarketBotItemsResponse>("/api/exchange/market/items"),
+  catalog: (params: { q?: string; category?: string } = {}) => {
+    const query = new URLSearchParams();
+    if (params.q) query.set("q", params.q);
+    if (params.category) query.set("category", params.category);
+    const suffix = query.toString();
+    return api<{ rows: MarketCatalogPickItem[] }>(`/api/exchange/market/items/catalog${suffix ? `?${suffix}` : ""}`);
+  },
+  save: (payload: MarketItemsSavePayload) => post<{ overrides: Record<string, Record<string, MarketItemOverridePatch>>; newItems: Record<string, MarketNewItemPayload> }>("/api/exchange/market/items", payload)
+};

--- a/console/web/src/features/exchange/BotItemsTab.tsx
+++ b/console/web/src/features/exchange/BotItemsTab.tsx
@@ -1,0 +1,442 @@
+import { useEffect, useMemo, useState } from "react";
+import { Plus, X } from "lucide-react";
+import { marketBotItemsApi, type MarketBotItemRow, type MarketCatalogPickItem } from "../../api/marketBotItems";
+
+type BotItemsTabProps = {
+  onError: (text: string) => void;
+};
+
+const BOT_ITEMS_PAGE_SIZES = [25, 50, 100, 200] as const;
+const BOT_ITEMS_DEFAULT_PAGE_SIZE = 50;
+
+function qualityLabel(quality: number) {
+  return quality > 0 ? `Q${quality}` : "Standard";
+}
+
+// Existing-row drafts are keyed by templateId::qualityLevel -- the same
+// template id repeats once per grade with its own price, so a template-only
+// key would apply one grade's edit to every grade of that item.
+function draftKey(templateId: string, qualityLevel: number) {
+  return `${templateId}::${qualityLevel}`;
+}
+
+type OverrideDraft = { price?: number; listings?: number; enabled?: boolean };
+type NewItemDraft = { name: string; category: string; price: number; listings: number; enabled: boolean; qualityLevel: number };
+
+function errorText(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function fmt(value: number) {
+  return Number(value || 0).toLocaleString();
+}
+
+function ItemPickerOverlay({ onClose, onPick, alreadyAdded }: { onClose: () => void; onPick: (item: MarketCatalogPickItem) => void; alreadyAdded: Set<string> }) {
+  const [q, setQ] = useState("");
+  const [category, setCategory] = useState("");
+  const [rows, setRows] = useState<MarketCatalogPickItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    const timeoutId = window.setTimeout(() => {
+      void marketBotItemsApi.catalog({ q, category })
+        .then((result) => { if (!cancelled) { setRows(result.rows || []); setLoading(false); } })
+        .catch((err) => { if (!cancelled) { setError(errorText(err)); setLoading(false); } });
+    }, 200);
+    return () => { cancelled = true; window.clearTimeout(timeoutId); };
+  }, [q, category]);
+
+  const categories = useMemo(() => [...new Set(rows.map((r) => r.category).filter(Boolean))].sort(), [rows]);
+
+  return (
+    <div className="modal-overlay" role="dialog" aria-modal="true" aria-label="Add bot item" onClick={onClose}>
+      <div className="confirm-modal exchange-config-modal" onClick={(event) => event.stopPropagation()}>
+        <div className="confirm-modal-title">
+          <h3>Add bot item</h3>
+          <button className="exchange-config-close" aria-label="Close" onClick={onClose}><X size={16} /></button>
+        </div>
+        <p>Pick from the item catalog. Buildings, contracts, emotes, and unsafe items are not selectable.</p>
+        <div className="action-row exchange-search-row">
+          <input value={q} onChange={(event) => setQ(event.target.value)} placeholder="Search item name" />
+          <label className="compact-select exchange-category-select">
+            Category
+            <select value={category} onChange={(event) => setCategory(event.target.value)}>
+              <option value="">All categories</option>
+              {categories.map((name) => <option key={name} value={name}>{name}</option>)}
+            </select>
+          </label>
+        </div>
+        {error && <p className="action-help-note error-text">{error}</p>}
+        {loading
+          ? <p className="muted">Loading…</p>
+          : <ul className="exchange-config-chips bot-item-picker-list">
+            {rows.length === 0 && <p className="muted exchange-config-empty">No matching items.</p>}
+            {rows.map((item) => {
+              const added = alreadyAdded.has(item.itemId);
+              return (
+                <li key={item.itemId} className="exchange-config-chip bot-item-picker-row">
+                  <span>{item.name}<em>{item.category}</em></span>
+                  <button type="button" disabled={added} onClick={() => onPick(item)}>{added ? "Added" : "Add"}</button>
+                </li>
+              );
+            })}
+          </ul>}
+        <div className="confirm-modal-actions">
+          <button onClick={onClose}>Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function BotItemsTab({ onError }: BotItemsTabProps) {
+  const [rows, setRows] = useState<MarketBotItemRow[]>([]);
+  const [supported, setSupported] = useState(true);
+  const [reason, setReason] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [search, setSearch] = useState("");
+  const [category, setCategory] = useState("");
+  const [qualityFilter, setQualityFilter] = useState("");
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState<number>(BOT_ITEMS_DEFAULT_PAGE_SIZE);
+  const [overrideDrafts, setOverrideDrafts] = useState<Record<string, OverrideDraft>>({});
+  const [newItemDrafts, setNewItemDrafts] = useState<Record<string, NewItemDraft>>({});
+  const [removedNewItems, setRemovedNewItems] = useState<string[]>([]);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  function load() {
+    setLoading(true);
+    void marketBotItemsApi.list()
+      .then((result) => {
+        setRows(result.rows || []);
+        setSupported(result.capabilities?.exchangeMarket !== false);
+        setReason(result.reason || "");
+        setLoading(false);
+      })
+      .catch((error) => {
+        onError(errorText(error));
+        setLoading(false);
+      });
+  }
+
+  useEffect(() => { load(); }, []);
+
+  const existingIds = useMemo(() => new Set(rows.map((row) => row.templateId)), [rows]);
+  const combinedRows = useMemo(() => {
+    const removedSet = new Set(removedNewItems);
+    const base = rows.filter((row) => !(row.isNew && removedSet.has(row.templateId)));
+    return [
+      ...base,
+      ...Object.entries(newItemDrafts)
+        .filter(([templateId]) => !existingIds.has(templateId))
+        .map(([templateId, draft]) => ({
+          templateId, displayName: draft.name, category: draft.category, qualityLevel: draft.qualityLevel,
+          price: draft.price, listings: draft.listings, enabled: draft.enabled, overridden: false, isNew: true, unsafe: false
+        }))
+    ] as MarketBotItemRow[];
+  }, [rows, newItemDrafts, removedNewItems, existingIds]);
+
+  // Option lists derive from the full combined set (before search/category/quality
+  // filters) so a dropdown's own options never disappear while it's the active filter.
+  const categories = useMemo(() => [...new Set(combinedRows.map((row) => row.category).filter(Boolean))].sort((a, b) => a.localeCompare(b)), [combinedRows]);
+  const qualityLevels = useMemo(() => [...new Set(combinedRows.map((row) => row.qualityLevel))].sort((a, b) => a - b), [combinedRows]);
+
+  const filteredRows = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return combinedRows.filter((row) => {
+      if (category && row.category !== category) return false;
+      if (qualityFilter !== "" && row.qualityLevel !== Number(qualityFilter)) return false;
+      if (!term) return true;
+      return row.displayName.toLowerCase().includes(term) || row.templateId.toLowerCase().includes(term) || row.category.toLowerCase().includes(term);
+    });
+  }, [combinedRows, search, category, qualityFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredRows.length / pageSize));
+  const safePage = Math.min(page, totalPages - 1);
+  const rangeStart = filteredRows.length === 0 ? 0 : safePage * pageSize + 1;
+  const visibleRows = useMemo(() => filteredRows.slice(safePage * pageSize, safePage * pageSize + pageSize), [filteredRows, safePage, pageSize]);
+  const rangeEnd = filteredRows.length === 0 ? 0 : rangeStart + visibleRows.length - 1;
+
+  function changeSearch(value: string) {
+    setSearch(value);
+    setPage(0);
+  }
+
+  function changeCategory(value: string) {
+    setCategory(value);
+    setPage(0);
+  }
+
+  function changeQuality(value: string) {
+    setQualityFilter(value);
+    setPage(0);
+  }
+
+  function changePageSize(nextSize: number) {
+    setPageSize(nextSize);
+    setPage(0);
+  }
+
+  const dirtyCount = Object.keys(overrideDrafts).length + Object.keys(newItemDrafts).length + removedNewItems.length;
+  const toggleableCount = useMemo(() => filteredRows.filter((row) => !row.unsafe).length, [filteredRows]);
+
+  function fieldValue(row: MarketBotItemRow, field: "price" | "listings" | "enabled") {
+    if (row.isNew && newItemDrafts[row.templateId]) return newItemDrafts[row.templateId][field === "listings" ? "listings" : field] as number | boolean;
+    const draft = overrideDrafts[draftKey(row.templateId, row.qualityLevel)];
+    if (draft && field in draft) return draft[field] as number | boolean;
+    return row[field];
+  }
+
+  function updateExisting(templateId: string, qualityLevel: number, patch: OverrideDraft) {
+    const key = draftKey(templateId, qualityLevel);
+    setOverrideDrafts((current) => ({ ...current, [key]: { ...current[key], ...patch } }));
+  }
+
+  // Bulk enable/disable over whatever the current search/category/quality
+  // filters resolve to (every matching page, not just the one on screen) --
+  // "view" means the filtered set, not the current 50-row slice.
+  function setEnabledForFilteredRows(enabled: boolean) {
+    const overridePatch: Record<string, OverrideDraft> = {};
+    const newItemPatch: Record<string, Partial<NewItemDraft>> = {};
+    for (const row of filteredRows) {
+      if (row.unsafe) continue;
+      if (row.isNew) newItemPatch[row.templateId] = { enabled };
+      else overridePatch[draftKey(row.templateId, row.qualityLevel)] = { enabled };
+    }
+    setOverrideDrafts((current) => {
+      const next = { ...current };
+      for (const [key, patch] of Object.entries(overridePatch)) next[key] = { ...next[key], ...patch };
+      return next;
+    });
+    setNewItemDrafts((current) => {
+      const next = { ...current };
+      for (const [templateId, patch] of Object.entries(newItemPatch)) next[templateId] = { ...next[templateId], ...patch } as NewItemDraft;
+      return next;
+    });
+  }
+
+  function updateNewDraft(templateId: string, patch: Partial<NewItemDraft>) {
+    setNewItemDrafts((current) => ({ ...current, [templateId]: { ...current[templateId], ...patch } as NewItemDraft }));
+  }
+
+  function removeNewDraft(templateId: string) {
+    setNewItemDrafts((current) => {
+      const next = { ...current };
+      delete next[templateId];
+      return next;
+    });
+  }
+
+  function removeExistingNewItem(templateId: string) {
+    setRemovedNewItems((current) => [...current, templateId]);
+  }
+
+  function pickItem(item: MarketCatalogPickItem) {
+    updateNewDraft(item.itemId, {
+      name: item.name,
+      category: item.category,
+      price: 100,
+      listings: 1,
+      enabled: true,
+      qualityLevel: 0
+    });
+  }
+
+  function discardAll() {
+    setOverrideDrafts({});
+    setNewItemDrafts({});
+    setRemovedNewItems([]);
+  }
+
+  // Flat draftKey (templateId::qualityLevel) -> per-template map of qualityLevel -> patch,
+  // matching the backend's nested overrides schema.
+  function buildOverridesPayload() {
+    const payload: Record<string, Record<string, OverrideDraft>> = {};
+    for (const [key, patch] of Object.entries(overrideDrafts)) {
+      const separatorIndex = key.lastIndexOf("::");
+      const templateId = key.slice(0, separatorIndex);
+      const qualityLevel = key.slice(separatorIndex + 2);
+      payload[templateId] = { ...payload[templateId], [qualityLevel]: patch };
+    }
+    return payload;
+  }
+
+  async function saveAll() {
+    setSaving(true);
+    onError("");
+    try {
+      await marketBotItemsApi.save({
+        overrides: buildOverridesPayload(),
+        newItems: Object.fromEntries(Object.entries(newItemDrafts).map(([templateId, draft]) => [templateId, {
+          name: draft.name, price: draft.price, listings: draft.listings, enabled: draft.enabled, qualityLevel: draft.qualityLevel
+        }])),
+        removedNewItems
+      });
+      discardAll();
+      load();
+    } catch (error) {
+      onError(errorText(error));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="loading-panel">
+        <span className="spinner" aria-hidden="true" />
+        <strong className="loading-dots">Loading bot items</strong>
+      </div>
+    );
+  }
+
+  if (!supported) {
+    return <p className="action-help-note">{reason || "The Market Bot is unsupported by the detected database schema."}</p>;
+  }
+
+  return (
+    <>
+      <div className="action-row exchange-search-row">
+        <input value={search} onChange={(event) => changeSearch(event.target.value)} placeholder="Search bot items" />
+        <label className="compact-select exchange-category-select">
+          Category
+          <select value={category} onChange={(event) => changeCategory(event.target.value)}>
+            <option value="">All categories</option>
+            {categories.map((name) => <option key={name} value={name}>{name}</option>)}
+          </select>
+        </label>
+        <label className="compact-select exchange-category-select">
+          Quality
+          <select value={qualityFilter} onChange={(event) => changeQuality(event.target.value)}>
+            <option value="">All qualities</option>
+            {qualityLevels.map((level) => <option key={level} value={level}>{qualityLabel(level)}</option>)}
+          </select>
+        </label>
+        <button className="bot-items-add-button" onClick={() => setPickerOpen(true)}><Plus size={14} /> Add item</button>
+      </div>
+      <div className="panel-title bot-items-summary-row">
+        <p className="action-help-note">Showing {rangeStart}-{rangeEnd} of {filteredRows.length.toLocaleString()} item{filteredRows.length === 1 ? "" : "s"}{filteredRows.length !== combinedRows.length ? ` (${combinedRows.length.toLocaleString()} total)` : ""}.</p>
+        <div className="action-row">
+          <button onClick={() => setEnabledForFilteredRows(false)} disabled={toggleableCount === 0}>Disable all in view</button>
+          <button onClick={() => setEnabledForFilteredRows(true)} disabled={toggleableCount === 0}>Enable all in view</button>
+        </div>
+      </div>
+      <div className="table-wrap bot-items-table-wrap">
+        <table className="bot-items-table">
+          <thead>
+            <tr>
+              <th>Item</th>
+              <th>Category</th>
+              <th>Quality</th>
+              <th>Price</th>
+              <th>Stock</th>
+              <th>On</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {visibleRows.length === 0 && (
+              <tr><td colSpan={7} className="muted">No bot items match this filter.</td></tr>
+            )}
+            {visibleRows.map((row) => {
+              const price = fieldValue(row, "price") as number;
+              const listings = fieldValue(row, "listings") as number;
+              const enabled = fieldValue(row, "enabled") as boolean;
+              const dirty = row.isNew ? Boolean(newItemDrafts[row.templateId]) : Boolean(overrideDrafts[draftKey(row.templateId, row.qualityLevel)]);
+              const disabled = row.unsafe;
+              return (
+                <tr key={`${row.templateId}:${row.qualityLevel}`} className={dirty ? "bot-item-row-dirty" : undefined}>
+                  <td>
+                    <span className="exchange-item-text">
+                      <span className="exchange-item-name">{row.displayName}</span>
+                      <span className="exchange-item-template" title={row.templateId}>{row.templateId}</span>
+                    </span>
+                    {row.unsafe && <span className="bot-item-badge bot-item-badge-unsafe">Unsafe — excluded</span>}
+                    {row.isNew && <span className="bot-item-badge bot-item-badge-new">New</span>}
+                  </td>
+                  <td>{row.category || <span className="muted">—</span>}</td>
+                  <td>{qualityLabel(row.qualityLevel)}</td>
+                  <td>
+                    <input
+                      type="number" min={1} disabled={disabled}
+                      className={dirty ? "bot-item-field-dirty" : undefined}
+                      value={price}
+                      onChange={(event) => {
+                        const next = Math.max(1, Math.trunc(Number(event.target.value) || 0));
+                        if (row.isNew) updateNewDraft(row.templateId, { price: next });
+                        else updateExisting(row.templateId, row.qualityLevel, { price: next });
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="number" min={1} max={99} disabled={disabled}
+                      className={dirty ? "bot-item-field-dirty" : undefined}
+                      value={listings}
+                      onChange={(event) => {
+                        const next = Math.min(99, Math.max(1, Math.trunc(Number(event.target.value) || 0)));
+                        if (row.isNew) updateNewDraft(row.templateId, { listings: next });
+                        else updateExisting(row.templateId, row.qualityLevel, { listings: next });
+                      }}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="checkbox" disabled={disabled}
+                      checked={enabled}
+                      onChange={(event) => {
+                        if (row.isNew) updateNewDraft(row.templateId, { enabled: event.target.checked });
+                        else updateExisting(row.templateId, row.qualityLevel, { enabled: event.target.checked });
+                      }}
+                    />
+                  </td>
+                  <td>
+                    {row.isNew && (
+                      newItemDrafts[row.templateId]
+                        ? <button type="button" onClick={() => removeNewDraft(row.templateId)}>Remove</button>
+                        : <button type="button" onClick={() => removeExistingNewItem(row.templateId)}>Remove</button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <div className="panel-title exchange-pagination-footer">
+        <p className="action-help-note">Showing {rangeStart}-{rangeEnd} of {filteredRows.length.toLocaleString()} items.</p>
+        <div className="database-pagination-controls">
+          <label className="compact-select">
+            Rows
+            <select value={String(pageSize)} onChange={(event) => changePageSize(Number(event.target.value))}>
+              {BOT_ITEMS_PAGE_SIZES.map((size) => <option key={size} value={size}>{size}</option>)}
+            </select>
+          </label>
+          <button disabled={safePage <= 0} onClick={() => setPage(0)}>First</button>
+          <button disabled={safePage <= 0} onClick={() => setPage(safePage - 1)}>Previous</button>
+          <span className="muted database-page-indicator">Page {safePage + 1} of {totalPages}</span>
+          <button disabled={safePage + 1 >= totalPages} onClick={() => setPage(safePage + 1)}>Next</button>
+          <button disabled={safePage + 1 >= totalPages} onClick={() => setPage(totalPages - 1)}>Last</button>
+        </div>
+      </div>
+      <div className="panel-title exchange-pagination-footer bot-items-footer">
+        <p className="action-help-note">{dirtyCount > 0 ? `${dirtyCount} unsaved change${dirtyCount === 1 ? "" : "s"}` : "No unsaved changes."}</p>
+        <div className="database-pagination-controls">
+          <button onClick={discardAll} disabled={saving || dirtyCount === 0}>Discard</button>
+          <button className="primary" onClick={() => void saveAll()} disabled={saving || dirtyCount === 0}>{saving ? "Saving…" : "Save all"}</button>
+        </div>
+      </div>
+      {pickerOpen && (
+        <ItemPickerOverlay
+          onClose={() => setPickerOpen(false)}
+          onPick={pickItem}
+          alreadyAdded={new Set([...existingIds, ...Object.keys(newItemDrafts)])}
+        />
+      )}
+    </>
+  );
+}

--- a/console/web/src/features/exchange/ExchangePanel.tsx
+++ b/console/web/src/features/exchange/ExchangePanel.tsx
@@ -6,6 +6,7 @@ import type { SortDirection } from "../../components/common/DataTable";
 import { ExchangeTable } from "./ExchangeTable";
 import { ExchangeConfigOverlay } from "./ExchangeConfigOverlay";
 import { MarketBotOverlay } from "./MarketBotOverlay";
+import { BotItemsTab } from "./BotItemsTab";
 
 type ExchangePanelProps = {
   onError: (text: string) => void;
@@ -73,6 +74,7 @@ export function ExchangePanel({ onError, confirmAction }: ExchangePanelProps) {
   const [loading, setLoading] = useState(() => exchangeCache === null);
   const [configOpen, setConfigOpen] = useState(false);
   const [marketBotOpen, setMarketBotOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<"exchange" | "bot-items">("exchange");
   // The Market Bot button only appears when the status endpoint answers, so
   // viewers without the exchange:market action never see a control they
   // cannot use. Checked silently once per mount.
@@ -207,7 +209,7 @@ export function ExchangePanel({ onError, confirmAction }: ExchangePanelProps) {
     setCategory("");
   }
 
-  if (loading && !rows.length) {
+  if (activeTab === "exchange" && loading && !rows.length) {
     return (
       <section className="panel">
         <div className="loading-panel">
@@ -229,35 +231,6 @@ export function ExchangePanel({ onError, confirmAction }: ExchangePanelProps) {
       <div className="panel-title">
         <h2>Market Board</h2>
         <div className="action-row">
-          <button onClick={() => void load(currentView())}>Refresh</button>
-        </div>
-      </div>
-      {supported
-        ? <p className="action-help-note">Read-only view of the CHOAM exchange. {totalCount.toLocaleString()}{totalCount !== totalItems ? ` of ${totalItems.toLocaleString()}` : ""} item{totalItems === 1 ? "" : "s"} listed for the current filter.</p>
-        : <p className="action-help-note">{reason || "The Market Board is unsupported by the detected database schema."}</p>}
-      {supported && <>
-        <div className="action-row exchange-search-row">
-          <input
-            value={q}
-            onChange={(event) => setQ(event.target.value)}
-            onKeyDown={(event) => { if (event.key === "Enter") submitSearch(); }}
-            placeholder="Search item name, category, or template"
-          />
-          <button onClick={submitSearch}>Search</button>
-          <button onClick={handleClearSearch} disabled={!q && !submittedQ}>Clear</button>
-          <label className="compact-select exchange-category-select">
-            Category
-            <select value={categories.includes(category) ? category : ""} onChange={(event) => setCategory(event.target.value)}>
-              <option value="">All categories</option>
-              {categories.map((name) => <option key={name} value={name}>{name}</option>)}
-            </select>
-          </label>
-          <label className="compact-select exchange-owner-select">
-            Show
-            <select value={owner} onChange={(event) => changeOwner(event.target.value as ExchangeOwner)}>
-              {OWNER_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
-            </select>
-          </label>
           <button className="exchange-config-button" title="Configure bots and blacklist" aria-label="Configure bots and blacklist" onClick={() => setConfigOpen(true)}>
             <Settings size={16} />
           </button>
@@ -267,31 +240,67 @@ export function ExchangePanel({ onError, confirmAction }: ExchangePanelProps) {
             </button>
           )}
         </div>
-        <ExchangeTable
-          rows={rows}
-          owner={owner}
-          sortColumn={sortColumn}
-          sortDirection={sortDirection}
-          onSort={handleSort}
-          emptyMessage="No market listings match this filter."
-        />
-        <div className="panel-title exchange-pagination-footer">
-          <p className="action-help-note">Showing {rangeStart}-{rangeEnd} of {totalCount} items.</p>
-          <div className="database-pagination-controls">
-            <label className="compact-select">
-              Rows
-              <select value={String(pageSize)} onChange={(event) => changePageSize(Number(event.target.value))}>
-                {EXCHANGE_PAGE_SIZES.map((size) => <option key={size} value={size}>{size}</option>)}
+      </div>
+      <div className="bases-expanded-tablist" role="tablist">
+        <button type="button" role="tab" aria-selected={activeTab === "exchange"} className={`bases-expanded-tab${activeTab === "exchange" ? " active" : ""}`} onClick={() => setActiveTab("exchange")}>Exchange</button>
+        <button type="button" role="tab" aria-selected={activeTab === "bot-items"} className={`bases-expanded-tab${activeTab === "bot-items" ? " active" : ""}`} onClick={() => setActiveTab("bot-items")}>Bot items</button>
+      </div>
+      {activeTab === "exchange" && <>
+        {supported
+          ? <p className="action-help-note">Read-only view of the CHOAM exchange. {totalCount.toLocaleString()}{totalCount !== totalItems ? ` of ${totalItems.toLocaleString()}` : ""} item{totalItems === 1 ? "" : "s"} listed for the current filter.</p>
+          : <p className="action-help-note">{reason || "The Market Board is unsupported by the detected database schema."}</p>}
+        {supported && <>
+          <div className="action-row exchange-search-row">
+            <input
+              value={q}
+              onChange={(event) => setQ(event.target.value)}
+              onKeyDown={(event) => { if (event.key === "Enter") submitSearch(); }}
+              placeholder="Search item name, category, or template"
+            />
+            <button onClick={submitSearch}>Search</button>
+            <button onClick={handleClearSearch} disabled={!q && !submittedQ}>Clear</button>
+            <label className="compact-select exchange-category-select">
+              Category
+              <select value={categories.includes(category) ? category : ""} onChange={(event) => setCategory(event.target.value)}>
+                <option value="">All categories</option>
+                {categories.map((name) => <option key={name} value={name}>{name}</option>)}
               </select>
             </label>
-            <button disabled={!hasPreviousPage} onClick={() => setPage(0)}>First</button>
-            <button disabled={!hasPreviousPage} onClick={() => setPage(page - 1)}>Previous</button>
-            <span className="muted database-page-indicator">Page {page + 1} of {totalPages}</span>
-            <button disabled={!hasNextPage} onClick={() => setPage(page + 1)}>Next</button>
-            <button disabled={!hasNextPage} onClick={() => setPage(totalPages - 1)}>Last</button>
+            <label className="compact-select exchange-owner-select">
+              Show
+              <select value={owner} onChange={(event) => changeOwner(event.target.value as ExchangeOwner)}>
+                {OWNER_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+              </select>
+            </label>
+            <button onClick={() => void load(currentView())}>Refresh</button>
           </div>
-        </div>
+          <ExchangeTable
+            rows={rows}
+            owner={owner}
+            sortColumn={sortColumn}
+            sortDirection={sortDirection}
+            onSort={handleSort}
+            emptyMessage="No market listings match this filter."
+          />
+          <div className="panel-title exchange-pagination-footer">
+            <p className="action-help-note">Showing {rangeStart}-{rangeEnd} of {totalCount} items.</p>
+            <div className="database-pagination-controls">
+              <label className="compact-select">
+                Rows
+                <select value={String(pageSize)} onChange={(event) => changePageSize(Number(event.target.value))}>
+                  {EXCHANGE_PAGE_SIZES.map((size) => <option key={size} value={size}>{size}</option>)}
+                </select>
+              </label>
+              <button disabled={!hasPreviousPage} onClick={() => setPage(0)}>First</button>
+              <button disabled={!hasPreviousPage} onClick={() => setPage(page - 1)}>Previous</button>
+              <span className="muted database-page-indicator">Page {page + 1} of {totalPages}</span>
+              <button disabled={!hasNextPage} onClick={() => setPage(page + 1)}>Next</button>
+              <button disabled={!hasNextPage} onClick={() => setPage(totalPages - 1)}>Last</button>
+            </div>
+          </div>
+        </>}
       </>}
+      {activeTab === "bot-items" && <BotItemsTab onError={onError} />}
       {configOpen && (
         <ExchangeConfigOverlay
           onClose={() => setConfigOpen(false)}

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2126,6 +2126,7 @@ tr.clickable:hover { background: rgba(198, 139, 74, .12); }
 /* Market Board (Exchange) */
 .exchange-search-row { margin: 12px 0; display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
 .exchange-search-row > input { flex: 1 1 220px; min-width: 160px; }
+.exchange-search-row > button { flex: 0 0 auto; white-space: nowrap; }
 /* Lay the filter controls out inline (label beside the select) instead of the
    default stacked label grid, so they share the search row's baseline with the
    input, buttons, and gear. The input's flex-grow right-aligns this cluster.
@@ -2200,6 +2201,21 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
 .exchange-config-add input { flex: 1; min-width: 0; }
 .exchange-config-add button { width: auto; min-width: 72px; }
 .exchange-config-modal .confirm-modal-actions .primary { background: var(--accent); color: #1a130a; border-color: var(--accent); }
+
+.bot-items-add-button { width: auto; min-width: 0; white-space: nowrap; }
+.bot-items-table th, .bot-items-table td { padding: 6px 8px; }
+.bot-items-table input[type="number"] { width: 96px; }
+.bot-item-row-dirty { background: rgba(198, 139, 74, .08); }
+.bot-item-field-dirty { border-color: var(--accent); }
+.bot-item-badge { display: inline-block; margin-left: 8px; font-size: 10px; letter-spacing: .04em; text-transform: uppercase; border-radius: 999px; padding: 2px 7px; vertical-align: middle; }
+.bot-item-badge-unsafe { background: #2b1414; border: 1px solid #5a2b2b; color: #e29a9a; }
+.bot-item-badge-new { background: #13212b; border: 1px solid #33556a; color: #a9d0e6; }
+.bot-items-footer .primary { background: var(--accent); color: #1a130a; border-color: var(--accent); }
+.bot-item-picker-list { max-height: 320px; overflow-y: auto; }
+.bot-item-picker-row { justify-content: space-between; width: 100%; }
+.bot-item-picker-row > span { display: inline-flex; flex-direction: column; align-items: flex-start; gap: 2px; }
+.bot-item-picker-row em { font-style: normal; font-size: 11px; color: var(--muted); }
+.bot-item-picker-row button { width: auto; min-width: 64px; }
 
 .market-bot-modal { width: min(1120px, calc(100vw - 32px)); max-height: calc(100vh - 48px); overflow-y: auto; }
 .market-bot-layout { display: grid; gap: 12px; }
@@ -5009,3 +5025,5 @@ td :where(.service-actions, .action-row, .map-action-buttons) { max-width: 100%;
     transition-duration: .01ms !important;
   }
 }
+
+.bot-items-table-wrap.table-wrap { max-height: none; overflow: visible; }

--- a/docs/README.md
+++ b/docs/README.md
@@ -58,7 +58,7 @@ by nature, so it gets its own.
 - [base-backups.md](console/base-backups.md) — Current. What the game's own "pick up base" tool actually does in the database, why the Bases panel excludes a picked-up base, and the Coriolis compatibility patch that preserves saved Deep Desert base actors.
 - [database-backups.md](console/database-backups.md) — Current. Safe database restore behavior when the backup and current deployment use different Battlegroup IDs.
 - [restart-queue.md](console/restart-queue.md) — Current. The Restart Queue toggle: player-aware countdowns with in-game warnings, the two broadcast variants, concurrency rules, crash recovery, the "Restart later" deferred-restart option, and the join-lock limitation.
-- [exchange.md](console/exchange.md) — Current. The read-only Market Board: aggregated-by-item CHOAM exchange listings, seller resolution, how bot listings are identified, and the bot/blacklist filter config.
+- [exchange.md](console/exchange.md) — Current. The read-only Market Board: aggregated-by-item CHOAM exchange listings, seller resolution, how bot listings are identified, the bot/blacklist filter config, the Market Bot seed/buyback engine, and the Bot items tab's per-item catalog overrides.
 
 ## Runtime (`runtime/`)
 

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -454,6 +454,9 @@ blacklist behaves.
 | POST | `/api/exchange/market/buyback/run` | Run a buyback sweep now with the saved schedule (probe → backup → sweep) | None |
 | POST | `/api/exchange/market/seed/run` | Run a market reseed now with the saved schedule (backup → clear bot listings → seed) | None |
 | POST | `/api/exchange/market/seed/clear` | Remove the bot's NPC listings from one exchange without reseeding (probe → backup → clear; no backup when the bot has none). Player listings and pending seller payments are never touched. Requires `exchange:market-write`. Rate-limited. | body: `exchangeId?` (defaults to the saved seed schedule's exchange) |
+| GET | `/api/exchange/market/items` | Merged, display-ready bot item catalog (bundled plan rows + admin-added new items), annotated with `overridden`/`isNew`/`unsafe` per row | None |
+| GET | `/api/exchange/market/items/catalog` | Item picker for "add item": `admin-items.json` filtered to allowed categories and unsafe-id-free | query: `q?`, `category?` |
+| POST | `/api/exchange/market/items` | Save per-item overrides/new items/removals in one batch (audited, rate-limited). Requires `exchange:market-write`. | body: `overrides?` (object of templateId → `{enabled?, price?, listings?}`), `newItems?` (object of templateId → `{name?, price, listings, enabled?, qualityLevel?, stackSize?}`), `removedNewItems?` (array of templateId) |
 
 The three category multipliers (`augmentMultiplier`, `rankedArmorMultiplier`,
 `rankedWeaponMultiplier`) accept 1–5 (up to two decimals, default 1 = no change)
@@ -470,6 +473,16 @@ allowlisted commodities a reseed lists (1–20, default 2). Unknown template ids
 are ignored. Units per stack stay at the plan `stack_size`. The catalog of
 editable items is returned on `GET /api/exchange/market` as
 `commodityStackCatalog` / `commodityStackGroups`.
+
+The `/api/exchange/market/items*` routes are a separate, per-item override layer
+on top of the bundled seed plan (`runtime/generated/market-bot/items.json`, never
+written back into `market-seed-plan.json`). They are merged in at read time for
+both the seed run and the buyback price caps, so a disabled or repriced item
+behaves the same in both jobs. New items may only reference a template id already
+present in `runtime/data/admin-items.json` (never free text); `buildings`,
+`contracts`, and `emotes` categories and any id in the seed plan's
+`unsafe_template_ids` are rejected outright. See
+[exchange.md](exchange.md#bot-items-catalog-overrides) for the full behavior.
 
 Unlike the board above, these routes **do write the game database** through the
 native Market Bot engine (`addonJobs.js` / `addonSeedJob.js`). Reads, the probe, and

--- a/docs/console/exchange.md
+++ b/docs/console/exchange.md
@@ -11,6 +11,11 @@ console's own theme and components.
 
 See [API-REFERENCE.md](API-REFERENCE.md#market-board) for the endpoint contract.
 
+The panel has two tabs: **Exchange** (the read-only board below) and **Bot
+items** (the Market Bot's editable catalog — see [Bot items](#bot-items-catalog-overrides)).
+The filter gear and Market Bot icons are unrelated to the tabs and work the
+same from either one.
+
 ## What it shows
 
 The board is **aggregated by item**: one row per `(template_id, quality_level)`,
@@ -168,6 +173,37 @@ Exchange Bot addon drives through the scheduler bridge, now first-class):
   to stay open) and survive restarts. They are console-owned and authorized by RBAC
   at save time. Seed and buyback share one running lock, so they can never write the
   exchange concurrently.
+
+### Bot items (catalog overrides)
+
+The **Bot items** tab, alongside the read-only **Exchange** tab, lets an admin
+edit the Market Bot's sellable catalog per item, beyond the reseed schedule's
+category-wide multipliers and its ~30-item commodity stack allowlist:
+
+- **Overrides** — enable/disable, reprice, or change the listing count of any
+  bundled seed-plan row. A disabled item is dropped from both reseed and
+  buyback entirely, not just hidden in the UI.
+- **New items** — add a template not in the bundled plan at all. New items can
+  only be picked from `runtime/data/admin-items.json` (the same catalog behind
+  Give Items / Care Packages), never typed freely. `buildings`, `contracts`,
+  and `emotes` categories are excluded from the picker. Any template id in the
+  seed plan's own `unsafe_template_ids` list (NPC-only weapon variants,
+  story-unique items, etc., flagged by the upstream generator) is hard-blocked
+  from both the picker and from being edited if it already exists as an
+  override.
+- Overrides are stored console-side in `runtime/generated/market-bot/items.json`
+  (`{ overrides: { <template_id>: { enabled, price, listings } }, newItems: {
+  <template_id>: { name, category, price, listings, ... } } }`) and are never
+  written back into the bundled `market-seed-plan.json`. They are merged in at
+  read time for both the reseed run and the buyback price caps, so a
+  disabled/repriced item's buyback cap always agrees with what the bot
+  actually lists.
+- `GET /api/exchange/market/items` returns the merged, display-ready catalog;
+  `GET /api/exchange/market/items/catalog` backs the "add item" picker;
+  `POST /api/exchange/market/items` saves overrides/new items/removals in one
+  batch. Reads use the `exchange:market` action, saves use
+  `exchange:market-write` — the same actions as the reseed/buyback schedule
+  routes.
 
 ### EDA Exchange Bot retirement
 


### PR DESCRIPTION
## Summary
- Adds a "Bot items" tab alongside the read-only Exchange board, letting admins enable/disable, reprice, and change listing counts per item and grade, or add new items from admin-items.json.
- New items are restricted to admin-items.json (never free text); `buildings`/`contracts`/`emotes` categories and any `unsafe_template_ids` entry are hard-blocked from both the picker and edits.
- Overrides persist to `runtime/generated/market-bot/items.json`, keyed by `(templateId, qualityLevel)`, and merge into both the reseed and buyback runs so the bot's actual behavior matches what the UI shows.
- Adds category/quality filters, pagination, and bulk enable/disable across the filtered view to the new tab.

## Test plan
- [x] `console/api` suite passes in the CI-parity container (1276/1276, 0 skipped)
- [x] `tsc --noEmit` clean on `console/web`
- [x] Live-tested against a real Postgres restore: tab switching, filters, per-grade price edits, bulk toggle, add-item flow, and category/unsafe exclusions all verified end-to-end
- [x] Manual review of a live reseed/buyback run picking up an override