### PR TITLE
fix(console): recover from a failed lazy-chunk load instead of crashing

### DIFF
--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { Fragment, Suspense, lazy, useCallback, useEffect, useRef, useState } from "react";
+import { Fragment, lazy, useCallback, useEffect, useRef, useState } from "react";
 import { Archive, Bug, Building2, Car, CircleArrowUp, CircleHelp, Database, ExternalLink, FileText, Gift, Heart, Home, Landmark, Map as MapIcon, Menu, MessageCircle, PackagePlus, RefreshCw, Server, Settings, Shield, Sparkles, Store, Users, X } from "lucide-react";
 import { api, AUTH_SESSION_EXPIRED_EVENT, AUTH_SESSION_EXPIRED_MESSAGE, post, setCsrfToken } from "./api/client";
 import { setServerPorts, setAdminPort, type ServerPorts } from "./api/serverPorts";
@@ -10,6 +10,7 @@ import { setupApi, type Task } from "./api/setup";
 import { SetupWizard } from "./components/SetupWizard";
 import { TaskProgress } from "./components/TaskProgress";
 import { ConfirmDialog, type ConfirmDialogDetail, type ConfirmDialogOutcome, type ConfirmDialogRequest } from "./components/common/ConfirmDialog";
+import { LazyTabBoundary } from "./components/common/LazyTabBoundary";
 import type { RestartGateChoice } from "./features/server/restartQueueGuard";
 import { loadPinnedAddons, savePinnedAddons, type PinnedAddon } from "./features/addons/pinnedAddons";
 import { hasAddonUpdates } from "./features/addons/addonVersions";
@@ -303,12 +304,6 @@ function AppFooter() {
       </a>
     </footer>
   );
-}
-
-function LazyTabBoundary({ children, label = "Loading Section" }: { children: React.ReactNode; label?: string }) {
-  return <Suspense fallback={<section className="panel loading-panel tab-loading-panel"><span className="spinner" aria-hidden="true" /><strong className="loading-dots">{label}</strong></section>}>
-    {children}
-  </Suspense>;
 }
 
 export function App() {

--- a/console/web/src/components/common/LazyTabBoundary.test.tsx
+++ b/console/web/src/components/common/LazyTabBoundary.test.tsx
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { LazyTabBoundary } from "./LazyTabBoundary";
+
+function Bomb(): never {
+  throw new Error("Failed to fetch dynamically imported module");
+}
+
+describe("LazyTabBoundary", () => {
+  it("renders children when the lazy import succeeds", () => {
+    render(<LazyTabBoundary label="Loading Widget"><span>Loaded</span></LazyTabBoundary>);
+    expect(screen.getByText("Loaded")).toBeTruthy();
+  });
+
+  it("shows a manual refresh option instead of crashing when a lazy chunk fails to load", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<LazyTabBoundary label="Loading Widget"><Bomb /></LazyTabBoundary>);
+    expect(screen.getByText("Could not load this section.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Refresh Now" })).toBeTruthy();
+    spy.mockRestore();
+  });
+});

--- a/console/web/src/components/common/LazyTabBoundary.test.tsx
+++ b/console/web/src/components/common/LazyTabBoundary.test.tsx
@@ -1,22 +1,82 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
-import { LazyTabBoundary } from "./LazyTabBoundary";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LazyTabBoundary, isLazyChunkLoadError, lazyTabBoundaryInternals } from "./LazyTabBoundary";
 
-function Bomb(): never {
-  throw new Error("Failed to fetch dynamically imported module");
+function Bomb({ message = "Failed to fetch dynamically imported module" }: { message?: string }): never {
+  throw new Error(message);
 }
+
+function memoryStorage(initial: Record<string, string> = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => { values.set(key, value); })
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("LazyTabBoundary", () => {
   it("renders children when the lazy import succeeds", () => {
     render(<LazyTabBoundary label="Loading Widget"><span>Loaded</span></LazyTabBoundary>);
-    expect(screen.getByText("Loaded")).toBeTruthy();
+    expect(screen.getByText("Loaded")).toBeInTheDocument();
   });
 
-  it("shows a manual refresh option instead of crashing when a lazy chunk fails to load", () => {
-    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
-    render(<LazyTabBoundary label="Loading Widget"><Bomb /></LazyTabBoundary>);
-    expect(screen.getByText("Could not load this section.")).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Refresh Now" })).toBeTruthy();
-    spy.mockRestore();
+  it("automatically reloads once for a recognized stale chunk failure", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const reload = vi.fn();
+    const storage = memoryStorage();
+    render(<LazyTabBoundary label="Loading Widget" reload={reload} storage={storage} now={() => 100_000}><Bomb /></LazyTabBoundary>);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledWith(lazyTabBoundaryInternals.CHUNK_RELOAD_KEY, "100000");
+  });
+
+  it("uses the manual fallback during the cooldown instead of reloading forever", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const reload = vi.fn();
+    const storage = memoryStorage({ [lazyTabBoundaryInternals.CHUNK_RELOAD_KEY]: "90000" });
+    render(<LazyTabBoundary label="Loading Widget" reload={reload} storage={storage} now={() => 100_000}><Bomb /></LazyTabBoundary>);
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(screen.getByText("Could not load this section.")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh Now" }));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not auto-reload an ordinary render error", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const reload = vi.fn();
+    render(<LazyTabBoundary reload={reload} storage={memoryStorage()}><Bomb message="Cannot read properties of undefined" /></LazyTabBoundary>);
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(screen.getByText("This section encountered an unexpected error. Refresh and try again.")).toBeInTheDocument();
+  });
+
+  it("falls back safely when session storage is unavailable", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const reload = vi.fn();
+    render(<LazyTabBoundary reload={reload} storage={null}><Bomb /></LazyTabBoundary>);
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Refresh Now" })).toBeInTheDocument();
+  });
+});
+
+describe("isLazyChunkLoadError", () => {
+  it.each([
+    "Failed to fetch dynamically imported module: /assets/Panel-old.js",
+    "error loading dynamically imported module",
+    "Importing a module script failed.",
+    "Loading chunk 42 failed.",
+    "Unable to preload CSS for /assets/Panel-old.css"
+  ])("recognizes browser and bundler chunk failures: %s", (message) => {
+    expect(isLazyChunkLoadError(new Error(message))).toBe(true);
+  });
+
+  it("does not classify ordinary application errors as chunk failures", () => {
+    expect(isLazyChunkLoadError(new TypeError("Cannot read properties of undefined"))).toBe(false);
   });
 });

--- a/console/web/src/components/common/LazyTabBoundary.tsx
+++ b/console/web/src/components/common/LazyTabBoundary.tsx
@@ -1,43 +1,98 @@
 import { Component, Suspense, type ReactNode } from "react";
 
-type LazyTabBoundaryProps = { children: ReactNode; label?: string };
-type LazyTabErrorBoundaryState = { failed: boolean };
+const CHUNK_RELOAD_KEY = "dune-console:lazy-chunk-reload-at";
+const CHUNK_RELOAD_COOLDOWN_MS = 60_000;
+
+type ReloadStorage = Pick<Storage, "getItem" | "setItem">;
+type LazyTabBoundaryProps = {
+  children: ReactNode;
+  label?: string;
+  // Injection points keep reload/cooldown behavior testable without replacing
+  // jsdom's non-configurable Location object. App callers use the defaults.
+  reload?: () => void;
+  storage?: ReloadStorage | null;
+  now?: () => number;
+};
+type LazyTabErrorBoundaryState = { failed: boolean; chunkFailure: boolean };
+
+export function isLazyChunkLoadError(error: unknown) {
+  const text = `${error instanceof Error ? error.name : ""} ${error instanceof Error ? error.message : String(error || "")}`;
+  return /ChunkLoadError|Loading chunk .* failed|dynamically imported module|Importing a module script failed|Failed to load module script|Unable to preload CSS/i.test(text);
+}
+
+function browserStorage(): ReloadStorage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    // Privacy/security settings can deny storage access. Without a durable
+    // cooldown marker, stay on the manual fallback instead of risking a loop.
+    return null;
+  }
+}
+
+function browserReload() {
+  window.location.reload();
+}
 
 // A lazy-loaded tab's dynamic import() rejects outright -- it never resolves
 // to a component -- when the console was updated since this page loaded and
-// the chunk hash this bundle asks for no longer exists on the server. React's
-// Suspense only handles the pending state; an unhandled import rejection
-// otherwise crashes the whole app to a blank screen, and the only way out a
-// user finds is a hard refresh. Catch it here and offer a normal reload
-// instead, which is enough on its own once the server stops mislabeling the
-// SPA fallback as an immutable asset (see console/api/src/http/staticFiles.js).
+// the chunk hash this bundle asks for no longer exists on the server. Suspense
+// only handles the pending state. Recognized chunk/preload failures get one
+// automatic normal reload per browser tab per minute; a recurring failure or
+// an ordinary render bug stays on a manual recovery panel instead of looping.
 class LazyTabErrorBoundary extends Component<LazyTabBoundaryProps, LazyTabErrorBoundaryState> {
-  state: LazyTabErrorBoundaryState = { failed: false };
+  state: LazyTabErrorBoundaryState = { failed: false, chunkFailure: false };
 
-  static getDerivedStateFromError() {
-    return { failed: true };
+  static getDerivedStateFromError(error: unknown): LazyTabErrorBoundaryState {
+    return { failed: true, chunkFailure: isLazyChunkLoadError(error) };
   }
 
   componentDidCatch(error: unknown) {
     console.error(`Failed to load section: ${this.props.label || "section"}`, error);
+    if (!isLazyChunkLoadError(error)) return;
+
+    const storage = this.props.storage === undefined ? browserStorage() : this.props.storage;
+    if (!storage) return;
+    const now = this.props.now?.() ?? Date.now();
+    let lastAttempt = 0;
+    try {
+      lastAttempt = Number(storage.getItem(CHUNK_RELOAD_KEY) || 0);
+    } catch {
+      return;
+    }
+    const elapsed = now - lastAttempt;
+    if (Number.isFinite(lastAttempt) && lastAttempt > 0 && elapsed >= 0 && elapsed < CHUNK_RELOAD_COOLDOWN_MS) return;
+
+    try {
+      // Write before reload. If the current bundle is genuinely broken, the
+      // next page load sees the marker and cannot enter a refresh loop.
+      storage.setItem(CHUNK_RELOAD_KEY, String(now));
+    } catch {
+      return;
+    }
+    (this.props.reload || browserReload)();
   }
 
   render() {
     if (this.state.failed) {
-      return <section className="panel loading-panel tab-loading-panel">
+      return <section className="panel loading-panel tab-loading-panel" role="alert">
         <strong>Could not load this section.</strong>
-        <p className="muted">The console was updated since this page was loaded. Refresh to load the current version.</p>
-        <button onClick={() => window.location.reload()}>Refresh Now</button>
+        <p className="muted">{this.state.chunkFailure
+          ? "The console may have been updated since this page was loaded. Refresh to load the current version."
+          : "This section encountered an unexpected error. Refresh and try again."}</p>
+        <button onClick={this.props.reload || browserReload}>Refresh Now</button>
       </section>;
     }
     return this.props.children;
   }
 }
 
-export function LazyTabBoundary({ children, label = "Loading Section" }: LazyTabBoundaryProps) {
-  return <LazyTabErrorBoundary label={label}>
+export function LazyTabBoundary({ children, label = "Loading Section", reload, storage, now }: LazyTabBoundaryProps) {
+  return <LazyTabErrorBoundary label={label} reload={reload} storage={storage} now={now}>
     <Suspense fallback={<section className="panel loading-panel tab-loading-panel"><span className="spinner" aria-hidden="true" /><strong className="loading-dots">{label}</strong></section>}>
       {children}
     </Suspense>
   </LazyTabErrorBoundary>;
 }
+
+export const lazyTabBoundaryInternals = Object.freeze({ CHUNK_RELOAD_KEY, CHUNK_RELOAD_COOLDOWN_MS });

--- a/console/web/src/components/common/LazyTabBoundary.tsx
+++ b/console/web/src/components/common/LazyTabBoundary.tsx
@@ -1,0 +1,43 @@
+import { Component, Suspense, type ReactNode } from "react";
+
+type LazyTabBoundaryProps = { children: ReactNode; label?: string };
+type LazyTabErrorBoundaryState = { failed: boolean };
+
+// A lazy-loaded tab's dynamic import() rejects outright -- it never resolves
+// to a component -- when the console was updated since this page loaded and
+// the chunk hash this bundle asks for no longer exists on the server. React's
+// Suspense only handles the pending state; an unhandled import rejection
+// otherwise crashes the whole app to a blank screen, and the only way out a
+// user finds is a hard refresh. Catch it here and offer a normal reload
+// instead, which is enough on its own once the server stops mislabeling the
+// SPA fallback as an immutable asset (see console/api/src/http/staticFiles.js).
+class LazyTabErrorBoundary extends Component<LazyTabBoundaryProps, LazyTabErrorBoundaryState> {
+  state: LazyTabErrorBoundaryState = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error(`Failed to load section: ${this.props.label || "section"}`, error);
+  }
+
+  render() {
+    if (this.state.failed) {
+      return <section className="panel loading-panel tab-loading-panel">
+        <strong>Could not load this section.</strong>
+        <p className="muted">The console was updated since this page was loaded. Refresh to load the current version.</p>
+        <button onClick={() => window.location.reload()}>Refresh Now</button>
+      </section>;
+    }
+    return this.props.children;
+  }
+}
+
+export function LazyTabBoundary({ children, label = "Loading Section" }: LazyTabBoundaryProps) {
+  return <LazyTabErrorBoundary label={label}>
+    <Suspense fallback={<section className="panel loading-panel tab-loading-panel"><span className="spinner" aria-hidden="true" /><strong className="loading-dots">{label}</strong></section>}>
+      {children}
+    </Suspense>
+  </LazyTabErrorBoundary>;
+}


### PR DESCRIPTION
## Summary
- Follow-up to #181. After that fix (and even before it), a browser still running the pre-update bundle that opens a lazily-loaded tab it hasn't visited yet (e.g. Care Package) can hit an `import()` rejection for a chunk hash the rebuild removed. `Suspense` only covers the pending state — nothing caught the rejection, so it crashed the whole app to a blank screen with no in-app way to recover except a hard refresh.
- `LazyTabBoundary` now wraps `Suspense` in an error boundary. On a failed import it reloads automatically — a fresh load pulls the current build's chunk map, so it isn't repeating the same failure — bounded to one attempt per 60s via `sessionStorage` so a genuine bug can't loop the tab forever. If the failure recurs immediately after that attempt, it falls back to a manual "Refresh Now" button instead of retrying forever.

## Changes
- `console/web/src/components/common/LazyTabBoundary.tsx`: new shared boundary (Suspense + error recovery + bounded auto-reload), used by every lazily-loaded tab in `App.tsx`.
- `console/web/src/App.tsx`: switched to the shared `LazyTabBoundary` import, removing the old Suspense-only local definition.

## Test plan
- [x] `console/web` full suite via `npm test`: 540/540 pass
- [x] `console/web` typecheck via `tsc -b`: clean
- [x] `console/web` production build via `npm run build`: succeeds, confirms `CarePackagePanel` is still code-split into its own chunk
- [x] New `LazyTabBoundary.test.tsx`: covers success, first-failure auto-reload, and cooldown fallback to the manual button