### PR TITLE
fix(console): stop requiring a hard refresh after Console Update

### DIFF
--- a/console/api/src/http/staticFiles.js
+++ b/console/api/src/http/staticFiles.js
@@ -35,6 +35,14 @@ export function serveStatic(config, req, res) {
     json(res, 200, { app: config.appName, message: "Frontend is not built yet. Run npm install && npm run build in console/web/." });
     return;
   }
-  res.writeHead(200, withSecurityHeaders({ "content-type": contentTypeForPath(target), "cache-control": cacheControlForPath(path) }));
+  // safeStaticTarget silently falls back to index.html for any unrecognized
+  // path, including a stale /assets/*.js URL a pre-update browser still
+  // references after a rebuild removes it. Deciding cache-control from the
+  // *requested* path alone would tag that fallback response -- the HTML
+  // shell -- as an immutable JS asset forever, so a stale browser could never
+  // recover without a hard refresh. Only the path that actually resolved to
+  // a real file under /assets/ earns the long-lived cache.
+  const servedRequestedAsset = path.startsWith("/assets/") && !target.endsWith("index.html");
+  res.writeHead(200, withSecurityHeaders({ "content-type": contentTypeForPath(target), "cache-control": servedRequestedAsset ? cacheControlForPath(path) : "no-cache" }));
   createReadStream(target).pipe(res);
 }

--- a/console/api/test/staticFiles.test.js
+++ b/console/api/test/staticFiles.test.js
@@ -65,3 +65,27 @@ test("serveStatic sends cache-control: no-cache for index.html and immutable for
     rmSync(dist, { recursive: true, force: true });
   }
 });
+
+test("serveStatic never tags a stale-asset fallback to index.html as an immutable asset", async () => {
+  // A pre-update browser can still reference a hashed /assets file a rebuild
+  // has since removed. safeStaticTarget falls back to index.html for that
+  // request; cacheControlForPath(path) alone would misread the /assets/
+  // prefix and cache the HTML shell forever under that JS URL, so no reload
+  // could ever recover without a hard refresh.
+  const dist = mkdtempSync(join(tmpdir(), "static-files-test-"));
+  try {
+    mkdirSync(join(dist, "assets"));
+    writeFileSync(join(dist, "index.html"), "<html></html>");
+    writeFileSync(join(dist, "assets", "index-newhash.js"), "console.log(1);");
+    const config = { staticDir: dist, appName: "Test" };
+
+    const staleAssetRes = fakeResponse();
+    serveStatic(config, { url: "/assets/index-oldhash.js" }, staleAssetRes);
+    await once(staleAssetRes, "finish");
+    assert.equal(staleAssetRes.status, 200);
+    assert.equal(staleAssetRes.headers["content-type"], "text/html; charset=utf-8");
+    assert.equal(staleAssetRes.headers["cache-control"], "no-cache");
+  } finally {
+    rmSync(dist, { recursive: true, force: true });
+  }
+});

--- a/console/web/src/features/updates/UpdatesPanel.tsx
+++ b/console/web/src/features/updates/UpdatesPanel.tsx
@@ -648,6 +648,7 @@ function StackUpdateProgress({
     </div>
     <p>{formatResultMessage(progress.message)}</p>
     {refreshCountdown !== null && <div className="action-line"><button onClick={() => window.location.reload()}>Refresh Now</button></div>}
+    {refreshCountdown === null && helperProgress?.state === "succeeded" && <div className="action-line"><button onClick={() => window.location.reload()}>Refresh Now</button><span className="muted">The update helper finished. Refresh manually if this page does not detect it shortly.</span></div>}
     {task.status === "succeeded" && !isDetachedStackUpdateTask(task) && <div className="action-line"><button onClick={() => window.location.reload()}>Refresh Console</button></div>}
     {task.status === "failed" && <div className="action-line"><button onClick={onRetry}>Retry Console Update</button></div>}
   </div>;


### PR DESCRIPTION
## Summary
- Console update was still requiring a hard refresh often to load pages after applying. Root cause: the static file server tagged the SPA's `index.html` fallback as an immutable, forever-cached JS asset whenever a browser (running the pre-update bundle) requested an old hashed asset filename the rebuild had removed. Cache-control was decided from the request path, not from what was actually served — poisoning the browser cache under the old asset URL until a hard refresh cleared it.
- The detached update flow's own version-match polling had no manual fallback: if it never detected the new version, the UI spun on "Waiting for Updated Console" indefinitely with no way to recover except a manual browser refresh.

## Changes
- `console/api/src/http/staticFiles.js`: cache-control is now based on whether a real `/assets/` file was actually served, not the raw request path.
- `console/web/src/features/updates/UpdatesPanel.tsx`: show a manual "Refresh Now" button as soon as the update helper reports success, instead of only after the frontend's own version-match polling succeeds.

## Test plan
- [x] `console/api` full suite via `.claude/scripts/test-api.sh` (compliant Docker/Postgres runner): 1226/1226 pass, 0 skipped
- [x] `console/web` typecheck via direct `tsc` binary: clean
- [x] `console/web` `UpdatesPanel` unit tests via vitest: pass