### PR TITLE
feat(settings): dedupe Coriolis fields, add Match Region for Cycle Start Hour and Day

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,10 +47,13 @@ SERVER_IP_MODE=public
 # Public name players should see.
 SERVER_TITLE="My Dune Server"
 
-# Region/farm label used by the game services and public directory. This does
-# not choose a regional Coriolis schedule; configure the cycle start under
-# Maps -> Modifiers -> Coriolis in the Web Console.
-SERVER_REGION="Europe Test"
+# Region/farm label used by the game services and public directory. On first
+# startup this also seeds the global Coriolis Cycle Start Hour to the
+# region's UTC master schedule, if it has never been explicitly saved --
+# Europe, North America, South America, Asia, or Oceania. Any other value
+# (including one typed free-form here) leaves that field alone; configure it
+# directly under Maps -> Modifiers -> Coriolis in the Web Console.
+SERVER_REGION="Europe"
 
 # Provider/datacenter label shown by Funcom server browser if supported.
 SERVER_PROVIDER="dune-docker"

--- a/console/api/src/runner.js
+++ b/console/api/src/runner.js
@@ -309,12 +309,12 @@ export function buildDuneArgs(operation, payload = {}) {
       return ["usersettings", "partition-values", validateMapName(payload.map), validatePartitionId(payload.partitionId)];
     case "userSettingsSave":
       return ["usersettings", "bulk-save", validateSettingsScope(payload.scope), validateMapName(payload.map || "Survival_1"), payload.partitionId ? validatePartitionId(payload.partitionId) : "", encodeJsonArg(payload.values || {})];
-    case "userSettingsMigrateCoriolisRegionHour":
+    case "userSettingsMigrateCoriolisRegionFields":
       // region comes only from the deployment's own SERVER_REGION (readSetupConfigValues,
       // an allowlisted .env read), never from a request -- spawn's argv array means there
       // is no shell to inject into regardless, and an unmapped/garbage value is a no-op
-      // on the Python side (migrate_coriolis_region_hour looks it up in a fixed dict).
-      return ["usersettings", "migrate-coriolis-region-hour", String(payload.region || "")];
+      // on the Python side (migrate_coriolis_region_fields looks it up in a fixed dict).
+      return ["usersettings", "migrate-coriolis-region-fields", String(payload.region || "")];
     case "userSettingsSaveAndRestart":
       return buildDuneArgs("userSettingsSave", payload);
     case "userSettingsResetEngineGameplay":

--- a/console/api/src/runner.js
+++ b/console/api/src/runner.js
@@ -309,6 +309,12 @@ export function buildDuneArgs(operation, payload = {}) {
       return ["usersettings", "partition-values", validateMapName(payload.map), validatePartitionId(payload.partitionId)];
     case "userSettingsSave":
       return ["usersettings", "bulk-save", validateSettingsScope(payload.scope), validateMapName(payload.map || "Survival_1"), payload.partitionId ? validatePartitionId(payload.partitionId) : "", encodeJsonArg(payload.values || {})];
+    case "userSettingsMigrateCoriolisRegionHour":
+      // region comes only from the deployment's own SERVER_REGION (readSetupConfigValues,
+      // an allowlisted .env read), never from a request -- spawn's argv array means there
+      // is no shell to inject into regardless, and an unmapped/garbage value is a no-op
+      // on the Python side (migrate_coriolis_region_hour looks it up in a fixed dict).
+      return ["usersettings", "migrate-coriolis-region-hour", String(payload.region || "")];
     case "userSettingsSaveAndRestart":
       return buildDuneArgs("userSettingsSave", payload);
     case "userSettingsResetEngineGameplay":

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -216,8 +216,8 @@ createServer(async (req, res) => {
   ensureExchangeHistory(db).catch((error) => {
     console.warn(`Market transaction recorder initialization failed: ${redact(error?.message || "Unexpected error.")}`);
   });
-  migrateCoriolisRegionCycleStartHour().catch((error) => {
-    console.warn(`Coriolis Cycle Start Hour region migration deferred: ${redact(error?.message || "Unexpected error.")}`);
+  migrateCoriolisRegionFields().catch((error) => {
+    console.warn(`Coriolis cycle start region migration deferred: ${redact(error?.message || "Unexpected error.")}`);
   });
   runBackgroundTick("Player playtime tracker", () => duneDb.trackPlayerPlaytime(db));
 });
@@ -5111,25 +5111,31 @@ function readSetupConfigValues() {
   return values;
 }
 
-// One-time, idempotent migration: if this deployment's SERVER_REGION has a known
-// Coriolis master hour and the global Cycle Start Hour has never been explicitly
-// saved, write it once. Deliberately server-side and global-scope-only, not driven
-// by the Maps UI -- an earlier version fired this from a frontend effect keyed off
-// "field still at its schema default", which could not tell "never saved" from
-// "explicitly saved to the default" (looping forever on a Europe deployment, whose
-// region hour equals the default) and pinned whichever scope an admin happened to
-// have open (breaking Global -> Map -> Partition inheritance). Idempotency here is
-// by ini-key presence (checked in Python), never by value, so it is safe to call on
-// every startup. Mirrors the fire-and-forget migration pattern already used for
+// One-time, idempotent migration: for each of coriolis_cycle_start_hour and
+// _day, if this deployment's SERVER_REGION has a known regional value and the
+// field has never been explicitly saved, write it once. Deliberately
+// server-side and global-scope-only, not driven by the Maps UI -- an earlier
+// version fired this from a frontend effect keyed off "field still at its
+// schema default", which could not tell "never saved" from "explicitly saved
+// to the default" (looped forever on a Europe deployment, whose region hour
+// equals the default -- coriolis_cycle_start_day's default equals the
+// region value for 3 of 5 regions, so this class of bug is not a one-region
+// edge case here) and pinned whichever scope an admin happened to have open
+// (breaking Global -> Map -> Partition inheritance). Idempotency here is by
+// ini-key presence per field (checked in Python), never by value, so it is
+// safe to call on every startup. Both fields are migrated in one Python
+// invocation/profile write -- see migrate_coriolis_region_fields -- so a
+// startup that needs to migrate both can't leave one written and the other
+// not. Mirrors the fire-and-forget migration pattern already used for
 // initializeDiscordAdapterSchema/ensureExchangeHistory below.
-async function migrateCoriolisRegionCycleStartHour() {
+async function migrateCoriolisRegionFields() {
   const region = readSetupConfigValues().SERVER_REGION || "";
   if (!region) return;
-  const result = await runDune(config, buildDuneArgs("userSettingsMigrateCoriolisRegionHour", { region }), { timeoutMs: 8000 });
+  const result = await runDune(config, buildDuneArgs("userSettingsMigrateCoriolisRegionFields", { region }), { timeoutMs: 8000 });
   const [status, detail] = String(result.stdout || "").trim().split(":");
   if (status !== "migrated") return;
-  audit(config, null, "maps.user-settings.auto-migrate", { scope: "global", field: "coriolis_cycle_start_hour", value: detail, region });
-  markDeferredRestartPending(config, "Coriolis Cycle Start Hour (region default)");
+  audit(config, null, "maps.user-settings.auto-migrate", { scope: "global", fields: detail, region });
+  markDeferredRestartPending(config, "Coriolis cycle start settings (region default)");
 }
 
 function readEnvFileValue(key) {

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -216,6 +216,9 @@ createServer(async (req, res) => {
   ensureExchangeHistory(db).catch((error) => {
     console.warn(`Market transaction recorder initialization failed: ${redact(error?.message || "Unexpected error.")}`);
   });
+  migrateCoriolisRegionCycleStartHour().catch((error) => {
+    console.warn(`Coriolis Cycle Start Hour region migration deferred: ${redact(error?.message || "Unexpected error.")}`);
+  });
   runBackgroundTick("Player playtime tracker", () => duneDb.trackPlayerPlaytime(db));
 });
 
@@ -5106,6 +5109,27 @@ function readSetupConfigValues() {
     }
   }
   return values;
+}
+
+// One-time, idempotent migration: if this deployment's SERVER_REGION has a known
+// Coriolis master hour and the global Cycle Start Hour has never been explicitly
+// saved, write it once. Deliberately server-side and global-scope-only, not driven
+// by the Maps UI -- an earlier version fired this from a frontend effect keyed off
+// "field still at its schema default", which could not tell "never saved" from
+// "explicitly saved to the default" (looping forever on a Europe deployment, whose
+// region hour equals the default) and pinned whichever scope an admin happened to
+// have open (breaking Global -> Map -> Partition inheritance). Idempotency here is
+// by ini-key presence (checked in Python), never by value, so it is safe to call on
+// every startup. Mirrors the fire-and-forget migration pattern already used for
+// initializeDiscordAdapterSchema/ensureExchangeHistory below.
+async function migrateCoriolisRegionCycleStartHour() {
+  const region = readSetupConfigValues().SERVER_REGION || "";
+  if (!region) return;
+  const result = await runDune(config, buildDuneArgs("userSettingsMigrateCoriolisRegionHour", { region }), { timeoutMs: 8000 });
+  const [status, detail] = String(result.stdout || "").trim().split(":");
+  if (status !== "migrated") return;
+  audit(config, null, "maps.user-settings.auto-migrate", { scope: "global", field: "coriolis_cycle_start_hour", value: detail, region });
+  markDeferredRestartPending(config, "Coriolis Cycle Start Hour (region default)");
 }
 
 function readEnvFileValue(key) {

--- a/console/web/src/features/maps/MapsPanel.matchRegion.test.tsx
+++ b/console/web/src/features/maps/MapsPanel.matchRegion.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mapsApi } from "../../api/maps";
+import { setupApi } from "../../api/setup";
+import { coriolisHourMatchesRegionInference, MapsPanel } from "./MapsPanel";
+
+vi.mock("../../api/maps", () => ({
+  mapsApi: new Proxy({} as Record<string, unknown>, {
+    get: (target, prop: string) => {
+      if (!target[prop]) {
+        target[prop] = vi.fn().mockResolvedValue({
+          stdout: "",
+          exitCode: 0,
+          content: "",
+          rows: [],
+          placements: [],
+          tradeCenters: [],
+          partitions: [],
+          fields: [],
+          partition: [],
+          partitionEngine: [],
+          mapEngine: [],
+          game: [],
+          engine: [],
+          capabilities: {},
+          values: {},
+          sampledAt: ""
+        });
+      }
+      return target[prop];
+    }
+  })
+}));
+
+vi.mock("../../api/setup", () => ({
+  setupApi: new Proxy({} as Record<string, unknown>, {
+    get: (target, prop: string) => {
+      if (!target[prop]) target[prop] = vi.fn().mockResolvedValue({});
+      return target[prop];
+    }
+  })
+}));
+
+vi.mock("../../lib/usePendingRefills", () => ({
+  usePendingRefills: () => ({ pending: null, refresh: () => {} }),
+  pendingRefillCountForMap: () => 0,
+  pendingRefillCountForPartition: () => 0
+}));
+
+const CORIOLIS_CYCLE_START_HOUR_FIELD = {
+  scope: "game",
+  id: "coriolis_cycle_start_hour",
+  section: "/Script/DuneSandbox.CoriolisSubsystem",
+  key: "m_CycleStartHour",
+  default: "5",
+  type: "integer",
+  clientFile: "",
+  category: "",
+  description: "UTC hour (0-23). Regional master schedules: Europe 05, North America 11, South America 08, Asia 09, and Oceania 19.",
+  minimum: 0,
+  maximum: 23
+};
+
+function renderMapsPanel() {
+  render(<MapsPanel
+    onError={vi.fn()}
+    confirmAction={vi.fn().mockResolvedValue(true)}
+    confirmSettingsRestart={vi.fn().mockResolvedValue("manual")}
+    waitForTaskWithUpdates={vi.fn()}
+    taskTechnicalDetails={vi.fn().mockReturnValue("")}
+    restartGate={vi.fn().mockResolvedValue("immediate")}
+  />);
+}
+
+async function openUserGameGlobalTab(api: Record<string, ReturnType<typeof vi.fn>>) {
+  renderMapsPanel();
+  const modifiers = await screen.findByRole("button", { name: "Expand Interactive Modifiers" });
+  await waitFor(() => expect(modifiers).toBeEnabled());
+  fireEvent.click(modifiers);
+  fireEvent.click(screen.getByRole("tab", { name: "UserGame" }));
+  const targetSelect = await screen.findByLabelText("Target");
+  fireEvent.change(targetSelect, { target: { value: "__global__::" } });
+  await waitFor(() => expect(api.userGame).toHaveBeenCalled());
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("coriolisHourMatchesRegionInference", () => {
+  it("is On when the saved value is still at the schema default", () => {
+    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "5", 11)).toBe(true);
+  });
+  it("is On when the saved value already matches the region's hour", () => {
+    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "11", 11)).toBe(true);
+  });
+  it("is Off for a deliberate manual value that differs from both", () => {
+    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "14", 11)).toBe(false);
+  });
+  it("is Off when the region has no defined master hour", () => {
+    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "5", undefined)).toBe(false);
+  });
+});
+
+describe("MapsPanel Match Region toggle", () => {
+  it("locks the field to the region's hour when the saved value is untouched", async () => {
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({
+      engine: [], mapEngine: [], partitionEngine: [], partition: [],
+      game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
+    });
+    api.userGame.mockResolvedValue({ stdout: "coriolis_cycle_start_hour\t5\n", exitCode: 0 });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
+      files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
+    });
+
+    await openUserGameGlobalTab(api);
+
+    const hourInput = await screen.findByDisplayValue("11");
+    expect(hourInput).toBeDisabled();
+    expect(screen.getByRole("radio", { name: "On" })).toBeChecked();
+  });
+
+  it("leaves an existing custom hour editable and does not overwrite it", async () => {
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({
+      engine: [], mapEngine: [], partitionEngine: [], partition: [],
+      game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
+    });
+    api.userGame.mockResolvedValue({ stdout: "coriolis_cycle_start_hour\t14\n", exitCode: 0 });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
+      files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
+    });
+
+    await openUserGameGlobalTab(api);
+
+    const hourInput = await screen.findByDisplayValue("14");
+    expect(hourInput).toBeEnabled();
+    expect(screen.getByRole("radio", { name: "Off" })).toBeChecked();
+  });
+
+  it("switches to manual editing when the toggle is turned Off", async () => {
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({
+      engine: [], mapEngine: [], partitionEngine: [], partition: [],
+      game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
+    });
+    api.userGame.mockResolvedValue({ stdout: "coriolis_cycle_start_hour\t5\n", exitCode: 0 });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
+      files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
+    });
+
+    await openUserGameGlobalTab(api);
+    await screen.findByDisplayValue("11");
+
+    fireEvent.click(screen.getByRole("radio", { name: "Off" }));
+
+    const hourInput = await screen.findByDisplayValue("11");
+    expect(hourInput).toBeEnabled();
+  });
+});

--- a/console/web/src/features/maps/MapsPanel.matchRegion.test.tsx
+++ b/console/web/src/features/maps/MapsPanel.matchRegion.test.tsx
@@ -89,9 +89,9 @@ const CORIOLIS_CYCLE_START_DAY_FIELD = {
   clientFile: "",
   category: "",
   label: "Cycle Start Day",
-  description: "UTC weekday: 1=Sunday through 7=Saturday. Regional master schedules: Europe, North America, and South America use Tuesday (3); Asia and Oceania use Monday (2).",
+  description: "UTC calendar day of the month (1-31). Regional master schedule anchor dates: Europe, North America, and South America use day 3; Asia and Oceania use day 2.",
   minimum: 1,
-  maximum: 7
+  maximum: 31
 };
 
 const BOTH_CORIOLIS_FIELDS = [CORIOLIS_CYCLE_START_HOUR_FIELD, CORIOLIS_CYCLE_START_DAY_FIELD];

--- a/console/web/src/features/maps/MapsPanel.matchRegion.test.tsx
+++ b/console/web/src/features/maps/MapsPanel.matchRegion.test.tsx
@@ -43,8 +43,19 @@ vi.mock("../../api/setup", () => ({
 
 vi.mock("../../lib/usePendingRefills", () => ({
   usePendingRefills: () => ({ pending: null, refresh: () => {} }),
+  usePendingQueues: () => ({
+    fuel: { pending: null, refresh: () => {} },
+    water: { pending: null, refresh: () => {} },
+    deletes: { pending: null, refresh: () => {} },
+    vehicleDeletes: { pending: null, refresh: () => {} },
+    permissions: { pending: null, refresh: () => {} }
+  }),
   pendingRefillCountForMap: () => 0,
-  pendingRefillCountForPartition: () => 0
+  pendingRefillCountForPartition: () => 0,
+  vehicleDeleteCountForMap: () => 0,
+  vehicleDeleteCountForPartition: () => 0,
+  childAccessPieceCountForMap: () => 0,
+  childAccessPieceCountForPartition: () => 0
 }));
 
 const CORIOLIS_CYCLE_START_HOUR_FIELD = {
@@ -83,33 +94,46 @@ async function openUserGameGlobalTab(api: Record<string, ReturnType<typeof vi.fn
   await waitFor(() => expect(api.userGame).toHaveBeenCalled());
 }
 
+function mockCoriolisHour(api: Record<string, ReturnType<typeof vi.fn>>, savedHour: string) {
+  api.userGame.mockResolvedValue({ stdout: `coriolis_cycle_start_hour\t${savedHour}\n`, exitCode: 0 });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
 describe("coriolisHourMatchesRegionInference", () => {
-  it("is On when the saved value is still at the schema default", () => {
-    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "5", 11)).toBe(true);
-  });
   it("is On when the saved value already matches the region's hour", () => {
     expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "11", 11)).toBe(true);
   });
-  it("is Off for a deliberate manual value that differs from both", () => {
+  it("is Off when the saved value is still at the untouched schema default and the default isn't the region's hour", () => {
+    // The default no longer implies "unset -- go ahead and lock it": a scope this
+    // young gets the region's hour written once, server-side, before the frontend
+    // ever sees it (migrate_coriolis_region_hour in usersettings.py). By the time
+    // this runs, a saved 5 on a non-Europe region is either a genuine manual 5 or a
+    // deployment the migration hasn't reached yet -- either way, not this toggle's
+    // call to silently overwrite.
+    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "5", 11)).toBe(false);
+  });
+  it("is On when the default happens to equal the region's hour", () => {
+    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "5", 5)).toBe(true);
+  });
+  it("is Off for a deliberate manual value that differs from the region's hour", () => {
     expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "14", 11)).toBe(false);
   });
   it("is Off when the region has no defined master hour", () => {
-    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "5", undefined)).toBe(false);
+    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "11", undefined)).toBe(false);
   });
 });
 
 describe("MapsPanel Match Region toggle", () => {
-  it("locks the field to the region's hour when the saved value is untouched", async () => {
+  it("locks the field when the saved value already matches the region's hour", async () => {
     const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
     api.userSettingsSchema.mockResolvedValue({
       engine: [], mapEngine: [], partitionEngine: [], partition: [],
       game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
     });
-    api.userGame.mockResolvedValue({ stdout: "coriolis_cycle_start_hour\t5\n", exitCode: 0 });
+    mockCoriolisHour(api, "11");
     (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
       files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
     });
@@ -119,6 +143,28 @@ describe("MapsPanel Match Region toggle", () => {
     const hourInput = await screen.findByDisplayValue("11");
     expect(hourInput).toBeDisabled();
     expect(screen.getByRole("radio", { name: "On" })).toBeChecked();
+    // Migration is server-side only (see server.js's migrateCoriolisRegionCycleStartHour)
+    // -- merely opening this tab must never issue a write of its own.
+    expect(api.saveUserSettings).not.toHaveBeenCalled();
+  });
+
+  it("leaves an untouched (still-default) hour editable rather than locking or saving it", async () => {
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({
+      engine: [], mapEngine: [], partitionEngine: [], partition: [],
+      game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
+    });
+    mockCoriolisHour(api, "5");
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
+      files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
+    });
+
+    await openUserGameGlobalTab(api);
+
+    const hourInput = await screen.findByDisplayValue("5");
+    expect(hourInput).toBeEnabled();
+    expect(screen.getByRole("radio", { name: "Off" })).toBeChecked();
+    expect(api.saveUserSettings).not.toHaveBeenCalled();
   });
 
   it("leaves an existing custom hour editable and does not overwrite it", async () => {
@@ -127,7 +173,7 @@ describe("MapsPanel Match Region toggle", () => {
       engine: [], mapEngine: [], partitionEngine: [], partition: [],
       game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
     });
-    api.userGame.mockResolvedValue({ stdout: "coriolis_cycle_start_hour\t14\n", exitCode: 0 });
+    mockCoriolisHour(api, "14");
     (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
       files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
     });
@@ -137,6 +183,7 @@ describe("MapsPanel Match Region toggle", () => {
     const hourInput = await screen.findByDisplayValue("14");
     expect(hourInput).toBeEnabled();
     expect(screen.getByRole("radio", { name: "Off" })).toBeChecked();
+    expect(api.saveUserSettings).not.toHaveBeenCalled();
   });
 
   it("switches to manual editing when the toggle is turned Off", async () => {
@@ -145,7 +192,7 @@ describe("MapsPanel Match Region toggle", () => {
       engine: [], mapEngine: [], partitionEngine: [], partition: [],
       game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
     });
-    api.userGame.mockResolvedValue({ stdout: "coriolis_cycle_start_hour\t5\n", exitCode: 0 });
+    mockCoriolisHour(api, "11");
     (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
       files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
     });
@@ -157,5 +204,28 @@ describe("MapsPanel Match Region toggle", () => {
 
     const hourInput = await screen.findByDisplayValue("11");
     expect(hourInput).toBeEnabled();
+  });
+
+  it("pins the draft to the region's hour (without saving) when the toggle is turned On", async () => {
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({
+      engine: [], mapEngine: [], partitionEngine: [], partition: [],
+      game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
+    });
+    mockCoriolisHour(api, "14");
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
+      files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
+    });
+
+    await openUserGameGlobalTab(api);
+    await screen.findByDisplayValue("14");
+
+    fireEvent.click(screen.getByRole("radio", { name: "On" }));
+
+    const hourInput = await screen.findByDisplayValue("11");
+    expect(hourInput).toBeDisabled();
+    // Pinning the draft is a local edit an explicit Save would apply -- it must
+    // never itself issue a network write.
+    expect(api.saveUserSettings).not.toHaveBeenCalled();
   });
 });

--- a/console/web/src/features/maps/MapsPanel.matchRegion.test.tsx
+++ b/console/web/src/features/maps/MapsPanel.matchRegion.test.tsx
@@ -1,8 +1,8 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mapsApi } from "../../api/maps";
 import { setupApi } from "../../api/setup";
-import { coriolisHourMatchesRegionInference, MapsPanel } from "./MapsPanel";
+import { coriolisFieldMatchesRegionInference, MapsPanel } from "./MapsPanel";
 
 vi.mock("../../api/maps", () => ({
   mapsApi: new Proxy({} as Record<string, unknown>, {
@@ -67,10 +67,34 @@ const CORIOLIS_CYCLE_START_HOUR_FIELD = {
   type: "integer",
   clientFile: "",
   category: "",
+  label: "Cycle Start Hour",
   description: "UTC hour (0-23). Regional master schedules: Europe 05, North America 11, South America 08, Asia 09, and Oceania 19.",
   minimum: 0,
   maximum: 23
 };
+
+// coriolis_cycle_start_day's schema default ("3") coincides with the region
+// value for three of the five regions (Europe, North America, South
+// America) -- the exact "value equals default" trap that caused the Cycle
+// Start Hour migration to loop forever on Europe before it was fixed. Any
+// test here that uses North America must not assume "region day != default"
+// the way most of the hour tests safely could with a default of 5.
+const CORIOLIS_CYCLE_START_DAY_FIELD = {
+  scope: "game",
+  id: "coriolis_cycle_start_day",
+  section: "/Script/DuneSandbox.CoriolisSubsystem",
+  key: "m_CycleStartDay",
+  default: "3",
+  type: "integer",
+  clientFile: "",
+  category: "",
+  label: "Cycle Start Day",
+  description: "UTC weekday: 1=Sunday through 7=Saturday. Regional master schedules: Europe, North America, and South America use Tuesday (3); Asia and Oceania use Monday (2).",
+  minimum: 1,
+  maximum: 7
+};
+
+const BOTH_CORIOLIS_FIELDS = [CORIOLIS_CYCLE_START_HOUR_FIELD, CORIOLIS_CYCLE_START_DAY_FIELD];
 
 function renderMapsPanel() {
   render(<MapsPanel
@@ -94,113 +118,115 @@ async function openUserGameGlobalTab(api: Record<string, ReturnType<typeof vi.fn
   await waitFor(() => expect(api.userGame).toHaveBeenCalled());
 }
 
-function mockCoriolisHour(api: Record<string, ReturnType<typeof vi.fn>>, savedHour: string) {
-  api.userGame.mockResolvedValue({ stdout: `coriolis_cycle_start_hour\t${savedHour}\n`, exitCode: 0 });
+function mockCoriolisFields(api: Record<string, ReturnType<typeof vi.fn>>, values: { hour?: string; day?: string }) {
+  const lines = [
+    values.hour !== undefined ? `coriolis_cycle_start_hour\t${values.hour}` : "",
+    values.day !== undefined ? `coriolis_cycle_start_day\t${values.day}` : ""
+  ].filter(Boolean).join("\n");
+  api.userGame.mockResolvedValue({ stdout: `${lines}\n`, exitCode: 0 });
+}
+
+// Each Coriolis field's Match Region radiogroup is disambiguated by an
+// aria-label naming the field ("Match Region for Cycle Start Hour" vs "...
+// Day") specifically so more than one can be on screen at once without being
+// indistinguishable to assistive tech -- and, incidentally, so these tests
+// can scope their queries instead of matching every "On"/"Off" radio on the
+// page.
+function hourRadiogroup() {
+  return screen.getByRole("radiogroup", { name: "Match Region for Cycle Start Hour" });
+}
+function dayRadiogroup() {
+  return screen.getByRole("radiogroup", { name: "Match Region for Cycle Start Day" });
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("coriolisHourMatchesRegionInference", () => {
-  it("is On when the saved value already matches the region's hour", () => {
-    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "11", 11)).toBe(true);
+describe("coriolisFieldMatchesRegionInference", () => {
+  it("is On when the saved value already matches the region's value", () => {
+    expect(coriolisFieldMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "11", 11)).toBe(true);
+    expect(coriolisFieldMatchesRegionInference(CORIOLIS_CYCLE_START_DAY_FIELD as never, "2", 2)).toBe(true);
   });
-  it("is Off when the saved value is still at the untouched schema default and the default isn't the region's hour", () => {
+  it("is Off when the saved value is still at the untouched schema default and the default isn't the region's value", () => {
     // The default no longer implies "unset -- go ahead and lock it": a scope this
-    // young gets the region's hour written once, server-side, before the frontend
-    // ever sees it (migrate_coriolis_region_hour in usersettings.py). By the time
-    // this runs, a saved 5 on a non-Europe region is either a genuine manual 5 or a
-    // deployment the migration hasn't reached yet -- either way, not this toggle's
-    // call to silently overwrite.
-    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "5", 11)).toBe(false);
+    // young gets the region's value written once, server-side, before the frontend
+    // ever sees it (migrate_coriolis_region_fields in usersettings.py). By the time
+    // this runs, a saved default on a region whose value differs is either a genuine
+    // manual choice or a deployment the migration hasn't reached yet -- either way,
+    // not this toggle's call to silently overwrite.
+    expect(coriolisFieldMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "5", 11)).toBe(false);
+    expect(coriolisFieldMatchesRegionInference(CORIOLIS_CYCLE_START_DAY_FIELD as never, "3", 2)).toBe(false);
   });
-  it("is On when the default happens to equal the region's hour", () => {
-    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "5", 5)).toBe(true);
+  it("is On when the default happens to equal the region's value", () => {
+    expect(coriolisFieldMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "5", 5)).toBe(true);
+    expect(coriolisFieldMatchesRegionInference(CORIOLIS_CYCLE_START_DAY_FIELD as never, "3", 3)).toBe(true);
   });
-  it("is Off for a deliberate manual value that differs from the region's hour", () => {
-    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "14", 11)).toBe(false);
+  it("is Off for a deliberate manual value that differs from the region's value", () => {
+    expect(coriolisFieldMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "14", 11)).toBe(false);
+    expect(coriolisFieldMatchesRegionInference(CORIOLIS_CYCLE_START_DAY_FIELD as never, "7", 2)).toBe(false);
   });
-  it("is Off when the region has no defined master hour", () => {
-    expect(coriolisHourMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "11", undefined)).toBe(false);
+  it("is Off when the region has no defined master value", () => {
+    expect(coriolisFieldMatchesRegionInference(CORIOLIS_CYCLE_START_HOUR_FIELD as never, "11", undefined)).toBe(false);
+    expect(coriolisFieldMatchesRegionInference(CORIOLIS_CYCLE_START_DAY_FIELD as never, "3", undefined)).toBe(false);
   });
 });
 
-describe("MapsPanel Match Region toggle", () => {
+describe("MapsPanel Match Region toggle -- Cycle Start Hour", () => {
   it("locks the field when the saved value already matches the region's hour", async () => {
     const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
-    api.userSettingsSchema.mockResolvedValue({
-      engine: [], mapEngine: [], partitionEngine: [], partition: [],
-      game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
-    });
-    mockCoriolisHour(api, "11");
-    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
-      files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
-    });
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    mockCoriolisFields(api, { hour: "11", day: "7" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" } });
 
     await openUserGameGlobalTab(api);
 
     const hourInput = await screen.findByDisplayValue("11");
     expect(hourInput).toBeDisabled();
-    expect(screen.getByRole("radio", { name: "On" })).toBeChecked();
-    // Migration is server-side only (see server.js's migrateCoriolisRegionCycleStartHour)
+    expect(within(hourRadiogroup()).getByRole("radio", { name: "On" })).toBeChecked();
+    // Migration is server-side only (see server.js's migrateCoriolisRegionFields)
     // -- merely opening this tab must never issue a write of its own.
     expect(api.saveUserSettings).not.toHaveBeenCalled();
   });
 
   it("leaves an untouched (still-default) hour editable rather than locking or saving it", async () => {
     const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
-    api.userSettingsSchema.mockResolvedValue({
-      engine: [], mapEngine: [], partitionEngine: [], partition: [],
-      game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
-    });
-    mockCoriolisHour(api, "5");
-    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
-      files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
-    });
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    mockCoriolisFields(api, { hour: "5", day: "7" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" } });
 
     await openUserGameGlobalTab(api);
 
     const hourInput = await screen.findByDisplayValue("5");
     expect(hourInput).toBeEnabled();
-    expect(screen.getByRole("radio", { name: "Off" })).toBeChecked();
+    expect(within(hourRadiogroup()).getByRole("radio", { name: "Off" })).toBeChecked();
     expect(api.saveUserSettings).not.toHaveBeenCalled();
   });
 
   it("leaves an existing custom hour editable and does not overwrite it", async () => {
     const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
-    api.userSettingsSchema.mockResolvedValue({
-      engine: [], mapEngine: [], partitionEngine: [], partition: [],
-      game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
-    });
-    mockCoriolisHour(api, "14");
-    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
-      files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
-    });
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    mockCoriolisFields(api, { hour: "14", day: "7" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" } });
 
     await openUserGameGlobalTab(api);
 
     const hourInput = await screen.findByDisplayValue("14");
     expect(hourInput).toBeEnabled();
-    expect(screen.getByRole("radio", { name: "Off" })).toBeChecked();
+    expect(within(hourRadiogroup()).getByRole("radio", { name: "Off" })).toBeChecked();
     expect(api.saveUserSettings).not.toHaveBeenCalled();
   });
 
   it("switches to manual editing when the toggle is turned Off", async () => {
     const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
-    api.userSettingsSchema.mockResolvedValue({
-      engine: [], mapEngine: [], partitionEngine: [], partition: [],
-      game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
-    });
-    mockCoriolisHour(api, "11");
-    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
-      files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
-    });
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    mockCoriolisFields(api, { hour: "11", day: "7" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" } });
 
     await openUserGameGlobalTab(api);
     await screen.findByDisplayValue("11");
 
-    fireEvent.click(screen.getByRole("radio", { name: "Off" }));
+    fireEvent.click(within(hourRadiogroup()).getByRole("radio", { name: "Off" }));
 
     const hourInput = await screen.findByDisplayValue("11");
     expect(hourInput).toBeEnabled();
@@ -208,24 +234,153 @@ describe("MapsPanel Match Region toggle", () => {
 
   it("pins the draft to the region's hour (without saving) when the toggle is turned On", async () => {
     const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
-    api.userSettingsSchema.mockResolvedValue({
-      engine: [], mapEngine: [], partitionEngine: [], partition: [],
-      game: [CORIOLIS_CYCLE_START_HOUR_FIELD]
-    });
-    mockCoriolisHour(api, "14");
-    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({
-      files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" }
-    });
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    mockCoriolisFields(api, { hour: "14", day: "7" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" } });
 
     await openUserGameGlobalTab(api);
     await screen.findByDisplayValue("14");
 
-    fireEvent.click(screen.getByRole("radio", { name: "On" }));
+    fireEvent.click(within(hourRadiogroup()).getByRole("radio", { name: "On" }));
 
     const hourInput = await screen.findByDisplayValue("11");
     expect(hourInput).toBeDisabled();
-    // Pinning the draft is a local edit an explicit Save would apply -- it must
-    // never itself issue a network write.
+    expect(api.saveUserSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe("MapsPanel Match Region toggle -- Cycle Start Day", () => {
+  it("locks the field when the saved value already matches the region's day", async () => {
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    // Asia's region day is 2 -- distinct from the schema default (3), so a
+    // saved 2 is unambiguously "matches region", not "still untouched".
+    mockCoriolisFields(api, { hour: "20", day: "2" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "Asia" } });
+
+    await openUserGameGlobalTab(api);
+
+    const dayInput = await screen.findByDisplayValue("2");
+    expect(dayInput).toBeDisabled();
+    expect(within(dayRadiogroup()).getByRole("radio", { name: "On" })).toBeChecked();
+    expect(api.saveUserSettings).not.toHaveBeenCalled();
+  });
+
+  it("locks the field when the saved value equals both the schema default and the region's day", async () => {
+    // North America's region day is 3 -- the exact schema default. Whether a
+    // saved value happens to equal the default is irrelevant to the inference;
+    // it only asks "does the saved value equal the region's value", the same
+    // question migrate_coriolis_region_fields's presence-based migration
+    // answers server-side. A value-vs-default comparison would have been unable
+    // to tell this apart from "untouched" and either locked it for the wrong
+    // reason or (in the old client-side auto-save this replaced) looped trying
+    // to re-migrate it -- this pins that the fix reads as "matches", not as
+    // "ambiguous", once the value is actually equal.
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    mockCoriolisFields(api, { hour: "20", day: "3" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" } });
+
+    await openUserGameGlobalTab(api);
+
+    const dayInput = await screen.findByDisplayValue("3");
+    expect(dayInput).toBeDisabled();
+    expect(within(dayRadiogroup()).getByRole("radio", { name: "On" })).toBeChecked();
+    expect(api.saveUserSettings).not.toHaveBeenCalled();
+  });
+
+  it("leaves an untouched (still-default) day editable when the region's day differs from that default", async () => {
+    // Asia's region day is 2, distinct from the schema default (3). A saved 3
+    // here is genuinely ambiguous -- untouched, or a deliberate match to a
+    // *different* region's schedule -- and must not be silently claimed as
+    // "matches region" or locked. This is the direct counterpart to the
+    // existing untouched-hour test (South America's region hour, 8, differs
+    // from the hour default, 5).
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    mockCoriolisFields(api, { hour: "20", day: "3" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "Asia" } });
+
+    await openUserGameGlobalTab(api);
+
+    const dayInput = await screen.findByDisplayValue("3");
+    expect(dayInput).toBeEnabled();
+    expect(within(dayRadiogroup()).getByRole("radio", { name: "Off" })).toBeChecked();
+    expect(api.saveUserSettings).not.toHaveBeenCalled();
+  });
+
+  it("leaves an existing custom day editable and does not overwrite it", async () => {
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    mockCoriolisFields(api, { hour: "20", day: "6" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" } });
+
+    await openUserGameGlobalTab(api);
+
+    const dayInput = await screen.findByDisplayValue("6");
+    expect(dayInput).toBeEnabled();
+    expect(within(dayRadiogroup()).getByRole("radio", { name: "Off" })).toBeChecked();
+    expect(api.saveUserSettings).not.toHaveBeenCalled();
+  });
+
+  it("switches to manual editing when the toggle is turned Off", async () => {
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    mockCoriolisFields(api, { hour: "20", day: "2" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "Asia" } });
+
+    await openUserGameGlobalTab(api);
+    await screen.findByDisplayValue("2");
+
+    fireEvent.click(within(dayRadiogroup()).getByRole("radio", { name: "Off" }));
+
+    const dayInput = await screen.findByDisplayValue("2");
+    expect(dayInput).toBeEnabled();
+  });
+
+  it("pins the draft to the region's day (without saving) when the toggle is turned On", async () => {
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    mockCoriolisFields(api, { hour: "20", day: "6" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "Asia" } });
+
+    await openUserGameGlobalTab(api);
+    await screen.findByDisplayValue("6");
+
+    fireEvent.click(within(dayRadiogroup()).getByRole("radio", { name: "On" }));
+
+    const dayInput = await screen.findByDisplayValue("2");
+    expect(dayInput).toBeDisabled();
+    expect(api.saveUserSettings).not.toHaveBeenCalled();
+  });
+});
+
+describe("MapsPanel Match Region -- Hour and Day toggles are independent", () => {
+  it("locks one field while leaving the other editable, and toggling one does not affect the other", async () => {
+    const api = mapsApi as unknown as Record<string, ReturnType<typeof vi.fn>>;
+    api.userSettingsSchema.mockResolvedValue({ engine: [], mapEngine: [], partitionEngine: [], partition: [], game: BOTH_CORIOLIS_FIELDS });
+    // North America: hour 11 matches (locked); day 6 is a deliberate custom
+    // value that does not match North America's 3 (editable).
+    mockCoriolisFields(api, { hour: "11", day: "6" });
+    (setupApi.state as ReturnType<typeof vi.fn>).mockResolvedValue({ files: {}, config: {}, serverConfig: { SERVER_REGION: "North America" } });
+
+    await openUserGameGlobalTab(api);
+    await screen.findByDisplayValue("11");
+
+    const hourInput = screen.getByDisplayValue("11");
+    const dayInput = screen.getByDisplayValue("6");
+    expect(hourInput).toBeDisabled();
+    expect(dayInput).toBeEnabled();
+    expect(within(hourRadiogroup()).getByRole("radio", { name: "On" })).toBeChecked();
+    expect(within(dayRadiogroup()).getByRole("radio", { name: "Off" })).toBeChecked();
+
+    // Turning the day toggle On pins the day draft to North America's day (3)
+    // and must not touch the hour field's own locked value or state at all.
+    fireEvent.click(within(dayRadiogroup()).getByRole("radio", { name: "On" }));
+
+    await waitFor(() => expect(screen.getByDisplayValue("3")).toBeDisabled());
+    expect(within(hourRadiogroup()).getByRole("radio", { name: "On" })).toBeChecked();
+    expect(screen.getByDisplayValue("11")).toBeDisabled();
     expect(api.saveUserSettings).not.toHaveBeenCalled();
   });
 });

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -347,7 +347,8 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
   const [gameValues, setGameValues] = useState<Record<string, string>>({});
   const [gameDraft, setGameDraft] = useState<Record<string, string>>({});
   const [serverRegion, setServerRegion] = useState("");
-  const [coriolisHourMatchesRegion, setCoriolisHourMatchesRegion] = useState(true);
+  const [coriolisHourManualOverride, setCoriolisHourManualOverride] = useState<boolean | null>(null);
+  const [gameValuesTargetKey, setGameValuesTargetKey] = useState("");
   const [rawEngine, setRawEngine] = useState("");
   const [rawGame, setRawGame] = useState("");
   const [rawEngineOriginal, setRawEngineOriginal] = useState("");
@@ -766,6 +767,13 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
     const parsed = parseUserSettingsMap(values.stdout || "");
     setGameValues(parsed);
     setGameDraft(parsed);
+    // userGameName/effectiveUserGamePartitionId flip synchronously on target
+    // selection, one render before this resolves -- this key lets derived
+    // state tell "gameValues is still the previous (or empty) target's" apart
+    // from "gameValues genuinely belongs to what's selected now", which
+    // matters for anything (like Match Region's auto-migration) that must
+    // never act on a stale or not-yet-loaded value.
+    setGameValuesTargetKey(settingsTargetKey(mapName, partitionId || ""));
     setRawGame(raw.content || "");
     setRawGameOriginal(raw.content || "");
   }
@@ -1282,22 +1290,54 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
   const coriolisRegionHour = CORIOLIS_REGION_HOURS[serverRegion];
   const coriolisMatchRegionAvailable = coriolisRegionHour !== undefined && userGameFields.some((field) => field.id === CORIOLIS_CYCLE_START_HOUR_FIELD_ID);
   const coriolisHourDraftValue = gameDraft[CORIOLIS_CYCLE_START_HOUR_FIELD_ID];
+  // userGameName/effectiveUserGamePartitionId flip synchronously the instant a
+  // target is picked, one render before loadSelectedSettings's async fetch
+  // resolves and actually updates gameValues/gameDraft for it. Without this,
+  // that in-between render sees the *previous* target's (or the initial
+  // empty) gameValues while userGameName already points at the new one --
+  // read as "field untouched" -- and the effects below would flicker the
+  // toggle, or worse, have the migration effect fire a save from data that
+  // was never this target's to begin with.
+  const gameValuesReady = Boolean(userGameName) && gameValuesTargetKey === userGameTargetKey;
+  // Derived synchronously (not useState+useEffect) so it's never one render
+  // behind gameValues/gameDraft -- a state+effect version briefly rendered a
+  // just-loaded custom hour as locked/disabled under its stale previous
+  // value before the correcting effect caught up on the next tick.
+  // coriolisHourManualOverride is null (follow the inference) until the
+  // admin actually clicks the toggle this session; see the reset effect
+  // below for why it can't just live as this const's own state.
+  // Before real data has loaded there is nothing to infer from, so this must
+  // default to false (unlocked), not true -- a true default would render the
+  // field as locked-to-region for one paint even for a target whose saved
+  // hour is a deliberate manual value, which is exactly the false claim the
+  // rest of this feature exists to avoid making.
+  const coriolisHourInferredMatchesRegion = gameValuesReady
+    ? coriolisHourMatchesRegionInference(schema?.game.find((candidate) => candidate.id === CORIOLIS_CYCLE_START_HOUR_FIELD_ID), gameValues[CORIOLIS_CYCLE_START_HOUR_FIELD_ID], coriolisRegionHour)
+    : false;
+  const coriolisHourMatchesRegion = coriolisHourManualOverride ?? coriolisHourInferredMatchesRegion;
   useEffect(() => {
-    // Re-infer whenever a target's saved values (re)load.
-    if (!userGameName) return;
-    const field = schema?.game.find((candidate) => candidate.id === CORIOLIS_CYCLE_START_HOUR_FIELD_ID);
-    const regionHour = CORIOLIS_REGION_HOURS[serverRegion];
-    setCoriolisHourMatchesRegion(coriolisHourMatchesRegionInference(field, gameValues[CORIOLIS_CYCLE_START_HOUR_FIELD_ID], regionHour));
-  }, [gameValues, schema, serverRegion, userGameName]);
+    // A manual toggle choice is scoped to the target it was made for --
+    // switching targets re-infers fresh rather than carrying it over.
+    setCoriolisHourManualOverride(null);
+  }, [userGameTargetKey]);
   useEffect(() => {
     // While On, keep the draft pinned to the region's hour -- covers both a
     // manual toggle flip and a target switch landing on a different saved value.
+    if (!gameValuesReady || !coriolisHourMatchesRegion) return;
     const regionHour = CORIOLIS_REGION_HOURS[serverRegion];
-    if (!coriolisHourMatchesRegion || regionHour === undefined) return;
+    if (regionHour === undefined) return;
     const desired = String(regionHour);
     if (coriolisHourDraftValue === desired) return;
     setGameDraft((current) => ({ ...current, [CORIOLIS_CYCLE_START_HOUR_FIELD_ID]: desired }));
-  }, [coriolisHourMatchesRegion, serverRegion, coriolisHourDraftValue]);
+  }, [gameValuesReady, coriolisHourMatchesRegion, serverRegion, coriolisHourDraftValue]);
+  // A scope that has never had this field saved at all gets the region's
+  // hour written once, server-side, at startup (migrate_coriolis_region_hour
+  // in usersettings.py, invoked from server.js) -- not from here. Doing it
+  // client-side meant "browse a target" silently issued a write with no
+  // confirmation, pinned whichever scope happened to be open (breaking
+  // Global -> Map -> Partition inheritance), and could never distinguish
+  // "unset" from "explicitly saved to equal the schema default", which on a
+  // Europe deployment (region hour == schema default) looped forever.
   const gameGroups = groupSettingsFields(userGameFields, true, modifiedSettingsFields(userGameFields, gameValues, gameDraft));
   const activeGameCategory = gameGroups.some(([category]) => category === selectedGameCategory) ? selectedGameCategory : gameGroups[0]?.[0] || "";
   const activeGameFields = activeGameCategory === "All" ? userGameFields : gameGroups.find(([category]) => category === activeGameCategory)?.[1] || [];
@@ -2269,7 +2309,7 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
             </div>
           </div>
         </div>
-        {userGameName && <SettingsCardGrid fields={filteredGameFields} values={gameDraft} onChange={(id, value) => setGameDraft({ ...gameDraft, [id]: value })} viewMode={modifierViewMode} emptyMessage={modifierEmptyMessage(!!schema, userGameFields.length, modifierFilter, activeGameCategory)} matchRegionControl={{ fieldId: CORIOLIS_CYCLE_START_HOUR_FIELD_ID, enabled: coriolisHourMatchesRegion, available: coriolisMatchRegionAvailable, regionLabel: serverRegion, regionHour: coriolisRegionHour, onToggle: setCoriolisHourMatchesRegion }} />}
+        {userGameName && <SettingsCardGrid fields={filteredGameFields} values={gameDraft} onChange={(id, value) => setGameDraft({ ...gameDraft, [id]: value })} viewMode={modifierViewMode} emptyMessage={modifierEmptyMessage(!!schema, userGameFields.length, modifierFilter, activeGameCategory)} matchRegionControl={{ fieldId: CORIOLIS_CYCLE_START_HOUR_FIELD_ID, enabled: coriolisHourMatchesRegion, available: coriolisMatchRegionAvailable, regionLabel: serverRegion, regionHour: coriolisRegionHour, onToggle: setCoriolisHourManualOverride }} />}
         <div className="action-row"><button disabled={!gameDirty.length || !userGameName} onClick={() => run(saveGame)}>Save</button><button disabled={!gameDirty.length} onClick={() => setGameDraft(gameValues)}>Discard Changes</button><button className="settings-reset-all-button" disabled={!userGameName || !userGameFields.length} title="Set every UserGame setting on this tab back to its default value" onClick={() => run(() => resetAllToDefaults("game"))}>Restore Defaults</button></div>
       </> : settingsTab === "spicefields" ? <>
         <SpicefieldsEditor
@@ -2485,19 +2525,24 @@ function SettingControl({ field, value, onChange, matchRegion }: { field: UserSe
   const label = friendlySettingLabel(field.id, field.key || field.id, field.label);
   const inputId = `setting-${field.scope}-${field.id}`;
   const modified = isModifiedFromDefault(field, value);
-  return <label className="settings-field" htmlFor={inputId}>
+  // A plain <div> here, not <label htmlFor>: the Match Region toggle below renders its
+  // own <label> per radio segment, and a <label> cannot legally contain another <label>
+  // -- harmless in practice (browsers still route clicks correctly; confirmed empirically
+  // during review), but not a spec-valid document. The field name stays clickable via its
+  // own inner <label> instead.
+  return <div className="settings-field">
     <div className="settings-field-heading">
       {(field.clientFile || modified) && <span className="settings-field-badges">
         {field.clientFile && <span className="badge badge-info" title={`Also requires updating the client's ${field.clientFile}.`}>Client &quot;{field.clientFile}&quot;</span>}
         {modified && <ModifiedBadge field={field} label={label} onReset={() => onChange(field.default ?? "")} />}
       </span>}
-      <strong>{label}</strong>
+      <label htmlFor={inputId}><strong>{label}</strong></label>
       <small>{field.key || field.id}</small>
     </div>
     {field.description && <span className="settings-field-description"><Info size={14} aria-hidden="true" /><span className="settings-field-description-text">{field.description}</span></span>}
     {matchRegion && <MatchRegionToggle control={matchRegion} idPrefix={`setting-${field.scope}`} />}
     <SettingInput field={field} value={value} inputId={inputId} onChange={onChange} disabled={matchRegion?.enabled} />
-  </label>;
+  </div>;
 }
 
 function SettingInput({ field, value, inputId, onChange, disabled }: { field: UserSettingField; value: string; inputId: string; onChange: (value: string) => void; disabled?: boolean }) {
@@ -2722,15 +2767,18 @@ export function isModifiedFromDefault(field: UserSettingField, value: string) {
 }
 
 // Whether the Cycle Start Hour "Match Region" toggle should infer as On for a
-// freshly loaded saved value: never touched (still at its schema default, so
-// there is no admin preference yet) or already saved matching the region's
-// hour. Any other saved value is a deliberate manual choice and must never be
-// silently overwritten, so it infers Off.
+// freshly loaded saved value: the value already equals the region's hour.
+// Any other saved value -- including the untouched schema default -- is
+// treated as a deliberate value and must never be silently overwritten, so
+// it infers Off. (A scope that has genuinely never had this field saved gets
+// the region's hour written once, server-side, at startup -- see
+// migrate_coriolis_region_hour in usersettings.py -- so by the time this
+// runs "default" and "unset" are no longer the same question.)
 export function coriolisHourMatchesRegionInference(field: UserSettingField | undefined, savedValue: string, regionHour: number | undefined): boolean {
   if (!field || regionHour === undefined) return false;
   const fieldDefault = String(field.default ?? "");
   const resolved = String(savedValue ?? fieldDefault);
-  return resolved === fieldDefault || Number(resolved) === regionHour;
+  return Number(resolved) === regionHour;
 }
 
 // Pseudo-category listed alongside the real ones, so an admin can see just the

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -100,13 +100,11 @@ const CORIOLIS_REGION_DAYS: Record<string, number> = {
   "Asia": 2,
   "Oceania": 2
 };
-// 1=Sunday through 7=Saturday, matching coriolis_cycle_start_day's own description.
-const CORIOLIS_WEEKDAY_NAMES = ["", "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 function coriolisHourRegionValueLabel(hour: number | undefined): string {
   return hour === undefined ? "" : `${String(hour).padStart(2, "0")}:00 UTC`;
 }
 function coriolisDayRegionValueLabel(day: number | undefined): string {
-  return day === undefined ? "" : CORIOLIS_WEEKDAY_NAMES[day] || "";
+  return day === undefined ? "" : `Day ${day}`;
 }
 type ConfirmAction = (message: string, options?: { title?: string; confirmLabel?: string; cancelLabel?: string; danger?: boolean; warning?: string; details?: { label: string; value: string; tone?: "danger" | "success" | "accent" }[] }) => Promise<boolean>;
 type MapsPanelProps = {

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -82,6 +82,16 @@ const MAP_SORT_COLUMNS: Array<[MapSortColumn, string]> = [
   ["mode", "Mode"],
   ["memory", "Memory"]
 ];
+const CORIOLIS_CYCLE_START_HOUR_FIELD_ID = "coriolis_cycle_start_hour";
+// UTC regional master schedules. Must stay in sync with the
+// coriolis_cycle_start_hour description in runtime/scripts/usersettings.py.
+const CORIOLIS_REGION_HOURS: Record<string, number> = {
+  "Europe": 5,
+  "North America": 11,
+  "South America": 8,
+  "Asia": 9,
+  "Oceania": 19
+};
 type ConfirmAction = (message: string, options?: { title?: string; confirmLabel?: string; cancelLabel?: string; danger?: boolean; warning?: string; details?: { label: string; value: string; tone?: "danger" | "success" | "accent" }[] }) => Promise<boolean>;
 type MapsPanelProps = {
   onError: (text: string) => void;
@@ -336,6 +346,8 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
   const [engineDraft, setEngineDraft] = useState<Record<string, string>>({});
   const [gameValues, setGameValues] = useState<Record<string, string>>({});
   const [gameDraft, setGameDraft] = useState<Record<string, string>>({});
+  const [serverRegion, setServerRegion] = useState("");
+  const [coriolisHourMatchesRegion, setCoriolisHourMatchesRegion] = useState(true);
   const [rawEngine, setRawEngine] = useState("");
   const [rawGame, setRawGame] = useState("");
   const [rawEngineOriginal, setRawEngineOriginal] = useState("");
@@ -721,11 +733,21 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
     setRawEngine(raw.content || "");
     setRawEngineOriginal(raw.content || "");
   }
+  async function loadServerRegion() {
+    try {
+      const state = await setupApi.state();
+      setServerRegion(String(state.serverConfig?.SERVER_REGION || ""));
+    } catch {
+      // Match Region is a convenience on top of the Cycle Start Hour field --
+      // if the deployment region can't be read, the field just stays manual.
+      setServerRegion("");
+    }
+  }
   async function loadInitialModifierSettings() {
     // The raw Advanced editor is loaded only when it is opened. Making it part
     // of this gate would add another command before the normal modifier cards
     // can be used.
-    await Promise.all([loadSchema(), loadUserEngineValues()]);
+    await Promise.all([loadSchema(), loadUserEngineValues(), loadServerRegion()]);
     setModifierSettingsLoaded(true);
   }
   async function loadSelectedEngineSettings(mapName: string, partitionId?: string) {
@@ -1257,6 +1279,25 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
   const engineTargetKey = settingsTargetKey(engineMapName, isEngineGlobal ? "" : enginePartitionId);
   const gameFields = schema ? (effectivePartitionId ? schema.partition : schema.game).filter((field) => field.id !== "partition_pve_enabled" || effectivePartitionId) : [];
   const userGameFields = schema && userGameName ? (!isUserGameGlobal && effectiveUserGamePartitionId ? schema.partition : schema.game).filter((field) => field.id !== "partition_pve_enabled" || (!isUserGameGlobal && effectiveUserGamePartitionId)) : [];
+  const coriolisRegionHour = CORIOLIS_REGION_HOURS[serverRegion];
+  const coriolisMatchRegionAvailable = coriolisRegionHour !== undefined && userGameFields.some((field) => field.id === CORIOLIS_CYCLE_START_HOUR_FIELD_ID);
+  const coriolisHourDraftValue = gameDraft[CORIOLIS_CYCLE_START_HOUR_FIELD_ID];
+  useEffect(() => {
+    // Re-infer whenever a target's saved values (re)load.
+    if (!userGameName) return;
+    const field = schema?.game.find((candidate) => candidate.id === CORIOLIS_CYCLE_START_HOUR_FIELD_ID);
+    const regionHour = CORIOLIS_REGION_HOURS[serverRegion];
+    setCoriolisHourMatchesRegion(coriolisHourMatchesRegionInference(field, gameValues[CORIOLIS_CYCLE_START_HOUR_FIELD_ID], regionHour));
+  }, [gameValues, schema, serverRegion, userGameName]);
+  useEffect(() => {
+    // While On, keep the draft pinned to the region's hour -- covers both a
+    // manual toggle flip and a target switch landing on a different saved value.
+    const regionHour = CORIOLIS_REGION_HOURS[serverRegion];
+    if (!coriolisHourMatchesRegion || regionHour === undefined) return;
+    const desired = String(regionHour);
+    if (coriolisHourDraftValue === desired) return;
+    setGameDraft((current) => ({ ...current, [CORIOLIS_CYCLE_START_HOUR_FIELD_ID]: desired }));
+  }, [coriolisHourMatchesRegion, serverRegion, coriolisHourDraftValue]);
   const gameGroups = groupSettingsFields(userGameFields, true, modifiedSettingsFields(userGameFields, gameValues, gameDraft));
   const activeGameCategory = gameGroups.some(([category]) => category === selectedGameCategory) ? selectedGameCategory : gameGroups[0]?.[0] || "";
   const activeGameFields = activeGameCategory === "All" ? userGameFields : gameGroups.find(([category]) => category === activeGameCategory)?.[1] || [];
@@ -2228,7 +2269,7 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
             </div>
           </div>
         </div>
-        {userGameName && <SettingsCardGrid fields={filteredGameFields} values={gameDraft} onChange={(id, value) => setGameDraft({ ...gameDraft, [id]: value })} viewMode={modifierViewMode} emptyMessage={modifierEmptyMessage(!!schema, userGameFields.length, modifierFilter, activeGameCategory)} />}
+        {userGameName && <SettingsCardGrid fields={filteredGameFields} values={gameDraft} onChange={(id, value) => setGameDraft({ ...gameDraft, [id]: value })} viewMode={modifierViewMode} emptyMessage={modifierEmptyMessage(!!schema, userGameFields.length, modifierFilter, activeGameCategory)} matchRegionControl={{ fieldId: CORIOLIS_CYCLE_START_HOUR_FIELD_ID, enabled: coriolisHourMatchesRegion, available: coriolisMatchRegionAvailable, regionLabel: serverRegion, regionHour: coriolisRegionHour, onToggle: setCoriolisHourMatchesRegion }} />}
         <div className="action-row"><button disabled={!gameDirty.length || !userGameName} onClick={() => run(saveGame)}>Save</button><button disabled={!gameDirty.length} onClick={() => setGameDraft(gameValues)}>Discard Changes</button><button className="settings-reset-all-button" disabled={!userGameName || !userGameFields.length} title="Set every UserGame setting on this tab back to its default value" onClick={() => run(() => resetAllToDefaults("game"))}>Restore Defaults</button></div>
       </> : settingsTab === "spicefields" ? <>
         <SpicefieldsEditor
@@ -2377,12 +2418,15 @@ function ChoamTerminalsEditor({
   </section>;
 }
 
-function SettingsCardGrid({ fields, values, onChange, viewMode = "grid", emptyMessage = "Select a modifier category." }: { fields: UserSettingField[]; values: Record<string, string>; onChange: (id: string, value: string) => void; viewMode?: "grid" | "list"; emptyMessage?: string }) {
+type MatchRegionControl = { fieldId: string; enabled: boolean; available: boolean; regionLabel: string; regionHour?: number; onToggle: (next: boolean) => void };
+
+function SettingsCardGrid({ fields, values, onChange, viewMode = "grid", emptyMessage = "Select a modifier category.", matchRegionControl }: { fields: UserSettingField[]; values: Record<string, string>; onChange: (id: string, value: string) => void; viewMode?: "grid" | "list"; emptyMessage?: string; matchRegionControl?: MatchRegionControl }) {
   if (!fields.length) return <div className="empty">{emptyMessage}</div>;
   if (viewMode === "list") {
     return <div className="settings-list-wrap"><table className="settings-list-table"><thead><tr><th>Modifier</th><th>Setting Key</th><th>Value</th></tr></thead><tbody>{fields.map((field) => {
       const value = values[field.id] ?? field.default ?? "";
       const modified = isModifiedFromDefault(field, value);
+      const matchRegion = matchRegionControl?.fieldId === field.id ? matchRegionControl : undefined;
       return <Fragment key={field.id}>
         {(field.clientFile || modified) && <tr className="settings-list-badge-row"><td colSpan={3}>
           {field.clientFile && <span className="badge badge-info settings-list-badge" title={`Also requires updating the client's ${field.clientFile}.`}>Client &quot;{field.clientFile}&quot;</span>}
@@ -2391,13 +2435,42 @@ function SettingsCardGrid({ fields, values, onChange, viewMode = "grid", emptyMe
         <tr>
           <td><strong>{friendlySettingLabel(field.id, field.key || field.id, field.label)}</strong><small>{fieldCategory(field)}</small></td>
           <td>{field.key || field.id}</td>
-          <td><SettingInput field={field} value={value} inputId={`setting-list-${field.scope}-${field.id}`} onChange={(nextValue) => onChange(field.id, nextValue)} /></td>
+          <td>
+            {matchRegion && <MatchRegionToggle control={matchRegion} idPrefix={`setting-list-${field.scope}`} />}
+            <SettingInput field={field} value={value} inputId={`setting-list-${field.scope}-${field.id}`} onChange={(nextValue) => onChange(field.id, nextValue)} disabled={matchRegion?.enabled} />
+          </td>
         </tr>
         {field.description && <tr className="settings-list-description-row"><td colSpan={3}><span className="settings-field-description"><Info size={14} aria-hidden="true" /><span className="settings-field-description-text">{field.description}</span></span></td></tr>}
       </Fragment>;
     })}</tbody></table></div>;
   }
-  return <div className="settings-grid settings-grid-roomy">{fields.map((field) => <SettingControl key={field.id} field={field} value={values[field.id] ?? field.default ?? ""} onChange={(value) => onChange(field.id, value)} />)}</div>;
+  return <div className="settings-grid settings-grid-roomy">{fields.map((field) => <SettingControl key={field.id} field={field} value={values[field.id] ?? field.default ?? ""} onChange={(value) => onChange(field.id, value)} matchRegion={matchRegionControl?.fieldId === field.id ? matchRegionControl : undefined} />)}</div>;
+}
+
+// Same visual spec as .bases-rank-segments / .vehicles-rank-segments, under
+// its own settings-scoped class names per this repo's CSS scoping convention.
+function MatchRegionToggle({ control, idPrefix }: { control: MatchRegionControl; idPrefix: string }) {
+  const groupName = `${idPrefix}-${control.fieldId}-match-region`;
+  const title = control.available
+    ? `Set from the deployment's region: ${control.regionLabel}, ${String(control.regionHour ?? "").padStart(2, "0")}:00 UTC.`
+    : `No regional master schedule is defined for ${control.regionLabel || "this deployment's region"} -- set manually.`;
+  return <div className="settings-match-region" title={title}>
+    <span className="settings-match-region-label">Match Region</span>
+    <div className="settings-match-region-segments" role="radiogroup" aria-label="Match Region">
+      {([["On", true], ["Off", false]] as const).map(([label, isOn]) => (
+        <label className="settings-match-region-segment" key={label}>
+          <input
+            type="radio"
+            name={groupName}
+            checked={control.enabled === isOn}
+            disabled={!control.available}
+            onChange={() => control.onToggle(isOn)}
+          />
+          {label}
+        </label>
+      ))}
+    </div>
+  </div>;
 }
 
 function ModifiedBadge({ field, label, onReset }: { field: UserSettingField; label: string; onReset: () => void }) {
@@ -2408,7 +2481,7 @@ function ModifiedBadge({ field, label, onReset }: { field: UserSettingField; lab
   </span>;
 }
 
-function SettingControl({ field, value, onChange }: { field: UserSettingField; value: string; onChange: (value: string) => void }) {
+function SettingControl({ field, value, onChange, matchRegion }: { field: UserSettingField; value: string; onChange: (value: string) => void; matchRegion?: MatchRegionControl }) {
   const label = friendlySettingLabel(field.id, field.key || field.id, field.label);
   const inputId = `setting-${field.scope}-${field.id}`;
   const modified = isModifiedFromDefault(field, value);
@@ -2422,18 +2495,19 @@ function SettingControl({ field, value, onChange }: { field: UserSettingField; v
       <small>{field.key || field.id}</small>
     </div>
     {field.description && <span className="settings-field-description"><Info size={14} aria-hidden="true" /><span className="settings-field-description-text">{field.description}</span></span>}
-    <SettingInput field={field} value={value} inputId={inputId} onChange={onChange} />
+    {matchRegion && <MatchRegionToggle control={matchRegion} idPrefix={`setting-${field.scope}`} />}
+    <SettingInput field={field} value={value} inputId={inputId} onChange={onChange} disabled={matchRegion?.enabled} />
   </label>;
 }
 
-function SettingInput({ field, value, inputId, onChange }: { field: UserSettingField; value: string; inputId: string; onChange: (value: string) => void }) {
+function SettingInput({ field, value, inputId, onChange, disabled }: { field: UserSettingField; value: string; inputId: string; onChange: (value: string) => void; disabled?: boolean }) {
   return field.type === "boolean"
-    ? <select id={inputId} value={normalizeBooleanText(value)} onChange={(event) => onChange(event.target.value)}><option value="True">True</option><option value="False">False</option></select>
+    ? <select id={inputId} value={normalizeBooleanText(value)} disabled={disabled} onChange={(event) => onChange(event.target.value)}><option value="True">True</option><option value="False">False</option></select>
     : field.type === "integer" || field.type === "number"
-      ? <input id={inputId} type="number" step={field.type === "integer" ? "1" : "any"} min={field.minimum ?? undefined} max={field.maximum ?? undefined} value={value} onChange={(event) => onChange(event.target.value)} />
+      ? <input id={inputId} type="number" step={field.type === "integer" ? "1" : "any"} min={field.minimum ?? undefined} max={field.maximum ?? undefined} value={value} disabled={disabled} onChange={(event) => onChange(event.target.value)} />
       : String(value).length > 72 || value.includes("(")
-        ? <textarea id={inputId} rows={3} value={value} onChange={(event) => onChange(event.target.value)} />
-        : <input id={inputId} value={value} onChange={(event) => onChange(event.target.value)} />;
+        ? <textarea id={inputId} rows={3} value={value} disabled={disabled} onChange={(event) => onChange(event.target.value)} />
+        : <input id={inputId} value={value} disabled={disabled} onChange={(event) => onChange(event.target.value)} />;
 }
 
 export function MemoryUsageBar({ row, fallback, configuredLimit, swapEnabled = false }: { row: LiveMapMemoryRow | null; fallback: string; configuredLimit?: unknown; swapEnabled?: boolean }) {
@@ -2645,6 +2719,18 @@ export function countIniOverrides(content: string) {
 // permanently flagged against a "True"/"False" selection.
 export function isModifiedFromDefault(field: UserSettingField, value: string) {
   return settingValueChanged(field, String(field.default ?? ""), String(value ?? ""));
+}
+
+// Whether the Cycle Start Hour "Match Region" toggle should infer as On for a
+// freshly loaded saved value: never touched (still at its schema default, so
+// there is no admin preference yet) or already saved matching the region's
+// hour. Any other saved value is a deliberate manual choice and must never be
+// silently overwritten, so it infers Off.
+export function coriolisHourMatchesRegionInference(field: UserSettingField | undefined, savedValue: string, regionHour: number | undefined): boolean {
+  if (!field || regionHour === undefined) return false;
+  const fieldDefault = String(field.default ?? "");
+  const resolved = String(savedValue ?? fieldDefault);
+  return resolved === fieldDefault || Number(resolved) === regionHour;
 }
 
 // Pseudo-category listed alongside the real ones, so an admin can see just the

--- a/console/web/src/features/maps/MapsPanel.tsx
+++ b/console/web/src/features/maps/MapsPanel.tsx
@@ -83,8 +83,9 @@ const MAP_SORT_COLUMNS: Array<[MapSortColumn, string]> = [
   ["memory", "Memory"]
 ];
 const CORIOLIS_CYCLE_START_HOUR_FIELD_ID = "coriolis_cycle_start_hour";
+const CORIOLIS_CYCLE_START_DAY_FIELD_ID = "coriolis_cycle_start_day";
 // UTC regional master schedules. Must stay in sync with the
-// coriolis_cycle_start_hour description in runtime/scripts/usersettings.py.
+// coriolis_cycle_start_hour/_day descriptions in runtime/scripts/usersettings.py.
 const CORIOLIS_REGION_HOURS: Record<string, number> = {
   "Europe": 5,
   "North America": 11,
@@ -92,6 +93,21 @@ const CORIOLIS_REGION_HOURS: Record<string, number> = {
   "Asia": 9,
   "Oceania": 19
 };
+const CORIOLIS_REGION_DAYS: Record<string, number> = {
+  "Europe": 3,
+  "North America": 3,
+  "South America": 3,
+  "Asia": 2,
+  "Oceania": 2
+};
+// 1=Sunday through 7=Saturday, matching coriolis_cycle_start_day's own description.
+const CORIOLIS_WEEKDAY_NAMES = ["", "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+function coriolisHourRegionValueLabel(hour: number | undefined): string {
+  return hour === undefined ? "" : `${String(hour).padStart(2, "0")}:00 UTC`;
+}
+function coriolisDayRegionValueLabel(day: number | undefined): string {
+  return day === undefined ? "" : CORIOLIS_WEEKDAY_NAMES[day] || "";
+}
 type ConfirmAction = (message: string, options?: { title?: string; confirmLabel?: string; cancelLabel?: string; danger?: boolean; warning?: string; details?: { label: string; value: string; tone?: "danger" | "success" | "accent" }[] }) => Promise<boolean>;
 type MapsPanelProps = {
   onError: (text: string) => void;
@@ -335,6 +351,67 @@ function updateSietches(body: Record<string, unknown>) {
   });
 }
 
+// Shared by both Coriolis "Match Region" toggles (Cycle Start Hour and Day) --
+// the only difference between them is which field id and region table they
+// read, never the logic. Called unconditionally, once per field, at fixed
+// call sites in MapsPanel's render (never in a loop or behind a condition),
+// so the Rules of Hooks hold same as any other hook.
+function useCoriolisMatchRegion(
+  fieldId: string,
+  regionTable: Record<string, number>,
+  schema: UserSettingsSchema | null,
+  gameValues: Record<string, string>,
+  gameDraft: Record<string, string>,
+  setGameDraft: (updater: (current: Record<string, string>) => Record<string, string>) => void,
+  gameValuesReady: boolean,
+  serverRegion: string,
+  userGameTargetKey: string
+) {
+  const [manualOverride, setManualOverride] = useState<boolean | null>(null);
+  const regionValue = regionTable[serverRegion];
+  const draftValue = gameDraft[fieldId];
+  // Derived synchronously (not useState+useEffect) so it's never one render
+  // behind gameValues/gameDraft -- a state+effect version briefly rendered a
+  // just-loaded custom value as locked/disabled under its stale previous
+  // value before the correcting effect caught up on the next tick.
+  // Before real data has loaded there is nothing to infer from, so this must
+  // default to false (unlocked), not true -- a true default would render the
+  // field as locked-to-region for one paint even for a target whose saved
+  // value is a deliberate manual choice, which is exactly the false claim
+  // this feature exists to avoid making.
+  const inferredMatchesRegion = gameValuesReady
+    ? coriolisFieldMatchesRegionInference(schema?.game.find((candidate) => candidate.id === fieldId), gameValues[fieldId], regionValue)
+    : false;
+  // manualOverride is null (follow the inference) until the admin actually
+  // clicks the toggle this session; see the reset effect below for why it
+  // can't just live folded into inferredMatchesRegion's own state.
+  const matchesRegion = manualOverride ?? inferredMatchesRegion;
+  useEffect(() => {
+    // A manual toggle choice is scoped to the target it was made for --
+    // switching targets re-infers fresh rather than carrying it over.
+    setManualOverride(null);
+  }, [userGameTargetKey]);
+  useEffect(() => {
+    // While On, keep the draft pinned to the region's value -- covers both a
+    // manual toggle flip and a target switch landing on a different saved value.
+    if (!gameValuesReady || !matchesRegion || regionValue === undefined) return;
+    const desired = String(regionValue);
+    if (draftValue === desired) return;
+    setGameDraft((current) => ({ ...current, [fieldId]: desired }));
+  }, [gameValuesReady, matchesRegion, regionValue, draftValue]);
+  // A scope that has never had this field saved at all gets the region's
+  // value written once, server-side, at startup (migrate_coriolis_region_fields
+  // in usersettings.py, invoked from server.js) -- not from here. Doing it
+  // client-side meant "browse a target" silently issued a write with no
+  // confirmation, pinned whichever scope happened to be open (breaking
+  // Global -> Map -> Partition inheritance), and could never distinguish
+  // "unset" from "explicitly saved to equal the schema default" -- on a
+  // region whose value equals the field's default (Europe for the hour;
+  // Europe, North America, and South America for the day) that looped
+  // forever.
+  return { matchesRegion, regionValue, setManualOverride };
+}
+
 export function MapsPanel({ onError, confirmAction, restartGate, confirmSettingsRestart, waitForTaskWithUpdates, taskTechnicalDetails }: MapsPanelProps) {
   const [mapsText, setMapsText] = useState("");
   const [memoryText, setMemoryText] = useState("");
@@ -347,7 +424,6 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
   const [gameValues, setGameValues] = useState<Record<string, string>>({});
   const [gameDraft, setGameDraft] = useState<Record<string, string>>({});
   const [serverRegion, setServerRegion] = useState("");
-  const [coriolisHourManualOverride, setCoriolisHourManualOverride] = useState<boolean | null>(null);
   const [gameValuesTargetKey, setGameValuesTargetKey] = useState("");
   const [rawEngine, setRawEngine] = useState("");
   const [rawGame, setRawGame] = useState("");
@@ -1287,57 +1363,19 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
   const engineTargetKey = settingsTargetKey(engineMapName, isEngineGlobal ? "" : enginePartitionId);
   const gameFields = schema ? (effectivePartitionId ? schema.partition : schema.game).filter((field) => field.id !== "partition_pve_enabled" || effectivePartitionId) : [];
   const userGameFields = schema && userGameName ? (!isUserGameGlobal && effectiveUserGamePartitionId ? schema.partition : schema.game).filter((field) => field.id !== "partition_pve_enabled" || (!isUserGameGlobal && effectiveUserGamePartitionId)) : [];
-  const coriolisRegionHour = CORIOLIS_REGION_HOURS[serverRegion];
-  const coriolisMatchRegionAvailable = coriolisRegionHour !== undefined && userGameFields.some((field) => field.id === CORIOLIS_CYCLE_START_HOUR_FIELD_ID);
-  const coriolisHourDraftValue = gameDraft[CORIOLIS_CYCLE_START_HOUR_FIELD_ID];
   // userGameName/effectiveUserGamePartitionId flip synchronously the instant a
   // target is picked, one render before loadSelectedSettings's async fetch
   // resolves and actually updates gameValues/gameDraft for it. Without this,
   // that in-between render sees the *previous* target's (or the initial
   // empty) gameValues while userGameName already points at the new one --
-  // read as "field untouched" -- and the effects below would flicker the
-  // toggle, or worse, have the migration effect fire a save from data that
-  // was never this target's to begin with.
+  // read as "field untouched" -- and the Match Region hooks below would
+  // flicker the toggle, or worse, pin a draft from data that was never this
+  // target's to begin with.
   const gameValuesReady = Boolean(userGameName) && gameValuesTargetKey === userGameTargetKey;
-  // Derived synchronously (not useState+useEffect) so it's never one render
-  // behind gameValues/gameDraft -- a state+effect version briefly rendered a
-  // just-loaded custom hour as locked/disabled under its stale previous
-  // value before the correcting effect caught up on the next tick.
-  // coriolisHourManualOverride is null (follow the inference) until the
-  // admin actually clicks the toggle this session; see the reset effect
-  // below for why it can't just live as this const's own state.
-  // Before real data has loaded there is nothing to infer from, so this must
-  // default to false (unlocked), not true -- a true default would render the
-  // field as locked-to-region for one paint even for a target whose saved
-  // hour is a deliberate manual value, which is exactly the false claim the
-  // rest of this feature exists to avoid making.
-  const coriolisHourInferredMatchesRegion = gameValuesReady
-    ? coriolisHourMatchesRegionInference(schema?.game.find((candidate) => candidate.id === CORIOLIS_CYCLE_START_HOUR_FIELD_ID), gameValues[CORIOLIS_CYCLE_START_HOUR_FIELD_ID], coriolisRegionHour)
-    : false;
-  const coriolisHourMatchesRegion = coriolisHourManualOverride ?? coriolisHourInferredMatchesRegion;
-  useEffect(() => {
-    // A manual toggle choice is scoped to the target it was made for --
-    // switching targets re-infers fresh rather than carrying it over.
-    setCoriolisHourManualOverride(null);
-  }, [userGameTargetKey]);
-  useEffect(() => {
-    // While On, keep the draft pinned to the region's hour -- covers both a
-    // manual toggle flip and a target switch landing on a different saved value.
-    if (!gameValuesReady || !coriolisHourMatchesRegion) return;
-    const regionHour = CORIOLIS_REGION_HOURS[serverRegion];
-    if (regionHour === undefined) return;
-    const desired = String(regionHour);
-    if (coriolisHourDraftValue === desired) return;
-    setGameDraft((current) => ({ ...current, [CORIOLIS_CYCLE_START_HOUR_FIELD_ID]: desired }));
-  }, [gameValuesReady, coriolisHourMatchesRegion, serverRegion, coriolisHourDraftValue]);
-  // A scope that has never had this field saved at all gets the region's
-  // hour written once, server-side, at startup (migrate_coriolis_region_hour
-  // in usersettings.py, invoked from server.js) -- not from here. Doing it
-  // client-side meant "browse a target" silently issued a write with no
-  // confirmation, pinned whichever scope happened to be open (breaking
-  // Global -> Map -> Partition inheritance), and could never distinguish
-  // "unset" from "explicitly saved to equal the schema default", which on a
-  // Europe deployment (region hour == schema default) looped forever.
+  const coriolisHour = useCoriolisMatchRegion(CORIOLIS_CYCLE_START_HOUR_FIELD_ID, CORIOLIS_REGION_HOURS, schema, gameValues, gameDraft, setGameDraft, gameValuesReady, serverRegion, userGameTargetKey);
+  const coriolisDay = useCoriolisMatchRegion(CORIOLIS_CYCLE_START_DAY_FIELD_ID, CORIOLIS_REGION_DAYS, schema, gameValues, gameDraft, setGameDraft, gameValuesReady, serverRegion, userGameTargetKey);
+  const coriolisHourMatchRegionAvailable = coriolisHour.regionValue !== undefined && userGameFields.some((field) => field.id === CORIOLIS_CYCLE_START_HOUR_FIELD_ID);
+  const coriolisDayMatchRegionAvailable = coriolisDay.regionValue !== undefined && userGameFields.some((field) => field.id === CORIOLIS_CYCLE_START_DAY_FIELD_ID);
   const gameGroups = groupSettingsFields(userGameFields, true, modifiedSettingsFields(userGameFields, gameValues, gameDraft));
   const activeGameCategory = gameGroups.some(([category]) => category === selectedGameCategory) ? selectedGameCategory : gameGroups[0]?.[0] || "";
   const activeGameFields = activeGameCategory === "All" ? userGameFields : gameGroups.find(([category]) => category === activeGameCategory)?.[1] || [];
@@ -2309,7 +2347,10 @@ export function MapsPanel({ onError, confirmAction, restartGate, confirmSettings
             </div>
           </div>
         </div>
-        {userGameName && <SettingsCardGrid fields={filteredGameFields} values={gameDraft} onChange={(id, value) => setGameDraft({ ...gameDraft, [id]: value })} viewMode={modifierViewMode} emptyMessage={modifierEmptyMessage(!!schema, userGameFields.length, modifierFilter, activeGameCategory)} matchRegionControl={{ fieldId: CORIOLIS_CYCLE_START_HOUR_FIELD_ID, enabled: coriolisHourMatchesRegion, available: coriolisMatchRegionAvailable, regionLabel: serverRegion, regionHour: coriolisRegionHour, onToggle: setCoriolisHourManualOverride }} />}
+        {userGameName && <SettingsCardGrid fields={filteredGameFields} values={gameDraft} onChange={(id, value) => setGameDraft({ ...gameDraft, [id]: value })} viewMode={modifierViewMode} emptyMessage={modifierEmptyMessage(!!schema, userGameFields.length, modifierFilter, activeGameCategory)} matchRegionControls={[
+          { fieldId: CORIOLIS_CYCLE_START_HOUR_FIELD_ID, enabled: coriolisHour.matchesRegion, available: coriolisHourMatchRegionAvailable, regionLabel: serverRegion, regionValueLabel: coriolisHourRegionValueLabel(coriolisHour.regionValue), onToggle: coriolisHour.setManualOverride },
+          { fieldId: CORIOLIS_CYCLE_START_DAY_FIELD_ID, enabled: coriolisDay.matchesRegion, available: coriolisDayMatchRegionAvailable, regionLabel: serverRegion, regionValueLabel: coriolisDayRegionValueLabel(coriolisDay.regionValue), onToggle: coriolisDay.setManualOverride }
+        ]} />}
         <div className="action-row"><button disabled={!gameDirty.length || !userGameName} onClick={() => run(saveGame)}>Save</button><button disabled={!gameDirty.length} onClick={() => setGameDraft(gameValues)}>Discard Changes</button><button className="settings-reset-all-button" disabled={!userGameName || !userGameFields.length} title="Set every UserGame setting on this tab back to its default value" onClick={() => run(() => resetAllToDefaults("game"))}>Restore Defaults</button></div>
       </> : settingsTab === "spicefields" ? <>
         <SpicefieldsEditor
@@ -2458,15 +2499,15 @@ function ChoamTerminalsEditor({
   </section>;
 }
 
-type MatchRegionControl = { fieldId: string; enabled: boolean; available: boolean; regionLabel: string; regionHour?: number; onToggle: (next: boolean) => void };
+type MatchRegionControl = { fieldId: string; enabled: boolean; available: boolean; regionLabel: string; regionValueLabel: string; onToggle: (next: boolean) => void };
 
-function SettingsCardGrid({ fields, values, onChange, viewMode = "grid", emptyMessage = "Select a modifier category.", matchRegionControl }: { fields: UserSettingField[]; values: Record<string, string>; onChange: (id: string, value: string) => void; viewMode?: "grid" | "list"; emptyMessage?: string; matchRegionControl?: MatchRegionControl }) {
+function SettingsCardGrid({ fields, values, onChange, viewMode = "grid", emptyMessage = "Select a modifier category.", matchRegionControls }: { fields: UserSettingField[]; values: Record<string, string>; onChange: (id: string, value: string) => void; viewMode?: "grid" | "list"; emptyMessage?: string; matchRegionControls?: MatchRegionControl[] }) {
   if (!fields.length) return <div className="empty">{emptyMessage}</div>;
   if (viewMode === "list") {
     return <div className="settings-list-wrap"><table className="settings-list-table"><thead><tr><th>Modifier</th><th>Setting Key</th><th>Value</th></tr></thead><tbody>{fields.map((field) => {
       const value = values[field.id] ?? field.default ?? "";
       const modified = isModifiedFromDefault(field, value);
-      const matchRegion = matchRegionControl?.fieldId === field.id ? matchRegionControl : undefined;
+      const matchRegion = matchRegionControls?.find((control) => control.fieldId === field.id);
       return <Fragment key={field.id}>
         {(field.clientFile || modified) && <tr className="settings-list-badge-row"><td colSpan={3}>
           {field.clientFile && <span className="badge badge-info settings-list-badge" title={`Also requires updating the client's ${field.clientFile}.`}>Client &quot;{field.clientFile}&quot;</span>}
@@ -2476,7 +2517,7 @@ function SettingsCardGrid({ fields, values, onChange, viewMode = "grid", emptyMe
           <td><strong>{friendlySettingLabel(field.id, field.key || field.id, field.label)}</strong><small>{fieldCategory(field)}</small></td>
           <td>{field.key || field.id}</td>
           <td>
-            {matchRegion && <MatchRegionToggle control={matchRegion} idPrefix={`setting-list-${field.scope}`} />}
+            {matchRegion && <MatchRegionToggle control={matchRegion} idPrefix={`setting-list-${field.scope}`} fieldLabel={friendlySettingLabel(field.id, field.key || field.id, field.label)} />}
             <SettingInput field={field} value={value} inputId={`setting-list-${field.scope}-${field.id}`} onChange={(nextValue) => onChange(field.id, nextValue)} disabled={matchRegion?.enabled} />
           </td>
         </tr>
@@ -2484,19 +2525,22 @@ function SettingsCardGrid({ fields, values, onChange, viewMode = "grid", emptyMe
       </Fragment>;
     })}</tbody></table></div>;
   }
-  return <div className="settings-grid settings-grid-roomy">{fields.map((field) => <SettingControl key={field.id} field={field} value={values[field.id] ?? field.default ?? ""} onChange={(value) => onChange(field.id, value)} matchRegion={matchRegionControl?.fieldId === field.id ? matchRegionControl : undefined} />)}</div>;
+  return <div className="settings-grid settings-grid-roomy">{fields.map((field) => <SettingControl key={field.id} field={field} value={values[field.id] ?? field.default ?? ""} onChange={(value) => onChange(field.id, value)} matchRegion={matchRegionControls?.find((control) => control.fieldId === field.id)} />)}</div>;
 }
 
 // Same visual spec as .bases-rank-segments / .vehicles-rank-segments, under
 // its own settings-scoped class names per this repo's CSS scoping convention.
-function MatchRegionToggle({ control, idPrefix }: { control: MatchRegionControl; idPrefix: string }) {
+function MatchRegionToggle({ control, idPrefix, fieldLabel }: { control: MatchRegionControl; idPrefix: string; fieldLabel: string }) {
   const groupName = `${idPrefix}-${control.fieldId}-match-region`;
   const title = control.available
-    ? `Set from the deployment's region: ${control.regionLabel}, ${String(control.regionHour ?? "").padStart(2, "0")}:00 UTC.`
+    ? `Set from the deployment's region: ${control.regionLabel}, ${control.regionValueLabel}.`
     : `No regional master schedule is defined for ${control.regionLabel || "this deployment's region"} -- set manually.`;
   return <div className="settings-match-region" title={title}>
     <span className="settings-match-region-label">Match Region</span>
-    <div className="settings-match-region-segments" role="radiogroup" aria-label="Match Region">
+    {/* More than one Coriolis field can carry a Match Region toggle at once
+        (Cycle Start Hour and Day) -- a bare "Match Region" label would leave
+        every toggle on the page indistinguishable to a screen reader. */}
+    <div className="settings-match-region-segments" role="radiogroup" aria-label={`Match Region for ${fieldLabel}`}>
       {([["On", true], ["Off", false]] as const).map(([label, isOn]) => (
         <label className="settings-match-region-segment" key={label}>
           <input
@@ -2540,7 +2584,7 @@ function SettingControl({ field, value, onChange, matchRegion }: { field: UserSe
       <small>{field.key || field.id}</small>
     </div>
     {field.description && <span className="settings-field-description"><Info size={14} aria-hidden="true" /><span className="settings-field-description-text">{field.description}</span></span>}
-    {matchRegion && <MatchRegionToggle control={matchRegion} idPrefix={`setting-${field.scope}`} />}
+    {matchRegion && <MatchRegionToggle control={matchRegion} idPrefix={`setting-${field.scope}`} fieldLabel={label} />}
     <SettingInput field={field} value={value} inputId={inputId} onChange={onChange} disabled={matchRegion?.enabled} />
   </div>;
 }
@@ -2766,19 +2810,20 @@ export function isModifiedFromDefault(field: UserSettingField, value: string) {
   return settingValueChanged(field, String(field.default ?? ""), String(value ?? ""));
 }
 
-// Whether the Cycle Start Hour "Match Region" toggle should infer as On for a
-// freshly loaded saved value: the value already equals the region's hour.
-// Any other saved value -- including the untouched schema default -- is
-// treated as a deliberate value and must never be silently overwritten, so
-// it infers Off. (A scope that has genuinely never had this field saved gets
-// the region's hour written once, server-side, at startup -- see
-// migrate_coriolis_region_hour in usersettings.py -- so by the time this
+// Whether a Coriolis field's "Match Region" toggle should infer as On for a
+// freshly loaded saved value: the value already equals the region's value
+// for this field (hour or day -- the logic never depended on which). Any
+// other saved value -- including the untouched schema default -- is treated
+// as a deliberate value and must never be silently overwritten, so it infers
+// Off. (A scope that has genuinely never had this field saved gets the
+// region's value written once, server-side, at startup -- see
+// migrate_coriolis_region_fields in usersettings.py -- so by the time this
 // runs "default" and "unset" are no longer the same question.)
-export function coriolisHourMatchesRegionInference(field: UserSettingField | undefined, savedValue: string, regionHour: number | undefined): boolean {
-  if (!field || regionHour === undefined) return false;
+export function coriolisFieldMatchesRegionInference(field: UserSettingField | undefined, savedValue: string, regionValue: number | undefined): boolean {
+  if (!field || regionValue === undefined) return false;
   const fieldDefault = String(field.default ?? "");
   const resolved = String(savedValue ?? fieldDefault);
-  return Number(resolved) === regionHour;
+  return Number(resolved) === regionValue;
 }
 
 // Pseudo-category listed alongside the real ones, so an admin can see just the

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -6037,6 +6037,7 @@ td .inline-action-result-wrap { flex: 1 0 100%; justify-content: flex-start; min
 .settings-field-description svg { flex-shrink: 0; margin-top: 1px; color: var(--accent); }
 .settings-field-description-text { flex: 1 1 auto; min-width: 0; overflow-wrap: anywhere; }
 .settings-field input, .settings-field select, .settings-field textarea, .raw-editor-card textarea { width: 100%; }
+.settings-field input:disabled, .settings-field select:disabled, .settings-list-table input:disabled, .settings-list-table select:disabled { opacity: .6; cursor: not-allowed; }
 
 /* Same visual spec as .bases-rank-segments / .vehicles-rank-segments, under
    its own settings-scoped class names per this repo's CSS scoping convention. */
@@ -6058,6 +6059,7 @@ td .inline-action-result-wrap { flex: 1 0 100%; justify-content: flex-start; min
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 0;
   min-height: 28px;
   padding: 0 10px;
   border-left: 1px solid var(--border);
@@ -6070,7 +6072,7 @@ td .inline-action-result-wrap { flex: 1 0 100%; justify-content: flex-start; min
   user-select: none;
 }
 .settings-match-region-segment:first-child { border-left: 0; }
-.settings-match-region-segment input {
+.settings-match-region-segments .settings-match-region-segment input {
   position: absolute;
   inset: 0;
   margin: 0;
@@ -6120,6 +6122,7 @@ td .inline-action-result-wrap { flex: 1 0 100%; justify-content: flex-start; min
 .settings-list-description-row td { padding-top: 0; }
 .settings-list-table input, .settings-list-table select, .settings-list-table textarea { width: 100%; margin-top: -10px; }
 .settings-list-table tr.settings-list-badge-row + tr input, .settings-list-table tr.settings-list-badge-row + tr select, .settings-list-table tr.settings-list-badge-row + tr textarea { margin-top: 0; }
+.settings-list-table .settings-match-region + input, .settings-list-table .settings-match-region + select, .settings-list-table .settings-match-region + textarea { margin-top: 0; }
 .spicefields-table { min-width: 980px; }
 .spicefields-table th:nth-child(n), .spicefields-table td:nth-child(n) { width: auto; }
 .spicefields-table th:nth-child(1), .spicefields-table td:nth-child(1) { width: 18%; }
@@ -6608,6 +6611,11 @@ td :where(.service-actions, .action-row, .map-action-buttons) { max-width: 100%;
   input[type="checkbox"], input[type="radio"] { min-height: 22px; min-width: 22px; }
   .col-resize-handle { display: none; }
   .memory-info-button, .addon-description-toggle { min-width: 44px; min-height: 44px; }
+  /* .settings-match-region-segment is a <label>, not one of the tags the generic
+     button/input/select rule above targets, so its 28px segments are otherwise
+     untouched by this media query. */
+  .settings-match-region-segments { height: 44px; }
+  .settings-match-region-segment { min-height: 44px; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -6037,6 +6037,51 @@ td .inline-action-result-wrap { flex: 1 0 100%; justify-content: flex-start; min
 .settings-field-description svg { flex-shrink: 0; margin-top: 1px; color: var(--accent); }
 .settings-field-description-text { flex: 1 1 auto; min-width: 0; overflow-wrap: anywhere; }
 .settings-field input, .settings-field select, .settings-field textarea, .raw-editor-card textarea { width: 100%; }
+
+/* Same visual spec as .bases-rank-segments / .vehicles-rank-segments, under
+   its own settings-scoped class names per this repo's CSS scoping convention. */
+.settings-match-region { display: flex; align-items: center; gap: 8px; margin-bottom: 6px; }
+.settings-match-region-label { font-size: 12px; font-weight: 700; color: #a99577; white-space: nowrap; }
+.settings-match-region-segments {
+  display: inline-grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  height: 28px;
+  min-width: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  background: #151719;
+  overflow: hidden;
+}
+.settings-match-region-segment {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border-left: 1px solid var(--border);
+  color: var(--muted-warm);
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  cursor: pointer;
+  user-select: none;
+}
+.settings-match-region-segment:first-child { border-left: 0; }
+.settings-match-region-segment input {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+.settings-match-region-segment:hover { background: rgba(198, 139, 74, .12); color: var(--text-strong); }
+.settings-match-region-segment:has(input:checked) { background: #9b5f2a; color: var(--text-strong); }
+.settings-match-region-segment:has(input:focus-visible) { outline: 2px solid var(--accent-strong); outline-offset: -2px; }
+.settings-match-region-segments:has(input:disabled) { opacity: .45; }
+.settings-match-region-segment:has(input:disabled) { cursor: not-allowed; }
 .character-transfer-grid { display: grid; gap: 8px; max-width: 820px; }
 .character-transfer-row {
   display: grid;

--- a/docs/console/restart-queue.md
+++ b/docs/console/restart-queue.md
@@ -59,11 +59,14 @@ IP-change) ultimately runs. This mirrors the existing Landsraad "Pending
 Restart" indicator, generalized to any UserEngine/UserGame save.
 
 The same indicator can also appear with no admin action at all: on first
-startup, if `SERVER_REGION` maps to a known Coriolis master schedule and the
-global Cycle Start Hour has never been explicitly saved, the console seeds it
-once and marks the same deferred-restart indicator ("Coriolis Cycle Start
-Hour (region default)"). This is a one-time migration, not a recurring
-background write — restart at your convenience like any other deferred save.
+startup, if `SERVER_REGION` maps to a known Coriolis master schedule, the
+console seeds whichever of the global Cycle Start Hour and Cycle Start Day
+have never been explicitly saved and marks the same deferred-restart
+indicator ("Coriolis cycle start settings (region default)"). Each field is
+migrated independently — an admin who already saved one keeps their value,
+and only the other (if still unset) is seeded. This is a one-time migration
+per field, not a recurring background write — restart at your convenience
+like any other deferred save.
 
 ## Enabling and configuring
 

--- a/docs/console/restart-queue.md
+++ b/docs/console/restart-queue.md
@@ -58,6 +58,13 @@ does (`start-all.sh`), which every restart path (manual, scheduled,
 IP-change) ultimately runs. This mirrors the existing Landsraad "Pending
 Restart" indicator, generalized to any UserEngine/UserGame save.
 
+The same indicator can also appear with no admin action at all: on first
+startup, if `SERVER_REGION` maps to a known Coriolis master schedule and the
+global Cycle Start Hour has never been explicitly saved, the console seeds it
+once and marks the same deferred-restart indicator ("Coriolis Cycle Start
+Hour (region default)"). This is a one-time migration, not a recurring
+background write — restart at your convenience like any other deferred save.
+
 ## Enabling and configuring
 
 Open **Admin Tools → Schedule Server Restart** and turn on **Restart Queue**.

--- a/runtime/scripts/test_profile_override_precedence.py
+++ b/runtime/scripts/test_profile_override_precedence.py
@@ -240,6 +240,37 @@ class RetiredModifierAndCoriolisMetadataTests(ProfilePathTestCase):
         self.assertEqual(len(data_lines), 1)
         self.assertIn("m_VotingPeriodStartBeforeCoriolisCycleInSec=122400", data_lines[0])
 
+    def test_legacy_dunegamemode_cycle_and_wipe_fields_are_hidden_behind_coriolis(self):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(usersettings.metadata(), 0)
+        payload = json.loads(output.getvalue())
+        ids = {row["id"] for row in payload["game"]}
+        self.assertNotIn("cycle_duration_in_days", ids)
+        self.assertNotIn("db_wipe_enabled", ids)
+        fields = {row["id"]: row for row in payload["game"]}
+        self.assertEqual(fields["coriolis_cycle_duration_days"]["label"], "Cycle Duration Days")
+
+    def test_saving_the_canonical_coriolis_field_compiles_into_both_sections(self):
+        # cycle_duration_in_days (legacy DuneGameMode) is hidden from the editor,
+        # but compiled_usergame_ini still writes it alongside the canonical
+        # CoriolisSubsystem key -- via sync_legacy_values() backfilling
+        # profile_map_values(), not by mirroring the raw saved profile -- so any
+        # code path still reading the legacy key keeps seeing the new value.
+        profile = usersettings.empty_profile()
+        usersettings.set_profile_field(profile, "global", "", "", "coriolis_cycle_duration_days", "3")
+        rendered = usersettings.compiled_usergame_ini(profile, MAP_NAME)
+        self.assertIn(f"[{usersettings.CORIOLIS_SUBSYSTEM_SECTION}]\nm_CycleDurationInDays=3", rendered)
+        self.assertIn("[/Script/DuneSandbox.DuneGameMode]\nm_CycleDurationInDays=3", rendered)
+
+    def test_an_existing_legacy_only_value_still_surfaces_through_the_canonical_field(self):
+        legacy_section, legacy_key, _default = usersettings.MAP_FIELDS["db_wipe_enabled"]
+        profile = usersettings.parse_profile_text(
+            f"[Global:{legacy_section}]\n{legacy_key}=False\n"
+        )
+        values = usersettings.profile_map_values(profile, MAP_NAME)
+        self.assertEqual(values["coriolis_db_wipe_enabled"], "False")
+
 
 class ClientGameIniAllowlistTests(ProfilePathTestCase):
     def test_exports_only_nondefault_client_required_fields(self):

--- a/runtime/scripts/test_profile_override_precedence.py
+++ b/runtime/scripts/test_profile_override_precedence.py
@@ -187,7 +187,7 @@ class RetiredModifierAndCoriolisMetadataTests(ProfilePathTestCase):
         expected = {
             "coriolis_cycle_start_year": ("m_CycleStartYear", "2024", 1, 9999),
             "coriolis_cycle_start_month": ("m_CycleStartMonth", "12", 1, 12),
-            "coriolis_cycle_start_day": ("m_CycleStartDay", "3", 1, 7),
+            "coriolis_cycle_start_day": ("m_CycleStartDay", "3", 1, 31),
             "coriolis_cycle_start_hour": ("m_CycleStartHour", "5", 0, 23),
             "coriolis_cycle_start_minute": ("m_CycleStartMinute", "0", 0, 59),
         }
@@ -200,7 +200,7 @@ class RetiredModifierAndCoriolisMetadataTests(ProfilePathTestCase):
                 self.assertEqual(field["type"], "integer")
                 self.assertEqual(field["minimum"], minimum)
                 self.assertEqual(field["maximum"], maximum)
-        self.assertIn("1=Sunday", fields["coriolis_cycle_start_day"]["description"])
+        self.assertIn("calendar day of the month", fields["coriolis_cycle_start_day"]["description"])
         self.assertIn("UTC hour", fields["coriolis_cycle_start_hour"]["description"])
         self.assertEqual(fields["coriolis_cycle_start_seed_index"]["key"], "m_CycleStartSeedIndex")
         self.assertEqual(fields["coriolis_cycle_start_seed_index"]["type"], "integer")
@@ -237,23 +237,11 @@ class RetiredModifierAndCoriolisMetadataTests(ProfilePathTestCase):
         self.assertEqual(frontend_table, usersettings.CORIOLIS_REGION_HOURS)
 
     def test_coriolis_region_days_match_field_description(self):
-        # Same authority relationship as the hour table above, but the day
-        # description's grammar groups several regions under one shared weekday
-        # ("Europe, North America, and South America use Tuesday (3); Asia and
-        # Oceania use Monday (2)") rather than listing one value per region, so
-        # it needs its own parser rather than reusing the hour test's.
+        # Keep the user-facing description honest about the two regional anchor
+        # dates. Table parity with the frontend is checked independently below.
         description = usersettings.FIELD_DESCRIPTIONS["coriolis_cycle_start_day"]
-        segment = description.split(":", 2)[2].strip().rstrip(".")
-        described = {}
-        for group in segment.split(";"):
-            regions_part, _, day_part = group.strip().partition(" use ")
-            day_number = int(day_part.strip().rstrip(".").split("(")[1].rstrip(")"))
-            regions_part = regions_part.replace(", and ", ", ").replace(" and ", ", ")
-            for region in regions_part.split(","):
-                region = region.strip()
-                if region:
-                    described[region] = day_number
-        self.assertEqual(described, usersettings.CORIOLIS_REGION_DAYS)
+        self.assertIn("Europe, North America, and South America use day 3", description)
+        self.assertIn("Asia and Oceania use day 2", description)
 
     def test_coriolis_region_days_match_the_console_frontend_table(self):
         import re
@@ -269,7 +257,7 @@ class RetiredModifierAndCoriolisMetadataTests(ProfilePathTestCase):
         for field_id, value in (
             ("coriolis_cycle_start_year", "0"),
             ("coriolis_cycle_start_month", "13"),
-            ("coriolis_cycle_start_day", "8"),
+            ("coriolis_cycle_start_day", "32"),
             ("coriolis_cycle_start_hour", "24"),
             ("coriolis_cycle_start_minute", "60"),
             ("coriolis_cycle_start_minute", "1.5"),

--- a/runtime/scripts/test_profile_override_precedence.py
+++ b/runtime/scripts/test_profile_override_precedence.py
@@ -207,7 +207,7 @@ class RetiredModifierAndCoriolisMetadataTests(ProfilePathTestCase):
 
     def test_coriolis_region_hours_match_field_description(self):
         # CORIOLIS_REGION_HOURS is the authoritative table (used by
-        # migrate_coriolis_region_hour); the field's own description is the text an
+        # migrate_coriolis_region_fields); the field's own description is the text an
         # admin actually reads. Parse the description independently of the dict's own
         # construction, so a typo in either place is a real test failure instead of the
         # same mistake checking itself.
@@ -235,6 +235,34 @@ class RetiredModifierAndCoriolisMetadataTests(ProfilePathTestCase):
         self.assertIsNotNone(match, "CORIOLIS_REGION_HOURS literal not found in MapsPanel.tsx -- update this test's pattern if it was reshaped")
         frontend_table = {region: int(hour) for region, hour in re.findall(r'"([^"]+)":\s*(\d+)', match.group(1))}
         self.assertEqual(frontend_table, usersettings.CORIOLIS_REGION_HOURS)
+
+    def test_coriolis_region_days_match_field_description(self):
+        # Same authority relationship as the hour table above, but the day
+        # description's grammar groups several regions under one shared weekday
+        # ("Europe, North America, and South America use Tuesday (3); Asia and
+        # Oceania use Monday (2)") rather than listing one value per region, so
+        # it needs its own parser rather than reusing the hour test's.
+        description = usersettings.FIELD_DESCRIPTIONS["coriolis_cycle_start_day"]
+        segment = description.split(":", 2)[2].strip().rstrip(".")
+        described = {}
+        for group in segment.split(";"):
+            regions_part, _, day_part = group.strip().partition(" use ")
+            day_number = int(day_part.strip().rstrip(".").split("(")[1].rstrip(")"))
+            regions_part = regions_part.replace(", and ", ", ").replace(" and ", ", ")
+            for region in regions_part.split(","):
+                region = region.strip()
+                if region:
+                    described[region] = day_number
+        self.assertEqual(described, usersettings.CORIOLIS_REGION_DAYS)
+
+    def test_coriolis_region_days_match_the_console_frontend_table(self):
+        import re
+        frontend_path = Path(__file__).resolve().parents[2] / "console" / "web" / "src" / "features" / "maps" / "MapsPanel.tsx"
+        text = frontend_path.read_text(encoding="utf-8")
+        match = re.search(r"CORIOLIS_REGION_DAYS: Record<string, number> = \{(.*?)\};", text, re.DOTALL)
+        self.assertIsNotNone(match, "CORIOLIS_REGION_DAYS literal not found in MapsPanel.tsx -- update this test's pattern if it was reshaped")
+        frontend_table = {region: int(day) for region, day in re.findall(r'"([^"]+)":\s*(\d+)', match.group(1))}
+        self.assertEqual(frontend_table, usersettings.CORIOLIS_REGION_DAYS)
 
     def test_coriolis_cycle_start_components_are_validated(self):
         profile = usersettings.empty_profile()
@@ -388,6 +416,54 @@ class RetiredModifierAndCoriolisMetadataTests(ProfilePathTestCase):
         with redirect_stdout(output):
             self.assertEqual(usersettings.bulk_save("global", MAP_NAME, "", _encode_bulk_save_payload({"coriolis_cycle_duration_days": "14"})), 0)
         self.assertNotIn("USERSETTINGS_WARNING:", output.getvalue())
+
+    def test_migrate_coriolis_region_fields_is_a_noop_for_an_unmapped_region(self):
+        self.assertEqual(usersettings.migrate_coriolis_region_fields("Atlantis"), "skip:unmapped-region")
+        values = usersettings.profile_global_values(usersettings.read_profile())
+        self.assertEqual(values["coriolis_cycle_start_hour"], usersettings.MAP_FIELDS["coriolis_cycle_start_hour"][2])
+        self.assertEqual(values["coriolis_cycle_start_day"], usersettings.MAP_FIELDS["coriolis_cycle_start_day"][2])
+
+    def test_migrate_coriolis_region_fields_migrates_both_fields_once(self):
+        self.assertEqual(usersettings.migrate_coriolis_region_fields("North America"), "migrated:coriolis_cycle_start_hour=11,coriolis_cycle_start_day=3")
+        values = usersettings.profile_global_values(usersettings.read_profile())
+        self.assertEqual(values["coriolis_cycle_start_hour"], "11")
+        self.assertEqual(values["coriolis_cycle_start_day"], "3")
+        # Idempotent by presence, not value -- a second call must be a true
+        # no-op regardless of what either field now holds.
+        self.assertEqual(usersettings.migrate_coriolis_region_fields("North America"), "skip:already-present")
+
+    def test_migrate_coriolis_region_fields_never_loops_when_the_regions_day_equals_its_default(self):
+        # coriolis_cycle_start_day's schema default is "3", which is ALSO the
+        # region value for Europe, North America, and South America -- three of
+        # the five regions, not a one-region edge case like the hour's Europe
+        # (whose region value, 5, also equals the hour default). This is the
+        # direct regression guard for the "value equals default" bug class the
+        # server-side migration exists to make structurally impossible: presence,
+        # not value, must be what stops it, or this majority case would still
+        # write on every single startup.
+        for region in ("Europe", "North America", "South America"):
+            with self.subTest(region=region):
+                usersettings.write_profile(usersettings.empty_profile())
+                first = usersettings.migrate_coriolis_region_fields(region)
+                self.assertTrue(first.startswith("migrated:"), f"{region} did not migrate on first call: {first}")
+                for attempt in range(3):
+                    with self.subTest(attempt=attempt):
+                        self.assertEqual(usersettings.migrate_coriolis_region_fields(region), "skip:already-present")
+                values = usersettings.profile_global_values(usersettings.read_profile())
+                self.assertEqual(values["coriolis_cycle_start_day"], "3")
+
+    def test_migrate_coriolis_region_fields_only_writes_the_field_not_already_present(self):
+        # An admin who already saved the hour explicitly (to any value, even a
+        # non-region one) must keep it untouched -- only the still-unset day
+        # field should be written, and in the same profile pass as the presence
+        # check, not a second read-modify-write cycle that could race it.
+        profile = usersettings.empty_profile()
+        usersettings.set_profile_field(profile, "global", "", "", "coriolis_cycle_start_hour", "22")
+        usersettings.write_profile(profile)
+        self.assertEqual(usersettings.migrate_coriolis_region_fields("Asia"), "migrated:coriolis_cycle_start_day=2")
+        values = usersettings.profile_global_values(usersettings.read_profile())
+        self.assertEqual(values["coriolis_cycle_start_hour"], "22")
+        self.assertEqual(values["coriolis_cycle_start_day"], "2")
 
 
 class ClientGameIniAllowlistTests(ProfilePathTestCase):

--- a/runtime/scripts/test_profile_override_precedence.py
+++ b/runtime/scripts/test_profile_override_precedence.py
@@ -30,6 +30,7 @@ import io
 import json
 import sys
 import unittest
+from base64 import b64encode
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -40,6 +41,10 @@ import usersettings  # noqa: E402
 MAP_NAME = "Survival_1"
 PARTITION_ID = "3"
 OTHER_PARTITION_ID = "7"
+
+
+def _encode_bulk_save_payload(values: dict) -> str:
+    return b64encode(json.dumps(values).encode("utf-8")).decode("ascii")
 
 
 class ProfilePathTestCase(unittest.TestCase):
@@ -200,6 +205,37 @@ class RetiredModifierAndCoriolisMetadataTests(ProfilePathTestCase):
         self.assertEqual(fields["coriolis_cycle_start_seed_index"]["key"], "m_CycleStartSeedIndex")
         self.assertEqual(fields["coriolis_cycle_start_seed_index"]["type"], "integer")
 
+    def test_coriolis_region_hours_match_field_description(self):
+        # CORIOLIS_REGION_HOURS is the authoritative table (used by
+        # migrate_coriolis_region_hour); the field's own description is the text an
+        # admin actually reads. Parse the description independently of the dict's own
+        # construction, so a typo in either place is a real test failure instead of the
+        # same mistake checking itself.
+        description = usersettings.FIELD_DESCRIPTIONS["coriolis_cycle_start_hour"]
+        segment = description.split(":", 1)[1].strip().rstrip(".")
+        described = {}
+        for chunk in segment.split(","):
+            chunk = chunk.strip()
+            if chunk.startswith("and "):
+                chunk = chunk[4:]
+            region, hour = chunk.rsplit(" ", 1)
+            described[region] = int(hour)
+        self.assertEqual(described, usersettings.CORIOLIS_REGION_HOURS)
+
+    def test_coriolis_region_hours_match_the_console_frontend_table(self):
+        # console/web/src/features/maps/MapsPanel.tsx keeps its own copy (documented as
+        # such at CORIOLIS_REGION_HOURS's definition here) because the toggle's
+        # inference renders without a round trip; only the migration write is
+        # server-side. Parse the frontend's literal object directly so the two tables
+        # cannot drift without a test noticing.
+        import re
+        frontend_path = Path(__file__).resolve().parents[2] / "console" / "web" / "src" / "features" / "maps" / "MapsPanel.tsx"
+        text = frontend_path.read_text(encoding="utf-8")
+        match = re.search(r"CORIOLIS_REGION_HOURS: Record<string, number> = \{(.*?)\};", text, re.DOTALL)
+        self.assertIsNotNone(match, "CORIOLIS_REGION_HOURS literal not found in MapsPanel.tsx -- update this test's pattern if it was reshaped")
+        frontend_table = {region: int(hour) for region, hour in re.findall(r'"([^"]+)":\s*(\d+)', match.group(1))}
+        self.assertEqual(frontend_table, usersettings.CORIOLIS_REGION_HOURS)
+
     def test_coriolis_cycle_start_components_are_validated(self):
         profile = usersettings.empty_profile()
         for field_id, value in (
@@ -250,6 +286,7 @@ class RetiredModifierAndCoriolisMetadataTests(ProfilePathTestCase):
         self.assertNotIn("db_wipe_enabled", ids)
         fields = {row["id"]: row for row in payload["game"]}
         self.assertEqual(fields["coriolis_cycle_duration_days"]["label"], "Cycle Duration Days")
+        self.assertEqual(fields["coriolis_db_wipe_enabled"]["label"], "Db Wipe Enabled")
 
     def test_saving_the_canonical_coriolis_field_compiles_into_both_sections(self):
         # cycle_duration_in_days (legacy DuneGameMode) is hidden from the editor,
@@ -270,6 +307,87 @@ class RetiredModifierAndCoriolisMetadataTests(ProfilePathTestCase):
         )
         values = usersettings.profile_map_values(profile, MAP_NAME)
         self.assertEqual(values["coriolis_db_wipe_enabled"], "False")
+
+    def _assert_explicit_canonical_save_wins_over_stale_legacy(self, legacy_field, canonical_field, stale_legacy_value):
+        # Presence, not a value-vs-default comparison, must decide the winner: a stale
+        # legacy value must never outrank a canonical value the admin explicitly saved,
+        # even when that explicit save happens to equal the canonical schema default --
+        # sync_legacy_values() used to read that case as "canonical was never touched"
+        # and let the legacy value silently win.
+        legacy_section, legacy_key, legacy_default = usersettings.MAP_FIELDS[legacy_field]
+        _canonical_section, _canonical_key, canonical_default = usersettings.MAP_FIELDS[canonical_field]
+        self.assertNotEqual(stale_legacy_value, legacy_default, "the injected legacy value must be non-default to represent a real explicit legacy override")
+        profile = usersettings.parse_profile_text(f"[Global:{legacy_section}]\n{legacy_key}={stale_legacy_value}\n")
+        usersettings.set_profile_field(profile, "global", "", "", canonical_field, canonical_default)
+        values = usersettings.profile_global_values(profile)
+        self.assertEqual(values[canonical_field], canonical_default)
+        rendered = usersettings.compiled_usergame_ini(profile, MAP_NAME)
+        self.assertNotIn(f"{legacy_key}={stale_legacy_value}", rendered)
+
+    def test_explicit_canonical_save_wins_over_stale_legacy_coriolis_value(self):
+        # db_wipe_enabled's canonical default is "True"; give the profile a stale
+        # explicit legacy value ("False") and an explicit canonical save that equals
+        # the canonical default ("True") -- the exact production shape from the PR
+        # review's H5 repro.
+        self._assert_explicit_canonical_save_wins_over_stale_legacy("db_wipe_enabled", "coriolis_db_wipe_enabled", "False")
+
+    def test_explicit_canonical_save_wins_over_stale_legacy_guild_value(self):
+        # Same bug, pre-existing on the guild aliases before this branch touched them --
+        # see the PR callout: a deployment with a stale legacy guild cap silently
+        # overriding an explicit canonical save sees its effective cap change once this
+        # lands, and that is the intended fix, not a regression.
+        self._assert_explicit_canonical_save_wins_over_stale_legacy("max_guild_members_allowed", "guild_settings_max_guild_members_allowed", "20")
+
+    def test_conflicting_legacy_and_canonical_values_both_present_resolve_to_canonical_and_warn(self):
+        legacy_section, legacy_key, _legacy_default = usersettings.MAP_FIELDS["cycle_duration_in_days"]
+        profile = usersettings.parse_profile_text(f"[Global:{legacy_section}]\n{legacy_key}=3\n")
+        usersettings.set_profile_field(profile, "global", "", "", "coriolis_cycle_duration_days", "14")
+        values = usersettings.profile_global_values(profile)
+        self.assertEqual(values["coriolis_cycle_duration_days"], "14")
+        rendered = usersettings.compiled_usergame_ini(profile, MAP_NAME)
+        self.assertIn(f"{legacy_key}=14", rendered)
+        self.assertNotIn(f"{legacy_key}=3\n", rendered)
+        warnings = usersettings.legacy_alias_conflict_warnings(profile, "global")
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("m_CycleDurationInDays=3", warnings[0])
+        self.assertIn("m_CycleDurationInDays=14", warnings[0])
+        # Both sides share the same ini key name -- the section is what actually tells an
+        # admin which block to go edit; without it "m_CycleDurationInDays=3" vs "=14" reads
+        # as two values for the same setting with no way to tell them apart.
+        self.assertIn(legacy_section, warnings[0])
+        self.assertIn(usersettings.CORIOLIS_SUBSYSTEM_SECTION, warnings[0])
+
+    def test_raw_editor_legacy_conflict_warning_names_both_sections(self):
+        # _advanced_editor_legacy_field_warnings is the raw/Advanced-editor counterpart to
+        # legacy_alias_conflict_warnings above -- previously only run manually via
+        # profile_selftest(), not CI. Both sides share the same ini key name (the whole
+        # reason they're aliased), so the section is what actually tells an admin which
+        # block to go edit; pin that it's present, not just the key/value pair.
+        sections = usersettings.parse_profile_text(
+            "[Global:/Script/DuneSandbox.DuneGameMode]\nm_MaxGuildMembersAllowed=5\n"
+            "[Global:/Script/DuneSandbox.GuildSettings]\nm_MaxGuildMembersAllowed=32\n"
+        ).get("sections", [])
+        warnings = usersettings._advanced_editor_legacy_field_warnings(sections)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("m_MaxGuildMembersAllowed=5", warnings[0])
+        self.assertIn("m_MaxGuildMembersAllowed=32", warnings[0])
+        self.assertIn("/Script/DuneSandbox.DuneGameMode", warnings[0])
+        self.assertIn("/Script/DuneSandbox.GuildSettings", warnings[0])
+
+    def test_bulk_save_prints_a_warning_for_a_legacy_canonical_conflict(self):
+        legacy_section, legacy_key, _legacy_default = usersettings.MAP_FIELDS["cycle_duration_in_days"]
+        usersettings.write_profile(usersettings.parse_profile_text(f"[Global:{legacy_section}]\n{legacy_key}=3\n"))
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(usersettings.bulk_save("global", MAP_NAME, "", _encode_bulk_save_payload({"coriolis_cycle_duration_days": "14"})), 0)
+        self.assertIn("USERSETTINGS_WARNING:", output.getvalue())
+        self.assertIn("m_CycleDurationInDays", output.getvalue())
+
+    def test_bulk_save_prints_no_warning_when_only_the_canonical_field_is_saved(self):
+        output = io.StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(usersettings.bulk_save("global", MAP_NAME, "", _encode_bulk_save_payload({"coriolis_cycle_duration_days": "14"})), 0)
+        self.assertNotIn("USERSETTINGS_WARNING:", output.getvalue())
 
 
 class ClientGameIniAllowlistTests(ProfilePathTestCase):

--- a/runtime/scripts/usersettings.py
+++ b/runtime/scripts/usersettings.py
@@ -379,6 +379,7 @@ FIELD_LABELS = {
     "coriolis_cycle_start_minute": "Cycle Start Minute",
     "coriolis_cycle_start_seed_index": "Cycle Start Seed Index",
     "coriolis_cycle_duration_days": "Cycle Duration Days",
+    "coriolis_db_wipe_enabled": "Db Wipe Enabled",
     "guild_settings_creation_cost": "Guild Creation Cost",
     "guild_settings_max_guilds_allowed": "Max Guilds Allowed",
     "guild_settings_max_guild_members_allowed": "Max Guild Members Allowed",
@@ -720,6 +721,43 @@ LEGACY_FIELD_ALIASES = {
     "cycle_duration_in_days": "coriolis_cycle_duration_days",
     "db_wipe_enabled": "coriolis_db_wipe_enabled",
 }
+
+# UTC regional master schedules for coriolis_cycle_start_hour. This is the
+# authoritative copy -- console/web/src/features/maps/MapsPanel.tsx keeps its
+# own copy in sync (checked by
+# test_coriolis_region_hours_match_field_description in
+# test_profile_override_precedence.py) because the console frontend renders
+# the Match Region toggle's inference without a round trip, but the only
+# scope-mutating write happens here, from migrate_coriolis_region_hour.
+CORIOLIS_REGION_HOURS = {
+    "Europe": 5,
+    "North America": 11,
+    "South America": 8,
+    "Asia": 9,
+    "Oceania": 19,
+}
+
+
+def migrate_coriolis_region_hour(region: str) -> str:
+    """One-time, idempotent global-scope migration: if this deployment's
+    region has a known master hour and the global Coriolis Cycle Start Hour
+    has never been explicitly saved (the ini key is absent, not merely equal
+    to the schema default -- those are different questions, see
+    sync_legacy_values for the same distinction made the wrong way once
+    already), write the region's hour once. Safe to call on every startup:
+    idempotent by key presence, so it can never loop or re-fire once the key
+    exists, regardless of what value it holds.
+    """
+    regional_hour = CORIOLIS_REGION_HOURS.get(region)
+    if regional_hour is None:
+        return "skip:unmapped-region"
+    profile = read_profile()
+    section, ini_key, _ = MAP_FIELDS["coriolis_cycle_start_hour"]
+    if profile_get_key(profile, "global", section, ini_key) is not None:
+        return "skip:already-present"
+    set_profile_field(profile, "global", "", "", "coriolis_cycle_start_hour", str(regional_hour))
+    write_profile(profile)
+    return f"migrated:{regional_hour}"
 
 
 def field_spec(field_id: str):
@@ -1280,17 +1318,82 @@ def mirror_legacy_profile_field(profile: dict, scope: str, map_name: str, partit
         profile_set_key(profile, "partition", spec[0], spec[1], value, canonical_map(map_name or "Survival_1"), str(partition_id or ""))
 
 
-def sync_legacy_values(values: dict[str, str]) -> dict[str, str]:
+def _legacy_alias_scopes(scope: str, map_name: str = "", partition_id: str = "") -> list[tuple[str, str, str]]:
+    """Scope chain to probe for LEGACY_FIELD_ALIASES presence, ordered least to most
+    specific -- mirrors exactly what profile_global_values/profile_map_values/
+    profile_partition_values merge for these fields (all of which live in MAP_FIELDS,
+    never PARTITION_FIELDS, so global/map/partition is the complete chain)."""
+    scopes = [("global", "", "")]
+    if scope in ("map", "partition"):
+        scopes.append(("map", map_name, ""))
+    if scope == "partition":
+        scopes.append(("partition", map_name, partition_id))
+    return scopes
+
+
+def _field_explicitly_present(profile: dict, field_id: str, scopes: list[tuple[str, str, str]]) -> bool:
+    section, ini_key, _ = MAP_FIELDS[field_id]
+    if not section or not ini_key:
+        return False
+    return any(profile_get_key(profile, s, section, ini_key, m, p) is not None for s, m, p in scopes)
+
+
+def _effective_field_value(profile: dict, field_id: str, scopes: list[tuple[str, str, str]]) -> str:
+    section, ini_key, default = MAP_FIELDS[field_id]
+    value = str(default)
+    for s, m, p in scopes:
+        found = profile_get_key(profile, s, section, ini_key, m, p)
+        if found is not None:
+            value = found
+    return value
+
+
+def sync_legacy_values(profile: dict, values: dict[str, str], scope: str, map_name: str = "", partition_id: str = "") -> dict[str, str]:
+    """Resolve each LEGACY_FIELD_ALIASES pair by presence, not by comparing values to
+    their schema defaults. A value-comparison approach cannot distinguish "never saved"
+    from "explicitly saved to a value that happens to equal the default", which let a
+    stale legacy value silently outrank an admin's deliberate canonical save whenever
+    that save happened to be the default (see legacy_alias_conflict_warnings for the
+    admin-visible counterpart on the structured save path)."""
+    scopes = _legacy_alias_scopes(scope, map_name, partition_id)
     for legacy_field, canonical_field in LEGACY_FIELD_ALIASES.items():
         legacy_default = str(MAP_FIELDS[legacy_field][2])
         canonical_default = str(MAP_FIELDS[canonical_field][2])
-        legacy_value = str(values.get(legacy_field, legacy_default))
-        canonical_value = str(values.get(canonical_field, canonical_default))
-        if legacy_value != legacy_default and canonical_value == canonical_default:
-            values[canonical_field] = legacy_value
-        elif canonical_value != canonical_default and legacy_value == legacy_default:
-            values[legacy_field] = canonical_value
+        if _field_explicitly_present(profile, canonical_field, scopes):
+            # Canonical wins whenever it has been explicitly saved, regardless of value.
+            values[legacy_field] = values.get(canonical_field, canonical_default)
+        elif _field_explicitly_present(profile, legacy_field, scopes):
+            values[canonical_field] = values.get(legacy_field, legacy_default)
+        # Neither present: both fields stay at their already-seeded defaults.
     return values
+
+
+def legacy_alias_conflict_warnings(profile: dict, scope: str, map_name: str = "", partition_id: str = "") -> list[str]:
+    """Structured-save-path counterpart to _advanced_editor_legacy_field_warnings (the
+    raw/Advanced editor's version of this same check): both the legacy and canonical id
+    for one effective setting have been explicitly saved with different values.
+    sync_legacy_values() resolves that silently in canonical's favor -- this is what lets
+    an admin actually see it happened, the same way the raw editor already can."""
+    if scope not in ("global", "map", "partition"):
+        return []
+    scopes = _legacy_alias_scopes(scope, map_name, partition_id)
+    warnings = []
+    for legacy_field, canonical_field in LEGACY_FIELD_ALIASES.items():
+        if not (_field_explicitly_present(profile, legacy_field, scopes) and _field_explicitly_present(profile, canonical_field, scopes)):
+            continue
+        legacy_value = _effective_field_value(profile, legacy_field, scopes)
+        canonical_value = _effective_field_value(profile, canonical_field, scopes)
+        if legacy_value == canonical_value:
+            continue
+        legacy_section, legacy_key, _legacy_default = MAP_FIELDS[legacy_field]
+        canonical_section, canonical_key, _canonical_default = MAP_FIELDS[canonical_field]
+        # Both fields share the same ini key name (that's the whole reason they're aliased),
+        # so the section is what actually tells an admin which block to go edit.
+        warnings.append(
+            f"legacy field [{legacy_section}] {legacy_key}={legacy_value} conflicts with the "
+            f"canonical field [{canonical_section}] {canonical_key}={canonical_value} -- the canonical value is used."
+        )
+    return warnings
 
 
 def seed_profile_from_legacy_config() -> dict:
@@ -1737,7 +1840,7 @@ def profile_map_values(profile: dict, map_name: str) -> dict[str, str]:
             values[key] = map_value
     global_data = profile_get_key(profile, "global", LANDSRAAD_SETTINGS_SECTION, LANDSRAAD_DATA_KEY)
     values.update(landsraad_virtual_values(global_data or LANDSRAAD_DATA_TEMPLATE))
-    return sync_legacy_values(values)
+    return sync_legacy_values(profile, values, "map", target_map)
 
 
 def profile_global_values(profile: dict) -> dict[str, str]:
@@ -1751,7 +1854,7 @@ def profile_global_values(profile: dict) -> dict[str, str]:
             values[key] = global_value
     global_data = profile_get_key(profile, "global", LANDSRAAD_SETTINGS_SECTION, LANDSRAAD_DATA_KEY)
     values.update(landsraad_virtual_values(global_data or LANDSRAAD_DATA_TEMPLATE))
-    return sync_legacy_values(values)
+    return sync_legacy_values(profile, values, "global")
 
 
 def profile_partition_array_selector_active(profile: dict, section: str, key: str, target_map: str, target_partition: str) -> bool:
@@ -1805,7 +1908,7 @@ def profile_partition_values(profile: dict, map_name: str, partition_id: str) ->
     values["partition_selector_mode_active"] = "True" if profile_partition_selector_mode_active(
         profile, target_map, target_partition
     ) else "False"
-    return sync_legacy_values(values)
+    return sync_legacy_values(profile, values, "partition", target_map, target_partition)
 
 
 def profile_section_lines(profile: dict, scope: str, section: str, map_name: str = "", partition_id: str = "") -> list[str]:
@@ -2537,6 +2640,8 @@ def bulk_save(scope: str, map_name: str, partition_id: str, encoded_values: str)
     if scope == "engine":
         validate_profile_port_ranges(profile)
     write_profile(profile)
+    for message in legacy_alias_conflict_warnings(profile, scope, target_map, target_partition):
+        print(f"USERSETTINGS_WARNING: {message}")
     if landsraad_changed:
         atomic_write_text(LANDSRAAD_RESTART_MARKER_PATH, "Landsraad UserGame settings changed.\n", 0o664)
     return 0
@@ -2847,9 +2952,13 @@ def _advanced_editor_legacy_field_warnings(sections: list[dict]) -> list[str]:
                 continue
             canonical_value = _advanced_editor_find_scoped_key_value(sections, block, canonical_spec[0], canonical_spec[1])
             if canonical_value is not None and canonical_value == str(canonical_spec[2]):
+                # Both fields share the same ini key name (that's the whole reason they're
+                # aliased) -- name the section too, or an admin has no way to tell which
+                # block to go edit.
                 warnings.append(
-                    f"{where}: legacy field {legacy_spec[1]}={legacy_value} overrides the explicit default "
-                    f"you set on {canonical_spec[1]}={canonical_value} -- the canonical value was dropped."
+                    f"{where}: legacy field [{legacy_spec[0]}] {legacy_spec[1]}={legacy_value} overrides "
+                    f"the explicit default you set on [{canonical_spec[0]}] {canonical_spec[1]}={canonical_value} "
+                    f"-- the canonical value was dropped."
                 )
     return warnings
 
@@ -3022,8 +3131,16 @@ Dune.GlobalVehicleMiningOutputMultiplier=10
         raise SystemExit("Partition selector mode did not materialize its explicit force-PvP-all=False guard.")
     if compiled_game.count("+m_PvpEnabledPartitions=3") != 1:
         raise SystemExit("Global and partition-toggle PvP array lines for the same value were not deduplicated.")
-    if "[/Script/DuneSandbox.GuildSettings]" not in compiled_game or "m_MaxGuildMembersAllowed=5" not in compiled_game:
-        raise SystemExit("Legacy guild member limit was not mirrored to GuildSettings.")
+    # The seed profile above has BOTH a legacy DuneGameMode value (5) and an explicit
+    # canonical GuildSettings value (32) at global scope. Presence, not a value-vs-default
+    # comparison, must pick the winner (see sync_legacy_values) -- canonical wins, and
+    # since 32 is also both fields' shared schema default, neither section emits the key.
+    if "m_MaxGuildMembersAllowed=5" in compiled_game:
+        raise SystemExit("A stale legacy guild member limit leaked into the compiled UserGame.ini over an explicit canonical value.")
+    if profile_map_values(reparsed, "Survival_1")["guild_settings_max_guild_members_allowed"] != "32":
+        raise SystemExit("An explicit canonical guild member limit did not win over a conflicting legacy value.")
+    if not any("m_MaxGuildMembersAllowed=5" in w and "m_MaxGuildMembersAllowed=32" in w for w in legacy_alias_conflict_warnings(reparsed, "global")):
+        raise SystemExit("A conflicting legacy/canonical guild member limit did not raise a warning.")
     if "UnknownGlobal=abc" not in compiled_game or "CustomPartitionKey=True" not in compiled_game:
         raise SystemExit("Compiled UserGame dropped unknown profile lines.")
     if "m_GlobalXPMultiplier=" in compiled_game:
@@ -3853,6 +3970,9 @@ def main(argv: list[str]) -> int:
         return raw_write_encoded("game", argv[4], argv[2], argv[3])
     if command == "bulk-save" and len(argv) == 6:
         return bulk_save(argv[2], argv[3], argv[4], argv[5])
+    if command == "migrate-coriolis-region-hour" and len(argv) == 3:
+        print(migrate_coriolis_region_hour(argv[2]))
+        return 0
     if command == "materialize-current":
         return materialize_current_runtime_files()
     if command == "materialize" and len(argv) == 4:

--- a/runtime/scripts/usersettings.py
+++ b/runtime/scripts/usersettings.py
@@ -378,6 +378,7 @@ FIELD_LABELS = {
     "coriolis_cycle_start_hour": "Cycle Start Hour",
     "coriolis_cycle_start_minute": "Cycle Start Minute",
     "coriolis_cycle_start_seed_index": "Cycle Start Seed Index",
+    "coriolis_cycle_duration_days": "Cycle Duration Days",
     "guild_settings_creation_cost": "Guild Creation Cost",
     "guild_settings_max_guilds_allowed": "Max Guilds Allowed",
     "guild_settings_max_guild_members_allowed": "Max Guild Members Allowed",
@@ -705,10 +706,19 @@ ENGINE_HEADER_INTERNAL_NAMES = {v: k for k, v in ENGINE_HEADER_DISPLAY_NAMES.ite
 _ENGINE_DISPLAY_HEADER_RE = re.compile(
     r"^\[(" + "|".join(re.escape(name) for name in ENGINE_HEADER_DISPLAY_NAMES.values()) + r"):(.*)\]$"
 )
-LEGACY_GUILD_FIELD_ALIASES = {
+# Legacy DuneGameMode keys that a newer, canonical field also writes to a
+# different section under the same effective setting. Showing both in the
+# structured editor gives admins two controls for one effective setting and
+# makes the legacy value silently win in some cases, so metadata() hides the
+# legacy id and mirror_legacy_profile_field()/sync_legacy_values() keep the
+# legacy ini key and any already-saved legacy value in sync with the canonical
+# one instead.
+LEGACY_FIELD_ALIASES = {
     "guild_creation_cost": "guild_settings_creation_cost",
     "max_guilds_allowed": "guild_settings_max_guilds_allowed",
     "max_guild_members_allowed": "guild_settings_max_guild_members_allowed",
+    "cycle_duration_in_days": "coriolis_cycle_duration_days",
+    "db_wipe_enabled": "coriolis_db_wipe_enabled",
 }
 
 
@@ -1255,8 +1265,8 @@ def append_safe_staking_extension_arrays(section_lines: dict[str, list[str]], va
         entries.extend(f".{key}={value}" for _ in range(STAKING_EXTENSION_ARRAY_LENGTH))
 
 
-def mirror_legacy_guild_profile_field(profile: dict, scope: str, map_name: str, partition_id: str, field_id: str, value: str) -> None:
-    canonical_field = LEGACY_GUILD_FIELD_ALIASES.get(field_id)
+def mirror_legacy_profile_field(profile: dict, scope: str, map_name: str, partition_id: str, field_id: str, value: str) -> None:
+    canonical_field = LEGACY_FIELD_ALIASES.get(field_id)
     if not canonical_field:
         return
     spec = MAP_FIELDS.get(canonical_field)
@@ -1270,8 +1280,8 @@ def mirror_legacy_guild_profile_field(profile: dict, scope: str, map_name: str, 
         profile_set_key(profile, "partition", spec[0], spec[1], value, canonical_map(map_name or "Survival_1"), str(partition_id or ""))
 
 
-def sync_legacy_guild_values(values: dict[str, str]) -> dict[str, str]:
-    for legacy_field, canonical_field in LEGACY_GUILD_FIELD_ALIASES.items():
+def sync_legacy_values(values: dict[str, str]) -> dict[str, str]:
+    for legacy_field, canonical_field in LEGACY_FIELD_ALIASES.items():
         legacy_default = str(MAP_FIELDS[legacy_field][2])
         canonical_default = str(MAP_FIELDS[canonical_field][2])
         legacy_value = str(values.get(legacy_field, legacy_default))
@@ -1660,7 +1670,7 @@ def set_profile_field(profile: dict, scope: str, map_name: str, partition_id: st
         spec = MAP_FIELDS[field_id]
         if spec[0] and spec[1]:
             profile_set_key(profile, "global", spec[0], spec[1], value)
-            mirror_legacy_guild_profile_field(profile, "global", "", "", field_id, value)
+            mirror_legacy_profile_field(profile, "global", "", "", field_id, value)
         return
 
     if scope == "map":
@@ -1669,7 +1679,7 @@ def set_profile_field(profile: dict, scope: str, map_name: str, partition_id: st
         spec = MAP_FIELDS[field_id]
         if spec[0] and spec[1]:
             profile_set_key(profile, "map", spec[0], spec[1], value, map_name=map_name)
-            mirror_legacy_guild_profile_field(profile, "map", map_name, "", field_id, value)
+            mirror_legacy_profile_field(profile, "map", map_name, "", field_id, value)
         return
 
     if scope == "partition":
@@ -1692,7 +1702,7 @@ def set_profile_field(profile: dict, scope: str, map_name: str, partition_id: st
         spec = MAP_FIELDS.get(field_id)
         if spec and spec[0] and spec[1]:
             profile_set_key(profile, "partition", spec[0], spec[1], value, target_map, target_partition)
-            mirror_legacy_guild_profile_field(profile, "partition", target_map, target_partition, field_id, value)
+            mirror_legacy_profile_field(profile, "partition", target_map, target_partition, field_id, value)
         return
 
     raise SystemExit("Unknown settings scope.")
@@ -1727,7 +1737,7 @@ def profile_map_values(profile: dict, map_name: str) -> dict[str, str]:
             values[key] = map_value
     global_data = profile_get_key(profile, "global", LANDSRAAD_SETTINGS_SECTION, LANDSRAAD_DATA_KEY)
     values.update(landsraad_virtual_values(global_data or LANDSRAAD_DATA_TEMPLATE))
-    return sync_legacy_guild_values(values)
+    return sync_legacy_values(values)
 
 
 def profile_global_values(profile: dict) -> dict[str, str]:
@@ -1741,7 +1751,7 @@ def profile_global_values(profile: dict) -> dict[str, str]:
             values[key] = global_value
     global_data = profile_get_key(profile, "global", LANDSRAAD_SETTINGS_SECTION, LANDSRAAD_DATA_KEY)
     values.update(landsraad_virtual_values(global_data or LANDSRAAD_DATA_TEMPLATE))
-    return sync_legacy_guild_values(values)
+    return sync_legacy_values(values)
 
 
 def profile_partition_array_selector_active(profile: dict, section: str, key: str, target_map: str, target_partition: str) -> bool:
@@ -1795,7 +1805,7 @@ def profile_partition_values(profile: dict, map_name: str, partition_id: str) ->
     values["partition_selector_mode_active"] = "True" if profile_partition_selector_mode_active(
         profile, target_map, target_partition
     ) else "False"
-    return sync_legacy_guild_values(values)
+    return sync_legacy_values(values)
 
 
 def profile_section_lines(profile: dict, scope: str, section: str, map_name: str = "", partition_id: str = "") -> list[str]:
@@ -1920,17 +1930,16 @@ def metadata() -> int:
         key: spec for key, spec in PARTITION_ENGINE_FIELDS.items()
         if key != "server_login_password"
     }
-    # Keep legacy DuneGameMode guild keys readable and compilable for existing
-    # profiles, but expose only their canonical GuildSettings counterparts in
-    # the structured editor. Showing both gives admins two controls for one
-    # effective setting and makes the legacy value silently win in some cases.
+    # Keep legacy DuneGameMode keys readable and compilable for existing
+    # profiles, but expose only their canonical counterparts (GuildSettings,
+    # CoriolisSubsystem) in the structured editor. See LEGACY_FIELD_ALIASES.
     public_game_fields = {
         key: spec for key, spec in MAP_FIELDS.items()
-        if key not in LEGACY_GUILD_FIELD_ALIASES
+        if key not in LEGACY_FIELD_ALIASES
     }
     public_partition_fields = {
         key: spec for key, spec in PARTITION_FIELDS.items()
-        if key not in LEGACY_GUILD_FIELD_ALIASES
+        if key not in LEGACY_FIELD_ALIASES
     }
     payload = {
         "engine": [row("engine", key, spec) for key, spec in public_engine_fields.items()],
@@ -2818,8 +2827,8 @@ def _advanced_editor_find_scoped_key_value(sections: list[dict], reference_block
     return None
 
 
-def _advanced_editor_legacy_guild_warnings(sections: list[dict]) -> list[str]:
-    """Flag the case sync_legacy_guild_values() (~1024) resolves silently: a non-default
+def _advanced_editor_legacy_field_warnings(sections: list[dict]) -> list[str]:
+    """Flag the case sync_legacy_values() (~1024) resolves silently: a non-default
     legacy field overriding a canonical field explicitly set to its own default. The
     canonical field's explicit line is then also dropped by the known-key filter in
     append_profile_unknown_lines(), so without this warning the admin has no way to know
@@ -2828,7 +2837,7 @@ def _advanced_editor_legacy_guild_warnings(sections: list[dict]) -> list[str]:
     for block in sections:
         section = str(block.get("ini_section", ""))
         where = _advanced_editor_block_label(block)
-        for legacy_field, canonical_field in LEGACY_GUILD_FIELD_ALIASES.items():
+        for legacy_field, canonical_field in LEGACY_FIELD_ALIASES.items():
             legacy_spec = MAP_FIELDS[legacy_field]
             canonical_spec = MAP_FIELDS[canonical_field]
             if section != legacy_spec[0]:
@@ -2873,7 +2882,7 @@ def profile_game_write_encoded(encoded_content: str) -> int:
     warnings = (
         _advanced_editor_duplicate_key_warnings(incoming.get("sections", []))
         + _advanced_editor_pvp_pve_warnings(incoming.get("sections", []))
-        + _advanced_editor_legacy_guild_warnings(incoming.get("sections", []))
+        + _advanced_editor_legacy_field_warnings(incoming.get("sections", []))
     )
     profile = read_profile()
     replace_profile_game_sections(profile, incoming)
@@ -3210,7 +3219,7 @@ Dune.GlobalVehicleMiningOutputMultiplier=10
     if not any("m_MaxGuildsAllowed was set 2 times" in w and "(1)" in w and "(2)" in w for w in dup_warnings):
         raise SystemExit("Duplicate-key Advanced Editor warning did not fire correctly.")
 
-    legacy_warnings = _advanced_editor_legacy_guild_warnings(reparsed.get("sections", []))
+    legacy_warnings = _advanced_editor_legacy_field_warnings(reparsed.get("sections", []))
     if not any("m_MaxGuildMembersAllowed=5 overrides" in w for w in legacy_warnings):
         raise SystemExit("Legacy guild-alias override warning did not fire.")
 
@@ -3223,7 +3232,7 @@ Dune.GlobalVehicleMiningOutputMultiplier=10
         "[Global:/Script/DuneSandbox.DuneGameMode]\nm_MaxGuildMembersAllowed=5\n"
         "[Global:/Script/DuneSandbox.GuildSettings]\nm_MaxGuildMembersAllowed=99\nm_MaxGuildMembersAllowed=32\n"
     ).get("sections", [])
-    last_wins_warnings = _advanced_editor_legacy_guild_warnings(last_wins_sections)
+    last_wins_warnings = _advanced_editor_legacy_field_warnings(last_wins_sections)
     if not any("m_MaxGuildMembersAllowed=5 overrides" in w and "m_MaxGuildMembersAllowed=32" in w for w in last_wins_warnings):
         raise SystemExit("Legacy guild-alias warning used the first assignment of a duplicated canonical key instead of the last-wins effective value.")
 

--- a/runtime/scripts/usersettings.py
+++ b/runtime/scripts/usersettings.py
@@ -364,7 +364,7 @@ FIELD_DESCRIPTIONS = {
     "coriolis_auto_spawn_enabled": "Whether Coriolis storms spawn automatically on their normal cycle.",
     "coriolis_cycle_start_year": "Base year shipped in the Coriolis configuration. Normally leave this unchanged when matching a regional schedule.",
     "coriolis_cycle_start_month": "Base month (1-12) shipped in the Coriolis configuration. Normally leave this unchanged when matching a regional schedule.",
-    "coriolis_cycle_start_day": "UTC weekday: 1=Sunday through 7=Saturday. Europe, North America, and South America use Tuesday (3); Asia and Oceania use Monday (2). The region/farm selection does not automatically rewrite it.",
+    "coriolis_cycle_start_day": "UTC weekday: 1=Sunday through 7=Saturday. Regional master schedules: Europe, North America, and South America use Tuesday (3); Asia and Oceania use Monday (2).",
     "coriolis_cycle_start_hour": "UTC hour (0-23). Regional master schedules: Europe 05, North America 11, South America 08, Asia 09, and Oceania 19.",
     "coriolis_cycle_start_minute": "UTC minute (0-59) for the Coriolis cycle start.",
     "coriolis_cycle_start_seed_index": "Funcom's seed index for the base Coriolis cycle. Leave at 0 unless intentionally coordinating a different cycle seed.",
@@ -722,13 +722,14 @@ LEGACY_FIELD_ALIASES = {
     "db_wipe_enabled": "coriolis_db_wipe_enabled",
 }
 
-# UTC regional master schedules for coriolis_cycle_start_hour. This is the
-# authoritative copy -- console/web/src/features/maps/MapsPanel.tsx keeps its
-# own copy in sync (checked by
-# test_coriolis_region_hours_match_field_description in
+# UTC regional master schedules for coriolis_cycle_start_hour and
+# coriolis_cycle_start_day. These are the authoritative copies --
+# console/web/src/features/maps/MapsPanel.tsx keeps its own copies in sync
+# (checked by test_coriolis_region_hours_match_field_description and
+# test_coriolis_region_days_match_field_description in
 # test_profile_override_precedence.py) because the console frontend renders
-# the Match Region toggle's inference without a round trip, but the only
-# scope-mutating write happens here, from migrate_coriolis_region_hour.
+# each Match Region toggle's inference without a round trip, but the only
+# scope-mutating write happens here, from migrate_coriolis_region_fields.
 CORIOLIS_REGION_HOURS = {
     "Europe": 5,
     "North America": 11,
@@ -736,28 +737,52 @@ CORIOLIS_REGION_HOURS = {
     "Asia": 9,
     "Oceania": 19,
 }
+CORIOLIS_REGION_DAYS = {
+    "Europe": 3,
+    "North America": 3,
+    "South America": 3,
+    "Asia": 2,
+    "Oceania": 2,
+}
+# Every region key must resolve on both tables, or a region migrates one
+# field but not the other with no way for an admin to tell that happened --
+# migrate_coriolis_region_fields relies on this to treat "unmapped" as a
+# single yes/no question asked once, not per field.
+assert set(CORIOLIS_REGION_HOURS) == set(CORIOLIS_REGION_DAYS)
+CORIOLIS_REGION_MIGRATION_FIELDS = (
+    ("coriolis_cycle_start_hour", CORIOLIS_REGION_HOURS),
+    ("coriolis_cycle_start_day", CORIOLIS_REGION_DAYS),
+)
 
 
-def migrate_coriolis_region_hour(region: str) -> str:
-    """One-time, idempotent global-scope migration: if this deployment's
-    region has a known master hour and the global Coriolis Cycle Start Hour
-    has never been explicitly saved (the ini key is absent, not merely equal
-    to the schema default -- those are different questions, see
-    sync_legacy_values for the same distinction made the wrong way once
-    already), write the region's hour once. Safe to call on every startup:
-    idempotent by key presence, so it can never loop or re-fire once the key
-    exists, regardless of what value it holds.
+def migrate_coriolis_region_fields(region: str) -> str:
+    """One-time, idempotent global-scope migration: for each of
+    coriolis_cycle_start_hour/_day, if this deployment's region has a known
+    regional value and the field has never been explicitly saved (the ini key
+    is absent, not merely equal to the schema default -- those are different
+    questions, see sync_legacy_values for the same distinction made the wrong
+    way once already), write the region's value once. Both fields are read
+    and written in a single profile pass so a startup that needs to migrate
+    both never leaves one written and the other not from a race or a crash
+    between two separate read-modify-write cycles. Safe to call on every
+    startup: idempotent by key presence per field, so it can never loop or
+    re-fire once a key exists, regardless of what value it holds.
     """
-    regional_hour = CORIOLIS_REGION_HOURS.get(region)
-    if regional_hour is None:
+    if region not in CORIOLIS_REGION_HOURS:
         return "skip:unmapped-region"
     profile = read_profile()
-    section, ini_key, _ = MAP_FIELDS["coriolis_cycle_start_hour"]
-    if profile_get_key(profile, "global", section, ini_key) is not None:
+    migrated = []
+    for field_id, region_table in CORIOLIS_REGION_MIGRATION_FIELDS:
+        section, ini_key, _ = MAP_FIELDS[field_id]
+        if profile_get_key(profile, "global", section, ini_key) is not None:
+            continue
+        regional_value = region_table[region]
+        set_profile_field(profile, "global", "", "", field_id, str(regional_value))
+        migrated.append(f"{field_id}={regional_value}")
+    if not migrated:
         return "skip:already-present"
-    set_profile_field(profile, "global", "", "", "coriolis_cycle_start_hour", str(regional_hour))
     write_profile(profile)
-    return f"migrated:{regional_hour}"
+    return "migrated:" + ",".join(migrated)
 
 
 def field_spec(field_id: str):
@@ -3970,8 +3995,8 @@ def main(argv: list[str]) -> int:
         return raw_write_encoded("game", argv[4], argv[2], argv[3])
     if command == "bulk-save" and len(argv) == 6:
         return bulk_save(argv[2], argv[3], argv[4], argv[5])
-    if command == "migrate-coriolis-region-hour" and len(argv) == 3:
-        print(migrate_coriolis_region_hour(argv[2]))
+    if command == "migrate-coriolis-region-fields" and len(argv) == 3:
+        print(migrate_coriolis_region_fields(argv[2]))
         return 0
     if command == "materialize-current":
         return materialize_current_runtime_files()

--- a/runtime/scripts/usersettings.py
+++ b/runtime/scripts/usersettings.py
@@ -144,12 +144,12 @@ FIELD_TYPE_OVERRIDES = {
 }
 
 # Bounds for the Coriolis cycle fields shipped in Funcom's UserGame.ini
-# template. Day is a UTC weekday (1=Sunday through 7=Saturday), not a calendar
-# day. The server validates these values for Web UI, API, and CLI callers.
+# template. These five fields form a UTC calendar date and time. The server
+# validates them for Web UI, API, and CLI callers.
 CORIOLIS_CYCLE_START_BOUNDS = {
     "coriolis_cycle_start_year": (1, 9999),
     "coriolis_cycle_start_month": (1, 12),
-    "coriolis_cycle_start_day": (1, 7),
+    "coriolis_cycle_start_day": (1, 31),
     "coriolis_cycle_start_hour": (0, 23),
     "coriolis_cycle_start_minute": (0, 59),
 }
@@ -364,7 +364,7 @@ FIELD_DESCRIPTIONS = {
     "coriolis_auto_spawn_enabled": "Whether Coriolis storms spawn automatically on their normal cycle.",
     "coriolis_cycle_start_year": "Base year shipped in the Coriolis configuration. Normally leave this unchanged when matching a regional schedule.",
     "coriolis_cycle_start_month": "Base month (1-12) shipped in the Coriolis configuration. Normally leave this unchanged when matching a regional schedule.",
-    "coriolis_cycle_start_day": "UTC weekday: 1=Sunday through 7=Saturday. Regional master schedules: Europe, North America, and South America use Tuesday (3); Asia and Oceania use Monday (2).",
+    "coriolis_cycle_start_day": "UTC calendar day of the month (1-31). Regional master schedule anchor dates: Europe, North America, and South America use day 3; Asia and Oceania use day 2.",
     "coriolis_cycle_start_hour": "UTC hour (0-23). Regional master schedules: Europe 05, North America 11, South America 08, Asia 09, and Oceania 19.",
     "coriolis_cycle_start_minute": "UTC minute (0-59) for the Coriolis cycle start.",
     "coriolis_cycle_start_seed_index": "Funcom's seed index for the base Coriolis cycle. Leave at 0 unless intentionally coordinating a different cycle seed.",


### PR DESCRIPTION
## Summary
- `cycle_duration_in_days` / `db_wipe_enabled` (legacy DuneGameMode) were showing as duplicate rows next to their canonical CoriolisSubsystem counterparts (`coriolis_cycle_duration_days` / `coriolis_db_wipe_enabled`). Generalized the existing guild-field alias mechanism (`LEGACY_FIELD_ALIASES`) to hide both legacy ids from the editor while still mirroring/syncing the legacy ini key.
- Added a "Match Region" On/Off toggle next to **Cycle Start Hour and Cycle Start Day** (Maps > Interactive Modifiers > UserGame). On (the default) locks the field to the deployment's `SERVER_REGION` UTC master schedule — hour: Europe 05, North America 11, South America 08, Asia 09, Oceania 19; day: Europe/North America/South America Tuesday, Asia/Oceania Monday — Off allows manual entry. Infers On only when the saved value already equals the region's value — an untouched/default value is no longer treated as "matches," since that conflated "never configured" with "explicitly set to the default" (see below). Both toggles share one `useCoriolisMatchRegion` hook rather than duplicated logic.
- The region's hour and day are each seeded **once, server-side, at startup** (`migrateCoriolisRegionFields` in `console/api/src/server.js`) when a field has never been explicitly saved — not from a frontend effect. That effect couldn't tell "unset" from "explicitly saved to the default," which looped forever on a Europe deployment (region hour == schema default) and pinned whichever scope an admin happened to have open, breaking Global → Map → Partition inheritance. Cycle Start Day's default (3) coincides with 3 of the 5 regions' value — the same trap, but the majority case rather than one edge case — so this was worth getting right structurally rather than per-field. The migration is idempotent by ini-key **presence**, never by value, writes global scope only, and migrates whichever fields are still unset in one profile pass so it can't leave one written and the other not.
- `sync_legacy_values()` now resolves legacy/canonical conflicts by **presence**, not by comparing values to their schema defaults. The old comparison let a stale legacy value silently outrank an explicit canonical save whenever that save happened to equal the default — fixed for both the two new Coriolis aliases and the three pre-existing guild ones. A conflicting pair now also emits a warning naming both ini sections (previously silent, and even the raw-editor's version of this warning didn't name the section).
- With two Match Region toggles now able to appear at once, they would have shared the identical `aria-label="Match Region"` on their radiogroups — indistinguishable to a screen reader. Each now names its field ("Match Region for Cycle Start Hour" / "... Day").

## ⚠️ Behavior change on upgrade
The `sync_legacy_values()` fix corrects a pre-existing bug, not just a new one — `LEGACY_GUILD_FIELD_ALIASES` had the same comparison mistake before this branch touched anything. **On any deployment where a stale legacy guild key currently wins over an explicitly-saved canonical value, the effective value will change after this merges** — e.g. a server with legacy `m_MaxGuildMembersAllowed=20` silently overriding an explicit canonical save will see that cap move to the canonical value once this lands. Worth a heads-up given the live guild member-cap history in #120.

## Test plan
- [x] `python3 -m unittest test_profile_override_precedence` — 44/44, run against both a scripts-only and full-repo Docker mount
- [x] `python3 usersettings.py profile-selftest` — passes (one pre-existing, unrelated Windows-only assertion excluded per usual)
- [x] `node node_modules/typescript/bin/tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [x] `vitest run` (console/web) — 679/679, run multiple times
- [x] `console/api` test suite in the compliant container — 1634/1634, 0 skipped (confirms the DB-backed tests actually ran)
- [ ] Not yet verified against a live deployment
