### PR TITLE
Add vehicle permissions

### DIFF
--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -153,6 +153,7 @@ export const ROUTE_ACTIONS = {
 
   // --- Vehicles ---
   "GET /api/vehicles":                         "vehicles:read",
+  "GET /api/vehicles/permission-candidates":   "vehicles:read",
 
   // --- Exchange (Market Board) — read-only board + console-local filter config ---
   "GET /api/exchange/items":                   "exchange:read",
@@ -332,6 +333,9 @@ export const REGEX_ACTIONS = [
   // Bases (parameterized)
   ["/api/bases/", "bases:read"],
 
+  // Vehicles (parameterized)
+  ["/api/vehicles/", "vehicles:read"],
+
   // Storage (parameterized)
   ["/api/storage/", "storage:read"],
 
@@ -365,6 +369,8 @@ export const REGEX_ACTIONS_BY_METHOD = {
   "POST /api/bases/":      "bases:mutate",
   "DELETE /api/bases/":    "bases:mutate",
   "PUT /api/bases/":       "bases:mutate",
+
+  "PUT /api/vehicles/":    "vehicles:mutate",
 
   "POST /api/storage/":    "storage:mutate",
 

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -3343,16 +3343,31 @@ const DEFAULT_MAX_PERMISSIONS_PER_ACTOR = 32;
 // the owner's open Permissions panel with no relog and no restart. Writing the
 // table directly would land the row and leave the running server unaware of it,
 // which is the silently-reverted behaviour this avoids.
-async function supportsBasePermissionEditing(db) {
+// Shared by bases and vehicles -- both are permission_actor_rank actors and
+// the capability only depends on the shipped schema/procedures, not on which
+// kind of actor is being edited. `knownTables` lets a caller that already
+// probed some of these tables (e.g. listVehicles' requiredTables check) skip
+// re-checking them.
+async function permissionEditingSupported(db, { knownTables } = {}) {
+  const known = knownTables || new Set();
   for (const table of ["permission_actor_rank", "permission_actor", "actors", "player_state", "map_names"]) {
+    if (known.has(table)) continue;
     if (!(await tableExists(db, table))) return false;
   }
   return await functionExists(db, "dune.permission_set_player_rank(bigint,bigint,smallint,text)")
     && await functionExists(db, "dune.permission_remove_player_rank(bigint,bigint)");
 }
 
+async function supportsBasePermissionEditing(db) {
+  return permissionEditingSupported(db);
+}
+
 export async function basePermissionsSupported(db) {
   return supportsBasePermissionEditing(db).catch(() => false);
+}
+
+export async function vehiclePermissionsSupported(db) {
+  return permissionEditingSupported(db).catch(() => false);
 }
 
 // The base id the Bases table shows is min(buildings.id) for the claim, which is
@@ -3417,7 +3432,7 @@ export async function basePermissionActor(db, baseId) {
 // not permission_actor. Joining the table into the shared query would break
 // deletion on a schema that lacks it. Both callers of this helper already gate
 // on supportsBasePermissionEditing, which does probe permission_actor.
-async function basePermissionActorClaimed(db, actorId) {
+async function permissionActorClaimed(db, actorId) {
   const result = await db.query(
     "select exists (select 1 from dune.permission_actor where actor_id = $1::bigint) as claimed",
     [actorId]);
@@ -3467,15 +3482,9 @@ export async function baseIsBackedUp(db, baseId) {
 // operator rather than silently vanishing from the roster: resolving the name
 // through owner_account_id is how listBases does it, and every actors row of an
 // account maps to the same character name.
-export async function listBasePermissions(db, baseId) {
-  await requireCapability(await supportsBasePermissionEditing(db),
-    "Base permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
-  const { actorId, map, mapNameId } = await basePermissionActor(db, baseId);
-  // Reading an unclaimed base still succeeds -- the roster is simply empty, and
-  // seeing that is how an operator diagnoses the base in the first place. The
-  // flag rides along so the editor can disable the writes that would fail
-  // instead of offering controls that end in an FK error.
-  const claimed = await basePermissionActorClaimed(db, actorId);
+// Shared by bases and vehicles -- the roster query only depends on the
+// permission actor id, not on what kind of actor it is.
+async function listPermissionRoster(db, actorId) {
   const encryptedPlayerStateColumns = await tableExists(db, "encrypted_player_state")
     ? await columnsFor(db, "encrypted_player_state")
     : new Set();
@@ -3518,6 +3527,29 @@ export async function listBasePermissions(db, baseId) {
     ) fallback on true
     where par.permission_actor_id = $1::bigint
     order by par.rank asc, coalesce(ps.character_name, fallback.character_name, '') asc`, [actorId]);
+  return result.rows.map((row) => ({
+    playerId: String(row.player_id),
+    name: String(row.character_name || ""),
+    rank: Number(row.rank),
+    label: permissionRankLabel(Number(row.rank)),
+    // False means this row names an actor that is not the account's
+    // player_controller_id, so the game ignores it. Surfaced rather than
+    // hidden: it is the one roster state the console can see and the game
+    // client cannot.
+    canonical: row.canonical === true
+  }));
+}
+
+export async function listBasePermissions(db, baseId) {
+  await requireCapability(await supportsBasePermissionEditing(db),
+    "Base permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
+  const { actorId, map, mapNameId } = await basePermissionActor(db, baseId);
+  // Reading an unclaimed base still succeeds -- the roster is simply empty, and
+  // seeing that is how an operator diagnoses the base in the first place. The
+  // flag rides along so the editor can disable the writes that would fail
+  // instead of offering controls that end in an FK error.
+  const claimed = await permissionActorClaimed(db, actorId);
+  const entries = await listPermissionRoster(db, actorId);
   const systemCustodian = await basePermissionSystemCustodian(db);
   return {
     baseId: intParam(baseId, "base id", 1),
@@ -3527,17 +3559,7 @@ export async function listBasePermissions(db, baseId) {
     claimed,
     unclaimedReason: claimed ? "" : BASE_UNCLAIMED_MESSAGE,
     systemCustodian,
-    entries: result.rows.map((row) => ({
-      playerId: String(row.player_id),
-      name: String(row.character_name || ""),
-      rank: Number(row.rank),
-      label: permissionRankLabel(Number(row.rank)),
-      // False means this row names an actor that is not the account's
-      // player_controller_id, so the game ignores it. Surfaced rather than
-      // hidden: it is the one roster state the console can see and the game
-      // client cannot.
-      canonical: row.canonical === true
-    }))
+    entries
   };
 }
 
@@ -3625,9 +3647,10 @@ export async function basePermissionSystemCustodian(db) {
 // Candidates for the roster picker. Deliberately keyed on player_controller_id
 // rather than reusing listPlayers' actor_id: listPlayers is row-per-pawn, and
 // handing a pawn id to permission_set_player_rank writes a row the game ignores.
-export async function basePermissionCandidates(db, { q = "", limit = 25 } = {}) {
-  await requireCapability(await supportsBasePermissionEditing(db),
-    "Base permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
+// Shared by bases and vehicles -- deliberately keyed on player_controller_id
+// rather than reusing listPlayers' actor_id: listPlayers is row-per-pawn, and
+// handing a pawn id to permission_set_player_rank writes a row the game ignores.
+async function permissionCandidatesQuery(db, { q = "", limit = 25 } = {}) {
   const safeLimit = intParam(limit, "limit", 1, 100);
   const playerStateColumns = await columnsFor(db, "player_state");
   const internalGmPawnFilter = playerStateColumns.has("player_pawn_id")
@@ -3658,14 +3681,26 @@ export async function basePermissionCandidates(db, { q = "", limit = 25 } = {}) 
   return result.rows.map((row) => ({ playerId: String(row.player_id), name: String(row.character_name || "") }));
 }
 
-function normalizeDesiredPermissions(entries) {
+export async function basePermissionCandidates(db, opts = {}) {
+  await requireCapability(await supportsBasePermissionEditing(db),
+    "Base permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
+  return permissionCandidatesQuery(db, opts);
+}
+
+export async function vehiclePermissionCandidates(db, opts = {}) {
+  await requireCapability(await vehiclePermissionsSupported(db),
+    "Vehicle permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
+  return permissionCandidatesQuery(db, opts);
+}
+
+function normalizeDesiredPermissions(entries, subject = "base") {
   if (!Array.isArray(entries)) throw new Error("Permissions must be a list of players and ranks.");
   const seen = new Set();
   const desired = entries.map((entry) => {
     const playerId = String(intParam(entry?.playerId, "player id", 1));
     const rank = Number(entry?.rank);
     if (!PERMISSION_EDITABLE_RANKS.has(rank)) {
-      throw new Error(`Rank ${entry?.rank} is not a valid base permission rank.`);
+      throw new Error(`Rank ${entry?.rank} is not a valid ${subject} permission rank.`);
     }
     if (seen.has(playerId)) throw new Error("The same player was listed twice.");
     seen.add(playerId);
@@ -3674,8 +3709,8 @@ function normalizeDesiredPermissions(entries) {
   const owners = desired.filter((entry) => entry.rank === PERMISSION_OWNER_RANK);
   if (owners.length !== 1) {
     throw new Error(owners.length === 0
-      ? "A base must have exactly one Owner. Promote a player to Owner before saving."
-      : `A base can only have one Owner; ${owners.length} were selected.`);
+      ? `A ${subject} must have exactly one Owner. Promote a player to Owner before saving.`
+      : `A ${subject} can only have one Owner; ${owners.length} were selected.`);
   }
   return desired;
 }
@@ -3693,7 +3728,22 @@ function normalizeDesiredPermissions(entries) {
 // LIMIT 1, so a moment with two rank-1 rows could stamp the wrong owner onto the
 // base marker. Removals run first, then non-owner ranks, then the Owner last --
 // so at most one rank-1 row exists when the owner write lands.
-async function mutateBasePermissions(db, target, safeMax, desiredRoster) {
+// Applies a whole roster in one transaction, built entirely from the shipped
+// procedures. Shared by bases and vehicles via the resolveActor/subject/
+// idKey/idValue parameterization -- everything below is actor-kind-agnostic.
+// Two invariants the procedures do NOT enforce are enforced here:
+//
+//   - One Owner. permission_set_player_rank is a plain upsert, so setting rank 1
+//     for a second player would simply leave the actor with two owners.
+//   - The cap. The procedure never counts rows; the limit comes from live server
+//     config (see parseEffectivePermissionLimit), not a constant.
+//
+// Write order matters even though NOTIFY is only delivered at commit: the marker
+// refresh inside permission_set_player_rank looks up the rank-1 holder with a
+// LIMIT 1, so a moment with two rank-1 rows could stamp the wrong owner onto the
+// actor's marker. Removals run first, then non-owner ranks, then the Owner last --
+// so at most one rank-1 row exists when the owner write lands.
+async function mutatePermissionRoster(db, { resolveActor, unclaimedMessage, notFoundMessage, subject, idKey, idValue }, safeMax, desiredRoster) {
   return db.transaction(async (tx) => {
     // The shipped procedures reference their tables unqualified and carry no
     // `SET search_path` of their own; they resolve only because the console
@@ -3703,31 +3753,31 @@ async function mutateBasePermissions(db, target, safeMax, desiredRoster) {
     // is ever pointed at a differently-named role.
     await tx.query("set local search_path to dune, public");
 
-    const actor = await basePermissionActor(tx, target);
+    const actor = await resolveActor(tx);
     if (!actor.mapNameId) {
-      throw new Error(`This base's map (${actor.map || "unknown"}) has no dune.map_names entry, so the game cannot be notified of the change.`);
+      throw new Error(`This ${subject}'s map (${actor.map || "unknown"}) has no dune.map_names entry, so the game cannot be notified of the change.`);
     }
-    // Lock the claim actor row, not the rank rows: a base whose roster is being
-    // fully replaced may have no rank rows to lock, and `for update` over zero
-    // rows serializes nothing. The actors row is guaranteed to exist.
+    // Lock the claim actor row, not the rank rows: an actor whose roster is
+    // being fully replaced may have no rank rows to lock, and `for update` over
+    // zero rows serializes nothing. The actors row is guaranteed to exist.
     const locked = await tx.query("select id from dune.actors where id = $1::bigint for update", [actor.actorId]);
-    if (!locked.rowCount) throw new Error("That base was not found.");
+    if (!locked.rowCount) throw new Error(notFoundMessage);
 
     // After the lock, not before: this is the last read the transaction can make
     // before it starts calling the procedures. The game's own pickup path does
     // not take this lock, so a pickup landing mid-edit can still slip past and
     // hit the FK -- that race is what the constraint is for. What this removes
-    // is the far more common steady-state case, an unclaimed base sitting in the
-    // panel that every route currently accepts a write for.
-    if (!(await basePermissionActorClaimed(tx, actor.actorId))) throw new Error(BASE_UNCLAIMED_MESSAGE);
+    // is the far more common steady-state case, an unclaimed actor sitting in
+    // the panel that every route currently accepts a write for.
+    if (!(await permissionActorClaimed(tx, actor.actorId))) throw new Error(unclaimedMessage);
 
     const existing = await tx.query(
       "select player_id::text as player_id, rank::int as rank from dune.permission_actor_rank where permission_actor_id = $1::bigint",
       [actor.actorId]);
     const currentByPlayer = new Map(existing.rows.map((row) => [String(row.player_id), Number(row.rank)]));
-    const desired = normalizeDesiredPermissions(await desiredRoster(existing.rows, tx));
+    const desired = normalizeDesiredPermissions(await desiredRoster(existing.rows, tx), subject);
     if (desired.length > safeMax) {
-      throw new Error(`This base would hold ${desired.length} permissions, above the configured maximum of ${safeMax}.`);
+      throw new Error(`This ${subject} would hold ${desired.length} permissions, above the configured maximum of ${safeMax}.`);
     }
 
     // Every target player must be a real permission holder, i.e. an account's
@@ -3773,7 +3823,7 @@ async function mutateBasePermissions(db, target, safeMax, desiredRoster) {
 
     return {
       ok: true,
-      baseId: target,
+      [idKey]: idValue,
       actorId: actor.actorId,
       map: actor.map,
       added: changed.filter((entry) => !currentByPlayer.has(entry.playerId)).length,
@@ -3787,6 +3837,17 @@ async function mutateBasePermissions(db, target, safeMax, desiredRoster) {
   });
 }
 
+async function mutateBasePermissions(db, target, safeMax, desiredRoster) {
+  return mutatePermissionRoster(db, {
+    resolveActor: (tx) => basePermissionActor(tx, target),
+    unclaimedMessage: BASE_UNCLAIMED_MESSAGE,
+    notFoundMessage: "That base was not found.",
+    subject: "base",
+    idKey: "baseId",
+    idValue: target
+  }, safeMax, desiredRoster);
+}
+
 export async function setBasePermissions(db, baseId, entries, maxPermissionsPerActor = DEFAULT_MAX_PERMISSIONS_PER_ACTOR) {
   await requireCapability(await supportsBasePermissionEditing(db),
     "Base permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
@@ -3795,7 +3856,7 @@ export async function setBasePermissions(db, baseId, entries, maxPermissionsPerA
   // Validate before opening the transaction too, so malformed input fails
   // without taking a claim lock. It is normalized again after the lock because
   // the shared mutation path also accepts a roster built from current state.
-  const desired = normalizeDesiredPermissions(entries);
+  const desired = normalizeDesiredPermissions(entries, "base");
   return mutateBasePermissions(db, target, safeMax, async () => desired);
 }
 
@@ -3824,6 +3885,80 @@ export async function transferBaseToSystemCustodian(db, baseId, maxPermissionsPe
       ? `This base is already owned by the ${custodian.name} system custodian.`
       : `Ownership was transferred to the ${custodian.name} system custodian. The change applies to the running map immediately.`
   };
+}
+
+// Deliberately distinct from BASE_UNCLAIMED_MESSAGE: it names the vehicle
+// situation directly rather than talking about a base-backup/redeploy path
+// that does not apply here.
+const VEHICLE_UNCLAIMED_MESSAGE = "This vehicle is not claimed -- it has no dune.permission_actor row, so the game has nothing to attach permissions to. A player must claim it in-game first.";
+
+// Unlike a base (buildings -> building_instances -> actor_fgl_entities ->
+// actors), a vehicle IS its own permission actor:
+// dune.vehicles.id = dune.actors.id = dune.permission_actor.actor_id. The join
+// through dune.vehicles is still load-bearing even though it adds no
+// indirection -- it is what rejects a non-vehicle actor id (a base's, say)
+// passed to this route, rather than the query silently resolving it via
+// dune.actors alone.
+export async function vehiclePermissionActor(db, vehicleId) {
+  const target = intParam(vehicleId, "vehicle id", 1);
+  const result = await db.query(`
+    select a.id::text as actor_id,
+           coalesce(a.map, '') as map,
+           coalesce(mn.map_name_id, 0)::int as map_name_id,
+           coalesce(a.partition_id, 0)::int as partition_id
+    from dune.vehicles v
+    join dune.actors a on a.id = v.id
+    left join dune.map_names mn on mn.map_name = a.map
+    where v.id = $1`, [target]);
+  const row = result.rows[0];
+  if (!row) throw new Error("That vehicle was not found.");
+  return {
+    vehicleId: target,
+    actorId: String(row.actor_id),
+    map: String(row.map || ""),
+    mapNameId: Number(row.map_name_id || 0),
+    partitionId: Number(row.partition_id || 0)
+  };
+}
+
+export async function listVehiclePermissions(db, vehicleId) {
+  await requireCapability(await vehiclePermissionsSupported(db),
+    "Vehicle permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
+  const { actorId, map, mapNameId } = await vehiclePermissionActor(db, vehicleId);
+  // Reading an unclaimed vehicle still succeeds -- the roster is simply empty,
+  // and seeing that is how an operator diagnoses the vehicle in the first
+  // place. The flag rides along so the editor can disable the writes that
+  // would fail instead of offering controls that end in an FK error.
+  const claimed = await permissionActorClaimed(db, actorId);
+  const entries = await listPermissionRoster(db, actorId);
+  return {
+    vehicleId: intParam(vehicleId, "vehicle id", 1),
+    actorId,
+    map,
+    mapNameId,
+    claimed,
+    unclaimedReason: claimed ? "" : VEHICLE_UNCLAIMED_MESSAGE,
+    entries
+  };
+}
+
+export async function setVehiclePermissions(db, vehicleId, entries, maxPermissionsPerActor = DEFAULT_MAX_PERMISSIONS_PER_ACTOR) {
+  await requireCapability(await vehiclePermissionsSupported(db),
+    "Vehicle permission editing requires dune.permission_actor_rank, dune.map_names, and the dune.permission_set_player_rank/permission_remove_player_rank functions.");
+  const target = intParam(vehicleId, "vehicle id", 1);
+  const safeMax = intParam(maxPermissionsPerActor, "maximum permissions per vehicle", 1, 2147483647);
+  // Validate before opening the transaction too, so malformed input fails
+  // without taking a claim lock. It is normalized again after the lock because
+  // the shared mutation path also accepts a roster built from current state.
+  const desired = normalizeDesiredPermissions(entries, "vehicle");
+  return mutatePermissionRoster(db, {
+    resolveActor: (tx) => vehiclePermissionActor(tx, target),
+    unclaimedMessage: VEHICLE_UNCLAIMED_MESSAGE,
+    notFoundMessage: "That vehicle was not found.",
+    subject: "vehicle",
+    idKey: "vehicleId",
+    idValue: target
+  }, safeMax, async () => desired);
 }
 
 const BASE_SORT_COLUMNS = {
@@ -5411,7 +5546,8 @@ export async function listVehicles(db, { q = "", page = 0, pageSize = 50, sortCo
   ];
   for (const table of requiredTables) {
     if (!(await tableExists(db, table))) {
-      return { ...unsupported("vehicles", requiredTables.map((t) => `dune.${t}`)), totalCount: 0, totalVehicles: 0 };
+      const result = unsupported("vehicles", requiredTables.map((t) => `dune.${t}`));
+      return { ...result, capabilities: { ...result.capabilities, vehiclePermissions: false }, totalCount: 0, totalVehicles: 0 };
     }
   }
 
@@ -5568,14 +5704,22 @@ export async function listVehicles(db, { q = "", page = 0, pageSize = 50, sortCo
       }));
     await attachVehicleRegions(db, rows);
 
+    // requiredTables above already proved permission_actor_rank/permission_actor/
+    // actors/player_state exist, so this only has to check map_names and the two
+    // shipped procedures -- not re-probe tables already known to be present.
+    const vehiclePermissions = await permissionEditingSupported(db, {
+      knownTables: new Set(["permission_actor_rank", "permission_actor", "actors", "player_state"])
+    }).catch(() => false);
+
     return {
-      capabilities: { vehicles: true },
+      capabilities: { vehicles: true, vehiclePermissions },
       totalCount: result.rows[0] ? Number(result.rows[0].total_count) : 0,
       totalVehicles: totalsResult.rows[0] ? Number(totalsResult.rows[0].total_vehicles) : 0,
       rows
     };
   } catch (error) {
-    return { ...unsupported("vehicles", requiredTables.map((t) => `dune.${t}`)), totalCount: 0, totalVehicles: 0, reason: `Vehicles query failed: ${error.message}` };
+    const result = unsupported("vehicles", requiredTables.map((t) => `dune.${t}`));
+    return { ...result, capabilities: { ...result.capabilities, vehiclePermissions: false }, totalCount: 0, totalVehicles: 0, reason: `Vehicles query failed: ${error.message}` };
   }
 }
 

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -656,6 +656,9 @@ async function handleApi(req, res) {
     sortColumn: url.searchParams.get("sortColumn") || "name",
     sortDirection: url.searchParams.get("sortDirection") || "asc"
   }));
+  if (path === "/api/vehicles/permission-candidates") return vehiclePermissionCandidatesRoute(res, url);
+  if (path.match(/^\/api\/vehicles\/[^/]+\/permissions$/) && req.method === "GET") return vehiclePermissionsRoute(res, path);
+  if (path.match(/^\/api\/vehicles\/[^/]+\/permissions$/) && req.method === "PUT") return vehicleSetPermissionsRoute(req, res, path);
   if (path === "/api/admin/items/catalog") return json(res, 200, { rows: listCatalogItems(config.repoRoot, { q: url.searchParams.get("q") || "", limit: url.searchParams.get("limit") || 500 }) });
   if (path === "/api/admin/items/search") return commandJson(res, "adminItemSearch", { q: url.searchParams.get("q") || "" });
   if (path === "/api/admin/items") return commandJson(res, url.searchParams.get("category") ? "adminItemListCategory" : "adminItemList", { category: url.searchParams.get("category") || "" });
@@ -2999,6 +3002,51 @@ async function baseSystemCustodianRoute(req, res, path) {
     if (custodian.canCreate) await ensureCarePackageServerPersona(db);
     return duneDb.transferBaseToSystemCustodian(db, baseId, maxPermissions);
   }, { baseId });
+}
+
+// Vehicles are their own permission actor (dune.vehicles.id = dune.actors.id),
+// so there is no base-delete-pending/backed-up equivalent to check here -- a
+// vehicle has no "queued delete" or "picked up" state these routes need to
+// guard against. The id guard matches intParam's contract (see baseWaterRoute/
+// baseInventoryRoute), so a genuine failure in the catch is honestly ours.
+async function vehiclePermissionsRoute(res, path) {
+  const vehicleId = Number(decodeURIComponent(path.split("/")[3]));
+  if (!Number.isInteger(vehicleId) || vehicleId < 1 || vehicleId > Number.MAX_SAFE_INTEGER) {
+    return json(res, 400, { error: "Invalid vehicle ID" });
+  }
+  try {
+    return json(res, 200, { supported: true, ...(await duneDb.listVehiclePermissions(db, vehicleId)) });
+  } catch (error) {
+    return json(res, 500, { supported: false, error: redact(error?.message || "Unexpected error."), reason: redact(error?.message || "Unexpected error.") });
+  }
+}
+
+async function vehiclePermissionCandidatesRoute(res, url) {
+  try {
+    const rows = await duneDb.vehiclePermissionCandidates(db, {
+      q: url.searchParams.get("q") || "",
+      limit: url.searchParams.get("limit") || 25
+    });
+    return json(res, 200, { supported: true, rows });
+  } catch (error) {
+    return json(res, 500, { supported: false, rows: [], error: redact(error?.message || "Unexpected error."), reason: redact(error?.message || "Unexpected error.") });
+  }
+}
+
+// No confirmation phrase, matching baseSetPermissionsRoute: reversible from
+// this same editor. Still rate limited and audited -- this writes to player
+// property. The cap is read from live server config on every save, same as
+// the base route.
+async function vehicleSetPermissionsRoute(req, res, path) {
+  const vehicleId = Number(decodeURIComponent(path.split("/")[3]));
+  if (!Number.isInteger(vehicleId) || vehicleId < 1 || vehicleId > Number.MAX_SAFE_INTEGER) {
+    return json(res, 400, { error: "Invalid vehicle ID" });
+  }
+  return directDbMutation(req, res, "vehicles.set-permissions", null, async (body) => {
+    const settings = await runDune(config, buildDuneArgs("userSettingsMapValues", { map: "Survival_1" }), { timeoutMs: 8000 });
+    const maxPermissions = parseEffectivePermissionLimit(settings.stdout);
+    return duneDb.setVehiclePermissions(db, vehicleId, body.entries, maxPermissions);
+  }, { vehicleId });
 }
 
 async function baseCancelQueuedRefillRoute(req, res, path) {

--- a/console/api/test/policy.test.js
+++ b/console/api/test/policy.test.js
@@ -130,14 +130,14 @@ test("vehicle permission routes resolve to their own read/mutate actions", () =>
 
 test("a vehicles:read-only policy denies vehicles:mutate", () => {
   const policies = {
-    viewer: {
+    observer: {
       version: 1,
-      tier: "viewer",
+      tier: "observer",
       statements: [{ Effect: "Allow", Action: ["vehicles:read"] }]
     }
   };
-  assert.equal(evaluate({ tier: "viewer" }, "vehicles:read", policies), true);
-  assert.equal(evaluate({ tier: "viewer" }, "vehicles:mutate", policies), false);
+  assert.equal(evaluate({ tier: "observer" }, "vehicles:read", policies), true);
+  assert.equal(evaluate({ tier: "observer" }, "vehicles:mutate", policies), false);
 });
 
 test("persisting a refreshed buyback log requires market write permission", () => {

--- a/console/api/test/policy.test.js
+++ b/console/api/test/policy.test.js
@@ -121,6 +121,25 @@ test("the container item delete route resolves to bases:delete-item without shad
   assert.equal(actionForRoute("/api/bases/5/containers/9", "GET"), "bases:read");
 });
 
+test("vehicle permission routes resolve to their own read/mutate actions", () => {
+  assert.equal(actionForRoute("/api/vehicles/5/permissions", "GET"), "vehicles:read");
+  assert.equal(actionForRoute("/api/vehicles/5/permissions", "PUT"), "vehicles:mutate");
+  assert.equal(actionForRoute("/api/vehicles/permission-candidates", "GET"), "vehicles:read");
+  assert.equal(actionForRoute("/api/vehicles", "GET"), "vehicles:read");
+});
+
+test("a vehicles:read-only policy denies vehicles:mutate", () => {
+  const policies = {
+    viewer: {
+      version: 1,
+      tier: "viewer",
+      statements: [{ Effect: "Allow", Action: ["vehicles:read"] }]
+    }
+  };
+  assert.equal(evaluate({ tier: "viewer" }, "vehicles:read", policies), true);
+  assert.equal(evaluate({ tier: "viewer" }, "vehicles:mutate", policies), false);
+});
+
 test("persisting a refreshed buyback log requires market write permission", () => {
   assert.equal(actionForRoute("/api/exchange/market/buyback/log", "GET"), "exchange:market");
   assert.equal(actionForRoute("/api/exchange/market/buyback/log", "POST"), "exchange:market-write");

--- a/console/api/test/vehiclePermissions.integration.test.js
+++ b/console/api/test/vehiclePermissions.integration.test.js
@@ -1,0 +1,301 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import pg from "pg";
+import { setVehiclePermissions, listVehiclePermissions, vehiclePermissionCandidates } from "../src/duneDb.js";
+import { pgConnectionConfig, pgTransactionalDb, withIsolatedDatabase } from "../test-support/pgIntegrationDb.js";
+
+const { Client } = pg;
+
+// The mocked suite in vehiclePermissions.test.js string-matches SQL and can
+// prove what we *intend* to send. It cannot catch the failures that only a
+// real PostgreSQL round trip surfaces -- see basePermissions.integration.test.js
+// for the three classes of bug this style of test exists to catch (argument
+// order, search_path, the unquoted notify payload). All three apply here
+// unchanged since setVehiclePermissions shares mutatePermissionRoster with
+// setBasePermissions.
+const OWNER_RANK = 1;
+const CO_OWNER_RANK = 2;
+const ASSOCIATE_RANK = 3;
+
+// Unlike a base, a vehicle IS its own permission actor -- no separate
+// building/entity chain to seed, and the displayed id equals the actor id.
+const VEHICLE_ID = 3001;
+const MAP_NAME = "DeepDesert";
+const MAP_NAME_ID = 7;
+
+// A second vehicle with every structural row intact and no dune.permission_actor
+// row -- an unclaimed vehicle.
+const UNCLAIMED_VEHICLE_ID = 3002;
+
+const SCHEMA = `
+  create schema dune;
+
+  create table dune.vehicles (id bigint primary key);
+  create table dune.actors (id bigint primary key, map text, partition_id bigint, owner_account_id bigint);
+  create table dune.map_names (map_name_id smallint primary key, map_name text not null);
+  create table dune.permission_actor (actor_id bigint primary key, actor_name text);
+  create table dune.permission_actor_rank (
+    permission_actor_id bigint not null references dune.permission_actor(actor_id) on delete cascade,
+    player_id bigint not null,
+    rank smallint not null
+  );
+  create table dune.player_state (account_id bigint, player_controller_id bigint, player_pawn_id bigint, character_name text);
+  create table dune.encrypted_player_state (
+    account_id bigint,
+    player_controller_id bigint,
+    player_state_id bigint,
+    player_pawn_id bigint,
+    encrypted_character_name bytea
+  );
+
+  create function dune.decrypt_user_data(value bytea)
+  returns text language sql immutable as $$ select convert_from(value, 'UTF8') $$;
+
+  create function dune.permission_actor_create_or_update_base_marker(in_actor_id bigint, in_player_id bigint, in_rank smallint)
+  returns void language plpgsql as $$ begin return; end $$;
+
+  create function dune.permission_set_player_rank(in_actor_id bigint, in_player_id bigint, in_rank smallint, in_map_id text)
+  returns void language plpgsql as $$
+  declare found_actor_id bigint;
+  begin
+    select permission_actor_id from permission_actor_rank
+      where permission_actor_id = in_actor_id and player_id = in_player_id into found_actor_id;
+    if not found then
+      insert into permission_actor_rank(permission_actor_id, player_id, rank) values(in_actor_id, in_player_id, in_rank);
+    else
+      update permission_actor_rank set rank = in_rank
+        where permission_actor_rank.permission_actor_id = in_actor_id and player_id = in_player_id;
+    end if;
+    perform permission_actor_create_or_update_base_marker(in_actor_id, in_player_id, in_rank);
+    perform pg_notify('permission_notify_channel',
+      format('set_rank#{"ActorId" : %s , "PlayerId" : %s, "PlayerGuildId" : %s, "Rank" : %s, "Map" : %s}',
+             in_actor_id, in_player_id, 0, in_rank, in_map_id));
+  end $$;
+
+  create function dune.permission_remove_player_rank(in_actor_id bigint, in_player_id bigint)
+  returns void language plpgsql as $$
+  begin
+    delete from permission_actor_rank where permission_actor_id = in_actor_id and player_id = in_player_id;
+    perform pg_notify('permission_notify_channel',
+      format('remove_rank#{"ActorId" : %s , "PlayerId" : %s}', in_actor_id, in_player_id));
+  end $$;
+`;
+
+const SEED = `
+  insert into dune.vehicles (id) values (${VEHICLE_ID});
+  insert into dune.actors (id, map, partition_id, owner_account_id) values (${VEHICLE_ID}, '${MAP_NAME}', 8, null);
+  insert into dune.map_names (map_name_id, map_name) values (${MAP_NAME_ID}, '${MAP_NAME}');
+  insert into dune.permission_actor (actor_id, actor_name) values (${VEHICLE_ID}, 'Vehicle Test');
+
+  insert into dune.vehicles (id) values (${UNCLAIMED_VEHICLE_ID});
+  insert into dune.actors (id, map, partition_id, owner_account_id) values (${UNCLAIMED_VEHICLE_ID}, '${MAP_NAME}', 8, null);
+  -- Deliberately no dune.permission_actor row for ${UNCLAIMED_VEHICLE_ID}.
+
+  insert into dune.actors (id, owner_account_id) values (4, 2), (5, 2), (23, 6), (29, 8);
+  insert into dune.player_state (account_id, player_controller_id, player_pawn_id, character_name)
+    values
+      (2, 4, 4, 'DarkShark'),
+      (6, 23, 23, 'Furizu'),
+      (8, 29, 29, 'Yaida');
+
+  insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values (${VEHICLE_ID}, 4, ${OWNER_RANK});
+`;
+
+async function withDatabase(t, run) {
+  return withIsolatedDatabase(t, {
+    namePrefix: "dune_vehicle_perms",
+    unavailableLabel: "the vehicle permission integration test"
+  }, async (pool, database) => {
+    await pool.query(SCHEMA);
+    await pool.query(SEED);
+    return run(pool, database);
+  });
+}
+
+async function ranks(pool) {
+  const result = await pool.query(
+    "select player_id::text as player_id, rank::int as rank from dune.permission_actor_rank where permission_actor_id = $1 order by rank, player_id",
+    [VEHICLE_ID]);
+  return result.rows.map((row) => ({ playerId: row.player_id, rank: row.rank }));
+}
+
+test("real PostgreSQL: an unclaimed vehicle is refused rather than violating the permission_actor foreign key", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+
+    await assert.rejects(
+      () => pool.query(
+        "insert into dune.permission_actor_rank (permission_actor_id, player_id, rank) values ($1, 4, $2)",
+        [UNCLAIMED_VEHICLE_ID, OWNER_RANK]),
+      /permission_actor_rank_permission_actor_id_fkey/);
+
+    await assert.rejects(
+      () => setVehiclePermissions(db, UNCLAIMED_VEHICLE_ID, [{ playerId: "4", rank: OWNER_RANK }], 32),
+      /not claimed/);
+
+    await assert.rejects(
+      () => setVehiclePermissions(db, UNCLAIMED_VEHICLE_ID, [{ playerId: "4", rank: OWNER_RANK }], 32),
+      (error) => !/foreign key|fkey/i.test(error.message));
+
+    const written = await pool.query(
+      "select count(*)::int as count from dune.permission_actor_rank where permission_actor_id = $1",
+      [UNCLAIMED_VEHICLE_ID]);
+    assert.equal(written.rows[0].count, 0);
+  });
+});
+
+test("real PostgreSQL: an unclaimed vehicle still reads, flagged, so the editor can explain itself", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const unclaimed = await listVehiclePermissions(db, UNCLAIMED_VEHICLE_ID);
+    assert.equal(unclaimed.claimed, false);
+    assert.match(unclaimed.unclaimedReason, /not claimed/);
+    assert.deepEqual(unclaimed.entries, []);
+
+    const claimed = await listVehiclePermissions(db, VEHICLE_ID);
+    assert.equal(claimed.claimed, true);
+    assert.equal(claimed.unclaimedReason, "");
+  });
+});
+
+test("real PostgreSQL: a roster save writes through the shipped procedures with the right argument order", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    const result = await setVehiclePermissions(db, VEHICLE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "23", rank: ASSOCIATE_RANK }
+    ], 32);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.actorId, String(VEHICLE_ID));
+    assert.deepEqual(await ranks(pool), [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "23", rank: ASSOCIATE_RANK }
+    ]);
+  });
+});
+
+test("real PostgreSQL: promoting swaps the owner without ever leaving two", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    await setVehiclePermissions(db, VEHICLE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "23", rank: CO_OWNER_RANK }
+    ], 32);
+    await setVehiclePermissions(db, VEHICLE_ID, [
+      { playerId: "23", rank: OWNER_RANK },
+      { playerId: "4", rank: CO_OWNER_RANK }
+    ], 32);
+
+    const rows = await ranks(pool);
+    assert.deepEqual(rows, [
+      { playerId: "23", rank: OWNER_RANK },
+      { playerId: "4", rank: CO_OWNER_RANK }
+    ]);
+    assert.equal(rows.filter((row) => row.rank === OWNER_RANK).length, 1);
+  });
+});
+
+test("real PostgreSQL: removing a player deletes only that rank row", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    await setVehiclePermissions(db, VEHICLE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "23", rank: ASSOCIATE_RANK },
+      { playerId: "29", rank: ASSOCIATE_RANK }
+    ], 32);
+    const result = await setVehiclePermissions(db, VEHICLE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "29", rank: ASSOCIATE_RANK }
+    ], 32);
+
+    assert.equal(result.removed, 1);
+    assert.deepEqual(await ranks(pool), [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "29", rank: ASSOCIATE_RANK }
+    ]);
+  });
+});
+
+test("real PostgreSQL: the emitted notification payload is well-formed JSON carrying the numeric map id", async (t) => {
+  await withDatabase(t, async (pool, database) => {
+    const listener = new Client(pgConnectionConfig(database));
+    const received = [];
+    await listener.connect();
+    listener.on("notification", (message) => received.push(message.payload));
+    await listener.query("listen permission_notify_channel");
+
+    const db = pgTransactionalDb(pool);
+    await setVehiclePermissions(db, VEHICLE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "23", rank: ASSOCIATE_RANK }
+    ], 32);
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    await listener.query("select 1");
+    await listener.end();
+
+    const setRank = received.find((payload) => payload.startsWith("set_rank#"));
+    assert.ok(setRank, `expected a set_rank notification, got ${JSON.stringify(received)}`);
+    const body = JSON.parse(setRank.slice("set_rank#".length));
+    assert.equal(body.ActorId, VEHICLE_ID);
+    assert.equal(body.PlayerId, 23);
+    assert.equal(body.Rank, ASSOCIATE_RANK);
+    assert.equal(body.Map, MAP_NAME_ID);
+  });
+});
+
+test("real PostgreSQL: a player id that is not a player_controller_id is refused", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    await assert.rejects(
+      () => setVehiclePermissions(db, VEHICLE_ID, [
+        { playerId: "4", rank: OWNER_RANK },
+        { playerId: "5", rank: ASSOCIATE_RANK }
+      ], 32),
+      /not a known player character/);
+    assert.deepEqual(await ranks(pool), [{ playerId: "4", rank: OWNER_RANK }]);
+  });
+});
+
+test("real PostgreSQL: the roster reads back with resolved names and rank labels", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    await setVehiclePermissions(db, VEHICLE_ID, [
+      { playerId: "4", rank: OWNER_RANK },
+      { playerId: "29", rank: CO_OWNER_RANK }
+    ], 32);
+
+    const roster = await listVehiclePermissions(db, VEHICLE_ID);
+    assert.equal(roster.actorId, String(VEHICLE_ID));
+    assert.equal(roster.mapNameId, MAP_NAME_ID);
+    assert.deepEqual(roster.entries.map((entry) => [entry.name, entry.label, entry.canonical]), [
+      ["DarkShark", "Owner", true],
+      ["Yaida", "Co-Owner", true]
+    ]);
+  });
+});
+
+// A base's actor id has no row in dune.vehicles, so the join that resolves
+// vehiclePermissionActor finds nothing for it. Regression guard for the class
+// of id-confusion bug fixed in 25818bb7.
+test("real PostgreSQL: a nonexistent vehicle id (including a foreign actor id) is refused, not silently accepted", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const db = pgTransactionalDb(pool);
+    await assert.rejects(
+      () => listVehiclePermissions(db, 999999),
+      /That vehicle was not found/);
+    await assert.rejects(
+      () => setVehiclePermissions(db, 999999, [{ playerId: "4", rank: OWNER_RANK }], 32),
+      /That vehicle was not found/);
+  });
+});
+
+test("real PostgreSQL: the candidate picker returns player_controller_ids", async (t) => {
+  await withDatabase(t, async (pool) => {
+    const candidates = await vehiclePermissionCandidates(pgTransactionalDb(pool), { limit: 50 });
+    const ids = candidates.map((row) => row.playerId);
+    assert.deepEqual(ids.sort(), ["23", "29", "4"].sort());
+    assert.ok(!ids.includes("5"), "5 belongs to the same account as 4 but is not a controller id");
+  });
+});

--- a/console/api/test/vehiclePermissions.test.js
+++ b/console/api/test/vehiclePermissions.test.js
@@ -1,0 +1,232 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { setVehiclePermissions, listVehiclePermissions } from "../src/duneDb.js";
+
+const SUPPORTED_TABLES = ["dune.permission_actor_rank", "dune.permission_actor", "dune.actors", "dune.player_state", "dune.encrypted_player_state", "dune.map_names"];
+const SUPPORTED_FUNCTIONS = [
+  "dune.permission_set_player_rank(bigint,bigint,smallint,text)",
+  "dune.permission_remove_player_rank(bigint,bigint)"
+];
+
+// Unlike a base, a vehicle IS its own permission actor: dune.vehicles.id =
+// dune.actors.id. So the id shown and the actor id are the same here, not two
+// different numbers the way BASE_ID/ACTOR_ID differ in basePermissions.test.js.
+const VEHICLE_ID = 2048;
+const ACTOR_ID = "2048";
+
+function createDb({
+  existing = [],
+  canonicalPlayers = ["4", "23", "29", "437"],
+  mapNameId = 7,
+  // Whether dune.permission_actor holds a row for this vehicle's actor.
+  // False mirrors an unclaimed vehicle: the vehicle and actor rows are intact,
+  // nothing for permission_actor_rank's foreign key to point at.
+  claimed = true,
+  // "missing" mirrors a vehicle id that does not exist at all -- including a
+  // base's actor id passed to this route by mistake, since dune.vehicles has
+  // no row for it either.
+  vehicles = "found"
+} = {}) {
+  const calls = [];
+  const db = {
+    calls,
+    query: async (text, values = []) => {
+      calls.push({ text, values });
+      if (text.includes("to_regclass")) {
+        return { rows: [{ exists: SUPPORTED_TABLES.includes(String(values[0] || "")) }] };
+      }
+      if (text.includes("to_regprocedure")) {
+        return { rows: [{ exists: SUPPORTED_FUNCTIONS.includes(String(values[0] || "")) }] };
+      }
+      if (text.includes("information_schema.columns")) {
+        const table = String(values[1] || "");
+        const columns = table === "player_state" || table === "encrypted_player_state"
+          ? ["account_id", "player_controller_id", "player_state_id", "player_pawn_id", table === "player_state" ? "character_name" : "encrypted_character_name"]
+          : [];
+        return { rows: columns.map((column_name) => ({ column_name })) };
+      }
+      if (text.includes("from dune.vehicles v")) {
+        if (vehicles === "missing") return { rows: [] };
+        return { rows: [{ actor_id: ACTOR_ID, map: "DeepDesert", map_name_id: mapNameId, partition_id: 59 }] };
+      }
+      if (text.includes("for update")) return { rows: [{ id: ACTOR_ID }], rowCount: 1 };
+      if (text.includes("from dune.permission_actor where actor_id")) return { rows: [{ claimed }] };
+      if (text.includes("from dune.permission_actor_rank")) {
+        return { rows: existing.map((entry) => ({ player_id: entry.playerId, rank: entry.rank })) };
+      }
+      if (text.includes("player_controller_id = any")) {
+        const requested = values[0] || [];
+        return { rows: requested.filter((id) => canonicalPlayers.includes(String(id))).map((id) => ({ player_id: String(id) })) };
+      }
+      return { rows: [] };
+    },
+    transaction: async (fn) => fn(db)
+  };
+  return db;
+}
+
+function procCalls(db, name) {
+  return db.calls.filter((call) => call.text.includes(name)).map((call) => call.values);
+}
+
+test("setVehiclePermissions rejects a roster without exactly one owner", async () => {
+  await assert.rejects(
+    () => setVehiclePermissions(createDb(), VEHICLE_ID, [{ playerId: "4", rank: 2 }]),
+    /exactly one Owner/);
+  await assert.rejects(
+    () => setVehiclePermissions(createDb(), VEHICLE_ID, [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 1 }]),
+    /only have one Owner/);
+});
+
+test("setVehiclePermissions rejects invalid ranks and duplicate players", async () => {
+  await assert.rejects(
+    () => setVehiclePermissions(createDb(), VEHICLE_ID, [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 4 }]),
+    /not a valid vehicle permission rank/);
+  await assert.rejects(
+    () => setVehiclePermissions(createDb(), VEHICLE_ID, [{ playerId: "4", rank: 1 }, { playerId: "4", rank: 3 }]),
+    /listed twice/);
+});
+
+// The cap comes from live server config, so it arrives as an argument rather
+// than a constant. Passing a small one proves it is actually enforced.
+test("setVehiclePermissions enforces the configured cap", async () => {
+  await assert.rejects(
+    () => setVehiclePermissions(createDb(), VEHICLE_ID, [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 3 }], 1),
+    /above the configured maximum of 1/);
+});
+
+test("setVehiclePermissions refuses a player id that is not a player_controller_id", async () => {
+  await assert.rejects(
+    () => setVehiclePermissions(createDb({ canonicalPlayers: ["4"] }), VEHICLE_ID, [
+      { playerId: "4", rank: 1 },
+      { playerId: "5", rank: 3 }
+    ]),
+    /not a known player character/);
+});
+
+test("setVehiclePermissions refuses a vehicle whose map has no map_names entry", async () => {
+  await assert.rejects(
+    () => setVehiclePermissions(createDb({ mapNameId: 0 }), VEHICLE_ID, [{ playerId: "4", rank: 1 }]),
+    /no dune.map_names entry/);
+});
+
+test("listVehiclePermissions rejects a vehicle id that does not exist", async () => {
+  await assert.rejects(
+    () => listVehiclePermissions(createDb({ vehicles: "missing" }), 999999),
+    /That vehicle was not found/);
+});
+
+// A base's actor id has no row in dune.vehicles, so the join that resolves
+// vehiclePermissionActor finds nothing for it -- the same "not found" path a
+// genuinely nonexistent id takes. This is the regression guard for the class
+// of id-confusion bug fixed in 25818bb7.
+test("setVehiclePermissions rejects a base's actor id passed as a vehicle id", async () => {
+  const db = createDb({ vehicles: "missing" });
+  await assert.rejects(
+    () => setVehiclePermissions(db, 1004, [{ playerId: "4", rank: 1 }]),
+    /That vehicle was not found/);
+  assert.equal(procCalls(db, "permission_set_player_rank").length, 0);
+});
+
+test("setVehiclePermissions refuses an unclaimed vehicle instead of failing the permission_actor foreign key", async () => {
+  const db = createDb({ claimed: false });
+  await assert.rejects(
+    () => setVehiclePermissions(db, VEHICLE_ID, [{ playerId: "4", rank: 1 }]),
+    /not claimed/);
+  assert.equal(procCalls(db, "permission_set_player_rank").length, 0);
+  assert.equal(procCalls(db, "permission_remove_player_rank").length, 0);
+});
+
+// Reading stays allowed -- an empty roster plus the flag is how an operator
+// diagnoses the vehicle, and the editor uses the flag to disable its controls.
+test("listVehiclePermissions reports an unclaimed vehicle rather than rejecting it", async () => {
+  const claimedResult = await listVehiclePermissions(createDb(), VEHICLE_ID);
+  assert.equal(claimedResult.claimed, true);
+  assert.equal(claimedResult.unclaimedReason, "");
+
+  const result = await listVehiclePermissions(createDb({ claimed: false }), VEHICLE_ID);
+  assert.equal(result.claimed, false);
+  assert.match(result.unclaimedReason, /not claimed/);
+});
+
+test("setVehiclePermissions writes through the shipped procedures, never raw DML", async () => {
+  const db = createDb({ existing: [{ playerId: "4", rank: 1 }] });
+  await setVehiclePermissions(db, VEHICLE_ID, [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 3 }]);
+  const written = db.calls.filter((call) => /insert into|update .*permission_actor_rank|delete from/i.test(call.text));
+  assert.deepEqual(written, [], "permission rows must only be written by the game's own procedures");
+  assert.equal(procCalls(db, "permission_set_player_rank").length, 1);
+});
+
+test("setVehiclePermissions passes the numeric map_name_id to the notify payload", async () => {
+  const db = createDb({ existing: [] });
+  await setVehiclePermissions(db, VEHICLE_ID, [{ playerId: "4", rank: 1 }]);
+  const [values] = procCalls(db, "permission_set_player_rank");
+  // Not "DeepDesert": the procedure interpolates this unquoted into JSON.
+  assert.equal(values[3], "7");
+});
+
+test("setVehiclePermissions skips unchanged rows", async () => {
+  const db = createDb({ existing: [{ playerId: "4", rank: 1 }, { playerId: "29", rank: 2 }] });
+  const result = await setVehiclePermissions(db, VEHICLE_ID, [{ playerId: "4", rank: 1 }, { playerId: "29", rank: 2 }]);
+  assert.equal(procCalls(db, "permission_set_player_rank").length, 0);
+  assert.equal(procCalls(db, "permission_remove_player_rank").length, 0);
+  assert.equal(result.added, 0);
+  assert.equal(result.reranked, 0);
+  assert.equal(result.removed, 0);
+});
+
+test("setVehiclePermissions demotes the outgoing owner before promoting the new one", async () => {
+  const db = createDb({ existing: [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 3 }] });
+  await setVehiclePermissions(db, VEHICLE_ID, [{ playerId: "23", rank: 1 }, { playerId: "4", rank: 2 }]);
+  const ranks = procCalls(db, "permission_set_player_rank").map((values) => ({ playerId: String(values[1]), rank: values[2] }));
+  assert.deepEqual(ranks, [{ playerId: "4", rank: 2 }, { playerId: "23", rank: 1 }]);
+});
+
+test("setVehiclePermissions removes dropped players before writing the owner", async () => {
+  const db = createDb({ existing: [{ playerId: "4", rank: 1 }, { playerId: "23", rank: 3 }] });
+  const result = await setVehiclePermissions(db, VEHICLE_ID, [{ playerId: "29", rank: 1 }]);
+  const order = db.calls
+    .filter((call) => /permission_remove_player_rank|permission_set_player_rank/.test(call.text))
+    .map((call) => call.text.includes("remove") ? "remove" : "set");
+  assert.deepEqual(order, ["remove", "remove", "set"]);
+  assert.equal(result.removed, 2);
+  assert.equal(result.added, 1);
+});
+
+test("setVehiclePermissions pins search_path for the transaction", async () => {
+  const db = createDb({ existing: [] });
+  await setVehiclePermissions(db, VEHICLE_ID, [{ playerId: "4", rank: 1 }]);
+  assert.ok(db.calls.some((call) => /set local search_path to dune/.test(call.text)));
+});
+
+// The lock has to be on a row guaranteed to exist. A vehicle whose roster is
+// being fully replaced may have no rank rows, and `for update` over zero rows
+// serializes nothing at all.
+test("setVehiclePermissions locks the actor row, not the rank rows", async () => {
+  const db = createDb({ existing: [] });
+  await setVehiclePermissions(db, VEHICLE_ID, [{ playerId: "4", rank: 1 }]);
+  const lock = db.calls.find((call) => call.text.includes("for update"));
+  assert.match(lock.text, /from dune\.actors/);
+  assert.deepEqual(lock.values, [ACTOR_ID]);
+});
+
+test("listVehiclePermissions labels ranks and flags rows the game ignores", async () => {
+  const db = createDb();
+  db.query = async (text, values = []) => {
+    if (text.includes("to_regclass")) return { rows: [{ exists: SUPPORTED_TABLES.includes(String(values[0] || "")) }] };
+    if (text.includes("to_regprocedure")) return { rows: [{ exists: SUPPORTED_FUNCTIONS.includes(String(values[0] || "")) }] };
+    if (text.includes("from dune.vehicles v")) {
+      return { rows: [{ actor_id: ACTOR_ID, map: "DeepDesert", map_name_id: 7, partition_id: 59 }] };
+    }
+    if (text.includes("from dune.permission_actor where actor_id")) return { rows: [{ claimed: true }] };
+    return { rows: [
+      { player_id: "4", character_name: "DarkShark", rank: 1, canonical: true },
+      { player_id: "29", character_name: "Yaida", rank: 2, canonical: true },
+      { player_id: "5", character_name: "DarkShark", rank: 3, canonical: false }
+    ] };
+  };
+  const result = await listVehiclePermissions(db, VEHICLE_ID);
+  assert.equal(result.actorId, ACTOR_ID);
+  assert.deepEqual(result.entries.map((entry) => entry.label), ["Owner", "Co-Owner", "Associate"]);
+  assert.deepEqual(result.entries.map((entry) => entry.canonical), [true, true, false]);
+});

--- a/console/api/test/vehicleRouteStatus.test.js
+++ b/console/api/test/vehicleRouteStatus.test.js
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { intParam } from "../src/db.js";
+
+// Same technique as baseRouteStatus.test.js: server.js is an entrypoint, so
+// its route handlers cannot be called directly, and this reads it as source
+// instead. Kept as its own file rather than folded into baseRouteStatus.test.js
+// because the guard's literal error text ("Invalid vehicle ID") differs from
+// the base routes' ("Invalid base ID"), which that file's assertions hardcode.
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
+const serverSource = readFileSync(resolve(repoRoot, "console/api/src/server.js"), "utf8");
+
+function routeBody(name) {
+  const start = serverSource.indexOf(`async function ${name}(`);
+  assert.notEqual(start, -1, `${name} not found in server.js`);
+  const end = serverSource.indexOf("\n}\n", start);
+  assert.notEqual(end, -1, `could not find the end of ${name}`);
+  return serverSource.slice(start, end);
+}
+
+test("the vehicle permissions route guard rejects everything intParam would", () => {
+  const guard = (vehicleId) => Number.isInteger(vehicleId) && vehicleId >= 1 && vehicleId <= Number.MAX_SAFE_INTEGER;
+
+  const cases = [4.5, 1e20, 0, -1, 0.5, Number.MAX_SAFE_INTEGER + 2, NaN, Infinity, 1, 5, 2048, Number.MAX_SAFE_INTEGER];
+  for (const vehicleId of cases) {
+    let intParamAccepts = true;
+    try { intParam(vehicleId, "vehicle id", 1); } catch { intParamAccepts = false; }
+    assert.equal(guard(vehicleId), intParamAccepts,
+      `guard and intParam disagree on ${vehicleId}: guard=${guard(vehicleId)} intParam=${intParamAccepts}`);
+  }
+});
+
+test("vehiclePermissionsRoute uses that guard, not a bare isFinite check", () => {
+  const body = routeBody("vehiclePermissionsRoute");
+  assert.match(body, /!Number\.isInteger\(vehicleId\)[\s\S]*?vehicleId > Number\.MAX_SAFE_INTEGER/,
+    "vehiclePermissionsRoute must match intParam's contract before the try block");
+  assert.doesNotMatch(body, /Number\.isFinite\(vehicleId\) \|\| vehicleId < 1/,
+    "vehiclePermissionsRoute still uses the looser isFinite guard, so bad input can reach the catch");
+});
+
+// An unsupported schema returns 200 with supported:false, and bad input is
+// rejected above -- so a throw here is a query or connection failure, which is
+// ours, not the caller's.
+test("vehiclePermissionsRoute answers a genuine failure with 500, not 400", () => {
+  const body = routeBody("vehiclePermissionsRoute");
+  const catchBlock = body.slice(body.indexOf("} catch (error) {"));
+  assert.match(catchBlock, /json\(res, 500,/, "vehiclePermissionsRoute must report a real failure as 500");
+  assert.doesNotMatch(catchBlock, /json\(res, 400,/, "vehiclePermissionsRoute must not report a real failure as 400");
+  assert.match(catchBlock, /supported: false/);
+  assert.match(catchBlock, /error: redact\(/);
+  assert.match(catchBlock, /reason: redact\(/);
+});
+
+// The id check has to stay outside the try, or a rejected id would be counted
+// as a server fault by the block above.
+test("vehiclePermissionsRoute keeps id validation on 400, before the try", () => {
+  const body = routeBody("vehiclePermissionsRoute");
+  const guardAt = body.indexOf("Invalid vehicle ID");
+  const tryAt = body.indexOf("try {");
+  assert.notEqual(guardAt, -1, "vehiclePermissionsRoute lost its invalid-id response");
+  assert.ok(guardAt < tryAt, "vehiclePermissionsRoute must reject a bad id before the try block");
+  assert.match(body.slice(0, tryAt), /json\(res, 400, \{ error: "Invalid vehicle ID" \}\)/);
+});
+
+test("vehicleSetPermissionsRoute uses the same strict guard before its directDbMutation call", () => {
+  const body = routeBody("vehicleSetPermissionsRoute");
+  assert.match(body, /!Number\.isInteger\(vehicleId\)[\s\S]*?vehicleId > Number\.MAX_SAFE_INTEGER/);
+  const guardAt = body.indexOf("Invalid vehicle ID");
+  const mutationAt = body.indexOf("directDbMutation");
+  assert.ok(guardAt !== -1 && guardAt < mutationAt, "vehicleSetPermissionsRoute must reject a bad id before mutating");
+});

--- a/console/web/src/api/vehicles.test.ts
+++ b/console/web/src/api/vehicles.test.ts
@@ -34,3 +34,32 @@ describe("vehiclesApi.list", () => {
     expect(api).toHaveBeenCalledWith("/api/players/player%2F42/vehicles");
   });
 });
+
+describe("vehiclesApi permissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reads a vehicle's roster with an encoded vehicle id", () => {
+    vehiclesApi.permissions("vehicle/1");
+    expect(api).toHaveBeenCalledWith("/api/vehicles/vehicle%2F1/permissions");
+  });
+
+  it("PUTs the whole roster, not a delta", () => {
+    vehiclesApi.setPermissions("5001", [{ playerId: "4", rank: 1 }, { playerId: "9", rank: 3 }]);
+    expect(api).toHaveBeenCalledWith("/api/vehicles/5001/permissions", {
+      method: "PUT",
+      body: JSON.stringify({ entries: [{ playerId: "4", rank: 1 }, { playerId: "9", rank: 3 }] })
+    });
+  });
+
+  it("searches candidates with a default limit of 25", () => {
+    vehiclesApi.permissionCandidates("Leto");
+    expect(api).toHaveBeenCalledWith("/api/vehicles/permission-candidates?q=Leto&limit=25");
+  });
+
+  it("omits an empty query but still sends the limit", () => {
+    vehiclesApi.permissionCandidates("", 50);
+    expect(api).toHaveBeenCalledWith("/api/vehicles/permission-candidates?limit=50");
+  });
+});

--- a/console/web/src/api/vehicles.ts
+++ b/console/web/src/api/vehicles.ts
@@ -42,8 +42,55 @@ export type VehiclesListResponse = {
   rows: VehicleRow[];
   totalCount: number;
   totalVehicles: number;
-  capabilities: { vehicles?: boolean } & Record<string, unknown>;
+  capabilities: { vehicles?: boolean; vehiclePermissions?: boolean } & Record<string, unknown>;
   reason?: string;
+};
+
+// rank 1/2/3 = Owner/Co-Owner/Associate, same semantics as base permissions --
+// shared_with above already surfaces the rank label, this is just the editor's
+// own type for the roster it reads and writes.
+export type VehiclePermissionRank = 1 | 2 | 3;
+
+export type VehiclePermissionEntry = {
+  playerId: string;
+  name: string;
+  rank: VehiclePermissionRank;
+  label: string;
+  // False when this row names an actor that is not the account's
+  // player_controller_id. The game ignores such rows, but they are shown
+  // rather than hidden -- it is a state the console can see and the game
+  // client cannot.
+  canonical: boolean;
+};
+
+export type VehiclePermissions = {
+  supported: boolean;
+  vehicleId: number;
+  actorId: string;
+  map: string;
+  mapNameId: number;
+  // False when the vehicle has no dune.permission_actor row -- unclaimed, so
+  // the permission table's foreign key rejects every write against it.
+  // Optional so an older API that omits it reads as claimed, matching the
+  // behaviour that existed before the flag rather than a new lockout.
+  claimed?: boolean;
+  unclaimedReason?: string;
+  entries: VehiclePermissionEntry[];
+  reason?: string;
+};
+
+export type VehiclePermissionCandidate = { playerId: string; name: string };
+
+export type SetVehiclePermissionsResult = {
+  ok: boolean;
+  vehicleId: number;
+  actorId: string;
+  map: string;
+  added: number;
+  reranked: number;
+  removed: number;
+  total: number;
+  message: string;
 };
 
 export const vehiclesApi = {
@@ -57,5 +104,21 @@ export const vehiclesApi = {
     const qs = search.toString();
     return api<VehiclesListResponse>(`/api/vehicles${qs ? `?${qs}` : ""}`);
   },
-  forPlayer: (playerId: string) => api<VehiclesListResponse>(`/api/players/${encodeURIComponent(playerId)}/vehicles`)
+  forPlayer: (playerId: string) => api<VehiclesListResponse>(`/api/players/${encodeURIComponent(playerId)}/vehicles`),
+  permissions: (vehicleId: string) =>
+    api<VehiclePermissions>(`/api/vehicles/${encodeURIComponent(vehicleId)}/permissions`),
+  // A whole roster, not a delta: the server diffs it against current state and
+  // applies the difference through the game's own stored procedures in one
+  // transaction. Changes reach a running map immediately -- no restart.
+  setPermissions: (vehicleId: string, entries: { playerId: string; rank: VehiclePermissionRank }[]) =>
+    api<{ supported: boolean; result?: SetVehiclePermissionsResult; reason?: string }>(
+      `/api/vehicles/${encodeURIComponent(vehicleId)}/permissions`,
+      { method: "PUT", body: JSON.stringify({ entries }) }),
+  permissionCandidates: (q: string, limit = 25) => {
+    const search = new URLSearchParams();
+    if (q) search.set("q", q);
+    search.set("limit", String(limit));
+    return api<{ supported: boolean; rows: VehiclePermissionCandidate[]; reason?: string }>(
+      `/api/vehicles/permission-candidates?${search.toString()}`);
+  }
 };

--- a/console/web/src/features/bases/BasePermissionsTab.tsx
+++ b/console/web/src/features/bases/BasePermissionsTab.tsx
@@ -1,11 +1,26 @@
 import { useCallback, useEffect, useState } from "react";
-import { Plus, Trash2, TriangleAlert } from "lucide-react";
+import { Plus, Trash2 } from "lucide-react";
 import {
   basesApi,
   type BasePermissionCandidate,
   type BasePermissionEntry,
   type BasePermissionRank
 } from "../../api/bases";
+import {
+  ASSOCIATE_RANK,
+  CO_OWNER_RANK,
+  EntryName,
+  OWNER_RANK,
+  RANK_OPTIONS,
+  RANK_LABELS,
+  RankSegments,
+  type DraftEntry,
+  errorText,
+  formatShareBreakdown,
+  sameRoster,
+  sortDraft,
+  toDraft
+} from "../permissions/rosterEditor";
 
 type BasePermissionsTabProps = {
   baseId: string;
@@ -13,142 +28,6 @@ type BasePermissionsTabProps = {
   onSaved: () => void;
   confirmAction: (message: string, options?: { title?: string; confirmLabel?: string; warning?: string; danger?: boolean; details?: { label: string; value: string; tone?: "accent" | "success" | "danger" }[] }) => Promise<boolean>;
 };
-
-const OWNER_RANK: BasePermissionRank = 1;
-const CO_OWNER_RANK: BasePermissionRank = 2;
-const ASSOCIATE_RANK: BasePermissionRank = 3;
-
-const RANK_LABELS: Record<BasePermissionRank, string> = {
-  1: "Owner",
-  2: "Co-Owner",
-  3: "Associate"
-};
-
-const RANK_OPTIONS: BasePermissionRank[] = [OWNER_RANK, CO_OWNER_RANK, ASSOCIATE_RANK];
-
-// `label` is the server's own rendering of the rank ("Owner", or "Rank 7" for
-// anything outside 1-3). Carried through so a rank the segmented control cannot
-// represent is still readable on screen -- see unknownRankLabel.
-type DraftEntry = { playerId: string; name: string; rank: BasePermissionRank; canonical: boolean; label: string };
-
-function toDraft(entries: BasePermissionEntry[]): DraftEntry[] {
-  return entries.map((entry) => ({
-    playerId: entry.playerId,
-    name: entry.name,
-    rank: entry.rank,
-    canonical: entry.canonical,
-    label: entry.label || ""
-  }));
-}
-
-function sortDraft(entries: DraftEntry[]) {
-  return [...entries].sort((left, right) => left.rank - right.rank || left.name.localeCompare(right.name));
-}
-
-function sameRoster(left: DraftEntry[], right: DraftEntry[]) {
-  if (left.length !== right.length) return false;
-  const rightByPlayer = new Map(right.map((entry) => [entry.playerId, entry.rank]));
-  return left.every((entry) => rightByPlayer.get(entry.playerId) === entry.rank);
-}
-
-function errorText(error: unknown) {
-  return error instanceof Error ? error.message : String(error);
-}
-
-function plural(count: number, word: string) {
-  return `${count} ${word}${count === 1 ? "" : "s"}`;
-}
-
-// "1 co-owner, 4 associates", skipping whichever count is zero so a base shared
-// with associates only does not advertise "0 co-owners". Empty when nobody is
-// on the roster -- the caller drops the element rather than rendering "".
-// `other` covers rows the game stored outside rank 1-3 plus any duplicate Owner;
-// they are real roster members and have to be counted, but calling them
-// Associates would put a rank on them that nobody chose.
-function formatShareBreakdown(coOwners: number, associates: number, other = 0) {
-  const parts: string[] = [];
-  if (coOwners) parts.push(plural(coOwners, "co-owner"));
-  if (associates) parts.push(plural(associates, "associate"));
-  if (other) parts.push(`${other} of another rank`);
-  return parts.join(", ");
-}
-
-// The three segments cover rank 1-3 only. Anything else the game stored has no
-// segment to check, so the control would render blank with no way to read the
-// real rank -- show it instead of silently dropping it.
-function unknownRankLabel(entry: DraftEntry) {
-  if (RANK_OPTIONS.includes(entry.rank)) return "";
-  return entry.label || `Rank ${entry.rank}`;
-}
-
-// Shared by the Owner hero card and the roster rows so the custodian pill and
-// the ignored-entry warning follow a player between the two as their rank
-// changes, instead of being duplicated in both places and drifting apart.
-function EntryName({ entry, isSystemCustodian, className }: {
-  entry: DraftEntry;
-  isSystemCustodian: boolean;
-  className: string;
-}) {
-  return (
-    <span className={className} title={entry.name || entry.playerId}>
-      {entry.name || `Player ${entry.playerId}`}
-      {unknownRankLabel(entry) && <span
-        className="bases-permissions-rank-unknown"
-        title="The game stored a rank this editor cannot represent. Changing it below replaces it with the rank you pick."
-      >{unknownRankLabel(entry)}</span>}
-      {isSystemCustodian && <span className="bases-permissions-system-label">System Custodian</span>}
-      {!entry.canonical && <span className="bases-permissions-orphan" title="This entry does not match a known player character, so the game ignores it. Removing it is safe.">
-        <TriangleAlert size={13} aria-label="Ignored by the game" />
-      </span>}
-    </span>
-  );
-}
-
-// Native radios rather than aria-pressed buttons: the browser supplies arrow-key
-// navigation and a single roving tab stop per group for free, so a five-member
-// roster costs five tab stops before Save instead of fifteen. aria-pressed would
-// also announce "toggle, pressed" with no set position, which is wrong for one
-// mutually exclusive value.
-function RankSegments({ entry, baseId, disabled, onChange }: {
-  entry: DraftEntry;
-  baseId: string;
-  disabled: boolean;
-  onChange: (rank: BasePermissionRank) => void;
-}) {
-  const who = entry.name || entry.playerId;
-  // baseId is in the group name so two rosters rendered at once could never
-  // merge two players' radios into one browser group, where selecting in one
-  // row would silently clear the other.
-  const groupName = `bases-rank-${baseId}-${entry.playerId}`;
-  return (
-    <div className="bases-rank-segments" role="radiogroup" aria-label={`Rank for ${who}`}>
-      {RANK_OPTIONS.map((rank) => (
-        <label className="bases-rank-segment" key={rank}>
-          <input
-            type="radio"
-            name={groupName}
-            value={rank}
-            checked={entry.rank === rank}
-            disabled={disabled}
-            // Full rank word in the accessible name, abbreviation on screen.
-            // Each abbreviation is a prefix of the full label, so the
-            // label-in-name requirement still holds for voice control.
-            aria-label={`${RANK_LABELS[rank]} for ${who}`}
-            onChange={() => onChange(rank)}
-            // Clicking an already-checked radio fires no change event, which
-            // would strand a base carrying two rank-1 rows: the duplicate's
-            // "Own" segment renders checked, so the click that is supposed to
-            // demote the other Owner would do nothing. onChange is still what
-            // arrow-key navigation fires, so both are needed. changeRank is
-            // idempotent for a rank the entry already holds.
-            onClick={() => onChange(rank)}
-          />
-          <span aria-hidden="true">{RANK_LABELS[rank]}</span>
-        </label>
-      ))}
-    </div>
-  );
-}
 
 // The Owner is the one thing an admin opens this tab to check, so it gets its
 // own card instead of being one row among many. The custodian transfer lives
@@ -499,7 +378,7 @@ export function BasePermissionsTab({ baseId, baseName, onSaved, confirmAction }:
               />
               <RankSegments
                 entry={entry}
-                baseId={baseId}
+                scopeId={baseId}
                 disabled={saving || Boolean(unclaimed)}
                 onChange={(rank) => changeRank(entry.playerId, rank)}
               />

--- a/console/web/src/features/permissions/rosterEditor.tsx
+++ b/console/web/src/features/permissions/rosterEditor.tsx
@@ -1,0 +1,161 @@
+import { TriangleAlert } from "lucide-react";
+
+// rank 1/2/3 = Owner/Co-Owner/Associate, confirmed in both directions against a
+// live server: the game's own Permissions panel writes exactly these values.
+// The 5/4/3 badges the game UI shows beside those labels are decoration, not
+// ranks -- no row in permission_actor_rank ever holds a 4 or 5. Shared by
+// bases and vehicles: both are permission_actor_rank actors with identical
+// rank semantics, just different id spaces.
+export type PermissionRank = 1 | 2 | 3;
+
+export type PermissionEntry = {
+  playerId: string;
+  name: string;
+  rank: PermissionRank;
+  label: string;
+  canonical: boolean;
+};
+
+export const OWNER_RANK: PermissionRank = 1;
+export const CO_OWNER_RANK: PermissionRank = 2;
+export const ASSOCIATE_RANK: PermissionRank = 3;
+
+export const RANK_LABELS: Record<PermissionRank, string> = {
+  1: "Owner",
+  2: "Co-Owner",
+  3: "Associate"
+};
+
+export const RANK_OPTIONS: PermissionRank[] = [OWNER_RANK, CO_OWNER_RANK, ASSOCIATE_RANK];
+
+// `label` is the server's own rendering of the rank ("Owner", or "Rank 7" for
+// anything outside 1-3). Carried through so a rank the segmented control cannot
+// represent is still readable on screen -- see unknownRankLabel.
+export type DraftEntry = { playerId: string; name: string; rank: PermissionRank; canonical: boolean; label: string };
+
+export function toDraft(entries: PermissionEntry[]): DraftEntry[] {
+  return entries.map((entry) => ({
+    playerId: entry.playerId,
+    name: entry.name,
+    rank: entry.rank,
+    canonical: entry.canonical,
+    label: entry.label || ""
+  }));
+}
+
+export function sortDraft(entries: DraftEntry[]) {
+  return [...entries].sort((left, right) => left.rank - right.rank || left.name.localeCompare(right.name));
+}
+
+export function sameRoster(left: DraftEntry[], right: DraftEntry[]) {
+  if (left.length !== right.length) return false;
+  const rightByPlayer = new Map(right.map((entry) => [entry.playerId, entry.rank]));
+  return left.every((entry) => rightByPlayer.get(entry.playerId) === entry.rank);
+}
+
+export function errorText(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function plural(count: number, word: string) {
+  return `${count} ${word}${count === 1 ? "" : "s"}`;
+}
+
+// "1 co-owner, 4 associates", skipping whichever count is zero so a roster
+// shared with associates only does not advertise "0 co-owners". Empty when
+// nobody is on the roster -- the caller drops the element rather than
+// rendering "". `other` covers rows the game stored outside rank 1-3 plus any
+// duplicate Owner; they are real roster members and have to be counted, but
+// calling them Associates would put a rank on them that nobody chose.
+export function formatShareBreakdown(coOwners: number, associates: number, other = 0) {
+  const parts: string[] = [];
+  if (coOwners) parts.push(plural(coOwners, "co-owner"));
+  if (associates) parts.push(plural(associates, "associate"));
+  if (other) parts.push(`${other} of another rank`);
+  return parts.join(", ");
+}
+
+// The three segments cover rank 1-3 only. Anything else the game stored has no
+// segment to check, so the control would render blank with no way to read the
+// real rank -- show it instead of silently dropping it.
+export function unknownRankLabel(entry: DraftEntry) {
+  if (RANK_OPTIONS.includes(entry.rank)) return "";
+  return entry.label || `Rank ${entry.rank}`;
+}
+
+// Shared by the Owner display and the roster rows so the custodian pill and
+// the ignored-entry warning follow a player between the two as their rank
+// changes, instead of being duplicated in both places and drifting apart.
+// isSystemCustodian defaults to false: vehicles have no system custodian
+// concept, so their Owner display never passes it.
+export function EntryName({ entry, isSystemCustodian = false, className }: {
+  entry: DraftEntry;
+  isSystemCustodian?: boolean;
+  className: string;
+}) {
+  return (
+    <span className={className} title={entry.name || entry.playerId}>
+      {entry.name || `Player ${entry.playerId}`}
+      {unknownRankLabel(entry) && <span
+        className="bases-permissions-rank-unknown"
+        title="The game stored a rank this editor cannot represent. Changing it below replaces it with the rank you pick."
+      >{unknownRankLabel(entry)}</span>}
+      {isSystemCustodian && <span className="bases-permissions-system-label">System Custodian</span>}
+      {!entry.canonical && <span className="bases-permissions-orphan" title="This entry does not match a known player character, so the game ignores it. Removing it is safe.">
+        <TriangleAlert size={13} aria-label="Ignored by the game" />
+      </span>}
+    </span>
+  );
+}
+
+// Native radios rather than aria-pressed buttons: the browser supplies arrow-key
+// navigation and a single roving tab stop per group for free, so a five-member
+// roster costs five tab stops before Save instead of fifteen. aria-pressed would
+// also announce "toggle, pressed" with no set position, which is wrong for one
+// mutually exclusive value.
+export function RankSegments({ entry, scopeId, disabled, onChange, groupClassName = "bases-rank-segments", segmentClassName = "bases-rank-segment" }: {
+  entry: DraftEntry;
+  scopeId: string;
+  disabled: boolean;
+  onChange: (rank: PermissionRank) => void;
+  // Bases and vehicles style this control through separate class names (see
+  // styles.css) even though the rules are identical today, so each feature can
+  // diverge later without touching the other. Defaults keep the base tab's
+  // existing markup unchanged.
+  groupClassName?: string;
+  segmentClassName?: string;
+}) {
+  const who = entry.name || entry.playerId;
+  // scopeId is in the group name so two rosters rendered at once (a base tab
+  // and a vehicle tab, say) could never merge two players' radios into one
+  // browser group, where selecting in one row would silently clear the other.
+  const groupName = `permissions-rank-${scopeId}-${entry.playerId}`;
+  return (
+    <div className={groupClassName} role="radiogroup" aria-label={`Rank for ${who}`}>
+      {RANK_OPTIONS.map((rank) => (
+        <label className={segmentClassName} key={rank}>
+          <input
+            type="radio"
+            name={groupName}
+            value={rank}
+            checked={entry.rank === rank}
+            disabled={disabled}
+            // Full rank word in the accessible name, abbreviation on screen.
+            // Each abbreviation is a prefix of the full label, so the
+            // label-in-name requirement still holds for voice control.
+            aria-label={`${RANK_LABELS[rank]} for ${who}`}
+            onChange={() => onChange(rank)}
+            // Clicking an already-checked radio fires no change event, which
+            // would strand a roster carrying two rank-1 rows: the duplicate's
+            // "Own" segment renders checked, so the click that is supposed to
+            // demote the other Owner would do nothing. onChange is still what
+            // arrow-key navigation fires, so both are needed. changeRank is
+            // idempotent for a rank the entry already holds.
+            onClick={() => onChange(rank)}
+          />
+          <span aria-hidden="true">{RANK_LABELS[rank]}</span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/console/web/src/features/players/PlayerVehiclesTab.test.tsx
+++ b/console/web/src/features/players/PlayerVehiclesTab.test.tsx
@@ -6,7 +6,14 @@ import { invalidateInstanceNames } from "../maps/instanceNames";
 import { PlayerVehiclesTab } from "./PlayerVehiclesTab";
 
 vi.mock("../../api/maps", () => ({ mapsApi: { sietchDimensions: vi.fn() } }));
-vi.mock("../../api/vehicles", () => ({ vehiclesApi: { forPlayer: vi.fn() } }));
+vi.mock("../../api/vehicles", () => ({
+  vehiclesApi: {
+    forPlayer: vi.fn(),
+    permissions: vi.fn(),
+    setPermissions: vi.fn(),
+    permissionCandidates: vi.fn()
+  }
+}));
 
 function response(overrides: Partial<VehiclesListResponse> = {}): VehiclesListResponse {
   return {
@@ -50,6 +57,48 @@ describe("PlayerVehiclesTab", () => {
     render(<PlayerVehiclesTab playerId="42" playerName="Kovalt" />);
     expect(await screen.findByText("Kovalt has no owned or shared vehicles.")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => expect(vehiclesApi.forPlayer).toHaveBeenCalledTimes(2));
+  });
+
+  // The default fixture above sends only { vehicles: true } with no
+  // vehiclePermissions flag -- this is the regression guard that an older/
+  // capability-less API keeps the tab hidden rather than defaulting it on.
+  it("hides the Permissions tab without the vehiclePermissions capability", async () => {
+    vi.mocked(vehiclesApi.forPlayer).mockResolvedValue(response());
+    render(<PlayerVehiclesTab playerId="42" playerName="Kovalt" />);
+
+    fireEvent.click(await screen.findByLabelText("Show components for Owned Bike"));
+    expect(screen.queryByRole("tab", { name: "Permissions" })).not.toBeInTheDocument();
+  });
+
+  it("shows the Permissions tab and refetches after a save when the capability is present", async () => {
+    vi.mocked(vehiclesApi.forPlayer).mockResolvedValue(response({ capabilities: { vehicles: true, vehiclePermissions: true } }));
+    vi.mocked(vehiclesApi.permissions).mockResolvedValue({
+      supported: true,
+      vehicleId: 1,
+      actorId: "1",
+      map: "HaggaBasin",
+      mapNameId: 1,
+      entries: [{ playerId: "4", name: "Kovalt", rank: 1, label: "", canonical: true }]
+    } as never);
+    render(<PlayerVehiclesTab playerId="42" playerName="Kovalt" />);
+
+    fireEvent.click(await screen.findByLabelText("Show components for Owned Bike"));
+    fireEvent.click(await screen.findByRole("tab", { name: "Permissions" }));
+    await screen.findByText("Kovalt", { selector: ".vehicles-permissions-owner-name" });
+
+    vi.mocked(vehiclesApi.setPermissions).mockResolvedValue({
+      supported: true,
+      result: { ok: true, vehicleId: 1, actorId: "1", map: "HaggaBasin", added: 1, reranked: 0, removed: 0, total: 2, message: "Permissions were updated." }
+    } as never);
+    vi.mocked(vehiclesApi.permissionCandidates).mockResolvedValue({ rows: [{ playerId: "9", name: "Leto_A" }] } as never);
+    fireEvent.change(screen.getByPlaceholderText("Search a player to add"), { target: { value: "Leto" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Add Leto_A" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+
+    // ownedCount is derived from row.relationship, which can shift after a
+    // rank change, so a save must refetch rather than trust stale rows.
     await waitFor(() => expect(vehiclesApi.forPlayer).toHaveBeenCalledTimes(2));
   });
 });

--- a/console/web/src/features/players/PlayerVehiclesTab.tsx
+++ b/console/web/src/features/players/PlayerVehiclesTab.tsx
@@ -10,6 +10,7 @@ export function PlayerVehiclesTab({ playerId, playerName }: { playerId: string; 
   const [rows, setRows] = useState<VehicleRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [supported, setSupported] = useState(true);
+  const [canEditPermissions, setCanEditPermissions] = useState(false);
   const [message, setMessage] = useState("");
   const requestIdRef = useRef(0);
 
@@ -22,11 +23,13 @@ export function PlayerVehiclesTab({ playerId, playerName }: { playerId: string; 
       if (requestIdRef.current !== requestId) return;
       setRows(result.rows || []);
       setSupported(result.capabilities?.vehicles !== false);
+      setCanEditPermissions(result.capabilities?.vehiclePermissions === true);
       setMessage(result.reason || "");
     } catch (error) {
       if (requestIdRef.current !== requestId) return;
       setRows([]);
       setSupported(true);
+      setCanEditPermissions(false);
       setMessage(errorText(error));
     } finally {
       if (requestIdRef.current === requestId) setLoading(false);
@@ -61,7 +64,16 @@ export function PlayerVehiclesTab({ playerId, playerName }: { playerId: string; 
                   <span><strong>{ownedCount}</strong> Owned</span>
                   <span><strong>{sharedCount}</strong> Shared</span>
                 </div>
-                <VehicleTable rows={rows} context="player" emptyMessage={`${playerName} has no owned or shared vehicles.`} />
+                <VehicleTable
+                  rows={rows}
+                  context="player"
+                  emptyMessage={`${playerName} has no owned or shared vehicles.`}
+                  canEditPermissions={canEditPermissions}
+                  // ownedCount above derives from row.relationship, which
+                  // shifts after a rank change -- refetch so the summary and
+                  // the table stay in sync with what was just saved.
+                  onPermissionsSaved={() => void load()}
+                />
               </>}
       </section>
     </div>

--- a/console/web/src/features/vehicles/VehiclePermissionsTab.test.tsx
+++ b/console/web/src/features/vehicles/VehiclePermissionsTab.test.tsx
@@ -1,0 +1,266 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { vehiclesApi, type VehiclePermissionEntry, type VehiclePermissionRank } from "../../api/vehicles";
+import { VehiclePermissionsTab } from "./VehiclePermissionsTab";
+
+vi.mock("../../api/vehicles", () => ({
+  vehiclesApi: {
+    permissions: vi.fn(),
+    setPermissions: vi.fn(),
+    permissionCandidates: vi.fn()
+  }
+}));
+
+function entry(playerId: string, name: string, rank: VehiclePermissionRank, canonical = true): VehiclePermissionEntry {
+  return { playerId, name, rank, label: "", canonical };
+}
+
+function mockRoster(
+  entries: VehiclePermissionEntry[],
+  claim: { claimed?: boolean; unclaimedReason?: string } = {}
+) {
+  vi.mocked(vehiclesApi.permissions).mockResolvedValue({
+    supported: true,
+    vehicleId: 3001,
+    actorId: "3001",
+    map: "DeepDesert",
+    mapNameId: 7,
+    entries,
+    ...claim
+  } as never);
+}
+
+function renderTab(overrides: Partial<Parameters<typeof VehiclePermissionsTab>[0]> = {}) {
+  const props = {
+    vehicleId: "3001",
+    vehicleName: "Sandcrawler MK-II",
+    onSaved: vi.fn(),
+    ...overrides
+  };
+  render(<VehiclePermissionsTab {...props} />);
+  return props;
+}
+
+function ownerName() {
+  return document.querySelector(".vehicles-permissions-owner-name");
+}
+
+const DEFAULT_ROSTER = [
+  entry("4", "DarkShark", 1),
+  entry("29", "Yaida", 2),
+  entry("31", "Stilgar", 3)
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("VehiclePermissionsTab layout", () => {
+  it("puts the Owner in the card and everyone else in the roster", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+
+    expect(await screen.findByText("DarkShark", { selector: ".vehicles-permissions-owner-name" })).toBeInTheDocument();
+    expect(screen.queryByRole("radiogroup", { name: "Rank for DarkShark" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Remove DarkShark" })).not.toBeInTheDocument();
+
+    expect(screen.getAllByRole("radiogroup")).toHaveLength(2);
+    expect(screen.getByRole("radiogroup", { name: "Rank for Yaida" })).toBeInTheDocument();
+    expect(screen.getByRole("radiogroup", { name: "Rank for Stilgar" })).toBeInTheDocument();
+  });
+
+  it("checks exactly the segment matching each player's rank", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+    await screen.findByRole("radio", { name: "Co-Owner for Yaida" });
+
+    expect(screen.getByRole("radio", { name: "Owner for Yaida" })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: "Co-Owner for Yaida" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "Associate for Yaida" })).not.toBeChecked();
+    expect(screen.getByRole("radio", { name: "Associate for Stilgar" })).toBeChecked();
+  });
+
+  it("keeps each row's rank group independent of the others", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Associate for Yaida" }));
+    await waitFor(() => expect(screen.getByRole("radio", { name: "Associate for Yaida" })).toBeChecked());
+    expect(screen.getByRole("radio", { name: "Associate for Stilgar" })).toBeChecked();
+  });
+
+  // The demote-on-already-checked path: clicking a segment that already reads
+  // checked fires no native change event, so onClick has to carry it too --
+  // this is what would strand a roster with two Owners if it regressed.
+  it("swaps the owner and the roster on promote, and swaps them back", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Owner for Yaida" }));
+    await waitFor(() => expect(ownerName()).toHaveTextContent("Yaida"));
+    expect(screen.getByRole("radio", { name: "Co-Owner for DarkShark" })).toBeChecked();
+
+    fireEvent.click(screen.getByRole("radio", { name: "Owner for DarkShark" }));
+    await waitFor(() => expect(ownerName()).toHaveTextContent("DarkShark"));
+    expect(screen.getByRole("radio", { name: "Co-Owner for Yaida" })).toBeChecked();
+  });
+
+  it("renders no breakdown at all when the vehicle is shared with nobody", async () => {
+    mockRoster([entry("4", "DarkShark", 1)]);
+    renderTab();
+    expect(await screen.findByText("Shared with · 0")).toBeInTheDocument();
+    expect(document.querySelector(".vehicles-permissions-section-meta")).toBeNull();
+    expect(screen.getByText("This vehicle is not shared with anyone else.")).toBeInTheDocument();
+  });
+
+  it("clears the player search after adding a result", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    vi.mocked(vehiclesApi.permissionCandidates).mockResolvedValue({
+      rows: [{ playerId: "32", name: "Chani" }]
+    } as never);
+    renderTab();
+
+    const search = await screen.findByPlaceholderText("Search a player to add");
+    fireEvent.change(search, { target: { value: "Chani" } });
+    fireEvent.click(screen.getByRole("button", { name: "Search" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Add Chani" }));
+
+    await waitFor(() => expect(search).toHaveValue(""));
+    expect(screen.queryByRole("button", { name: "Add Chani" })).not.toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: "Associate for Chani" })).toBeChecked();
+  });
+
+  // The explicit non-goal of this feature: no ownership-transfer control of
+  // any kind, anywhere in the tab.
+  it("never renders a transfer or custodian control", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+    await screen.findByText("DarkShark", { selector: ".vehicles-permissions-owner-name" });
+
+    expect(screen.queryByRole("button", { name: /transfer/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/custodian/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("VehiclePermissionsTab ownerless state", () => {
+  it("flags a vehicle with no Owner and refuses to save it", async () => {
+    mockRoster([entry("29", "Yaida", 2)]);
+    renderTab();
+
+    expect(await screen.findByText("No Owner set")).toBeInTheDocument();
+    expect(document.querySelector(".vehicles-permissions-owner-card")).toHaveClass("vehicles-permissions-owner-card-empty");
+    expect(screen.getByRole("alert")).toHaveTextContent("This vehicle has no Owner.");
+
+    fireEvent.click(screen.getByRole("radio", { name: "Associate for Yaida" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Revert" })).toBeEnabled());
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
+  });
+});
+
+describe("VehiclePermissionsTab unclaimed vehicle", () => {
+  const UNCLAIMED = "This vehicle is not claimed -- it has no dune.permission_actor row.";
+
+  it("explains the unclaimed state and blocks every write", async () => {
+    mockRoster([], { claimed: false, unclaimedReason: UNCLAIMED });
+    renderTab();
+
+    expect(await screen.findByText(UNCLAIMED)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save changes" })).toBeDisabled();
+    expect(screen.queryByText(/This vehicle has no Owner/)).not.toBeInTheDocument();
+  });
+
+  it("leaves the roster read-only rather than letting edits accumulate", async () => {
+    mockRoster(DEFAULT_ROSTER, { claimed: false, unclaimedReason: UNCLAIMED });
+    renderTab();
+
+    await screen.findByText(UNCLAIMED);
+    expect(screen.getByRole("radio", { name: "Associate for Yaida" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Remove Yaida" })).toBeDisabled();
+  });
+
+  it("treats a missing flag as claimed", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+
+    await screen.findByText("DarkShark", { selector: ".vehicles-permissions-owner-name" });
+    expect(screen.getByRole("radio", { name: "Associate for Yaida" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Remove Yaida" })).toBeEnabled();
+  });
+});
+
+describe("VehiclePermissionsTab entry warnings", () => {
+  it("flags a non-canonical Owner from inside the owner card", async () => {
+    mockRoster([entry("4", "DarkShark", 1, false), entry("29", "Yaida", 2)]);
+    renderTab();
+
+    const warning = await screen.findByLabelText("Ignored by the game");
+    expect(document.querySelector(".vehicles-permissions-owner-card")).toContainElement(warning);
+  });
+});
+
+describe("VehiclePermissionsTab saving", () => {
+  it("disables every control while a save is in flight", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    vi.mocked(vehiclesApi.setPermissions).mockReturnValue(new Promise(() => {}) as never);
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Associate for Yaida" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save changes" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Saving…" })).toBeInTheDocument());
+    screen.getAllByRole("radio").forEach((radio) => expect(radio).toBeDisabled());
+    expect(screen.getByRole("button", { name: "Remove Yaida" })).toBeDisabled();
+  });
+
+  it("restores the original segment on Revert without calling the server", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Associate for Yaida" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Revert" })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: "Revert" }));
+
+    await waitFor(() => expect(screen.getByRole("radio", { name: "Co-Owner for Yaida" })).toBeChecked());
+    expect(vehiclesApi.setPermissions).not.toHaveBeenCalled();
+  });
+
+  it("posts the whole roster, not a delta, and refetches on save", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    vi.mocked(vehiclesApi.setPermissions).mockResolvedValue({
+      supported: true,
+      result: { ok: true, vehicleId: 3001, actorId: "3001", map: "DeepDesert", added: 0, reranked: 1, removed: 0, total: 3, message: "Permissions were updated." }
+    } as never);
+    const props = renderTab();
+
+    fireEvent.click(await screen.findByRole("radio", { name: "Associate for Yaida" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(vehiclesApi.setPermissions).toHaveBeenCalledWith("3001", [
+      { playerId: "4", rank: 1 },
+      { playerId: "29", rank: 3 },
+      { playerId: "31", rank: 3 }
+    ]));
+    await waitFor(() => expect(props.onSaved).toHaveBeenCalled());
+  });
+});
+
+describe("VehiclePermissionsTab load states", () => {
+  it("reports loading, then the roster", async () => {
+    mockRoster(DEFAULT_ROSTER);
+    renderTab();
+    expect(screen.getByText("Loading permissions…")).toBeInTheDocument();
+    expect(await screen.findByText("Shared with · 2")).toBeInTheDocument();
+  });
+
+  it("offers a working Retry when the roster fails to load", async () => {
+    vi.mocked(vehiclesApi.permissions).mockRejectedValueOnce(new Error("Permissions are unavailable."));
+    renderTab();
+
+    expect(await screen.findByText(/Permissions are unavailable\./)).toBeInTheDocument();
+    mockRoster(DEFAULT_ROSTER);
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByText("Shared with · 2")).toBeInTheDocument();
+    expect(vehiclesApi.permissions).toHaveBeenCalledTimes(2);
+  });
+});

--- a/console/web/src/features/vehicles/VehiclePermissionsTab.tsx
+++ b/console/web/src/features/vehicles/VehiclePermissionsTab.tsx
@@ -1,0 +1,315 @@
+import { useCallback, useEffect, useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
+import {
+  vehiclesApi,
+  type VehiclePermissionCandidate,
+  type VehiclePermissionRank
+} from "../../api/vehicles";
+import {
+  ASSOCIATE_RANK,
+  CO_OWNER_RANK,
+  EntryName,
+  OWNER_RANK,
+  RANK_OPTIONS,
+  RANK_LABELS,
+  RankSegments,
+  type DraftEntry,
+  errorText,
+  formatShareBreakdown,
+  sameRoster,
+  sortDraft,
+  toDraft
+} from "../permissions/rosterEditor";
+
+type VehiclePermissionsTabProps = {
+  vehicleId: string;
+  vehicleName: string;
+  onSaved: () => void;
+};
+
+export function VehiclePermissionsTab({ vehicleId, vehicleName, onSaved }: VehiclePermissionsTabProps) {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [saved, setSaved] = useState<DraftEntry[]>([]);
+  const [draft, setDraft] = useState<DraftEntry[]>([]);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState("");
+  const [statusKind, setStatusKind] = useState<"" | "ok" | "fail">("");
+  const [candidateQuery, setCandidateQuery] = useState("");
+  const [candidates, setCandidates] = useState<VehiclePermissionCandidate[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [searched, setSearched] = useState(false);
+  const [addRank, setAddRank] = useState<VehiclePermissionRank>(ASSOCIATE_RANK);
+  // The server's explanation when the vehicle has no permission_actor row,
+  // empty otherwise. A string rather than a boolean so the banner and every
+  // disabled control's tooltip read back the same sentence the API chose.
+  const [unclaimed, setUnclaimed] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError("");
+    try {
+      const result = await vehiclesApi.permissions(vehicleId);
+      const entries = toDraft(result.entries || []);
+      setSaved(entries);
+      setDraft(entries);
+      // Only an explicit false locks the tab down. An API that predates the
+      // flag omits it, and reading that as unclaimed would disable editing on
+      // every vehicle it serves.
+      setUnclaimed(result.claimed === false
+        ? result.unclaimedReason || "This vehicle is not claimed, so its permissions cannot be edited."
+        : "");
+    } catch (error) {
+      setLoadError(errorText(error));
+    } finally {
+      setLoading(false);
+    }
+  }, [vehicleId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  useEffect(() => {
+    if (!status || statusKind !== "ok") return undefined;
+    // Keep this aligned with .inline-task-result.result-ok's 10.4s animation.
+    // CSS opacity does not release layout space, so retire successful results
+    // from React state when their visual lifetime ends. The animation handler
+    // below normally wins; this timer also covers reduced-motion/missed events.
+    const retire = window.setTimeout(() => {
+      setStatus("");
+      setStatusKind("");
+    }, 10_400);
+    return () => window.clearTimeout(retire);
+  }, [status, statusKind]);
+
+  const dirty = !sameRoster(saved, draft);
+  const owner = draft.find((entry) => entry.rank === OWNER_RANK);
+
+  // Promoting to Owner demotes whoever currently holds it, in the same local
+  // edit. The server enforces the one-owner rule too, but doing it here means
+  // the invariant can never be broken on screen -- there is no intermediate
+  // state showing two Owners for the user to try to save.
+  function changeRank(playerId: string, nextRank: VehiclePermissionRank) {
+    setDraft((current) => current.map((entry) => {
+      if (entry.playerId === playerId) return { ...entry, rank: nextRank };
+      if (nextRank === OWNER_RANK && entry.rank === OWNER_RANK) return { ...entry, rank: CO_OWNER_RANK };
+      return entry;
+    }));
+  }
+
+  function removeEntry(playerId: string) {
+    setDraft((current) => current.filter((entry) => entry.playerId !== playerId));
+  }
+
+  function addCandidate(candidate: VehiclePermissionCandidate) {
+    setDraft((current) => {
+      if (current.some((entry) => entry.playerId === candidate.playerId)) return current;
+      // No label: the rank is one this editor picked, so RANK_LABELS covers it.
+      const next = [...current, { playerId: candidate.playerId, name: candidate.name, rank: addRank, canonical: true, label: "" }];
+      // Adding straight to Owner has to demote the incumbent for the same
+      // reason changeRank does.
+      if (addRank !== OWNER_RANK) return next;
+      return next.map((entry) => entry.playerId === candidate.playerId || entry.rank !== OWNER_RANK
+        ? entry
+        : { ...entry, rank: CO_OWNER_RANK });
+    });
+    // Adding completes the search interaction. Reset it instead of leaving a
+    // stale query and result list sitting beneath the newly-added roster row.
+    setCandidateQuery("");
+    setCandidates([]);
+    setSearched(false);
+  }
+
+  // Explicit submit rather than search-as-you-type: this queries the server, and
+  // a debounced field would fire a request per keystroke.
+  async function submitCandidateSearch() {
+    setSearching(true);
+    try {
+      const result = await vehiclesApi.permissionCandidates(candidateQuery);
+      setCandidates(result.rows || []);
+      setSearched(true);
+    } catch (error) {
+      setStatus(errorText(error));
+      setStatusKind("fail");
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  function clearCandidateSearch() {
+    setCandidateQuery("");
+    setCandidates([]);
+    setSearched(false);
+  }
+
+  async function save() {
+    if (!owner) return;
+    setSaving(true);
+    setStatus("");
+    setStatusKind("");
+    try {
+      const response = await vehiclesApi.setPermissions(vehicleId, draft.map((entry) => ({ playerId: entry.playerId, rank: entry.rank })));
+      setSaved(draft);
+      setStatus(response.result?.message || "Permissions were updated.");
+      setStatusKind("ok");
+      onSaved();
+    } catch (error) {
+      setStatus(errorText(error));
+      setStatusKind("fail");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return <p className="muted" role="status">Loading permissions…</p>;
+  }
+  if (loadError) {
+    return <p className="vehicles-permissions-error" role="alert">
+      {loadError} <button onClick={() => void load()}>Retry</button>
+    </p>;
+  }
+
+  const alreadyOnRoster = new Set(draft.map((entry) => entry.playerId));
+  // The roster holds every entry except the one the Owner card is showing --
+  // keyed on that entry's id, not on "rank is not Owner". A vehicle whose rows
+  // the game wrote directly can carry a second rank-1 row (permission_set_
+  // player_rank is a plain upsert), and filtering by rank would drop it from
+  // the screen while leaving it in the draft that Save submits. Keeping it as
+  // a row makes it visible, removable, and fixable: its "Own" segment demotes
+  // the incumbent.
+  const nonOwners = sortDraft(draft.filter((entry) => entry.playerId !== owner?.playerId));
+  const coOwnerCount = nonOwners.filter((entry) => entry.rank === CO_OWNER_RANK).length;
+  const associateCount = nonOwners.filter((entry) => entry.rank === ASSOCIATE_RANK).length;
+  // Anything the game stored outside 1-3, plus any duplicate Owner row. Counted
+  // separately rather than folded into the associate tally, which would state
+  // something false about a rank nobody chose.
+  const otherRankCount = nonOwners.length - coOwnerCount - associateCount;
+  const shareBreakdown = formatShareBreakdown(coOwnerCount, associateCount, otherRankCount);
+
+  return (
+    <div className="vehicles-permissions" onClick={(event) => event.stopPropagation()}>
+      <div className="vehicles-permissions-content">
+        <div className="vehicles-permissions-intro">
+          <p className="action-help-note">
+            Exactly one Owner. Promoting a player demotes the current Owner to Co-Owner. Changes apply to the running map immediately.
+          </p>
+          <div className={`vehicles-permissions-owner-card${owner ? "" : " vehicles-permissions-owner-card-empty"}`}>
+            <div className="vehicles-permissions-owner-identity">
+              <span className="vehicles-permissions-owner-eyebrow">Owner</span>
+              {owner
+                ? <EntryName entry={owner} className="vehicles-permissions-owner-name" />
+                : <span className="vehicles-permissions-owner-name vehicles-permissions-owner-none">No Owner set</span>}
+            </div>
+          </div>
+        </div>
+
+        <div className="vehicles-permissions-toolbar">
+          <div className="vehicles-permissions-add">
+            <div className="action-row vehicles-permissions-search-row">
+              <input
+                value={candidateQuery}
+                placeholder="Search a player to add"
+                disabled={saving}
+                onChange={(event) => setCandidateQuery(event.target.value)}
+                onKeyDown={(event) => { if (event.key === "Enter") void submitCandidateSearch(); }}
+              />
+              <button disabled={searching || saving} onClick={() => void submitCandidateSearch()}>Search</button>
+              <button disabled={!candidateQuery && !searched} onClick={clearCandidateSearch}>Clear</button>
+              <label className="compact-select">
+                Add as
+                <select value={String(addRank)} disabled={saving} onChange={(event) => setAddRank(Number(event.target.value) as VehiclePermissionRank)}>
+                  {RANK_OPTIONS.map((rank) => <option key={rank} value={rank}>{RANK_LABELS[rank]}</option>)}
+                </select>
+              </label>
+            </div>
+            {searched && !candidates.length && <p className="muted">No players matched that search.</p>}
+            {candidates.length > 0 && <ul className="vehicles-permissions-candidates">
+              {candidates.map((candidate) => (
+                <li key={candidate.playerId}>
+                  <span>{candidate.name}</span>
+                  <button
+                    className="icon-toggle-button"
+                    disabled={alreadyOnRoster.has(candidate.playerId) || saving || Boolean(unclaimed)}
+                    title={unclaimed || (alreadyOnRoster.has(candidate.playerId) ? "Already shared with this vehicle" : `Add ${candidate.name} as ${RANK_LABELS[addRank]}`)}
+                    aria-label={`Add ${candidate.name}`}
+                    onClick={() => addCandidate(candidate)}
+                  ><Plus size={15} /></button>
+                </li>
+              ))}
+            </ul>}
+          </div>
+
+          <div className="vehicles-permissions-actions">
+            <span className="muted">{dirty ? "Unsaved changes" : ""}</span>
+            <button disabled={!dirty || saving} onClick={() => setDraft(saved)}>Revert</button>
+            <button
+              className="update-action"
+              disabled={!dirty || !owner || saving || Boolean(unclaimed)}
+              title={unclaimed || `Save permissions for ${vehicleName}`}
+              onClick={() => void save()}
+            >{saving ? "Saving…" : "Save changes"}</button>
+          </div>
+        </div>
+
+        {/* Do not reserve an empty message area. Warnings and results appear
+            only when they have useful information, matching the compact action
+            layouts elsewhere in the console. */}
+        {(dirty || !owner || unclaimed || status) && <div className="vehicles-permissions-banner-slot">
+          {dirty && <p className="confirm-modal-warning vehicles-permissions-warning" role="status">
+            Saving writes to the live database and notifies the running map server. An online player may need to reopen the vehicle's interaction panel to see the change.
+          </p>}
+          {unclaimed && <p className="vehicles-permissions-error" role="alert">{unclaimed}</p>}
+          {/* Suppressed on an unclaimed vehicle: it has no Owner either, but
+              "set one before saving" describes an action that cannot be
+              completed there and would bury the reason that can. */}
+          {!owner && !unclaimed && <p className="vehicles-permissions-error" role="alert">
+            This vehicle has no Owner. Set one before saving.
+          </p>}
+          {status && <p
+            className={`inline-task-result${statusKind ? ` result-${statusKind}` : ""}`}
+            role={statusKind === "fail" ? "alert" : "status"}
+            onAnimationEnd={() => {
+              if (statusKind !== "ok") return;
+              setStatus("");
+              setStatusKind("");
+            }}
+          >
+            <strong>{status}</strong>
+          </p>}
+        </div>}
+
+        <div className="vehicles-permissions-section-head">
+          <span className="vehicles-permissions-section-title">Shared with · {nonOwners.length}</span>
+          {shareBreakdown && <span className="vehicles-permissions-section-meta">{shareBreakdown}</span>}
+        </div>
+
+        <div className="vehicles-permissions-roster">
+          {nonOwners.map((entry) => (
+            <div className="vehicles-permissions-row" key={entry.playerId}>
+              <EntryName
+                entry={entry}
+                className="vehicles-permissions-name"
+              />
+              <RankSegments
+                entry={entry}
+                scopeId={vehicleId}
+                disabled={saving || Boolean(unclaimed)}
+                onChange={(rank) => changeRank(entry.playerId, rank)}
+                groupClassName="vehicles-rank-segments"
+                segmentClassName="vehicles-rank-segment"
+              />
+              <button
+                className="icon-toggle-button vehicles-permissions-remove"
+                disabled={saving || Boolean(unclaimed)}
+                title={unclaimed || `Remove ${entry.name || entry.playerId}`}
+                aria-label={`Remove ${entry.name || entry.playerId}`}
+                onClick={() => removeEntry(entry.playerId)}
+              ><Trash2 size={15} /></button>
+            </div>
+          ))}
+          {!nonOwners.length && <p className="muted">This vehicle is not shared with anyone else.</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/console/web/src/features/vehicles/VehicleTable.tsx
+++ b/console/web/src/features/vehicles/VehicleTable.tsx
@@ -168,7 +168,15 @@ export function VehicleTable({ rows, context = "global", emptyMessage = "No vehi
   // not on every render -- so a background row refresh never yanks focus
   // away from a control the user is mid-interaction with.
   useEffect(() => {
-    if (expandedId) expandedContentRef.current?.focus();
+    // preventScroll: a row expanding near the bottom of the viewport
+    // otherwise triggers the browser's default scroll-into-view on focus,
+    // which yanks the page out from under a mouse user who just clicked a
+    // row in place (confirmed live: a 147px jump). Keyboard/screen-reader
+    // users still get the focus move itself, which is what they need --
+    // browsers already keep a newly focused element approximately in view
+    // when it was reached via Tab, since the click that expanded it was
+    // already scrolled to.
+    if (expandedId) expandedContentRef.current?.focus({ preventScroll: true });
   }, [expandedId]);
 
   useEffect(() => {

--- a/console/web/src/features/vehicles/VehicleTable.tsx
+++ b/console/web/src/features/vehicles/VehicleTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import type { VehicleModule, VehicleRow, VehicleSharedEntry } from "../../api/vehicles";
 import { DataTable, type SortDirection } from "../../components/common/DataTable";
@@ -151,6 +151,7 @@ export function VehicleTable({ rows, context = "global", emptyMessage = "No vehi
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [expandedTab, setExpandedTab] = useState<"components" | "permissions">("components");
   const [instanceNames, setInstanceNames] = useState<Map<string, string>>(new Map());
+  const expandedContentRef = useRef<HTMLDivElement>(null);
   const columns = context === "player" ? PLAYER_COLUMNS : GLOBAL_COLUMNS;
   const partitionMapsKey = [...new Set(rows.map((row) => vehiclePartitionMap(row.map)).filter(Boolean))].sort().join(",");
 
@@ -160,6 +161,15 @@ export function VehicleTable({ rows, context = "global", emptyMessage = "No vehi
       setExpandedTab("components");
     }
   }, [expandedId, rows]);
+
+  // Moves focus into the expanded content so keyboard and screen-reader users
+  // land on what they just opened instead of staying on the (now possibly
+  // relocated) expand button. Fires only on an actual expandedId change --
+  // not on every render -- so a background row refresh never yanks focus
+  // away from a control the user is mid-interaction with.
+  useEffect(() => {
+    if (expandedId) expandedContentRef.current?.focus();
+  }, [expandedId]);
 
   useEffect(() => {
     const maps = partitionMapsKey ? partitionMapsKey.split(",") : [];
@@ -218,9 +228,12 @@ export function VehicleTable({ rows, context = "global", emptyMessage = "No vehi
           <p className="vehicles-expanded-header">{modules.length} component{modules.length === 1 ? "" : "s"}</p>
           {modules.length === 0 ? <p className="muted">No components fitted.</p> : <div className="vehicles-component-grid">{modules.map(renderComponent)}</div>}
         </div>;
-        if (!canEditPermissions) return componentsPanel;
+        // tabIndex=-1 makes this programmatically focusable (see the
+        // expandedId effect above) without adding it to the normal Tab
+        // order -- it is a landing point, not a control.
+        if (!canEditPermissions) return <div ref={expandedContentRef} tabIndex={-1}>{componentsPanel}</div>;
         return (
-          <div onClick={(event) => event.stopPropagation()}>
+          <div ref={expandedContentRef} tabIndex={-1} onClick={(event) => event.stopPropagation()}>
             <div className="vehicles-expanded-tablist" role="tablist">
               <button
                 role="tab"

--- a/console/web/src/features/vehicles/VehicleTable.tsx
+++ b/console/web/src/features/vehicles/VehicleTable.tsx
@@ -4,6 +4,7 @@ import type { VehicleModule, VehicleRow, VehicleSharedEntry } from "../../api/ve
 import { DataTable, type SortDirection } from "../../components/common/DataTable";
 import { cachedInstanceNames, resolveInstanceNames } from "../maps/instanceNames";
 import { friendlyMapName } from "../maps/mapNames";
+import { VehiclePermissionsTab } from "./VehiclePermissionsTab";
 
 const GLOBAL_COLUMNS = ["name", "type", "owner", "shared_with", "condition_percent", "fuel_percent", "location"];
 const PLAYER_COLUMNS = ["name", "type", "relationship", "owner", "condition_percent", "fuel_percent", "location"];
@@ -25,6 +26,8 @@ type VehicleTableProps = {
   sortColumn?: string;
   sortDirection?: SortDirection;
   onSort?: (column: string) => void;
+  canEditPermissions?: boolean;
+  onPermissionsSaved?: () => void;
 };
 
 function toNumber(value: unknown): number | null {
@@ -144,14 +147,18 @@ function renderComponent(module: VehicleModule, index: number) {
   );
 }
 
-export function VehicleTable({ rows, context = "global", emptyMessage = "No vehicles have been found yet.", sortColumn, sortDirection, onSort }: VehicleTableProps) {
+export function VehicleTable({ rows, context = "global", emptyMessage = "No vehicles have been found yet.", sortColumn, sortDirection, onSort, canEditPermissions = false, onPermissionsSaved }: VehicleTableProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [expandedTab, setExpandedTab] = useState<"components" | "permissions">("components");
   const [instanceNames, setInstanceNames] = useState<Map<string, string>>(new Map());
   const columns = context === "player" ? PLAYER_COLUMNS : GLOBAL_COLUMNS;
   const partitionMapsKey = [...new Set(rows.map((row) => vehiclePartitionMap(row.map)).filter(Boolean))].sort().join(",");
 
   useEffect(() => {
-    if (expandedId && !rows.some((row) => String(row.id) === expandedId)) setExpandedId(null);
+    if (expandedId && !rows.some((row) => String(row.id) === expandedId)) {
+      setExpandedId(null);
+      setExpandedTab("components");
+    }
   }, [expandedId, rows]);
 
   useEffect(() => {
@@ -170,6 +177,10 @@ export function VehicleTable({ rows, context = "global", emptyMessage = "No vehi
   }, [partitionMapsKey]);
 
   function toggleExpanded(id: string) {
+    // A different vehicle's expansion should never inherit the previous one's
+    // tab -- landing on Permissions for a vehicle that was never showing it
+    // would look like a stale/wrong panel.
+    setExpandedTab("components");
     setExpandedId((current) => current === id ? null : id);
   }
 
@@ -200,8 +211,45 @@ export function VehicleTable({ rows, context = "global", emptyMessage = "No vehi
       onRowClick={(row) => toggleExpanded(String((row as VehicleRow).id))}
       isRowExpanded={(row) => expandedId === String((row as VehicleRow).id)}
       renderExpandedRow={(row) => {
-        const modules: VehicleModule[] = Array.isArray((row as VehicleRow).modules) ? (row as VehicleRow).modules : [];
-        return <div className="vehicles-expanded"><p className="vehicles-expanded-header">{modules.length} component{modules.length === 1 ? "" : "s"}</p>{modules.length === 0 ? <p className="muted">No components fitted.</p> : <div className="vehicles-component-grid">{modules.map(renderComponent)}</div>}</div>;
+        const vehicle = row as VehicleRow;
+        const id = String(vehicle.id);
+        const modules: VehicleModule[] = Array.isArray(vehicle.modules) ? vehicle.modules : [];
+        const componentsPanel = <div className="vehicles-expanded">
+          <p className="vehicles-expanded-header">{modules.length} component{modules.length === 1 ? "" : "s"}</p>
+          {modules.length === 0 ? <p className="muted">No components fitted.</p> : <div className="vehicles-component-grid">{modules.map(renderComponent)}</div>}
+        </div>;
+        if (!canEditPermissions) return componentsPanel;
+        return (
+          <div onClick={(event) => event.stopPropagation()}>
+            <div className="vehicles-expanded-tablist" role="tablist">
+              <button
+                role="tab"
+                id={`vehicles-tab-components-${id}`}
+                aria-selected={expandedTab === "components"}
+                aria-controls={`vehicles-panel-components-${id}`}
+                className={`vehicles-expanded-tab${expandedTab === "components" ? " active" : ""}`}
+                onClick={() => setExpandedTab("components")}
+              >Components</button>
+              <button
+                role="tab"
+                id={`vehicles-tab-permissions-${id}`}
+                aria-selected={expandedTab === "permissions"}
+                aria-controls={`vehicles-panel-permissions-${id}`}
+                className={`vehicles-expanded-tab${expandedTab === "permissions" ? " active" : ""}`}
+                onClick={() => setExpandedTab("permissions")}
+              >Permissions</button>
+            </div>
+            {expandedTab === "components"
+              ? <div role="tabpanel" id={`vehicles-panel-components-${id}`} aria-labelledby={`vehicles-tab-components-${id}`}>{componentsPanel}</div>
+              : <div role="tabpanel" id={`vehicles-panel-permissions-${id}`} aria-labelledby={`vehicles-tab-permissions-${id}`}>
+                  <VehiclePermissionsTab
+                    vehicleId={id}
+                    vehicleName={String(vehicle.name || `vehicle ${id}`)}
+                    onSaved={() => onPermissionsSaved?.()}
+                  />
+                </div>}
+          </div>
+        );
       }}
       emptyMessage={emptyMessage}
     />

--- a/console/web/src/features/vehicles/VehiclesPanel.test.tsx
+++ b/console/web/src/features/vehicles/VehiclesPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mapsApi } from "../../api/maps";
 import { vehiclesApi, type VehiclesListResponse } from "../../api/vehicles";
@@ -9,7 +9,10 @@ vi.mock("../../api/maps", () => ({ mapsApi: { sietchDimensions: vi.fn() } }));
 
 vi.mock("../../api/vehicles", () => ({
   vehiclesApi: {
-    list: vi.fn()
+    list: vi.fn(),
+    permissions: vi.fn(),
+    setPermissions: vi.fn(),
+    permissionCandidates: vi.fn()
   }
 }));
 
@@ -291,5 +294,51 @@ describe("VehiclesPanel", () => {
     await waitFor(() => {
       expect(vi.mocked(vehiclesApi.list)).toHaveBeenCalledWith(expect.objectContaining({ pageSize: 100 }));
     });
+  });
+
+  it("hides the Permissions tab when the schema lacks the capability", async () => {
+    vi.mocked(vehiclesApi.list).mockResolvedValue(listResponse({ capabilities: { vehicles: true } }));
+    renderPanel();
+
+    fireEvent.click(await screen.findByLabelText("Show components for Sihaya"));
+    await screen.findByText("1 component");
+    expect(screen.queryByRole("tab", { name: "Permissions" })).not.toBeInTheDocument();
+  });
+
+  it("shows the Permissions tab and refetches the list after a save", async () => {
+    vi.mocked(vehiclesApi.list).mockResolvedValue(listResponse({ capabilities: { vehicles: true, vehiclePermissions: true } }));
+    vi.mocked(vehiclesApi.permissions).mockResolvedValue({
+      supported: true,
+      vehicleId: 5001,
+      actorId: "5001",
+      map: "HaggaBasin",
+      mapNameId: 1,
+      entries: [{ playerId: "4", name: "Duncan_Idaho", rank: 1, label: "", canonical: true }]
+    } as never);
+    renderPanel();
+
+    fireEvent.click(await screen.findByLabelText("Show components for Sihaya"));
+    fireEvent.click(await screen.findByRole("tab", { name: "Permissions" }));
+
+    await screen.findByText("Duncan_Idaho", { selector: ".vehicles-permissions-owner-name" });
+    expect(vi.mocked(vehiclesApi.list)).toHaveBeenCalledTimes(1);
+
+    vi.mocked(vehiclesApi.setPermissions).mockResolvedValue({
+      supported: true,
+      result: { ok: true, vehicleId: 5001, actorId: "5001", map: "HaggaBasin", added: 1, reranked: 0, removed: 0, total: 2, message: "Permissions were updated." }
+    } as never);
+    const search = screen.getByPlaceholderText("Search a player to add");
+    fireEvent.change(search, { target: { value: "Leto" } });
+    vi.mocked(vehiclesApi.permissionCandidates).mockResolvedValue({ rows: [{ playerId: "9", name: "Leto_A" }] } as never);
+    // Scoped to the permissions add row: the page's own vehicle search bar
+    // has its own "Search"/"Clear" buttons with the same accessible names.
+    const addRow = within(document.querySelector(".vehicles-permissions-add") as HTMLElement);
+    fireEvent.click(addRow.getByRole("button", { name: "Search" }));
+    fireEvent.click(await addRow.findByRole("button", { name: "Add Leto_A" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Save changes" }));
+
+    // A saved roster invalidates the list cache -- owner/shared_with are
+    // rendered from the list response, not the permissions tab's own state.
+    await waitFor(() => expect(vi.mocked(vehiclesApi.list)).toHaveBeenCalledTimes(2));
   });
 });

--- a/console/web/src/features/vehicles/VehiclesPanel.tsx
+++ b/console/web/src/features/vehicles/VehiclesPanel.tsx
@@ -26,6 +26,7 @@ type VehiclesCache = {
   totalCount: number;
   totalVehicles: number;
   supported: boolean;
+  canEditPermissions: boolean;
   reason: string;
   lastFetchedAt: number;
 };
@@ -51,6 +52,7 @@ export function VehiclesPanel({ onError }: VehiclesPanelProps) {
   const [totalCount, setTotalCount] = useState(() => vehiclesCache?.totalCount ?? 0);
   const [totalVehicles, setTotalVehicles] = useState(() => vehiclesCache?.totalVehicles ?? 0);
   const [supported, setSupported] = useState(() => vehiclesCache?.supported ?? true);
+  const [canEditPermissions, setCanEditPermissions] = useState(() => vehiclesCache?.canEditPermissions ?? false);
   const [reason, setReason] = useState(() => vehiclesCache?.reason ?? "");
   const [loading, setLoading] = useState(() => vehiclesCache === null);
   const requestIdRef = useRef(0);
@@ -96,10 +98,12 @@ export function VehiclesPanel({ onError }: VehiclesPanelProps) {
       if (requestIdRef.current !== requestId) return;
       const nextRows = result.rows || [];
       const nextSupported = result.capabilities?.vehicles !== false;
+      const nextCanEditPermissions = result.capabilities?.vehiclePermissions === true;
       setRows(nextRows);
       setTotalCount(result.totalCount || 0);
       setTotalVehicles(result.totalVehicles || 0);
       setSupported(nextSupported);
+      setCanEditPermissions(nextCanEditPermissions);
       setReason(result.reason || "");
       vehiclesCache = {
         q: params.q,
@@ -111,6 +115,7 @@ export function VehiclesPanel({ onError }: VehiclesPanelProps) {
         totalCount: result.totalCount || 0,
         totalVehicles: result.totalVehicles || 0,
         supported: nextSupported,
+        canEditPermissions: nextCanEditPermissions,
         reason: result.reason || "",
         lastFetchedAt: Date.now()
       };
@@ -132,6 +137,7 @@ export function VehiclesPanel({ onError }: VehiclesPanelProps) {
       setTotalCount(cacheHit.totalCount);
       setTotalVehicles(cacheHit.totalVehicles);
       setSupported(cacheHit.supported);
+      setCanEditPermissions(cacheHit.canEditPermissions);
       setReason(cacheHit.reason);
       setLoading(false);
     }
@@ -209,6 +215,14 @@ export function VehiclesPanel({ onError }: VehiclesPanelProps) {
           sortDirection={sortDirection}
           onSort={handleSort}
           emptyMessage="No vehicles have been found yet."
+          canEditPermissions={canEditPermissions}
+          // Owner and Shared With are rendered from the list response, so a
+          // saved roster has to refetch or the row above keeps showing the
+          // pre-edit names.
+          onPermissionsSaved={() => {
+            vehiclesCache = null;
+            void load({ q: submittedQ, page, pageSize, sortColumn, sortDirection }, { silent: true });
+          }}
         />
         <div className="panel-title vehicles-pagination-footer">
           <p className="action-help-note">Showing {rangeStart}-{rangeEnd} of {totalCount} vehicles.</p>

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -1502,7 +1502,14 @@ body.debug .technical-details { display: block; }
 .playerAdmin_actionRow .playerAdmin_fieldGroup { display: grid; grid-template-columns: repeat(auto-fit, minmax(0, 1fr)); gap: 10px; align-items: start; }
 .playerAdmin_actionRow .playerAdmin_fieldGroup input, .playerAdmin_actionRow .playerAdmin_fieldGroup select { width: 100%; max-width: none; min-height: 40px; }
 .playerAdmin_actionRow button, .playerAdmin_buttonRow button { width: auto; min-height: 40px; }
-.playerAdmin_actionNote, .action-help-note { margin: 0; color: #cbbd9f; font-size: 15px; font-style: italic; line-height: 1.4; }
+/* white-space: normal is not the no-op it looks like -- both notes can render
+   inside an expanded-row-cell <td>, and the global `td { white-space: nowrap }`
+   rule (table cell default, meant for compact data cells) otherwise inherits
+   straight through, letting a long explanatory sentence render as one
+   unbroken line that visually overflows a narrow grid column instead of
+   wrapping -- reproduced in the Base/Vehicle Permissions tabs' two-column
+   intro row at viewport widths around 700-900px. */
+.playerAdmin_actionNote, .action-help-note { margin: 0; color: #cbbd9f; font-size: 15px; font-style: italic; line-height: 1.4; white-space: normal; }
 .playerAdmin_actionNote { padding-left: 190px; max-width: 900px; font-style: italic; }
 .action-help-note { max-width: 820px; }
 .playerAdmin_box > p { font-style: italic; }

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2780,6 +2780,35 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
 }
 .bases-expanded-tab.active:hover { border-color: var(--border-strong); border-bottom-color: #25201b; }
 
+/* Same spec as .bases-expanded-tab* above, under vehicles' own class names --
+   see the vehicles-permissions CSS scoping decision. */
+.vehicles-expanded-tablist {
+  display: flex;
+  gap: 4px;
+  border-bottom: 1px solid var(--border-strong);
+  margin-bottom: 14px;
+  padding-top: 8px;
+}
+.vehicles-expanded-tab {
+  width: auto;
+  min-width: 0;
+  border: 1px solid transparent;
+  border-radius: 6px 6px 0 0;
+  background: transparent;
+  color: var(--muted);
+  padding: 9px 16px;
+  font-size: 13px;
+  margin-bottom: -1px;
+}
+.vehicles-expanded-tab:hover { color: var(--muted-warm); border-color: transparent; }
+.vehicles-expanded-tab.active {
+  background: #25201b;
+  border-color: var(--border-strong);
+  border-bottom-color: #25201b;
+  color: var(--title);
+}
+.vehicles-expanded-tab.active:hover { border-color: var(--border-strong); border-bottom-color: #25201b; }
+
 .playerAdmin_invGroupTabs { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
 .playerAdmin_invGroupTab {
   width: auto;
@@ -3683,6 +3712,285 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   }
   .bases-permissions-actions { justify-content: flex-end; }
 }
+
+/* Vehicle permissions. Same rules as .bases-permissions-* above (both editors
+   share the rosterEditor.tsx component and look identical today), kept under
+   separate class names so the two features can diverge in CSS independently
+   later without one edit touching the other's tab. */
+.vehicles-permissions {
+  --vehicles-permissions-measure: 100%;
+  --vehicles-permissions-inset: clamp(12px, 1.5vw, 18px);
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+}
+.vehicles-permissions-content {
+  display: grid;
+  gap: 12px;
+  width: 100%;
+  max-width: var(--vehicles-permissions-measure);
+  min-width: 0;
+  padding: var(--vehicles-permissions-inset);
+  box-sizing: border-box;
+}
+
+.vehicles-permissions-intro {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) minmax(360px, 500px);
+  align-items: center;
+  gap: clamp(18px, 3vw, 36px);
+}
+.vehicles-permissions-intro > .action-help-note {
+  max-width: 720px;
+}
+
+.vehicles-permissions-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 16px;
+  min-width: 0;
+  padding: 10px 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+/* Owner card. Read-only for vehicles -- no transfer action -- so this is
+   plain identity display, not the interactive hero card bases use. */
+.vehicles-permissions-owner-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--warning);
+  border-radius: 8px;
+  background: rgba(169, 121, 50, .08);
+}
+.vehicles-permissions-owner-card-empty {
+  border-color: var(--danger-strong);
+  background: rgba(167, 73, 73, .08);
+}
+.vehicles-permissions-owner-identity {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+.vehicles-permissions-owner-eyebrow {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  line-height: 1;
+}
+.vehicles-permissions-owner-name {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-strong);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1.2;
+}
+.vehicles-permissions-owner-none { color: var(--danger-text); font-style: italic; font-weight: 400; }
+
+.vehicles-permissions-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+.vehicles-permissions-section-title {
+  color: var(--title);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: .02em;
+  white-space: nowrap;
+}
+.vehicles-permissions-section-meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: right;
+}
+
+.vehicles-permissions-roster {
+  display: grid;
+  gap: 6px;
+  align-content: start;
+  max-height: 300px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.vehicles-permissions-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 38px;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  padding: 6px 10px;
+}
+.vehicles-permissions-name {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+.vehicles-permissions-remove { border-color: var(--danger-strong); color: var(--danger-text); }
+
+/* Segmented rank control -- same visual spec as .bases-rank-segments, under
+   its own class names per the vehicles-permissions CSS scoping decision. */
+.vehicles-rank-segments {
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  height: 38px;
+  min-width: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  background: #151719;
+  overflow: hidden;
+}
+.vehicles-rank-segment {
+  position: relative;
+  display: flex;
+  gap: 0;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 10px;
+  border-left: 1px solid var(--border);
+  color: var(--muted-warm);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+.vehicles-rank-segment:first-child { border-left: 0; }
+.vehicles-rank-segment input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+}
+.vehicles-rank-segment:hover { background: rgba(198, 139, 74, .12); color: var(--text-strong); }
+.vehicles-rank-segment:has(input:checked) { background: #9b5f2a; color: var(--text-strong); }
+.vehicles-rank-segment:has(input:focus-visible) { outline: 2px solid var(--accent-strong); outline-offset: -2px; }
+.vehicles-rank-segments:has(input:disabled) { opacity: .45; }
+.vehicles-rank-segment:has(input:disabled) { cursor: not-allowed; }
+
+.vehicles-permissions-add { display: grid; gap: 8px; min-width: 0; }
+.vehicles-permissions-search-row { flex-wrap: wrap; align-items: center; margin: 0; }
+.vehicles-permissions-search-row .compact-select {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  white-space: nowrap;
+}
+.vehicles-permissions-candidates {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.vehicles-permissions-candidates li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 5px 10px;
+  font-size: 13px;
+}
+.vehicles-permissions-candidates li span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.vehicles-permissions-banner-slot {
+  display: grid;
+  align-content: center;
+  gap: 8px;
+}
+.vehicles-permissions-warning { margin: 0; }
+.vehicles-permissions-error { color: var(--danger-text); margin: 0; }
+.vehicles-permissions-banner-slot .inline-task-result {
+  align-self: auto;
+  flex: 0 1 auto;
+  max-width: none;
+  margin: 0;
+}
+
+.vehicles-permissions-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  justify-content: flex-end;
+  min-width: 0;
+  min-height: 42px;
+}
+.vehicles-permissions-actions > .muted { font-size: 12px; white-space: nowrap; }
+.vehicles-permissions-actions > .muted:empty { display: none; }
+.vehicles-permissions-actions button { width: auto; }
+
+@media (max-width: 560px) {
+  .vehicles-permissions-row {
+    grid-template-columns: minmax(0, 1fr) 38px;
+    grid-template-areas: "name remove" "rank rank";
+    row-gap: 6px;
+  }
+  .vehicles-permissions-name { grid-area: name; }
+  .vehicles-rank-segments { grid-area: rank; display: grid; }
+  .vehicles-permissions-remove { grid-area: remove; }
+  .vehicles-permissions-owner-card {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: stretch;
+  }
+}
+@media (max-width: 700px) {
+  .vehicles-permissions-intro {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
+  }
+  .vehicles-permissions-intro > .action-help-note { max-width: none; }
+}
+@media (max-width: 900px) {
+  .vehicles-permissions-toolbar {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 10px;
+  }
+  .vehicles-permissions-actions { justify-content: flex-end; }
+}
+
 .bases-table th.bases-expand-column, .bases-table td.bases-expand-column {
   width: 32px;
   padding-inline: 4px;

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -3948,13 +3948,25 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   align-content: center;
   gap: 8px;
 }
-.vehicles-permissions-warning { margin: 0; }
-.vehicles-permissions-error { color: var(--danger-text); margin: 0; }
+/* white-space: normal for the same reason the action-help-note fix above
+   exists: unlike .bases-table, .vehicles-table has no blanket
+   `td { white-space: normal }` reset, so this prose (including the
+   server-supplied unclaimedReason string, and common -- ~1 in 5 vehicles is
+   unclaimed) would otherwise inherit nowrap from the global `th, td` rule
+   and render as one unbroken line clipped by the expanded-row-cell's
+   overflow:hidden instead of wrapping. */
+.vehicles-permissions-warning { margin: 0; white-space: normal; }
+.vehicles-permissions-error { color: var(--danger-text); margin: 0; white-space: normal; }
 .vehicles-permissions-banner-slot .inline-task-result {
   align-self: auto;
   flex: 0 1 auto;
   max-width: none;
   margin: 0;
+  /* Same inherited-nowrap gap as .vehicles-permissions-warning/-error above --
+     the save-result message (e.g. "Permissions were updated. The change
+     applies to the running map immediately.") is exactly the kind of prose
+     that bug clips instead of wraps. */
+  white-space: normal;
 }
 
 .vehicles-permissions-actions {

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,6 +53,7 @@ by nature, so it gets its own.
 - [generator-fuel-burn-rates.md](console/generator-fuel-burn-rates.md) — Current. Per-generator fuel burn constants and where they live in code.
 - [generator-refill-caps.md](console/generator-refill-caps.md) — Current. Refill-generators endpoint behavior and per-type fuel caps.
 - [base-permissions.md](console/base-permissions.md) — Current. Editing base ownership and sharing: ranks, the config-driven roster cap, and why the change needs no map restart.
+- [vehicle-permissions.md](console/vehicle-permissions.md) — Current. Editing vehicle ownership and sharing: the same roster engine as base permissions, minus the ownership-transfer action.
 - [base-inventory.md](console/base-inventory.md) — Current. The base Inventory tab: which placeables count as storage, the two inventories every refinery carries, per-slot container contents, and the stopped-map safety boundary for deleting stored items.
 - [base-deletion.md](console/base-deletion.md) — Current. Permanently deleting a base: what "the base" means for enumeration, the pending-delete queue for a live map, the mandatory pre-delete safety backup, and why a pending delete freezes every other mutation on that base.
 - [base-backups.md](console/base-backups.md) — Current. What the game's own "pick up base" tool actually does in the database, why the Bases panel excludes a picked-up base, and the Coriolis compatibility patch that preserves saved Deep Desert base actors.

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -358,11 +358,24 @@ tab can offer a retry only where retrying could actually help.
 |--------|-------|-------------|------------|
 | GET | `/api/vehicles` | List all player vehicles (paginated), each with owner, shared-with roster, lowest-component condition %, fuel %, map/partition, coordinates, and per-component durability | `q?`, `page?`, `pageSize?`, `sortColumn?`, `sortDirection?` |
 | GET | `/api/players/{playerId}/vehicles` | List the selected player's owned and shared vehicles using the same vehicle details | `playerId` |
+| GET | `/api/vehicles/{vehicleId}/permissions` | Get a vehicle's permission roster (Owner, Co-Owners, Associates) | `vehicleId` |
+| PUT | `/api/vehicles/{vehicleId}/permissions` | Replace a vehicle's permission roster | `vehicleId`, `entries[]` (`playerId`, `rank`) |
+| GET | `/api/vehicles/permission-candidates` | Search players eligible to be added to a vehicle roster | `q?`, `limit?` |
 
-Read-only. `GET /api/vehicles` reports `capabilities.vehicles`; it is false (with a
+`GET /api/vehicles` and the player-scoped list are read-only; the three
+permission routes above are the only vehicle mutations, and they share their
+implementation with the base permission routes -- see
+[vehicle-permissions.md](vehicle-permissions.md). Unlike bases, there is no
+vehicle transfer/system-custodian route by design.
+
+`GET /api/vehicles` reports `capabilities.vehicles`; it is false (with a
 `reason`) when the schema lacks the required tables (`vehicles`, `vehicle_modules`,
 `actors`, `permission_actor`, `permission_actor_rank`, `player_state`,
-`actor_fgl_entities`, `fgl_entities`). Sortable `sortColumn` values: `id`, `name`,
+`actor_fgl_entities`, `fgl_entities`). It also reports
+`capabilities.vehiclePermissions` (the schema additionally has `dune.map_names`
+and the game's `permission_set_player_rank` / `permission_remove_player_rank`
+procedures) -- the permission routes and the Permissions tab are unavailable
+when it is false. Sortable `sortColumn` values: `id`, `name`,
 `type`, `owner`, `condition_percent`, `fuel_percent`, `map`; `q` matches vehicle
 name, type, owner, map, and exact id. Response fields mirror the paginated-list
 convention (`rows`, `totalCount`, unfiltered `totalVehicles`). Owner resolves from

--- a/docs/console/base-permissions.md
+++ b/docs/console/base-permissions.md
@@ -242,4 +242,6 @@ once per list request rather than per row.
 
 - [generator-refill-caps.md](generator-refill-caps.md) — the refill endpoint, and
   the queue this feature deliberately does not use.
+- [vehicle-permissions.md](vehicle-permissions.md) — the same roster-editing
+  engine applied to vehicles, minus the system-custodian transfer.
 - [API-REFERENCE.md](API-REFERENCE.md) — full HTTP API reference.

--- a/docs/console/vehicle-permissions.md
+++ b/docs/console/vehicle-permissions.md
@@ -1,0 +1,137 @@
+# Vehicle permissions
+
+**Status:** Current | **Last Updated:** August 2026
+
+The Vehicles panel can edit who owns a vehicle and who it is shared with. The
+editor lives in the **Permissions** tab of an expanded vehicle row, alongside
+the existing **Components** tab. Both the global Vehicles panel and a player's
+own Vehicles tab expand through the same `VehicleTable` component, so the tab
+appears in either place once the schema supports it.
+
+Unlike generator refills, permission changes are **not** queued for a map
+restart — they reach a running map immediately. See
+[Why there is no queue](#why-there-is-no-queue).
+
+Vehicle permissions share nearly all of their implementation with
+[base permissions](base-permissions.md): the same `dune.permission_actor_rank`
+table, the same shipped stored procedures, and the same transactional
+roster-diff engine (`mutatePermissionRoster` in `duneDb.js`). The one
+deliberate difference is that vehicles have **no ownership-transfer action** —
+no equivalent of bases' Transfer to Custodian.
+
+## Ranks
+
+Permissions are rows in `dune.permission_actor_rank`, one per player per
+vehicle:
+
+| Rank | Label | Notes |
+|---:|---|---|
+| 1 | Owner | Exactly one per vehicle. Shown in the **Owner** column. |
+| 2 | Co-Owner | Shown in the **Shared With** column. |
+| 3 | Associate | Shown in the **Shared With** column. |
+
+Same 5/4/3 in-game decoration note as bases: the game's own panel displays
+those numbers beside the labels, but no row in `permission_actor_rank` ever
+holds a 4 or 5.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/vehicles/:vehicleId/permissions` | The vehicle's roster, with resolved names and rank labels. |
+| `PUT` | `/api/vehicles/:vehicleId/permissions` | Replace the roster. Body: `{ entries: [{ playerId, rank }] }`. |
+| `GET` | `/api/vehicles/permission-candidates?q=&limit=` | Player search for the add-player picker. |
+
+There is no vehicle equivalent of `POST /api/bases/:baseId/system-custodian` —
+by design, vehicles do not offer an ownership-transfer action.
+
+`PUT` takes a **whole roster**, not a delta, applied the same way bases'
+roster save is: the server diffs it against current state and applies only
+the difference, skipping an unchanged row since every write emits a
+notification.
+
+Roster saves are audited as `vehicles.set-permissions` and rate limited. No
+confirmation phrase is required by the API, matching the base roster save;
+the change is reversible from the same editor.
+
+## What the server enforces
+
+Client-side rules are re-checked server-side; none of them are trusted from
+the request.
+
+- **Exactly one Owner.** The outgoing Owner is demoted first, in the same
+  transaction, for the same reason as bases.
+- **The roster cap**, read from live server config (see below).
+- **Ranks limited to 1–3**, no duplicate players.
+- **Every player id must be a `player_controller_id`** — the same canonical
+  check bases use, since it validates against `player_state`/
+  `encrypted_player_state`, not anything vehicle-specific.
+- **The vehicle must be claimed** (see below).
+
+## An unclaimed vehicle is refused, not attempted
+
+Same foreign key as bases: `permission_actor_rank.permission_actor_id`
+references `dune.permission_actor(actor_id)`, and a vehicle can have every
+structural row intact — `dune.vehicles`, `dune.actors` — with no
+`permission_actor` row. The mutation route checks for that row, inside the
+transaction and after taking the actor lock, and refuses with *"This vehicle
+is not claimed…"* rather than letting the write reach the constraint and
+surface raw PostgreSQL text to the operator.
+
+`GET` still succeeds on such a vehicle — the roster is simply empty — and
+returns `claimed: false` plus `unclaimedReason`. The tab uses those to disable
+Save, the rank controls, and the remove buttons.
+
+## The roster cap comes from server config
+
+Same setting bases use — `permission_max_permissions_per_actor` — since the
+cap is per **permission actor**, and a vehicle is one. See
+[base-permissions.md's roster cap section](base-permissions.md#the-roster-cap-comes-from-server-config)
+for the full precedence explanation
+(`parseEffectivePermissionLimit`, the legacy `DuneGameMode` fallback, and the
+Advanced Editor footgun). Nothing about that logic is vehicle-specific.
+
+## A vehicle is its own permission actor
+
+Unlike a base — whose id and permission actor id differ, resolved through a
+`buildings → building_instances → actor_fgl_entities → actors` chain — a
+vehicle **is** its own actor:
+`dune.vehicles.id = dune.actors.id = dune.permission_actor.actor_id`. There is
+no separate id to resolve and no multi-hop join.
+
+`vehiclePermissionActor` still joins through `dune.vehicles` rather than
+resolving straight off `dune.actors`, even though that adds no indirection.
+That join is what rejects a non-vehicle actor id — a base's, say — passed to
+this route: an id with no row in `dune.vehicles` fails the join and surfaces
+as the ordinary *"That vehicle was not found"* error, the same message a
+genuinely nonexistent id gets.
+
+## Why there is no queue
+
+Same mechanism as bases: the game ships stored procedures that notify the
+running server, and the console calls those rather than writing the table
+directly.
+
+- `dune.permission_set_player_rank(actor_id, player_id, rank, map_id)`
+- `dune.permission_remove_player_rank(actor_id, player_id)`
+
+See [base-permissions.md](base-permissions.md#why-there-is-no-queue) for the
+full explanation of the notify channel and why direct DML is refused.
+
+## Capability gating
+
+The panel hides the editor unless `listVehicles` reports
+`capabilities.vehiclePermissions`. That requires the same schema base
+permissions do — `dune.permission_actor_rank`, `dune.permission_actor`,
+`dune.actors`, `dune.player_state`, `dune.map_names`, plus both stored
+procedures — probed once per list request. `listVehicles` already proves most
+of those tables exist via its own `requiredTables` check, so the capability
+probe only has to verify `dune.map_names` and the two procedures on top of
+that.
+
+## Related
+
+- [base-permissions.md](base-permissions.md) — the feature this one is
+  modeled on; read it first for the parts that are identical (the notify
+  mechanism, search_path, write ordering, and the roster cap).
+- [API-REFERENCE.md](API-REFERENCE.md) — full HTTP API reference.


### PR DESCRIPTION
## Summary
- Adds a Vehicle Permissions tab (Owner/Co-Owner/Associate roster editing) mirroring Base Permissions, minus the ownership-transfer/system-custodian action -- vehicles are their own permission actor (`dune.vehicles.id = dune.actors.id`), so there's no id resolution to do
- Extracts the shared roster-diff transaction engine out of the base-permission code (`permissionEditingSupported`, `permissionActorClaimed`, `listPermissionRoster`, `permissionCandidatesQuery`, `mutatePermissionRoster`) so both features share one correctness-critical write path
- New routes: `GET/PUT /api/vehicles/:id/permissions`, `GET /api/vehicles/permission-candidates`, gated behind `capabilities.vehiclePermissions` and RBAC's new `vehicles:mutate` action
- Fixes two CSS bugs found while live-testing: inherited `white-space: nowrap` clipping prose in the permissions tab (also affected Base Permissions, now fixed for both), and a scroll-jump when expanding a row near the viewport bottom

## Test plan
- [x] `console/api` full suite (Docker/Postgres 17.4 container): 1300/1300 pass
- [x] `console/web` full suite: 474/474 pass, typecheck clean
- [x] Live-tested against a restored production-shaped dataset (92 vehicles, ~22% unclaimed): unclaimed-vehicle banner, promote/demote/add/remove/save/revert, and the list-row refresh-after-save all verified working from both entry points (Vehicles panel and a player's Vehicles tab)
- [x] Confirmed no transfer/ownership-transfer control renders anywhere in the vehicle tab (explicit regression test)