### PR TITLE
fix(bases): post-merge fixes for Give/Fill volume_override, docs, and type accuracy

### DIFF
--- a/console/api/scripts/repair-volume-override.mjs
+++ b/console/api/scripts/repair-volume-override.mjs
@@ -74,6 +74,7 @@ try {
     select id, template_id, stack_size, volume_override
     from dune.items
     where volume_override is not null
+      and volume_override <> 0
     order by id`);
 
   let correct = 0;
@@ -146,7 +147,10 @@ try {
       await tx.query("update dune.items set volume_override = $1 where id = $2", [change.to, change.id]);
     }
     if (zeroRows.rows.length > 0) {
-      await tx.query("update dune.items set volume_override = null where volume_override = 0");
+      await tx.query(
+        "update dune.items set volume_override = null where id = any($1::bigint[]) and volume_override = 0",
+        [zeroRows.rows.map((row) => String(row.id))]
+      );
     }
   });
   console.log(`\nApplied ${changes.length + zeroRows.rows.length} correction(s) (${changes.length} recomputed, ${zeroRows.rows.length} cleared to NULL).`);

--- a/console/api/scripts/repair-volume-override.mjs
+++ b/console/api/scripts/repair-volume-override.mjs
@@ -30,6 +30,21 @@
 // item) is left untouched and reported separately -- there is nothing safe
 // to recompute it to.
 //
+// SECOND PASS (added 2026-08-20, post-merge review of upstream PR #182):
+// every Give/Fill insert site also had a related bug where an item with NO
+// catalogued volume at all (not a stale/wrong value -- genuinely never had
+// one) got volume_override stored as the number 0 instead of SQL NULL. Per
+// this same script's header comment above, the live engine NEVER itself
+// writes a non-null volume_override -- so any row with volume_override = 0
+// (exactly, not just non-null) is presumptively a console-inserted row from
+// this bug, safe to correct to NULL universally without needing to trace
+// which specific route created it. This pass finds every such row and
+// clears it to NULL, regardless of whether template_id is in today's
+// catalog (a 0 for a catalogued item with a real non-zero catalog volume is
+// still wrong -- correcting to NULL, not to the catalog value, matches the
+// insert-side fix: NULL, not a recomputed number, is what a fresh insert
+// would write today).
+//
 // Usage:
 //   node scripts/repair-volume-override.mjs            (dry run, default)
 //   node scripts/repair-volume-override.mjs --apply     (writes changes)
@@ -88,7 +103,22 @@ try {
   console.log(`  Unknown template_id (left untouched): ${unknownTemplate}`);
   console.log(`  To correct: ${toFix}`);
 
-  if (toFix === 0) {
+  // Second pass (2026-08-20): rows with volume_override exactly 0, from the
+  // uncatalogued-item Give/Fill insert bug fixed alongside this pass -- see
+  // this file's header comment. Scanned separately from the pass above
+  // because these rows need no catalog lookup at all: a stored 0 is never
+  // correct regardless of what the catalog says (a fresh insert today would
+  // write NULL, not a recomputed number), so every such row is corrected to
+  // NULL unconditionally.
+  const zeroRows = await db.query(`
+    select id, template_id, stack_size
+    from dune.items
+    where volume_override = 0
+    order by id`);
+
+  console.log(`\nScanned ${zeroRows.rows.length} row(s) with volume_override = 0 (the separate NULL-vs-0 bug).`);
+
+  if (toFix === 0 && zeroRows.rows.length === 0) {
     console.log("Nothing to do.");
     process.exit(0);
   }
@@ -102,6 +132,9 @@ try {
       `(engine-displayed volume ${displayedBefore} -> ${displayedAfter})`
     );
   }
+  for (const row of zeroRows.rows) {
+    console.log(`  id=${row.id} template_id=${row.template_id} stack_size=${row.stack_size} volume_override 0 -> NULL`);
+  }
 
   if (!apply) {
     console.log("\nDry run only -- no changes written. Re-run with --apply to write these corrections.");
@@ -112,8 +145,11 @@ try {
     for (const change of changes) {
       await tx.query("update dune.items set volume_override = $1 where id = $2", [change.to, change.id]);
     }
+    if (zeroRows.rows.length > 0) {
+      await tx.query("update dune.items set volume_override = null where volume_override = 0");
+    }
   });
-  console.log(`\nApplied ${changes.length} correction(s).`);
+  console.log(`\nApplied ${changes.length + zeroRows.rows.length} correction(s) (${changes.length} recomputed, ${zeroRows.rows.length} cleared to NULL).`);
 } finally {
   await db.close?.();
 }

--- a/console/api/src/adminCatalog.js
+++ b/console/api/src/adminCatalog.js
@@ -31,21 +31,28 @@ export function resolveFillableCatalogItem(repoRoot, query = {}) {
   if (!resolved.group || !FILLABLE_GROUPS.has(resolved.group)) {
     throw new Error("Item type not allowed for fill operation");
   }
-  // Every FILLABLE_GROUPS item is expected to carry real, individually
-  // verified catalog volume data (raw_resource/refined_resource/component
-  // -- see the 19-item tagging this restriction shipped with). Found during
-  // code review (2026-08-19): a catalog entry missing or reset to 0 volume
-  // would silently resolve here anyway, and every downstream volume-cap
-  // check in giveItemToBaseContainer/fillItemToBaseContainer/
+  // Every FILLABLE_GROUPS item is expected to carry real catalog volume
+  // data (raw_resource/refined_resource/component -- see the item-tagging
+  // this restriction shipped with). Found during code review (2026-08-19):
+  // a catalog entry missing or reset to 0 volume would silently resolve
+  // here anyway, and every downstream volume-cap check in
+  // giveItemToBaseContainer/fillItemToBaseContainer/
   // giveMultipleItemsToBaseContainer treats itemVolume <= 0 as "this item
   // is not volume-tracked, skip the cap" -- correct for the standalone
   // Storage tab's much broader catalog (most weapons/gear/schematics
   // genuinely have no volume data, by design), but wrong here: it would let
   // an operator give/fill an unbounded quantity of a fillable resource into
-  // a volume-capped container. Not currently triggerable (today's 19
-  // fillable items all have real, verified volumes), but this closes the
-  // gap at the one layer both Give and Fill share, rather than trusting
-  // every future catalog edit to keep that invariant by hand.
+  // a volume-capped container. Not currently triggerable -- verified
+  // 2026-08-20 (post-merge review of upstream PR #182, which expanded
+  // FILLABLE_GROUPS to include raw_resource) that all 99 currently-fillable
+  // items have a non-zero catalogued volume -- but this closes the gap at
+  // the one layer both Give and Fill share, rather than trusting every
+  // future catalog edit to keep that invariant by hand. Note this is a
+  // presence/non-zero check, not per-item verification against the live
+  // engine the way a small, hand-reviewed set could be -- at 99 items and
+  // growing, some entries' catalogued volume may not have been individually
+  // confirmed in-game the way MelangeSpice's was (see
+  // docs/incidents/INC-2026-08-19-VOLUME-OVERRIDE-DOUBLE-MULTIPLIED.md).
   const volume = Number(resolved.volume) || resolveItemVolume(repoRoot, resolved.itemId);
   if (!(volume > 0)) {
     throw new Error(`Item ${resolved.itemId} is missing catalogued volume data and cannot be given or filled into a volume-tracked container.`);

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -7042,6 +7042,23 @@ function quantityThatFitsByVolume(maxVolume, currentVolume, unitVolume) {
   return Math.max(0, Math.floor(Math.max(0, max - current) / unit));
 }
 
+// FIX (found during upstream PR #182 post-merge review, 2026-08-20):
+// every Give/Fill insert site computed itemVolumeNum as `Number(itemVolume)
+// || 0` (see each function's own param default below) and then wrote that
+// value straight into volume_override -- indistinguishable, at the
+// database level, from a real, catalogued, exactly-zero volume. server.js's
+// own route handlers already document this exact gap ("itemVolume defaults
+// to 0 for any item without catalogued volume data") but the fix belongs
+// here, at the one place that actually writes the column: NULL means "use
+// the engine's own catalog volume" (the resolvedItemUnitVolume()/
+// inventoryVolumeState() convention this file already established above),
+// so an uncatalogued item's per-unit volume must be stored as NULL, not 0
+// -- storing 0 makes the engine display the item as having no volume at
+// all, rather than falling back to its own real catalog value.
+function volumeOverrideForInsert(itemVolumeNum) {
+  return itemVolumeNum > 0 ? itemVolumeNum : null;
+}
+
 export async function giveItemToStorage(db, storageId, { itemName = "", itemId = "", templateId = "", quantity = 1, quality = 0, itemVolume = 0, augments = [], augmentQuality = 1 }) {
   await requireCapability(await supportsStorageGiveItem(db), "Storage give-item requires compatible dune.inventories and dune.items insert columns including volume_override.");
   const target = intParam(storageId, "storage id", 1);
@@ -7136,7 +7153,7 @@ export async function giveItemToStorage(db, storageId, { itemName = "", itemId =
     // a total, matching this corrected per-unit convention.
     if (itemColumns.has("volume_override")) {
       insertColumns.push("volume_override");
-      insertValues.push(itemVolumeNum);
+      insertValues.push(volumeOverrideForInsert(itemVolumeNum));
     }
     const insert = itemInsertShape(insertColumns, insertValues, itemColumns);
     const inserted = await tx.query(`
@@ -7229,7 +7246,7 @@ export async function giveItemToBaseContainer(db, baseId, placeableId, { itemNam
     const insertValues = [inventory.id, resolvedTemplate, stackSize, qualityLevel, positionIndex, JSON.stringify(stats)];
     if (itemColumns.has("volume_override")) {
       insertColumns.push("volume_override");
-      insertValues.push(itemVolumeNum);
+      insertValues.push(volumeOverrideForInsert(itemVolumeNum));
     }
     const insert = itemInsertShape(insertColumns, insertValues, itemColumns);
     const inserted = await tx.query(`
@@ -7361,7 +7378,7 @@ export async function fillItemToStorage(db, repoRoot, storageId, { itemName = ""
     // against this container correct too.
     if (itemColumns.has("volume_override")) {
       insertColumns.push("volume_override");
-      insertValues.push(itemVolumeNum);
+      insertValues.push(volumeOverrideForInsert(itemVolumeNum));
     }
     const insert = itemInsertShape(insertColumns, insertValues, itemColumns);
     const inserted = await tx.query(`
@@ -7451,7 +7468,7 @@ export async function fillItemToBaseContainer(db, repoRoot, baseId, placeableId,
     const insertValues = [inventory.id, resolvedTemplate, stackSize, qualityLevel, Number(position.rows[0]?.position_index || 0), JSON.stringify(stats)];
     if (itemColumns.has("volume_override")) {
       insertColumns.push("volume_override");
-      insertValues.push(itemVolumeNum);
+      insertValues.push(volumeOverrideForInsert(itemVolumeNum));
     }
     const insert = itemInsertShape(insertColumns, insertValues, itemColumns);
     const inserted = await tx.query(`
@@ -7684,7 +7701,7 @@ export async function giveMultipleItemsToBaseContainer(db, baseId, placeableId, 
       // giveItemToBaseContainer's matching comment for the full explanation.
       if (itemColumns.has("volume_override")) {
         insertColumns.push("volume_override");
-        insertValues.push(entry.itemVolumeNum);
+        insertValues.push(volumeOverrideForInsert(entry.itemVolumeNum));
       }
       const insert = itemInsertShape(insertColumns, insertValues, itemColumns);
       const inserted = await tx.query(`

--- a/console/api/test/adminCatalog.test.js
+++ b/console/api/test/adminCatalog.test.js
@@ -3,7 +3,10 @@ import assert from "node:assert/strict";
 import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { buildingUnlockStatus, itemImagePath, itemIsRankedSchematic, itemIsSchematic, itemRequiresDatabaseGrant, listBuildingUnlockItems, listCatalogItems, resolveCatalogItem, resolveFillableCatalogItem, resolveItemVolume } from "../src/adminCatalog.js";
+import { fileURLToPath } from "node:url";
+import { buildingUnlockStatus, isFillableItem, itemImagePath, itemIsRankedSchematic, itemIsSchematic, itemRequiresDatabaseGrant, listBuildingUnlockItems, listCatalogItems, resolveCatalogItem, resolveFillableCatalogItem, resolveItemVolume } from "../src/adminCatalog.js";
+
+const REAL_REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
 
 function fixtureRepo() {
   const root = mkdtempSync(join(tmpdir(), "web-admin-catalog-"));
@@ -152,6 +155,25 @@ test("resolveFillableCatalogItem accepts raw resources", () => {
   const item = resolveFillableCatalogItem(root, { itemId: "AzuriteOre" });
   assert.equal(item.group, "raw_resource");
   assert.equal(item.volume, 0.2);
+});
+
+// Regression guard for the finding in resolveFillableCatalogItem's own
+// comment (found during post-merge review of upstream PR #182, 2026-08-20:
+// the comment previously claimed "today's 19 fillable items" -- stale, the
+// real count is 99 once raw_resource was added to FILLABLE_GROUPS). The
+// runtime safety check (throws on missing/zero volume) already covers this
+// at request time, but this test catches a bad catalog edit at CI time
+// instead of waiting for an operator to trip the runtime error -- and keeps
+// the comment's "not currently triggerable" claim honest as the catalog
+// grows.
+test("every real, currently-fillable catalog item has a non-zero catalogued volume", () => {
+  const items = JSON.parse(readFileSync(join(REAL_REPO_ROOT, "runtime/data/admin-items.json"), "utf8"));
+  const missing = items
+    .filter((item) => isFillableItem(item))
+    .filter((item) => !(Number(item.volume) > 0))
+    .map((item) => item.id);
+  assert.deepEqual(missing, [],
+    `${missing.length} fillable-group item(s) have no catalogued volume and would fail resolveFillableCatalogItem() at request time: ${missing.join(", ")}`);
 });
 
 test("resolveFillableCatalogItem rejects untagged/unfillable items", () => {

--- a/console/api/test/db.test.js
+++ b/console/api/test/db.test.js
@@ -5198,6 +5198,35 @@ test("storage give-item does not check volume when itemVolume is omitted (backwa
   assert.equal(volumeCall, undefined, "volume sum query must not run when itemVolume is not provided");
 });
 
+// Regression test for a real bug found during post-merge review of upstream
+// PR #182 (2026-08-20): itemVolume defaults to 0 for any item with no
+// catalogued volume data (see server.js's storageGiveItemRoute/
+// baseContainerGiveItemRoute/baseContainerFillItemRoute, which resolve
+// itemVolume via `resolved.volume || resolveItemVolume(...)`), but every
+// insert site wrote that 0 straight into volume_override instead of NULL.
+// NULL means "use the engine's own catalog volume" (see the 2026-08-19
+// correction comment above giveItemToStorage's insert); a stored 0 makes
+// the engine display the item as having zero volume instead of falling
+// back to its real catalog value -- the same class of display corruption
+// INC-2026-08-19-VOLUME-OVERRIDE-DOUBLE-MULTIPLIED fixed, just in the
+// opposite (zero, not inflated) direction. Covers all 4 single-item Give/
+// Fill entry points; giveMultipleItemsToBaseContainer's batch path shares
+// the same volumeOverrideForInsert() helper, not independently re-tested
+// here.
+test("storage give-item stores volume_override as NULL, not 0, when itemVolume is omitted (uncatalogued item)", async () => {
+  const calls = [];
+  const db = fakeMutationDb(calls, {
+    storageRows: [{ id: 7, actor_id: 222, max_item_count: 30, max_item_volume: 0 }],
+    countRows: [{ count: 1 }],
+    insertedRows: [{ id: 599, template_id: "SomeUncatalogedWeapon", stack_size: 1, quality_level: 0, position_index: 5, inventory_id: 7, volume_override: null }]
+  });
+  await giveItemToStorage(db, 222, { templateId: "SomeUncatalogedWeapon", quantity: 1 });
+  const insert = calls.find((call) => call.text.includes("insert into dune.items"));
+  assert.ok(insert);
+  const volIdx = insert.values.length - 1;
+  assert.equal(insert.values[volIdx], null, "volume_override must be stored as NULL for an uncatalogued item, not 0");
+});
+
 test("storage give-multiple-items inserts every item in one transaction", async () => {
   const calls = [];
   const db = fakeMutationDb(calls, {
@@ -5220,6 +5249,28 @@ test("storage give-multiple-items inserts every item in one transaction", async 
   const inserts = calls.filter((call) => call.text.includes("insert into dune.items"));
   assert.equal(inserts.length, 2, "one insert per item");
   assert.equal(calls.filter((call) => call.text === "begin").length, 1, "single shared transaction");
+});
+
+// Batch-path coverage for the same NULL-vs-0 fix as giveItemToStorage's own
+// regression test above (QA hat finding, post-merge review of PR #182:
+// giveMultipleItemsToBaseContainer shares volumeOverrideForInsert() with the
+// 4 single-item entry points but had no independent test of its own).
+test("storage give-multiple-items stores volume_override as NULL, not 0, for an uncatalogued item", async () => {
+  const calls = [];
+  const db = fakeMutationDb(calls, {
+    storageRows: [{ id: 7, actor_id: 222, max_item_count: 30, max_item_volume: 0 }],
+    countRows: [{ count: 0 }],
+    insertedRowsSequence: [
+      { id: 601, template_id: "SomeUncatalogedWeapon", stack_size: 1, quality_level: 0, position_index: 2, inventory_id: 7, volume_override: null }
+    ]
+  });
+  await giveMultipleItemsToBaseContainer(db, 16836, 42, {
+    items: [{ templateId: "SomeUncatalogedWeapon", quantity: 1 }]
+  });
+  const insert = calls.find((call) => call.text.includes("insert into dune.items"));
+  assert.ok(insert);
+  const volIdx = insert.values.length - 1;
+  assert.equal(insert.values[volIdx], null, "volume_override must be stored as NULL for an uncatalogued item, not 0");
 });
 
 // DBA hat finding (Layer 2 audit, 2026-08-19): every existing volume/slot

--- a/console/api/test/giveFillVolumeOverride.integration.test.js
+++ b/console/api/test/giveFillVolumeOverride.integration.test.js
@@ -1,0 +1,88 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { giveItemToStorage } from "../src/duneDb.js";
+import { pgTransactionalDb, withIsolatedDatabase } from "../test-support/pgIntegrationDb.js";
+
+// Real PostgreSQL, not a mocked db. The unit tests in db.test.js prove
+// volumeOverrideForInsert() returns JS `null` for an uncatalogued item and
+// that the mocked query captures that value -- they cannot prove `null`
+// actually survives node-postgres' parameterized `$N::real` cast to become
+// real SQL NULL in the stored row, rather than silently coercing to 0 or
+// NaN somewhere in the driver. DBA hat finding (post-merge review of PR
+// #182, 2026-08-20): this repo already has the tooling
+// (test-support/pgIntegrationDb.js) to close that gap; this file does.
+test("real PostgreSQL: giving an uncatalogued item stores volume_override as SQL NULL, not 0", async (t) => {
+  await withIsolatedDatabase(t, {
+    namePrefix: "dune_give_volume_override",
+    unavailableLabel: "the give-item volume_override integration test",
+    createFailLabel: "the give-item volume_override integration test"
+  }, async (pool) => {
+    await pool.query(`
+      create schema dune;
+      create table dune.inventories (
+        id bigint primary key,
+        actor_id bigint not null,
+        max_item_count integer not null,
+        max_item_volume real not null default 0
+      );
+      create table dune.items (
+        id bigint generated always as identity primary key,
+        inventory_id bigint not null references dune.inventories(id),
+        template_id text not null,
+        stack_size integer not null,
+        quality_level integer not null,
+        position_index integer not null,
+        stats jsonb not null,
+        volume_override real
+      );
+      insert into dune.inventories (id, actor_id, max_item_count) values (701, 5001, 10);
+    `);
+
+    const db = pgTransactionalDb(pool);
+    const result = await giveItemToStorage(db, 5001, { templateId: "SomeUncatalogedWeapon", quantity: 1 });
+    assert.equal(result.ok, true);
+
+    const stored = await pool.query("select volume_override from dune.items where inventory_id = 701");
+    assert.equal(stored.rows.length, 1);
+    assert.equal(stored.rows[0].volume_override, null,
+      "real Postgres must store volume_override as SQL NULL for an uncatalogued item, not 0");
+  });
+});
+
+test("real PostgreSQL: giving an item WITH a declared volume stores that per-unit value, not NULL", async (t) => {
+  await withIsolatedDatabase(t, {
+    namePrefix: "dune_give_volume_override",
+    unavailableLabel: "the give-item volume_override integration test",
+    createFailLabel: "the give-item volume_override integration test"
+  }, async (pool) => {
+    await pool.query(`
+      create schema dune;
+      create table dune.inventories (
+        id bigint primary key,
+        actor_id bigint not null,
+        max_item_count integer not null,
+        max_item_volume real not null default 0
+      );
+      create table dune.items (
+        id bigint generated always as identity primary key,
+        inventory_id bigint not null references dune.inventories(id),
+        template_id text not null,
+        stack_size integer not null,
+        quality_level integer not null,
+        position_index integer not null,
+        stats jsonb not null,
+        volume_override real
+      );
+      insert into dune.inventories (id, actor_id, max_item_count) values (701, 5001, 10);
+    `);
+
+    const db = pgTransactionalDb(pool);
+    const result = await giveItemToStorage(db, 5001, { templateId: "AzuriteOre", quantity: 20, itemVolume: 0.2 });
+    assert.equal(result.ok, true);
+
+    const stored = await pool.query("select volume_override from dune.items where inventory_id = 701");
+    assert.equal(stored.rows.length, 1);
+    assert.equal(Number(stored.rows[0].volume_override), 0.2,
+      "a real, declared per-unit volume must still be stored, not overridden to NULL");
+  });
+});

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -532,10 +532,23 @@ export const basesApi = {
   // inserted -- never rejected outright -- so `given` can be less than
   // `requested`. Only genuinely zero room left (not even 1 unit fits) is
   // still a real error, surfaced via `error`/`reason` as before.
+  // `inserted` below is intentionally snake_case (id/template_id/stack_size/
+  // quality_level/position_index/inventory_id/volume_override), not
+  // camelCase like the rest of this API surface -- found during post-merge
+  // review of upstream PR #182 (2026-08-20): duneDb.js's giveItemToStorage/
+  // giveItemToBaseContainer/fillItemToStorage/fillItemToBaseContainer/
+  // giveMultipleItemsToBaseContainer all return `inserted: inserted.rows[0]`
+  // straight from a `returning ...` query, unlike addBaseContainerItem
+  // (a few lines below in duneDb.js), which explicitly builds a camelCase
+  // object for exactly this reason. This type previously declared the
+  // camelCase shape the rest of the codebase uses, which was never true at
+  // runtime -- currently latent (no caller here reads `.inserted` yet), but
+  // any future caller trusting the old declared type would have gotten
+  // `undefined` silently instead of a compile error.
   giveContainerItem: (baseId: string, placeableId: string, body: { itemName?: string; itemId?: string; quantity: number; confirmation: string }) =>
     api<{
       supported: boolean;
-      result?: { ok: boolean; inserted: { id: string; templateId: string; stackSize: number }; requested: number; given: number; clamped: boolean };
+      result?: { ok: boolean; inserted: { id: string; template_id: string; stack_size: number; quality_level: number; position_index: number; inventory_id: string; volume_override: number | null }; requested: number; given: number; clamped: boolean };
       error?: string;
       reason?: string;
     }>(`/api/bases/${encodeURIComponent(baseId)}/containers/${encodeURIComponent(placeableId)}/give-item`,
@@ -556,7 +569,10 @@ export const basesApi = {
       result?: {
         ok: boolean;
         results: {
-          inserted?: { id: string; templateId: string; stackSize: number };
+          // See giveContainerItem's own comment above -- same real
+          // snake_case shape, not the camelCase this type previously (and
+          // incorrectly) declared.
+          inserted?: { id: string; template_id: string; stack_size: number; quality_level: number; position_index: number; inventory_id: string; volume_override: number | null };
           templateId: string;
           requested: number;
           given: number;
@@ -576,10 +592,13 @@ export const basesApi = {
   // null for a "Fill to Capacity" call (quantity: 0, no specific amount was
   // ever asked for to compare against) and a real number for "Fill
   // Amount" (an explicit quantity that may itself get clamped down).
+  // See giveContainerItem's own comment above -- same real snake_case
+  // shape, not the camelCase this type previously (and incorrectly)
+  // declared.
   fillContainerItem: (baseId: string, placeableId: string, body: { itemName?: string; itemId?: string; quantity: number; confirmation: string }) =>
     api<{
       supported: boolean;
-      result?: { ok: boolean; inserted: { id: string; templateId: string; stackSize: number; volumeOverride?: number }; requested: number | null; given: number; clamped: boolean };
+      result?: { ok: boolean; inserted: { id: string; template_id: string; stack_size: number; quality_level: number; position_index: number; inventory_id: string; volume_override: number | null }; requested: number | null; given: number; clamped: boolean };
       error?: string;
       reason?: string;
     }>(`/api/bases/${encodeURIComponent(baseId)}/containers/${encodeURIComponent(placeableId)}/fill-item`,

--- a/docs/console/base-inventory.md
+++ b/docs/console/base-inventory.md
@@ -493,10 +493,24 @@ already used — through three new, Bases-scoped functions
 (`giveItemToBaseContainer`/`fillItemToBaseContainer`/
 `giveMultipleItemsToBaseContainer`, the last renamed from
 `giveMultipleItemsToStorage`, which never had a standalone-tab caller in
-the first place). `giveItemToStorage()`/`fillItemToStorage()` are
-unchanged and still used by the standalone Storage tab's own routes
-(`storageGiveItemRoute` etc.), which operate on an operator-supplied
-storage id directly and have no base+placeable ownership chain to verify.
+the first place). `giveItemToStorage()` is unchanged and still used by
+the standalone Storage tab's own `storageGiveItemRoute`
+(`POST /api/storage/{storageId}/give-item`), which operates on an
+operator-supplied storage id directly and has no base+placeable
+ownership chain to verify.
+
+**Corrected 2026-08-20** (post-merge review of upstream PR #182): the
+paragraph above previously also claimed `fillItemToStorage()` is "still
+used by the standalone Storage tab's own routes" -- verified directly
+against `server.js` (`grep -n "fillItemToStorage(" console/api/src/server.js`
+returns nothing) that this was never true: there is no
+`POST /api/storage/{storageId}/fill-item` route, and no other route
+calls `fillItemToStorage()` either. The function is fully implemented
+and unit-tested in `duneDb.js`, but unreachable via any real HTTP
+route today -- the standalone Storage tab only has a Give action, not
+a Fill action. Any operator or future contributor reading the previous
+wording would reasonably believe the Storage tab supports Fill; it
+does not.
 
 **Both Give and Fill are restricted to raw resources, refined resources, and components only.**
 `baseContainerGiveItemRoute`/`baseContainerGiveItemsRoute`/`baseContainerFillItemRoute` all resolve items
@@ -603,8 +617,9 @@ see "`volume_override` is per-unit, not per-stack" immediately below for why it 
 **A real, live in-game bug, not a design choice.** `dune.items.volume_override` is stored as
 the item's PER-UNIT volume, and every volume total (the running total `giveItemToBaseContainer`/
 `fillItemToBaseContainer`/`giveMultipleItemsToBaseContainer` check against a container's `max_item_volume`
-on this tab, the standalone Storage tab's own `giveItemToStorage`/`fillItemToStorage` checking the same
-thing, and every read-side total in `baseInventory`, the standalone Storage tab's `listStorage`, and
+on this tab, the standalone Storage tab's own `giveItemToStorage` checking the same thing (`fillItemToStorage`
+exists in `duneDb.js` and follows the same convention, but has no live HTTP route today -- see the Give/Fill
+route table above), and every read-side total in `baseInventory`, the standalone Storage tab's `listStorage`, and
 `baseContainerSlots`) is computed as `volume_override × stack_size`, summed across rows.
 
 An earlier version of this code stored `volume_override` as the stack's **total** volume

--- a/docs/incidents/INC-2026-08-19-VOLUME-OVERRIDE-DOUBLE-MULTIPLIED.md
+++ b/docs/incidents/INC-2026-08-19-VOLUME-OVERRIDE-DOUBLE-MULTIPLIED.md
@@ -173,3 +173,35 @@ green after the fix; `tsc --noEmit` clean.
 Investigation complete, root cause proven, code and catalog data fixed, data-repair script
 written. **This incident is resolved for the code and catalog; the existing-data repair on
 `dune-dev` itself is a tracked follow-up action to run after this fix deploys.**
+
+## Addendum (2026-08-20): a related, second `volume_override` bug survived this fix
+
+Found during post-merge review of upstream PR #182 (`giveItemToStorage`/
+`giveItemToBaseContainer`/`fillItemToStorage`/`fillItemToBaseContainer`/
+`giveMultipleItemsToBaseContainer`, tracked in
+`yacketrj/dune-awakening-selfhost-docker#396`): the "Fix the write-side
+convention" closure criterion above was correct for the bug this incident
+investigated (total-vs-per-unit), but it did not cover a second, related
+convention violation in the same insert sites -- an item with **no
+catalogued volume at all** (not a wrong value; genuinely never had one) had
+`volume_override` written as the number `0` instead of SQL `NULL`. Per this
+incident's own root-cause finding (a genuinely in-game-created row always
+has `volume_override = NULL`, meaning "use the engine's own catalog
+volume"), storing `0` for an uncatalogued item causes the same class of
+engine-display inaccuracy this incident fixed, just in the opposite
+direction (0 instead of inflated), and was independently confirmed to also
+under-count the console's own internal volume-capacity math for the same
+rows (`resolvedItemUnitVolume` treats an explicit `0` as a real, known
+value, not "unknown" -- it only falls back to catalog data for `NULL`).
+
+Fixed alongside this addendum: all 5 insert sites now write `NULL` (via a
+shared `volumeOverrideForInsert()` helper), and
+`repair-volume-override.mjs` gained a second pass correcting existing rows
+with `volume_override = 0` to `NULL` (no catalog lookup needed for this
+pass -- the engine never itself writes a non-null override, so any stored
+`0` is presumptively from this bug). **This addendum does not reopen this
+incident's own closure criteria** (they were accurate for the bug
+investigated here) -- it corrects the closure table's implicit claim of
+"the write-side convention is now fully correct," which was not true until
+this addendum's fix. See `#396` for the full fix and the rest of that
+review's findings.


### PR DESCRIPTION
## Executive summary

Post-merge fixes for #182 (Give/Fill/Delete Storage Inventory actions), found during an independent code review of the merged code -- both this fork's original submission and the maintainer's own follow-on fixes (`f264a2bc` and 2 test commits). Fixes a real `volume_override` bug that reintroduces (in the zero direction) the exact display-corruption class INC-2026-08-19-VOLUME-OVERRIDE-DOUBLE-MULTIPLIED already fixed once, plus a stale comment, a lying TypeScript type declaration, and a false docs claim. One related finding (batch augment-lookup efficiency) was investigated and deliberately **not** fixed here -- see "What was rejected" below. **Verified against a live deployment**, including through a full server restart -- see "Live deployment verification" below.

Tracked in this fork's own issue: `yacketrj/dune-awakening-selfhost-docker#396` (full findings register, including a Layer 2 Eight Hats audit, posted as a comment there).

## What this change does, and why

**The bug.** `giveItemToStorage`/`giveItemToBaseContainer`/`fillItemToStorage`/`fillItemToBaseContainer`/`giveMultipleItemsToBaseContainer` all compute `itemVolumeNum = Number(itemVolume) || 0` and previously wrote that value straight into `dune.items.volume_override` unconditionally. For an item with **no catalogued volume data at all**, `itemVolume` resolves to `0` (`server.js`: `resolved.volume || resolveItemVolume(...)`), so `volume_override` was stored as the number `0`.

Per this repo's own established convention (confirmed against `dune.item_audit_log` in the original incident): a genuinely in-game-created row always has `volume_override = NULL`, meaning "use the engine's own catalog volume." The engine multiplies a **non-null** `volume_override` by `stack_size` for display. Storing `0` for an uncatalogued item makes the engine display it as having **zero volume**, instead of falling back to whatever real volume it actually has -- the same class of display corruption the original incident fixed, just inverted (zero instead of inflated).

**Why this matters beyond display:** independently verified this also silently under-counts the console's own internal volume-capacity math for the same rows. `resolvedItemUnitVolume()` (added by `f264a2bc`) treats an explicit `0` as a real, known value -- it only falls back to catalog data for `NULL`. So a container holding one of these bad rows reports itself as having more free volume than it actually should, which a subsequent ordinary Give/Fill could exploit to overfill past the intended cap.

**The fix:** a single helper, `volumeOverrideForInsert(itemVolumeNum)`, returns `itemVolumeNum > 0 ? itemVolumeNum : null`, used at all 5 insert sites. Also extended the existing `repair-volume-override.mjs` (from the original incident) with a second pass correcting already-affected rows (`volume_override = 0` -> `NULL`), since a code fix alone doesn't repair data already written wrong.

**The other three fixes** (stale "19 items" comment -> real count of 99; a TypeScript type declaring the wrong response shape; a docs claim that `fillItemToStorage()` has a live HTTP route when it doesn't) are independent, small, low-risk corrections found during the same review pass -- see the commit message for each one's own detail.

## What was rejected / deferred

**`giveMultipleItemsToBaseContainer` calls `loadAugmentRollPayloads` per-item inside its batch loop**, instead of collecting all needed augment ids once up front. This looks like an obvious batching opportunity, and I initially assumed it was one -- but `loadAugmentRollPayloads`'s scoring (`augmentRollScore`) uses each item's own `sourceTemplateId` to bias which candidate augment roll gets selected when multiple items in a batch share an augment id, and the underlying candidate-row query's `LIMIT 200` window is tie-broken by that same `sourceTemplateId` match, not pre-filtered by it. A naive shared call would change *which* roll individual items receive -- a real gameplay-behavior risk for a real but comparatively minor efficiency gain. A safe fix needs `loadAugmentRollPayloads` split into a fetch-once phase and a score-per-item phase, which is a real refactor, not a one-line change. Tracked as item 5 in `#396`, not bundled into this fix.

**`bases.ts`'s snake_case-vs-camelCase inconsistency** with the sibling `addBaseContainerItem` function (which deliberately builds a camelCase response) is real but out of scope here -- normalizing the 5 Give/Fill functions' response shape would be a behavior change needing coordinated frontend updates, not a narrow bug fix. This PR corrects the *type declaration* to match current reality instead.

## Fresh-install behavior

No schema change. A fresh install/fresh database is entirely unaffected -- there are no pre-existing rows to be wrong.

## Migration / upgrade-path behavior

**No automatic migration.** Every row already inserted by the old buggy code (`volume_override = 0` for an uncatalogued item, from any operator who has used Give/Fill since #182 shipped) remains wrong after this PR merges, until an operator explicitly runs the repair script:

```
docker exec <console-container> node scripts/repair-volume-override.mjs            # dry run
docker exec <console-container> node scripts/repair-volume-override.mjs --apply    # writes changes
```

This mirrors the original incident's own repair-script pattern exactly (same script, same dry-run-by-default safety, extended rather than replaced). **This is a real gap for any operator who doesn't run the follow-up script** -- their affected rows stay wrong (both in-game display and the console's own capacity math) until they do. I considered making the repair automatic on deploy and rejected it: an unattended `UPDATE` against production game data on every deploy is a bigger blast-radius risk than leaving this as an explicit, operator-triggered, dry-run-by-default step, consistent with how the original incident's own repair script was designed.

## Break/fix behavior

- **Mid-run failure (code fix):** no new failure mode -- the insert logic is unchanged except for one value; if the insert itself fails, it fails exactly as it did before (existing transaction/error handling untouched).
- **Mid-run failure (repair script):** the second pass's `UPDATE dune.items SET volume_override = NULL WHERE volume_override = 0` runs inside the same `db.transaction(...)` block as the first pass's per-row corrections -- either both passes' changes commit together or neither does. No credential or secret is introduced by this change, so "what happens if it's lost" does not apply here.
- **What happens if an operator never runs `--apply`:** covered above under Migration -- old rows stay wrong (silently), new rows are correct going forward.

## Live deployment verification

Deployed this exact fix to a real, live dev server (not just unit/integration tests) and validated end-to-end, including through a full server restart:

1. Deployed via an authenticated real HTTP request through the full stack (console API -> route -> capability check -> `resolveCatalogItem` -> `giveItemToStorage` -> `volumeOverrideForInsert` -> real Postgres insert).
2. Gave a real, genuinely uncatalogued catalog item (`Radiation_Suit`) into a live base's storage container. API response confirmed `"volume_override":null`.
3. **Independently re-verified directly in Postgres** (`select ... from dune.items where id = ...`) -- the column is genuinely SQL `NULL`, not just a JSON `null` in the API layer.
4. Confirmed the container's derived state correctly reflects this: `volumeComplete: false` (the console flags the container's volume total as "unknown," the correct degraded-display behavior) rather than silently under-reporting.
5. **Regression check:** gave a real item *with* catalogued volume (`AzuriteOre`) into a clean container -- stored its correct real per-unit value (`0.2`), confirming no regression to the normal path.
6. **Full server restart:** restarted the live game server (map) the test data was sitting on, then re-verified both rows directly in Postgres and via the console API afterward -- both survived intact, `volume_override` unchanged (still `NULL` / still `0.2`), `volumeComplete` still correctly `false` for the affected container. No data loss or reset across a real restart.

This exercises the same real-database-write path this repo's own past incident (`INC-2026-07-31-FILL-ITEMS-VISIBLE-ONLY-AFTER-RESTART.md`) specifically flags as a place a fix can look correct pre-restart and break post-restart -- confirmed that is not the case here.

## Real test output

```
$ cd console/api && npm test
...
1..1403
# tests 1409
# suites 0
# pass 1409
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 26093.609543
```

Includes 2 new real-PostgreSQL integration tests (`giveFillVolumeOverride.integration.test.js`) proving the JS `null` this fix writes actually survives node-postgres' parameterized `$N::real` cast as SQL `NULL`, not just that a mock captured the right JS value -- and independently verified non-tautological by temporarily reverting the fix and confirming the test fails (`expected: null, actual: 0`) before restoring it.

```
$ cd console/web && npx tsc --noEmit -p .
(clean, exit 0)
```

## Real security-check output

```
$ gitleaks detect --source . --log-opts="upstream/main..HEAD"
1 commits scanned.
scanned ~18723 bytes (18.72 KB) in 244ms
no leaks found
```

```
$ semgrep --config auto <9 changed files>
Findings: 0 (0 blocking)
Rules run: 210
Targets scanned: 9
Ran 210 rules on 9 files: 0 findings.
```

## Eight Hats audit summary

Layer 2 (implementation) audit run as 8 independent dispatched agents against the real diff, per this fork's own governing process. Full per-hat findings register and STRIDE report posted to `yacketrj/dune-awakening-selfhost-docker#396` (comment). Summary:

| Hat | Findings | Resolution |
|---|---|---|
| Security Architect | None at CRITICAL/HIGH | Clean |
| Software Architect | 1 HIGH (commit message inaccuracy), 2 MEDIUM | All resolved/disclosed |
| GRC | 1 MEDIUM (incident doc overstated closure), 4 LOW | All resolved |
| Network Engineer | N/A | Confirmed, no findings |
| Cloud Security | N/A | Confirmed, no findings |
| DBA | **2 HIGH** (no backfill path; console's own capacity math also affected), 1 MEDIUM, 3 LOW | Both HIGH resolved (repair-script extension); rest resolved or honestly disclosed |
| QA/Test | 2 LOW/MEDIUM (test drift risk, missing batch-path coverage) | Both resolved |
| UI/UX Designer | 1 MEDIUM (pre-existing bad rows won't retroactively fix in console UI either), 3 LOW; **net verdict: this fix is a positive change, the console's own read-side logic was already built correctly and waiting for this data** | MEDIUM resolved by the same repair-script extension |

STRIDE: only one finding mapped to a STRIDE category (GRC's, Repudiation -- an audit trail overstating what was verified) -- resolved via the incident-doc addendum. Every other finding is a correctness/data-integrity/documentation-accuracy finding outside STRIDE's threat-model scope; every hat that found nothing STRIDE-mappable said so explicitly rather than omitting the section.
