### PR TITLE
fix(console): keep the active tab after an automatic recovery reload

### DIFF
--- a/console/web/src/App.activeTab.test.tsx
+++ b/console/web/src/App.activeTab.test.tsx
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { ALL_TABS, loadPersistedTab, persistActiveTab } from "./App";
+
+// Regression coverage for the tab surviving the automatic reload
+// LazyTabBoundary triggers after a stale post-update chunk load -- without
+// this, that reload always dropped the user back on Home instead of the tab
+// they were trying to open.
+describe("active tab persistence", () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("defaults to Home when nothing is persisted", () => {
+    expect(loadPersistedTab()).toBe("Home");
+  });
+
+  it("restores a tab that was persisted", () => {
+    persistActiveTab("Care Package");
+    expect(loadPersistedTab()).toBe("Care Package");
+  });
+
+  it("falls back to Home for a stale/invalid persisted value", () => {
+    window.sessionStorage.setItem("arrakis.activeTab", "Some Removed Tab");
+    expect(loadPersistedTab()).toBe("Home");
+  });
+
+  it("validates against every currently known tab", () => {
+    for (const tab of ALL_TABS) {
+      persistActiveTab(tab);
+      expect(loadPersistedTab()).toBe(tab);
+    }
+  });
+});

--- a/console/web/src/App.activeTab.test.tsx
+++ b/console/web/src/App.activeTab.test.tsx
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { ALL_TABS, loadPersistedTab, persistActiveTab } from "./App";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ALL_TABS, loadPersistedTab, persistActiveTab, useActiveTab } from "./App";
 
 // Regression coverage for the tab surviving the automatic reload
 // LazyTabBoundary triggers after a stale post-update chunk load -- without
@@ -29,5 +30,49 @@ describe("active tab persistence", () => {
       persistActiveTab(tab);
       expect(loadPersistedTab()).toBe(tab);
     }
+  });
+
+  it("does not throw and falls back to Home when sessionStorage.getItem throws", () => {
+    const spy = vi.spyOn(window.sessionStorage.__proto__, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError: storage access denied");
+    });
+    expect(loadPersistedTab()).toBe("Home");
+    spy.mockRestore();
+  });
+
+  it("does not throw when sessionStorage.setItem throws (quota exceeded, private browsing)", () => {
+    const spy = vi.spyOn(window.sessionStorage.__proto__, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceededError");
+    });
+    expect(() => persistActiveTab("Care Package")).not.toThrow();
+    spy.mockRestore();
+  });
+});
+
+// Covers the actual init-from-storage + persist-on-change wiring App() uses
+// (useState(loadPersistedTab) + useEffect(persistActiveTab)) end to end,
+// not just its two halves in isolation -- a break here only shows up in
+// practice as "the reload lost my tab", with no type or lint error.
+describe("useActiveTab", () => {
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("initializes from whatever tab was already persisted", () => {
+    persistActiveTab("Care Package");
+    const { result } = renderHook(() => useActiveTab());
+    expect(result.current[0]).toBe("Care Package");
+  });
+
+  it("persists to sessionStorage whenever the tab changes", () => {
+    const { result } = renderHook(() => useActiveTab());
+    expect(result.current[0]).toBe("Home");
+
+    act(() => {
+      result.current[1]("Settings");
+    });
+
+    expect(result.current[0]).toBe("Settings");
+    expect(loadPersistedTab()).toBe("Settings");
   });
 });

--- a/console/web/src/App.activeTab.test.tsx
+++ b/console/web/src/App.activeTab.test.tsx
@@ -1,6 +1,11 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, fireEvent, render, renderHook, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { ALL_TABS, loadPersistedTab, persistActiveTab, useActiveTab } from "./App";
+import { LazyTabBoundary } from "./components/common/LazyTabBoundary";
+
+function ChunkFailure(): never {
+  throw new Error("Failed to fetch dynamically imported module: /assets/Panel-old.js");
+}
 
 // Regression coverage for the tab surviving the automatic reload
 // LazyTabBoundary triggers after a stale post-update chunk load -- without
@@ -74,5 +79,25 @@ describe("useActiveTab", () => {
 
     expect(result.current[0]).toBe("Settings");
     expect(loadPersistedTab()).toBe("Settings");
+  });
+
+  it("persists the destination before a lazy chunk recovery reload", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const reload = vi.fn(() => {
+      expect(loadPersistedTab()).toBe("Care Package");
+    });
+
+    function Harness() {
+      const [tab, setTab] = useActiveTab();
+      return <>
+        <button onClick={() => setTab("Care Package")}>Open Care Package</button>
+        {tab === "Care Package" && <LazyTabBoundary reload={reload}><ChunkFailure /></LazyTabBoundary>}
+      </>;
+    }
+
+    render(<Harness />);
+    fireEvent.click(screen.getByRole("button", { name: "Open Care Package" }));
+
+    expect(reload).toHaveBeenCalledTimes(1);
   });
 });

--- a/console/web/src/App.activeTab.test.tsx
+++ b/console/web/src/App.activeTab.test.tsx
@@ -20,7 +20,7 @@ describe("active tab persistence", () => {
   });
 
   it("falls back to Home for a stale/invalid persisted value", () => {
-    window.sessionStorage.setItem("arrakis.activeTab", "Some Removed Tab");
+    window.sessionStorage.setItem("dune-console:active-tab", "Some Removed Tab");
     expect(loadPersistedTab()).toBe("Home");
   });
 

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -35,7 +35,36 @@ import {
 import { parseUpdateTask, stackVersionButtonLabel, stackVersionButtonTitle } from "./features/updates/updateUtils";
 import { formatUiSentence, stripAnsi, summarizeCommandText, titleCase } from "./lib/display";
 
-type Tab = "Home" | "Server Control" | "Services" | "Players" | "Guilds" | "Bases" | "Vehicles" | "Exchange" | "Landsraad" | "Admin Tools" | "Live Map" | "Maps" | "Care Package" | "Addons" | "Database" | "Storage" | "Backups" | "Logs" | "Updates" | "Settings";
+// The array is the source of truth (not just a type-level union) so restoring
+// a persisted tab (see loadPersistedTab below) can validate against the real,
+// current list at runtime instead of a hand-duplicated copy that could drift.
+export const ALL_TABS = ["Home", "Server Control", "Services", "Players", "Guilds", "Bases", "Vehicles", "Exchange", "Landsraad", "Admin Tools", "Live Map", "Maps", "Care Package", "Addons", "Database", "Storage", "Backups", "Logs", "Updates", "Settings"] as const;
+type Tab = typeof ALL_TABS[number];
+const ACTIVE_TAB_STORAGE_KEY = "arrakis.activeTab";
+
+// Persisted in sessionStorage, not localStorage: it should survive the
+// automatic reload LazyTabBoundary triggers after a stale chunk load (so the
+// user lands back on the tab they were opening, not Home), but should not
+// stick around and surprise someone who opens the console again days later
+// in a fresh tab.
+export function loadPersistedTab(): Tab {
+  if (typeof window === "undefined") return "Home";
+  try {
+    const raw = window.sessionStorage.getItem(ACTIVE_TAB_STORAGE_KEY);
+    return (ALL_TABS as readonly string[]).includes(raw || "") ? (raw as Tab) : "Home";
+  } catch {
+    return "Home";
+  }
+}
+
+export function persistActiveTab(tab: Tab) {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(ACTIVE_TAB_STORAGE_KEY, tab);
+  } catch {
+    // The tab still switches in-memory if sessionStorage is unavailable.
+  }
+}
 type SetupState = { files: Record<string, boolean>; config: Record<string, unknown> };
 type PublicDirectoryStatus = {
   mode?: string;
@@ -309,7 +338,7 @@ function AppFooter() {
 export function App() {
   const [auth, setAuth] = useState(false);
   const [password, setPassword] = useState("");
-  const [tab, setTab] = useState<Tab>("Home");
+  const [tab, setTab] = useState<Tab>(() => loadPersistedTab());
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [pinnedAddons, setPinnedAddons] = useState<PinnedAddon[]>(() => loadPinnedAddons());
   const [selectedPinnedAddonId, setSelectedPinnedAddonId] = useState("");
@@ -347,6 +376,10 @@ export function App() {
   useEffect(() => {
     preloadPlayerAdminIconRailAssets();
   }, []);
+
+  useEffect(() => {
+    persistActiveTab(tab);
+  }, [tab]);
 
   useEffect(() => {
     const handleSessionExpired = () => {

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -47,11 +47,15 @@ const ACTIVE_TAB_STORAGE_KEY = "dune-console:active-tab";
 // user lands back on the tab they were opening, not Home), but should not
 // stick around and surprise someone who opens the console again days later
 // in a fresh tab.
+function isTab(value: string): value is Tab {
+  return (ALL_TABS as readonly string[]).includes(value);
+}
+
 export function loadPersistedTab(): Tab {
   if (typeof window === "undefined") return "Home";
   try {
-    const raw = window.sessionStorage.getItem(ACTIVE_TAB_STORAGE_KEY);
-    return (ALL_TABS as readonly string[]).includes(raw || "") ? (raw as Tab) : "Home";
+    const raw = window.sessionStorage.getItem(ACTIVE_TAB_STORAGE_KEY) || "";
+    return isTab(raw) ? raw : "Home";
   } catch {
     return "Home";
   }

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -70,15 +70,16 @@ export function persistActiveTab(tab: Tab) {
   }
 }
 
-// Pulled out of App() so the init-from-storage + persist-on-change wiring is
-// covered directly (via renderHook in tests) instead of only its two halves
-// in isolation -- a regression here would only show up as "the reload lost
-// my tab" in practice, not as a type or lint error.
+// Persist before scheduling the render. LazyTabBoundary reloads from
+// componentDidCatch, which runs before passive effects, so writing from a
+// useEffect would still lose the destination tab during the exact recovery
+// path this state exists to support.
 export function useActiveTab() {
-  const [tab, setTab] = useState<Tab>(() => loadPersistedTab());
-  useEffect(() => {
-    persistActiveTab(tab);
-  }, [tab]);
+  const [tab, setTabState] = useState<Tab>(() => loadPersistedTab());
+  const setTab = useCallback((nextTab: Tab) => {
+    persistActiveTab(nextTab);
+    setTabState(nextTab);
+  }, []);
   return [tab, setTab] as const;
 }
 type SetupState = { files: Record<string, boolean>; config: Record<string, unknown> };

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -40,7 +40,7 @@ import { formatUiSentence, stripAnsi, summarizeCommandText, titleCase } from "./
 // current list at runtime instead of a hand-duplicated copy that could drift.
 export const ALL_TABS = ["Home", "Server Control", "Services", "Players", "Guilds", "Bases", "Vehicles", "Exchange", "Landsraad", "Admin Tools", "Live Map", "Maps", "Care Package", "Addons", "Database", "Storage", "Backups", "Logs", "Updates", "Settings"] as const;
 type Tab = typeof ALL_TABS[number];
-const ACTIVE_TAB_STORAGE_KEY = "arrakis.activeTab";
+const ACTIVE_TAB_STORAGE_KEY = "dune-console:active-tab";
 
 // Persisted in sessionStorage, not localStorage: it should survive the
 // automatic reload LazyTabBoundary triggers after a stale chunk load (so the

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -69,6 +69,18 @@ export function persistActiveTab(tab: Tab) {
     // The tab still switches in-memory if sessionStorage is unavailable.
   }
 }
+
+// Pulled out of App() so the init-from-storage + persist-on-change wiring is
+// covered directly (via renderHook in tests) instead of only its two halves
+// in isolation -- a regression here would only show up as "the reload lost
+// my tab" in practice, not as a type or lint error.
+export function useActiveTab() {
+  const [tab, setTab] = useState<Tab>(() => loadPersistedTab());
+  useEffect(() => {
+    persistActiveTab(tab);
+  }, [tab]);
+  return [tab, setTab] as const;
+}
 type SetupState = { files: Record<string, boolean>; config: Record<string, unknown> };
 type PublicDirectoryStatus = {
   mode?: string;
@@ -342,7 +354,7 @@ function AppFooter() {
 export function App() {
   const [auth, setAuth] = useState(false);
   const [password, setPassword] = useState("");
-  const [tab, setTab] = useState<Tab>(() => loadPersistedTab());
+  const [tab, setTab] = useActiveTab();
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [pinnedAddons, setPinnedAddons] = useState<PinnedAddon[]>(() => loadPinnedAddons());
   const [selectedPinnedAddonId, setSelectedPinnedAddonId] = useState("");
@@ -380,10 +392,6 @@ export function App() {
   useEffect(() => {
     preloadPlayerAdminIconRailAssets();
   }, []);
-
-  useEffect(() => {
-    persistActiveTab(tab);
-  }, [tab]);
 
   useEffect(() => {
     const handleSessionExpired = () => {


### PR DESCRIPTION
## Summary
- Follow-up to #188. Once a stale lazy-chunk failure auto-reloads the page, the user always landed back on Home instead of the tab they were opening -- tab selection lived only in `useState<Tab>("Home")` with no persistence, so a full reload had no way to know what was open.
- Persist the active tab to `sessionStorage` on every change and restore it on mount, validated against the current tab list. `Tab` is now derived from a single runtime array (`ALL_TABS`) instead of a separately hand-maintained string-literal union, so that validation can't silently drift from the real tab list over time.
- `sessionStorage`, not `localStorage`: it survives the reload LazyTabBoundary triggers, but clears when the browser tab closes rather than sticking around to surprise someone opening the console again days later.
- Storage key is `dune-console:active-tab`, matching the `dune-console:lazy-chunk-reload-at` convention Red-Blink introduced in #188's follow-up commit, rather than this repo's older `arrakis.*` dot-notation used elsewhere.

## Changes
- `console/web/src/App.tsx`:
  - `ALL_TABS` array as the runtime source of truth the `Tab` type is derived from.
  - `isTab(value): value is Tab` type guard, `loadPersistedTab`/`persistActiveTab` helpers.
  - `useActiveTab()` hook (`useState(loadPersistedTab)` + `useEffect(persistActiveTab)`) replacing the inline state/effect in `App()`, so the actual wiring is directly testable via `renderHook`.
- `console/web/src/App.activeTab.test.tsx` (new): covers default-to-Home, restore, stale/invalid value rejection, every current tab round-tripping, `sessionStorage.getItem`/`setItem` throwing (private browsing/quota), and the `useActiveTab` hook's init-from-storage + persist-on-change wiring end to end.

## Test plan
- [x] `console/web` full suite via `npm test`: 556/556 pass
- [x] `console/web` typecheck via `tsc -b`: clean
- [x] `console/web` production build via `npm run build`: succeeds