### PR TITLE
feat(console): auto-reload an idle tab when the console version changes

### DIFF
--- a/console/web/src/App.staleBuildWatcher.test.tsx
+++ b/console/web/src/App.staleBuildWatcher.test.tsx
@@ -1,0 +1,27 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const useStaleBuildWatcher = vi.hoisted(() => vi.fn());
+
+vi.mock("./lib/staleBuildWatcher", () => ({ useStaleBuildWatcher }));
+
+import { App } from "./App";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("App stale build watcher", () => {
+  it("stays active while logged out so a rebuild cannot strand the old bundle at login", () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      authenticated: false,
+      csrfToken: null,
+      config: { version: "v1.3.96" }
+    }), { status: 200, headers: { "content-type": "application/json" } })));
+
+    render(<App />);
+
+    expect(useStaleBuildWatcher).toHaveBeenCalledWith();
+  });
+});

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -34,6 +34,7 @@ import {
 } from "./features/server/ServerPanels";
 import { parseUpdateTask, stackVersionButtonLabel, stackVersionButtonTitle } from "./features/updates/updateUtils";
 import { formatUiSentence, stripAnsi, summarizeCommandText, titleCase } from "./lib/display";
+import { useStaleBuildWatcher } from "./lib/staleBuildWatcher";
 
 // The array is the source of truth (not just a type-level union) so restoring
 // a persisted tab (see loadPersistedTab below) can validate against the real,
@@ -393,6 +394,8 @@ export function App() {
   useEffect(() => {
     preloadPlayerAdminIconRailAssets();
   }, []);
+
+  useStaleBuildWatcher({ enabled: auth });
 
   useEffect(() => {
     const handleSessionExpired = () => {

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -395,7 +395,11 @@ export function App() {
     preloadPlayerAdminIconRailAssets();
   }, []);
 
-  useStaleBuildWatcher({ enabled: auth });
+  // /api/auth/state exposes the public build version without requiring a
+  // session. Keep watching through the logged-out state too: a Console
+  // rebuild clears the in-memory session, and disabling the watcher at that
+  // moment would let the old bundle survive through the next login.
+  useStaleBuildWatcher();
 
   useEffect(() => {
     const handleSessionExpired = () => {

--- a/console/web/src/api/client.ts
+++ b/console/web/src/api/client.ts
@@ -77,6 +77,22 @@ function announceSessionExpired() {
   if (typeof window !== "undefined") window.dispatchEvent(new Event(AUTH_SESSION_EXPIRED_EVENT));
 }
 
+// Bypasses the ordinary api() helper's caching (implicit `default` fetch
+// mode) on purpose: callers of this specific function need to know the
+// console's *actual current* running version -- used both by the console
+// update flow's own reload-readiness check and by useStaleBuildWatcher to
+// detect a version change on an idle tab -- so a cached response would
+// defeat the point.
+export async function fetchConsoleAuthState() {
+  const response = await fetch("/api/auth/state", {
+    credentials: "include",
+    cache: "no-store",
+    headers: { accept: "application/json" }
+  });
+  if (!response.ok) throw new Error(`Console state check failed: ${response.status}`);
+  return await response.json() as { config?: { version?: string } };
+}
+
 async function refreshCsrfToken() {
   try {
     const response = await fetch("/api/auth/state", { credentials: "include" });

--- a/console/web/src/features/updates/UpdatesPanel.tsx
+++ b/console/web/src/features/updates/UpdatesPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { BookOpen, ChevronDown, ChevronUp } from "lucide-react";
+import { fetchConsoleAuthState } from "../../api/client";
 import { setupApi, type Task } from "../../api/setup";
 import { updatesApi, type StackUpdateProgress as StackUpdateRunProgress } from "../../api/updates";
 import { KeyValueGrid, StatusPill } from "../../components/common/DisplayPrimitives";
@@ -721,15 +722,6 @@ function saveStackUpdateExpectedVersion(value: string) {
   }
 }
 
-async function fetchConsoleAuthState() {
-  const response = await fetch("/api/auth/state", {
-    credentials: "include",
-    cache: "no-store",
-    headers: { accept: "application/json" }
-  });
-  if (!response.ok) throw new Error(`Console state check failed: ${response.status}`);
-  return await response.json() as { config?: { version?: string } };
-}
 
 function stackUpdatePercent(text: string) {
   const stages: [RegExp, number][] = [

--- a/console/web/src/lib/staleBuildWatcher.test.ts
+++ b/console/web/src/lib/staleBuildWatcher.test.ts
@@ -1,0 +1,125 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { staleBuildWatcherInternals, useStaleBuildWatcher } from "./staleBuildWatcher";
+
+function memoryStorage(initial: Record<string, string> = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: vi.fn((key: string) => values.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => { values.set(key, value); })
+  };
+}
+
+// Returns `versions[0]` on every call until `advance()` is called, then
+// `versions[1]`, and so on -- avoids asserting an exact call count on
+// fetchVersion itself (this environment's fake timers can invoke a mounting
+// effect's async body more than once without that affecting the hook's real,
+// user-facing contract: whether/when reload() fires).
+function versionSource(...versions: (string | null)[]) {
+  let index = 0;
+  return {
+    fetchVersion: vi.fn(async () => versions[Math.min(index, versions.length - 1)]),
+    advance: () => { index = Math.min(index + 1, versions.length - 1); }
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useStaleBuildWatcher", () => {
+  it("does not reload on the initial poll -- it only establishes the baseline version", async () => {
+    const reload = vi.fn();
+    const { fetchVersion } = versionSource("v1.0.0");
+    renderHook(() => useStaleBuildWatcher({ fetchVersion, reload, storage: memoryStorage() }));
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does not reload while the polled version keeps matching the baseline", async () => {
+    const reload = vi.fn();
+    const { fetchVersion } = versionSource("v1.0.0");
+    renderHook(() => useStaleBuildWatcher({ fetchVersion, reload, storage: memoryStorage(), intervalMs: 1000 }));
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("reloads automatically the first time the polled version changes", async () => {
+    const reload = vi.fn();
+    const storage = memoryStorage();
+    const { fetchVersion, advance } = versionSource("v1.0.0", "v1.0.1");
+    renderHook(() => useStaleBuildWatcher({ fetchVersion, reload, storage, now: () => 100_000, intervalMs: 1000 }));
+    await vi.runOnlyPendingTimersAsync();
+    advance();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledWith(staleBuildWatcherInternals.RELOAD_COOLDOWN_KEY, "100000");
+  });
+
+  it("does not reload again within the cooldown window", async () => {
+    const reload = vi.fn();
+    const storage = memoryStorage({ [staleBuildWatcherInternals.RELOAD_COOLDOWN_KEY]: "90000" });
+    const { fetchVersion, advance } = versionSource("v1.0.0", "v1.0.1");
+    renderHook(() => useStaleBuildWatcher({ fetchVersion, reload, storage, now: () => 100_000, intervalMs: 1000 }));
+    await vi.runOnlyPendingTimersAsync();
+    advance();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does not reload when storage is unavailable, even once a new version is seen", async () => {
+    const reload = vi.fn();
+    const { fetchVersion, advance } = versionSource("v1.0.0", "v1.0.1");
+    renderHook(() => useStaleBuildWatcher({ fetchVersion, reload, storage: null, intervalMs: 1000 }));
+    await vi.runOnlyPendingTimersAsync();
+    advance();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("does not crash and does not reload when the version fetch fails", async () => {
+    const reload = vi.fn();
+    const fetchVersion = vi.fn().mockRejectedValue(new Error("network error"));
+    renderHook(() => useStaleBuildWatcher({ fetchVersion, reload, storage: memoryStorage(), intervalMs: 1000 }));
+    await vi.runOnlyPendingTimersAsync();
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("never polls while disabled", async () => {
+    const reload = vi.fn();
+    const { fetchVersion } = versionSource("v1.0.0");
+    renderHook(() => useStaleBuildWatcher({ enabled: false, fetchVersion, reload, storage: memoryStorage() }));
+    await vi.advanceTimersByTimeAsync(staleBuildWatcherInternals.DEFAULT_POLL_INTERVAL_MS * 2);
+
+    expect(fetchVersion).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("stops polling once disabled mid-flight", async () => {
+    const reload = vi.fn();
+    const { fetchVersion } = versionSource("v1.0.0");
+    const { rerender } = renderHook(
+      ({ enabled }) => useStaleBuildWatcher({ enabled, fetchVersion, reload, storage: memoryStorage(), intervalMs: 1000 }),
+      { initialProps: { enabled: true } }
+    );
+    await vi.runOnlyPendingTimersAsync();
+    fetchVersion.mockClear();
+    rerender({ enabled: false });
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(fetchVersion).not.toHaveBeenCalled();
+  });
+});

--- a/console/web/src/lib/staleBuildWatcher.ts
+++ b/console/web/src/lib/staleBuildWatcher.ts
@@ -1,0 +1,96 @@
+import { useEffect } from "react";
+import { fetchConsoleAuthState } from "../api/client";
+
+const RELOAD_COOLDOWN_KEY = "dune-console:stale-build-reload-at";
+const RELOAD_COOLDOWN_MS = 60_000;
+const DEFAULT_POLL_INTERVAL_MS = 120_000;
+
+type StaleBuildStorage = Pick<Storage, "getItem" | "setItem">;
+
+export type StaleBuildWatcherOptions = {
+  enabled?: boolean;
+  intervalMs?: number;
+  // Injection points keep this testable with fake timers, matching the
+  // pattern LazyTabBoundary uses for the same reason.
+  fetchVersion?: () => Promise<string | null>;
+  reload?: () => void;
+  storage?: StaleBuildStorage | null;
+  now?: () => number;
+};
+
+async function defaultFetchVersion(): Promise<string | null> {
+  const state = await fetchConsoleAuthState();
+  const version = state?.config?.version;
+  return typeof version === "string" && version.trim() ? version.trim() : null;
+}
+
+function browserStorage(): StaleBuildStorage | null {
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function browserReload() {
+  window.location.reload();
+}
+
+// Once loaded, a browser tab has no way to know the server's files changed
+// underneath it -- there is no push, and nothing else in this app watches
+// for a version change on an already-open, idle tab (LazyTabBoundary only
+// reacts when a lazy chunk it tries to load is already gone, and the
+// Updates panel's own reload flow only runs in the tab that triggered the
+// update). This closes that gap: poll the running console version and
+// reload automatically the first time it changes, so a tab left open
+// during someone else's console update recovers on its own instead of
+// running stale code indefinitely.
+export function useStaleBuildWatcher(options: StaleBuildWatcherOptions = {}) {
+  const {
+    enabled = true,
+    intervalMs = DEFAULT_POLL_INTERVAL_MS,
+    fetchVersion = defaultFetchVersion,
+    reload = browserReload,
+    storage = browserStorage(),
+    now = Date.now
+  } = options;
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    let baselineVersion: string | null = null;
+
+    async function poll() {
+      const version = await fetchVersion().catch(() => null);
+      if (cancelled || !version) return;
+      if (baselineVersion === null) {
+        baselineVersion = version;
+        return;
+      }
+      if (version === baselineVersion) return;
+
+      // Without a durable cooldown marker, don't risk an uncontrolled reload
+      // loop against a flapping deploy -- same fail-closed choice
+      // LazyTabBoundary makes when storage is unavailable.
+      if (!storage) return;
+      try {
+        const lastAttempt = Number(storage.getItem(RELOAD_COOLDOWN_KEY) || 0);
+        const elapsed = now() - lastAttempt;
+        if (Number.isFinite(lastAttempt) && lastAttempt > 0 && elapsed >= 0 && elapsed < RELOAD_COOLDOWN_MS) return;
+        storage.setItem(RELOAD_COOLDOWN_KEY, String(now()));
+      } catch {
+        return;
+      }
+      reload();
+    }
+
+    void poll();
+    const id = window.setInterval(poll, intervalMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [enabled, intervalMs, fetchVersion, reload, storage, now]);
+}
+
+export const staleBuildWatcherInternals = Object.freeze({ RELOAD_COOLDOWN_KEY, RELOAD_COOLDOWN_MS, DEFAULT_POLL_INTERVAL_MS });


### PR DESCRIPTION
## Summary
Builds on the chain of console-update reload fixes: #181 (stop caching the SPA fallback as an immutable asset), #188 (recover from a failed lazy-chunk load instead of crashing), and #190 (keep the active tab across that recovery reload). Those cover *reactive* recovery -- something has to actually fail (a stale asset request, a failed lazy import) before any of them kick in.

- Neither `LazyTabBoundary` (#188/#190 -- only reacts when a lazy tab's own chunk fails to load) nor the Updates panel's reload flow (only runs in the tab that triggered the update) helps an already-open, idle tab that never hits either path -- e.g. someone else applies a Console Update while you're sitting on Home. A browser fundamentally has no way to know the server's files changed underneath it once loaded; nothing in this app was watching for that.
- `useStaleBuildWatcher` closes that gap: it polls `/api/auth/state`'s `config.version` on an interval (default 2 minutes), captures it as a baseline on the first successful read, and calls `window.location.reload()` automatically the first time the polled version differs from the baseline. Cooldown-guarded via `sessionStorage` against a flapping deploy causing a reload loop -- same fail-closed choice `LazyTabBoundary` makes when storage is unavailable (skip the reload rather than risk looping).
- Dependency-injected (`fetchVersion`/`reload`/`storage`/`now`/`intervalMs`), matching the pattern established in `LazyTabBoundary`'s own hardening commit (#188), so the real timer/storage/reload behavior is directly testable with fake timers instead of only its pieces in isolation.

**Note on scope:** this doesn't avoid the re-login a rebuild already causes. `auth.js` keeps sessions in an in-memory `Map`, so a rebuild invalidates every existing session the moment the new process starts, independent of anything in the browser -- an idle tab already reaches the login screen on its own, reactively, the next time any background poll gets a 401 (`AUTH_SESSION_EXPIRED_EVENT`), no page reload involved. What this PR actually fixes is that without it, that same tab would log back in *while still running the old JS bundle* -- session freshness and code freshness are separate axes, and nothing was forcing the second one. With this, the tab reloads and picks up the current build before you're asked to sign back in.

## Changes
- `console/web/src/lib/staleBuildWatcher.ts` (new): `useStaleBuildWatcher()` hook + `staleBuildWatcherInternals` for tests.
- `console/web/src/App.tsx`: wired in as `useStaleBuildWatcher({ enabled: auth })` -- only polls once logged in.
- `console/web/src/api/client.ts`: `fetchConsoleAuthState()` moved here from `UpdatesPanel.tsx`. It was a lazily-loaded panel; statically importing from it in a module `App.tsx` imports directly pulled the whole Updates panel out of its own code-split chunk and into the main bundle (caught via Vite's `INEFFECTIVE_DYNAMIC_IMPORT` build warning and a ~30KB main-bundle regression). `UpdatesPanel.tsx` now imports it from `api/client.ts` too.

## Test plan
- [x] `console/web` full suite via `npm test`: 565/565 pass
- [x] `console/web` typecheck via `tsc -b`: clean
- [x] `console/web` production build via `npm run build`: succeeds, confirms `UpdatesPanel` is still its own chunk (no `INEFFECTIVE_DYNAMIC_IMPORT` warning, main bundle back to its prior size)
- [x] New `staleBuildWatcher.test.ts`: covers baseline capture, matching/changed versions, reload-once + cooldown, storage-unavailable fail-closed, fetch failure, and enable/disable (including mid-flight)