### PR TITLE
Rework the Home screen status layout

### DIFF
--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -40,7 +40,11 @@ import { useStaleBuildWatcher } from "./lib/staleBuildWatcher";
 // a persisted tab (see loadPersistedTab below) can validate against the real,
 // current list at runtime instead of a hand-duplicated copy that could drift.
 export const ALL_TABS = ["Home", "Server Control", "Services", "Players", "Guilds", "Bases", "Vehicles", "Exchange", "Landsraad", "Admin Tools", "Live Map", "Maps", "Care Package", "Addons", "Database", "Storage", "Backups", "Logs", "Updates", "Settings"] as const;
-type Tab = typeof ALL_TABS[number];
+// Exported so panels that route to another tab (HomePanel's subsystem rows)
+// can type their destination against the real list instead of `string`, and a
+// typo becomes a compile error. Type-only, so importing it back from a panel
+// this module already imports does not create a runtime cycle.
+export type Tab = typeof ALL_TABS[number];
 const ACTIVE_TAB_STORAGE_KEY = "dune-console:active-tab";
 
 // Persisted in sessionStorage, not localStorage: it should survive the
@@ -809,7 +813,7 @@ export function App() {
         </header>
         {error && <div className="error-banner">{error}</div>}
         {redeploySetupOpen && <SetupWizard initialStep={setupJump.step} jumpNonce={setupJump.nonce} mode="redeploy" onSetupComplete={async () => setSetupState(await setupApi.state())} />}
-        {!redeploySetupOpen && tab === "Home" && <HomePanel status={status} readiness={readiness} taskResult={homeTaskResult} setTaskResult={setHomeTaskResult} funcomTokenResult={funcomTokenResult} setFuncomTokenResult={setFuncomTokenResult} runningAction={homeRunningAction} restartStartObserved={homeRestartStarted} setRunningAction={setHomeRunningAction} onLoad={loadStackStatus} confirmAction={confirmDialog} restartGate={restartGateChoice} />}
+        {!redeploySetupOpen && tab === "Home" && <HomePanel status={status} readiness={readiness} taskResult={homeTaskResult} setTaskResult={setHomeTaskResult} funcomTokenResult={funcomTokenResult} setFuncomTokenResult={setFuncomTokenResult} runningAction={homeRunningAction} restartStartObserved={homeRestartStarted} setRunningAction={setHomeRunningAction} onLoad={loadStackStatus} confirmAction={confirmDialog} restartGate={restartGateChoice} onNavigate={(nextTab) => { setRedeploySetupOpen(false); setSelectedPinnedAddonId(""); setTab(nextTab); }} />}
         {!redeploySetupOpen && tab === "Server Control" && <ServerPanel setTask={setTask} setStatus={setStatus} status={status} setReadiness={setReadiness} setPorts={setPorts} setDoctor={setDoctor} ports={ports} readiness={readiness} doctor={doctor} taskResult={homeTaskResult} setTaskResult={setHomeTaskResult} funcomTokenResult={funcomTokenResult} setFuncomTokenResult={setFuncomTokenResult} runningAction={homeRunningAction} restartStartObserved={homeRestartStarted} setRunningAction={setHomeRunningAction} onError={setError} confirmAction={confirmDialog} restartGate={restartGateChoice} onRedeploy={() => {
           setSetupJump((current) => ({ step: 0, nonce: current.nonce + 1 }));
           setSelectedPinnedAddonId("");

--- a/console/web/src/features/server/ServerPanels.homeCards.test.tsx
+++ b/console/web/src/features/server/ServerPanels.homeCards.test.tsx
@@ -1,0 +1,468 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HomePanel,
+  formatFreshness,
+  homeNeedsWarmRefresh,
+  homeOverallBadge,
+  homeOverallHeading,
+  homeStateDotTone,
+  isHomeActionComplete,
+  performanceCardStatus,
+  performanceTrackTone,
+  type HomeLoadResult
+} from "./ServerPanels";
+import { normalizeStatus } from "../../lib/display";
+
+// The panel polls performance every 3s and the Funcom token every 10s on mount.
+// Neither is what these tests are about, so both are stubbed; `performance`
+// is re-pointed per test to drive the utilisation thresholds.
+const performanceMock = vi.fn();
+const checkFuncomTokenMock = vi.fn();
+
+vi.mock("../../api/server", () => ({
+  serverApi: {
+    performance: () => performanceMock(),
+    checkFuncomToken: (since: string) => checkFuncomTokenMock(since),
+    start: vi.fn(),
+    stop: vi.fn(),
+    restart: vi.fn(),
+    status: vi.fn(),
+    readiness: vi.fn(),
+    restartQueue: vi.fn()
+  }
+}));
+
+// The pending-queue hooks each hit their own endpoint on mount; the refill note
+// they feed is not under test here.
+vi.mock("../../lib/usePendingRefills", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/usePendingRefills")>();
+  return {
+    ...actual,
+    usePendingQueues: () => ({
+      fuel: { pending: null },
+      water: { pending: null },
+      deletes: { pending: null },
+      vehicleDeletes: { pending: null },
+      permissions: { pending: null }
+    })
+  };
+});
+
+const STATUS_TEXT = [
+  "Title: Kovalt",
+  "Region: EU",
+  "Mode: public",
+  "Server IP: 10.0.0.4",
+  "Battlegroup: bg-12345",
+  "Population: 14"
+].join("\n");
+
+function snapshot(cpu: number | null, memoryPercent: number | null, diskPercent: number | null) {
+  return {
+    cpuPercent: cpu,
+    memory: { usedBytes: 8e9, totalBytes: 16e9, availableBytes: 8e9, percent: memoryPercent },
+    disk: { usedBytes: 4e11, totalBytes: 5e11, freeBytes: 1e11, percent: diskPercent },
+    uptimeSeconds: 561600,
+    uptime: "6d 12h 00m",
+    sampledAt: new Date(0).toISOString()
+  };
+}
+
+function loadResult(overrides: Partial<HomeLoadResult> = {}): HomeLoadResult {
+  return {
+    statusLoaded: true,
+    readinessLoaded: true,
+    statusError: "",
+    readinessError: "",
+    statusText: STATUS_TEXT,
+    readinessText: "READY: all checks passed",
+    ...overrides
+  };
+}
+
+function renderHome(props: Partial<Parameters<typeof HomePanel>[0]> = {}) {
+  const onLoad = props.onLoad || vi.fn().mockResolvedValue(loadResult());
+  return {
+    onLoad,
+    ...render(<HomePanel
+      status={STATUS_TEXT}
+      readiness="READY: all checks passed"
+      taskResult={null}
+      setTaskResult={vi.fn()}
+      funcomTokenResult={null}
+      setFuncomTokenResult={vi.fn()}
+      runningAction=""
+      restartStartObserved={false}
+      setRunningAction={vi.fn()}
+      onLoad={onLoad}
+      confirmAction={vi.fn().mockResolvedValue(true)}
+      restartGate={vi.fn()}
+      {...props}
+    />)
+  };
+}
+
+// Find the .status-card whose title cell holds this label.
+function card(label: string) {
+  const title = screen.getAllByText(label).find((node) => node.closest(".status-card-title"));
+  const found = title?.closest(".status-card");
+  if (!found) throw new Error(`no status card for ${label}`);
+  return found as HTMLElement;
+}
+
+beforeEach(() => {
+  performanceMock.mockResolvedValue(snapshot(30, 40, 50));
+  checkFuncomTokenMock.mockResolvedValue({ ok: true, mismatch: false, checkedSince: "10m" });
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("performanceCardStatus", () => {
+  // Before this the badge was `performance ? "OK" : "INFO"`, so a disk at 96%
+  // showed the same green pill as one at 4% and the band could never report a
+  // problem at all.
+  it("grades a reading against its own value, not merely whether a sample arrived", () => {
+    expect(performanceCardStatus(30, true)).toBe("OK");
+    expect(performanceCardStatus(74.9, true)).toBe("OK");
+    expect(performanceCardStatus(75, true)).toBe("WARN");
+    expect(performanceCardStatus(90, true)).toBe("WARN");
+    expect(performanceCardStatus(90.1, true)).toBe("FAILED");
+    expect(performanceCardStatus(96.7, true)).toBe("FAILED");
+  });
+
+  it("reports INFO until a sample lands, and no status at all without a percentage", () => {
+    expect(performanceCardStatus(30, false)).toBe("INFO");
+    expect(performanceCardStatus(Number.NaN, true)).toBe("INFO");
+    // Uptime carries percent: null -- it must render no badge rather than a
+    // fabricated OK.
+    expect(performanceCardStatus(null, true)).toBe("");
+    expect(performanceCardStatus(null, false)).toBe("");
+  });
+
+  it("moves the bar tone with the badge so the two cannot disagree", () => {
+    expect(performanceTrackTone(30, true)).toBe("");
+    expect(performanceTrackTone(85, true)).toBe("metric-track-warn");
+    expect(performanceTrackTone(95, true)).toBe("metric-track-fail");
+  });
+});
+
+describe("homeOverallHeading", () => {
+  it("passes ordinary readings through", () => {
+    expect(homeOverallHeading("OK")).toBe("OK");
+    expect(homeOverallHeading("Stopped")).toBe("Stopped");
+    expect(homeOverallHeading("Starting")).toBe("Starting");
+    expect(homeOverallHeading("Needs Review")).toBe("Needs Review");
+    expect(homeOverallHeading(undefined)).toBe("Unknown");
+  });
+
+  // summarizeHomeStatus yields "Restarting Battlegroup" mid-restart, which
+  // under the "Battlegroup Status:" prefix would say Battlegroup twice.
+  it("drops the redundant word the heading prefix already supplies", () => {
+    expect(homeOverallHeading("Restarting Battlegroup")).toBe("Restarting");
+  });
+});
+
+describe("homeOverallBadge", () => {
+  it("keeps the readings that were already correct", () => {
+    expect(normalizeStatus(homeOverallBadge("OK"))).toBe("pass");
+    expect(normalizeStatus(homeOverallBadge("Stopped"))).toBe("warn");
+    expect(normalizeStatus(homeOverallBadge("Starting"))).toBe("warn");
+    expect(normalizeStatus(homeOverallBadge("Stopping"))).toBe("warn");
+    expect(normalizeStatus(homeOverallBadge("Restarting Battlegroup"))).toBe("warn");
+    expect(normalizeStatus(homeOverallBadge("Unknown"))).toBe("info");
+    expect(normalizeStatus(homeOverallBadge("Checking"))).toBe("info");
+  });
+
+  // "Readiness checked" is only ever the label for a readiness run that did
+  // not pass -- a passing one reads "OK". inferStatus matched the word
+  // "checked" against its pass list, so the dot went green at the exact moment
+  // readiness had failed.
+  it("does not report a failed readiness check as healthy", () => {
+    expect(normalizeStatus(homeOverallBadge("Readiness checked"))).toBe("warn");
+  });
+
+  // Previously fell through to Info, the same neutral grey as "Unknown", so a
+  // flagged subsystem looked identical to nothing being known yet.
+  it("distinguishes a flagged subsystem from an unknown state", () => {
+    expect(normalizeStatus(homeOverallBadge("Needs Review"))).toBe("warn");
+    expect(normalizeStatus(homeOverallBadge("Needs Review"))).not.toBe(normalizeStatus(homeOverallBadge("Unknown")));
+  });
+});
+
+describe("homeStateDotTone", () => {
+  const healthy = [{ status: "Ready" }, { status: "Ready" }];
+  const failed = [{ status: "Ready" }, { status: "FAILED" }];
+
+  it("separates in-motion states from the ones that need a human", () => {
+    // All four of these were the same amber as "Needs Review" before.
+    expect(homeStateDotTone("Starting", healthy)).toBe("motion");
+    expect(homeStateDotTone("Stopping", healthy)).toBe("motion");
+    expect(homeStateDotTone("Restarting Battlegroup", healthy)).toBe("motion");
+    expect(homeStateDotTone("Needs Review", healthy)).toBe("attention");
+    expect(homeStateDotTone("Readiness checked", healthy)).toBe("attention");
+  });
+
+  it("treats a deliberate stop as off, not as a warning", () => {
+    expect(homeStateDotTone("Stopped", healthy)).toBe("off");
+  });
+
+  it("distinguishes having no reading from having a bad one", () => {
+    expect(homeStateDotTone("Checking", healthy)).toBe("loading");
+    expect(homeStateDotTone("Unknown", healthy)).toBe("nodata");
+    expect(homeStateDotTone("Status loaded", healthy)).toBe("nodata");
+    expect(homeStateDotTone("", healthy)).toBe("attention");
+  });
+
+  it("stays green only when nothing is wrong", () => {
+    expect(homeStateDotTone("OK", healthy)).toBe("ok");
+  });
+
+  // summarizeHomeStatus's token-mismatch branch overrides its own ready
+  // override, so "OK" can be reported while Funcom/FLS is FAILED right beside
+  // it. The dot has to reflect the worst thing on screen, not just the word.
+  it("escalates past the heading word when a subsystem has failed", () => {
+    expect(homeStateDotTone("OK", failed)).toBe("failed");
+    expect(homeStateDotTone("Needs Review", failed)).toBe("failed");
+  });
+
+  // A stop or restart takes the subsystems down on purpose; going red there
+  // would cry wolf on an action the operator just triggered.
+  it("does not escalate during an action the operator asked for", () => {
+    expect(homeStateDotTone("Restarting Battlegroup", failed)).toBe("motion");
+    expect(homeStateDotTone("Stopping", failed)).toBe("motion");
+    expect(homeStateDotTone("Stopped", failed)).toBe("off");
+  });
+});
+
+describe("formatFreshness", () => {
+  it("counts seconds, then minutes, then hours", () => {
+    const base = 1_000_000;
+    expect(formatFreshness(base, base + 8_000)).toBe("8s ago");
+    expect(formatFreshness(base, base + 59_000)).toBe("59s ago");
+    expect(formatFreshness(base, base + 61_000)).toBe("1m ago");
+    expect(formatFreshness(base, base + 3_600_000)).toBe("1h 0m ago");
+    expect(formatFreshness(base, base + 5_400_000)).toBe("1h 30m ago");
+  });
+
+  it("renders nothing before the first successful load", () => {
+    expect(formatFreshness(0, 1_000_000)).toBe("");
+  });
+});
+
+describe("HomePanel performance band", () => {
+  it("badges each utilisation card from its own reading", async () => {
+    performanceMock.mockResolvedValue(snapshot(30, 85, 95));
+    renderHome();
+    await waitFor(() => expect(within(card("CPU Usage")).getByText("OK")).toBeTruthy());
+    expect(within(card("Memory")).getByText("WARN")).toBeTruthy();
+    expect(within(card("Disk")).getByText("FAILED")).toBeTruthy();
+  });
+
+  it("tones the meter bar to match", async () => {
+    performanceMock.mockResolvedValue(snapshot(30, 85, 95));
+    renderHome();
+    await waitFor(() => expect(card("Disk").querySelector(".metric-track span")).toBeTruthy());
+    expect(card("CPU Usage").querySelector(".metric-track span")?.className).toBe("");
+    expect(card("Memory").querySelector(".metric-track span")?.className).toBe("metric-track-warn");
+    expect(card("Disk").querySelector(".metric-track span")?.className).toBe("metric-track-fail");
+  });
+
+  it("gives Uptime no badge at all rather than a constant OK", async () => {
+    renderHome();
+    await waitFor(() => expect(card("Uptime")).toBeTruthy());
+    expect(card("Uptime").querySelector(".badge")).toBeNull();
+  });
+});
+
+describe("HomePanel server identity", () => {
+  it("leads with the overall verdict as the hero heading", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-state")).toBeTruthy());
+    expect(container.querySelector(".home-hero-state")?.textContent).toBe("Battlegroup Status:OK");
+    expect(container.querySelector(".home-hero-state-value")?.textContent).toBe("OK");
+    // The label is an h3 so it matches the "Readiness & Health" and
+    // "Performance" section headings by element rather than by restated CSS.
+    const label = container.querySelector(".home-hero-state-label");
+    expect(label?.tagName).toBe("H3");
+    expect(label?.textContent).toBe("Battlegroup Status:");
+  });
+
+  it("summarises the identity values on one line under the state", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-identity")).toBeTruthy());
+    const line = container.querySelector(".home-hero-identity")?.textContent || "";
+    expect(line).toContain("Kovalt");
+    expect(line).toContain("EU");
+    expect(line).toContain("Public");
+    expect(line).toContain("14 online");
+  });
+
+  // The Performance band carries Uptime on its own card; the hero line said it
+  // a second time.
+  it("leaves uptime to the Performance band", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-identity")).toBeTruthy());
+    expect(container.querySelector(".home-hero-identity")?.textContent).not.toContain("6d 12h 00m");
+    expect(card("Uptime").textContent).toContain("6d 12h 00m");
+  });
+
+  it("carries Server IP and Battlegroup as labelled reference values in the hero", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-meta")).toBeTruthy());
+    const pairs = Array.from(container.querySelectorAll(".home-hero-meta-item")).map((node) => [
+      node.querySelector("dt")?.textContent,
+      node.querySelector("dd")?.textContent
+    ]);
+    expect(pairs).toEqual([["Server IP", "10.0.0.4"], ["Battlegroup", "bg-12345"]]);
+  });
+
+  // These two are now the only place those values appear, so an absent one has
+  // to read "Unknown" rather than silently vanish from the panel.
+  it("still names Server IP and Battlegroup when the status text omits them", async () => {
+    const onLoad = vi.fn().mockResolvedValue(loadResult({ statusText: "Title: Kovalt" }));
+    const { container } = renderHome({ status: "Title: Kovalt", onLoad });
+    await waitFor(() => expect(container.querySelector(".home-hero-meta")).toBeTruthy());
+    const pairs = Array.from(container.querySelectorAll(".home-hero-meta-item")).map((node) => [
+      node.querySelector("dt")?.textContent,
+      node.querySelector("dd")?.textContent
+    ]);
+    expect(pairs).toEqual([["Server IP", "Unknown"], ["Battlegroup", "Unknown"]]);
+  });
+
+  // The Server Identity band repeated Title/Region/Mode/Population, which the
+  // hero summary line already carries. Only the performance cards remain.
+  it("no longer renders a Server Identity band", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-meta")).toBeTruthy());
+    expect(container.querySelector(".home-health")).toBeNull();
+    expect(screen.queryByText("Server Identity")).toBeNull();
+    const cardLabels = Array.from(container.querySelectorAll(".status-card-title > span:not(.badge)")).map((node) => node.textContent);
+    expect(cardLabels).toEqual(["CPU Usage", "Memory", "Disk", "Uptime"]);
+  });
+
+  it("states each identity value exactly once", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-meta")).toBeTruthy());
+    const text = container.textContent || "";
+    for (const value of ["Kovalt", "10.0.0.4", "bg-12345"]) {
+      expect(text.split(value).length - 1).toBe(1);
+    }
+  });
+});
+
+describe("HomePanel subsystem rows", () => {
+  const SUBSYSTEMS = ["Containers", "Listeners", "Database", "Game Servers", "RabbitMQ", "Funcom/FLS"];
+
+  it("lists every readiness subsystem", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelectorAll(".home-subsystem-row").length).toBe(6));
+    const labels = Array.from(container.querySelectorAll(".home-subsystem-label")).map((node) => node.textContent);
+    expect(labels).toEqual(SUBSYSTEMS);
+  });
+
+  it("routes an unhealthy subsystem to the tab that can fix it", async () => {
+    const onNavigate = vi.fn();
+    const { container } = renderHome({ onNavigate });
+    await waitFor(() => expect(container.querySelectorAll(".home-subsystem-button").length).toBe(6));
+    const rowFor = (label: string) => {
+      const node = Array.from(container.querySelectorAll(".home-subsystem-label")).find((item) => item.textContent === label);
+      return node?.closest("button") as HTMLButtonElement;
+    };
+    rowFor("Database").click();
+    expect(onNavigate).toHaveBeenCalledWith("Database");
+    rowFor("Game Servers").click();
+    expect(onNavigate).toHaveBeenCalledWith("Services");
+    // PortChecklist and the Change Funcom Token form both live on Server
+    // Control, not Settings.
+    rowFor("Listeners").click();
+    expect(onNavigate).toHaveBeenCalledWith("Server Control");
+    rowFor("Funcom/FLS").click();
+    expect(onNavigate).toHaveBeenCalledWith("Server Control");
+  });
+
+  it("renders plain rows, not buttons to nowhere, when no navigation is wired", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelectorAll(".home-subsystem-row").length).toBe(6));
+    expect(container.querySelectorAll(".home-subsystem-button").length).toBe(0);
+    expect(container.querySelectorAll(".home-subsystem-static").length).toBe(6);
+  });
+});
+
+describe("HomePanel status freshness", () => {
+  it("dates the values once a load succeeds", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-freshness")).toBeTruthy());
+    expect(container.querySelector(".home-freshness")?.textContent).toMatch(/^Updated \d+s ago$/);
+    expect(container.querySelector(".home-freshness.stale")).toBeNull();
+  });
+
+  // The three polling effects all swallow their errors, so before this a
+  // backend that started failing after the first load left the last-good
+  // values up forever with no cue that they were frozen.
+  it("warns that values may be stale after consecutive failed polls, without blanking them", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const onLoad = vi.fn().mockResolvedValue(loadResult());
+    const { container } = renderHome({ onLoad });
+    await vi.waitFor(() => expect(container.querySelector(".home-freshness")).toBeTruthy());
+
+    onLoad.mockRejectedValue(new Error("connection refused"));
+    // Two ticks of the idle 30s poll -- STALE_POLL_THRESHOLD consecutive misses.
+    for (let i = 0; i < 2; i += 1) {
+      await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
+    }
+
+    await vi.waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeTruthy());
+    expect(container.querySelector(".home-freshness")?.textContent).toMatch(/^Status may be stale/);
+    // The last good values are still on screen -- the point is to date them,
+    // not blank the panel.
+    expect(container.querySelector(".home-hero-identity")?.textContent).toContain("Kovalt");
+    expect(container.querySelector(".home-hero-meta")?.textContent).toContain("10.0.0.4");
+  });
+
+  it("clears the stale warning once a poll succeeds again", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const onLoad = vi.fn().mockResolvedValue(loadResult());
+    const { container } = renderHome({ onLoad });
+    await vi.waitFor(() => expect(container.querySelector(".home-freshness")).toBeTruthy());
+
+    onLoad.mockRejectedValue(new Error("connection refused"));
+    for (let i = 0; i < 2; i += 1) {
+      await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
+    }
+    await vi.waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeTruthy());
+
+    onLoad.mockResolvedValue(loadResult());
+    await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
+    await vi.waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeNull());
+  });
+});
+
+// Regression guard for the constraint that made this refactor safe.
+// summarizeHomeStatus is not only a view model: its health/identity arrays
+// drive the restart lifecycle. Removing the Readiness & Health *band* must not
+// remove the health *entries*. Emptying that array makes the first case here
+// fail, which is exactly the accident this guards.
+describe("summarizeHomeStatus consumers still see identity and health entries", () => {
+  const WARMING_STATUS = ["Overall: WARMING", "Title: Kovalt", "", "Game servers", "Survival_1 WARMING"].join("\n");
+
+  it("treats a READY readiness as a completed action via the health array", () => {
+    // No required-signal lines, so isHomeReadinessOperational is false and the
+    // verdict has to come from summary.health being fully OK.
+    expect(isHomeActionComplete("Title: Kovalt", "READY: all checks passed")).toBe(true);
+  });
+
+  it("still reports an incomplete action when nothing is ready", () => {
+    expect(isHomeActionComplete("", "")).toBe(false);
+  });
+
+  it("reads Overall and Game Servers to pick the warm poll cadence", () => {
+    expect(homeNeedsWarmRefresh(WARMING_STATUS, "")).toBe(true);
+    expect(homeNeedsWarmRefresh("Title: Kovalt", "READY: all checks passed")).toBe(false);
+  });
+});

--- a/console/web/src/features/server/ServerPanels.homeCards.test.tsx
+++ b/console/web/src/features/server/ServerPanels.homeCards.test.tsx
@@ -136,13 +136,16 @@ describe("performanceCardStatus", () => {
     expect(performanceCardStatus(96.7, true)).toBe("FAILED");
   });
 
-  it("reports INFO until a sample lands, and no status at all without a percentage", () => {
+  // The API returns null routinely, not exceptionally -- cpuPercent is null on
+  // the first sample after every API start, because it needs two samples for a
+  // delta. Reporting that as OK is the exact failure this function exists to
+  // prevent, and the card literal used to collapse it to 0 before this guard.
+  it("reports INFO for a missing or nonsensical reading, never OK", () => {
     expect(performanceCardStatus(30, false)).toBe("INFO");
+    expect(performanceCardStatus(null, true)).toBe("INFO");
+    expect(performanceCardStatus(null, false)).toBe("INFO");
     expect(performanceCardStatus(Number.NaN, true)).toBe("INFO");
-    // Uptime carries percent: null -- it must render no badge rather than a
-    // fabricated OK.
-    expect(performanceCardStatus(null, true)).toBe("");
-    expect(performanceCardStatus(null, false)).toBe("");
+    expect(performanceCardStatus(-5, true)).toBe("INFO");
   });
 
   it("moves the bar tone with the badge so the two cannot disagree", () => {
@@ -273,10 +276,26 @@ describe("HomePanel performance band", () => {
     expect(card("Disk").querySelector(".metric-track span")?.className).toBe("metric-track-fail");
   });
 
-  it("gives Uptime no badge at all rather than a constant OK", async () => {
+  it("gives Uptime no badge or bar at all -- it is not a utilisation figure", async () => {
     renderHome();
     await waitFor(() => expect(card("Uptime")).toBeTruthy());
     expect(card("Uptime").querySelector(".badge")).toBeNull();
+    expect(card("Uptime").querySelector(".metric-track")).toBeNull();
+  });
+
+  // Regression: the card literal read `performance?.cpuPercent ?? 0`, which
+  // collapsed a null reading to 0 before performanceCardStatus could see it,
+  // so an unmeasured CPU rendered a green OK pill beside the text "Sampling...".
+  it("does not badge an unmeasured metric as OK", async () => {
+    performanceMock.mockResolvedValue(snapshot(null, 40, 50));
+    renderHome();
+    await waitFor(() => expect(card("CPU Usage").textContent).toContain("Sampling"));
+    expect(within(card("CPU Usage")).getByText("INFO")).toBeTruthy();
+    expect(within(card("CPU Usage")).queryByText("OK")).toBeNull();
+    // No bar either -- a 0%-wide track would read as "measured, and idle".
+    expect(card("CPU Usage").querySelector(".metric-track")).toBeNull();
+    // The metrics that did report still grade normally.
+    expect(within(card("Memory")).getByText("OK")).toBeTruthy();
   });
 });
 
@@ -301,6 +320,25 @@ describe("HomePanel server identity", () => {
     expect(line).toContain("EU");
     expect(line).toContain("Public");
     expect(line).toContain("14 online");
+  });
+
+  // The Server Identity band was the only renderer of Population's WARN, so
+  // folding population into the plain summary string dropped the signal that
+  // the count could not be read.
+  it("marks an unreadable player count instead of printing it as fact", async () => {
+    const status = "Title: Kovalt\nPopulation: 14 / ?";
+    const { container } = renderHome({ status, onLoad: vi.fn().mockResolvedValue(loadResult({ statusText: status })) });
+    await waitFor(() => expect(container.querySelector(".home-hero-identity")).toBeTruthy());
+    const warn = container.querySelector(".home-population-warn");
+    expect(warn).not.toBeNull();
+    expect(warn?.textContent).toContain("?");
+  });
+
+  it("leaves a healthy player count unmarked", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-identity")).toBeTruthy());
+    expect(container.querySelector(".home-population-warn")).toBeNull();
+    expect(container.querySelector(".home-hero-identity")?.textContent).toContain("14 online");
   });
 
   // The Performance band carries Uptime on its own card; the hero line said it

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -499,7 +499,7 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
           this region with no accessible name. The three h3s below it (this
           hero's status label, Readiness & Health, Performance) are its
           children, so the level is correct as well as present. */}
-      <article className="hero-panel wide home-hero" aria-labelledby="home-hero-heading">
+      <article className="hero-panel wide" aria-labelledby="home-hero-heading">
         <h2 id="home-hero-heading" className="sr-only">Server overview</h2>
         <div className="home-hero-split">
           <div className="home-hero-primary">
@@ -642,7 +642,13 @@ function HomeSubsystemList({ items, onNavigate }: { items: { label: string; valu
     <h3>Readiness & Health</h3>
     <ul className="home-subsystem-list">
       {items.map((item) => {
-        const route = HOME_SUBSYSTEM_ROUTES[item.label];
+        // hasOwn, not a bare index: a plain object inherits Object.prototype,
+        // so a label of "constructor" or "toString" would return a truthy
+        // non-Tab value and be handed to setTab. Labels are compile-time
+        // literals today, but the value beside them is server-parsed and the
+        // two live in the same object -- this keeps the lookup fail-closed if
+        // that ever stops being true.
+        const route = Object.hasOwn(HOME_SUBSYSTEM_ROUTES, item.label) ? HOME_SUBSYSTEM_ROUTES[item.label] : undefined;
         const body = <>
           <span className="home-subsystem-label">{item.label}</span>
           <span className="home-subsystem-value">

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
+import type { Tab } from "../../App";
 import { Play, Trash2 } from "lucide-react";
 import { serverApi, type PerformanceSnapshot } from "../../api/server";
 import { runGatedRestart, serviceRestartTarget, type RestartGate } from "./restartQueueGuard";
@@ -8,7 +9,7 @@ import { PortChecklist } from "../../components/PortChecklist";
 import { ReadinessTimeline } from "../../components/ReadinessTimeline";
 import { SecretInput } from "../../components/SecretInput";
 import { KeyValueGrid, StatusPill, TechnicalDetails } from "../../components/common/DisplayPrimitives";
-import { formatDisplayValue, formatUiSentence, friendlyColumnName, stripAnsi, summarizeCommandText, titleCase } from "../../lib/display";
+import { formatDisplayValue, formatUiSentence, friendlyColumnName, normalizeStatus, stripAnsi, summarizeCommandText, titleCase } from "../../lib/display";
 import { friendlyServiceName } from "../../lib/serviceDisplay";
 import { conciseTaskError, funcomTokenMismatchDetected } from "../../lib/taskDisplay";
 import { QueueBadges, queueCountsSummary, queueCountsTotal, type QueueCounts } from "../../components/common/QueueBadges";
@@ -112,7 +113,60 @@ export function isRestartLifecycleReady(action: "start" | "stop" | "restart" | "
   return action !== "restart" || state.startObserved;
 }
 
-export function HomePanel({ status, readiness, taskResult, setTaskResult, funcomTokenResult, setFuncomTokenResult, runningAction, restartStartObserved, setRunningAction, onLoad, confirmAction, restartGate }: {
+// A utilisation card's badge is derived from its own reading rather than from
+// "did any sample arrive at all". The previous `performance ? "OK" : "INFO"`
+// painted a 96%-full disk the same green as a 4%-full one, so the whole
+// Performance band could never report a problem. These strings are the ones
+// normalizeStatus() already maps to badge-pass / badge-warn / badge-fail, so
+// StatusPill needs no change. Uptime has no percentage and returns "" -- it
+// gets no badge at all rather than a fabricated OK.
+export const PERFORMANCE_WARN_PERCENT = 75;
+export const PERFORMANCE_FAIL_PERCENT = 90;
+
+export function performanceCardStatus(percent: number | null, sampled: boolean) {
+  if (percent === null) return "";
+  if (!sampled || !Number.isFinite(percent)) return "INFO";
+  if (percent > PERFORMANCE_FAIL_PERCENT) return "FAILED";
+  if (percent >= PERFORMANCE_WARN_PERCENT) return "WARN";
+  return "OK";
+}
+
+export function performanceTrackTone(percent: number | null, sampled: boolean) {
+  const status = performanceCardStatus(percent, sampled);
+  if (status === "FAILED") return "metric-track-fail";
+  if (status === "WARN") return "metric-track-warn";
+  return "";
+}
+
+// Where an unhealthy subsystem is actually dealt with. Keyed on the labels
+// summarizeHomeStatus() already produces, so the map and the summary cannot
+// drift apart silently -- a renamed label just loses its route rather than
+// pointing somewhere wrong. Listeners and Funcom/FLS both land on Server
+// Control because PortChecklist and the Change Funcom Token form live there.
+export const HOME_SUBSYSTEM_ROUTES: Record<string, Tab> = {
+  Containers: "Services",
+  Listeners: "Server Control",
+  Database: "Database",
+  "Game Servers": "Services",
+  RabbitMQ: "Services",
+  "Funcom/FLS": "Server Control"
+};
+
+// Two consecutive misses rather than one: a single failed poll is routine
+// (the console restarting, a request racing a container bounce) and flagging
+// it would cry wolf. Two misses is ~1 minute on the idle 30s cadence.
+export const STALE_POLL_THRESHOLD = 2;
+
+export function formatFreshness(lastUpdatedAt: number, now: number) {
+  if (!lastUpdatedAt) return "";
+  const seconds = Math.max(0, Math.round((now - lastUpdatedAt) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m ago`;
+}
+
+export function HomePanel({ status, readiness, taskResult, setTaskResult, funcomTokenResult, setFuncomTokenResult, runningAction, restartStartObserved, setRunningAction, onLoad, confirmAction, restartGate, onNavigate }: {
   status: string;
   readiness: string;
   taskResult: HomeTaskResult | null;
@@ -125,6 +179,9 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
   onLoad: () => Promise<HomeLoadResult>;
   confirmAction: ConfirmAction;
   restartGate: RestartGate;
+  // Optional so the panel still renders standalone in tests; without it the
+  // subsystem rows are plain text instead of buttons to nowhere.
+  onNavigate?: (tab: Tab) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const [localError, setLocalError] = useState("");
@@ -132,6 +189,8 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
   const [performance, setPerformance] = useState<PerformanceSnapshot | null>(null);
   const [performanceError, setPerformanceError] = useState("");
   const [hasLoaded, setHasLoaded] = useState(Boolean(status || readiness));
+  const [lastUpdatedAt, setLastUpdatedAt] = useState(0);
+  const [pollFailures, setPollFailures] = useState(0);
   const homeActionRunId = useRef(0);
   const homeActionStartedAt = useRef(0);
   const homeRestartLifecycle = useRef<RestartLifecycleState>(createRestartLifecycleState());
@@ -147,8 +206,25 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     if (!runningAction) homeActionStartedAt.current = 0;
   }, [runningAction]);
 
+  // The three polling effects below all swallow their errors, so without this
+  // a backend that starts failing after the first successful load leaves the
+  // last-good values on screen indefinitely with no cue that they are frozen.
+  // Recorded here rather than per-effect so every path that refreshes the
+  // panel -- poll, manual refresh, and the pre/post loads around a server
+  // action -- dates the data the same way.
+  function recordLoadOutcome(loaded: boolean) {
+    if (loaded) {
+      setLastUpdatedAt(Date.now());
+      setPollFailures(0);
+    } else {
+      setPollFailures((count) => count + 1);
+    }
+  }
+
   function applyHomeLoadResult(result: HomeLoadResult) {
-    if (result.statusLoaded || result.readinessLoaded) setHasLoaded(true);
+    const loaded = result.statusLoaded || result.readinessLoaded;
+    if (loaded) setHasLoaded(true);
+    recordLoadOutcome(loaded);
     setReadinessWarning(!result.readinessLoaded && result.readinessError ? result.readinessError : "");
     if (!result.statusLoaded && !result.readinessLoaded && result.statusError) setLocalError(friendlyHomeStatusError(result.statusError));
   }
@@ -164,10 +240,14 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
       if (result.statusLoaded || result.readinessLoaded) {
         applyHomeLoadResult(result);
       } else {
+        recordLoadOutcome(false);
         setLocalError(friendlyHomeStatusError(result.statusError || result.readinessError || "Server status and readiness checks failed."));
       }
     } catch (error) {
-      if (isActive() && refreshRunId.current === runId) setLocalError(friendlyHomeStatusError(error instanceof Error ? error.message : String(error)));
+      if (isActive() && refreshRunId.current === runId) {
+        recordLoadOutcome(false);
+        setLocalError(friendlyHomeStatusError(error instanceof Error ? error.message : String(error)));
+      }
     } finally {
       if (isActive() && refreshRunId.current === runId) setLoading(false);
     }
@@ -295,7 +375,8 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     let active = true;
     const id = window.setInterval(async () => {
       const result = await onLoad().catch(() => null);
-      if (active && result) applyHomeLoadResult(result);
+      if (!active) return;
+      if (result) applyHomeLoadResult(result); else recordLoadOutcome(false);
     }, 5000);
     return () => {
       active = false;
@@ -309,7 +390,8 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     const id = window.setInterval(async () => {
       if (document.hidden) return;
       const result = await onLoad().catch(() => null);
-      if (active && result) applyHomeLoadResult(result);
+      if (!active) return;
+      if (result) applyHomeLoadResult(result); else recordLoadOutcome(false);
     }, 30000);
     return () => {
       active = false;
@@ -322,7 +404,8 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     let active = true;
     const id = window.setInterval(async () => {
       const result = await onLoad().catch(() => null);
-      if (active && result) applyHomeLoadResult(result);
+      if (!active) return;
+      if (result) applyHomeLoadResult(result); else recordLoadOutcome(false);
     }, 1500);
     return () => {
       active = false;
@@ -388,25 +471,160 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     </section>;
   }
 
+  const funcomTokenCheckRunning = funcomTokenResult?.status === "running";
+  // Computed here rather than inside the health band so the hero can lead with
+  // the overall verdict and the subsystem rows. The summary object's shape is
+  // unchanged -- isHomeActionComplete and homeNeedsWarmRefresh still read the
+  // same identity/health entries.
+  const summary = summarizeHomeStatus(status, readiness, readinessWarning, loading, runningAction, taskResult, restartStartObserved, !funcomTokenCheckRunning && (isFuncomTokenAuthFailure(funcomTokenResult) || hasPersistedFuncomTokenAuthFailure()));
+  const overall = summary.identity.find((item) => item.label === "Overall");
+  const identityCards = summary.identity.filter((item) => item.label !== "Overall");
+
   return (
     <section className="grid">
-      <article className="hero-panel">
-        <h2>Server Overview</h2>
-        <p>Use this dashboard for setup, service health, logs, backups, updates, and player admin actions.</p>
-        <div className="action-row">
-          <button className={loading ? "refresh-status-button refreshing" : "refresh-status-button"} disabled={refreshDisabled} onClick={() => refresh()}>{loading ? <span className="loading-dots">Refreshing</span> : "Refresh Status"}</button>
-          <button disabled={startDisabled} title={controlsState.running ? "Battlegroup is already running." : ""} onClick={() => runServerAction("start")}><Play size={16} /> Start</button>
-          <button disabled={stopDisabled} onClick={() => runServerAction("stop")}>Stop</button>
-          <button disabled={restartDisabled} onClick={() => runServerAction("restart")}>Restart Battlegroup</button>
+      <article className="hero-panel wide home-hero">
+        <div className="home-hero-split">
+          <div className="home-hero-primary">
+            {/* An h3, not a styled span: it is the peer of the "Readiness &
+                Health" and "Performance" headings, so matching them by using
+                the same element guarantees the same size and colour instead of
+                restating their computed value here. The reading sits beside it
+                rather than inside, so the heading text stays just the label. */}
+            <div className="home-hero-state">
+              <h3 className="home-hero-state-label">Battlegroup Status:</h3>
+              <span className={`home-state-dot home-state-dot-${homeStateDotTone(overall?.value, summary.health)}`} aria-hidden="true" />
+              <span className="home-hero-state-value">{homeOverallHeading(overall?.value)}</span>
+            </div>
+            <p className="home-hero-identity">{homeIdentityLine(identityCards)}</p>
+            <dl className="home-hero-meta">
+              {HOME_HERO_META_LABELS.map((label) => <div className="home-hero-meta-item" key={label}>
+                <dt>{label}</dt>
+                <dd>{formatDisplayValue(identityCards.find((item) => item.label === label)?.value || "Unknown")}</dd>
+              </div>)}
+            </dl>
+            <div className="action-row">
+              <button className={loading ? "refresh-status-button refreshing" : "refresh-status-button"} disabled={refreshDisabled} onClick={() => refresh()}>{loading ? <span className="loading-dots">Refreshing</span> : "Refresh Status"}</button>
+              <button disabled={startDisabled} title={controlsState.running ? "Battlegroup is already running." : ""} onClick={() => runServerAction("start")}><Play size={16} /> Start</button>
+              <button className="danger-button" disabled={stopDisabled} onClick={() => runServerAction("stop")}>Stop</button>
+              <button disabled={restartDisabled} onClick={() => runServerAction("restart")}>Restart Battlegroup</button>
+            </div>
+            <StatusFreshness lastUpdatedAt={lastUpdatedAt} pollFailures={pollFailures} />
+            <PendingRefillNote />
+            {taskResult && <HomeTaskResultCard result={taskResult} />}
+            {localError && <p className="error">{localError}</p>}
+          </div>
+          <HomeSubsystemList items={summary.health} onNavigate={onNavigate} />
         </div>
-        <PendingRefillNote />
-        {taskResult && <HomeTaskResultCard result={taskResult} />}
-        {localError && <p className="error">{localError}</p>}
       </article>
       <PerformanceCards performance={performance} error={performanceError} />
-      <HomeHealthCards status={status} readiness={readiness} readinessWarning={readinessWarning} loading={loading} runningAction={runningAction} restartStartObserved={restartStartObserved} taskResult={taskResult} funcomTokenResult={funcomTokenResult} />
     </section>
   );
+}
+
+export type HomeStateTone = "ok" | "motion" | "off" | "attention" | "failed" | "loading" | "nodata";
+
+// The dot used to be normalizeStatus(overall.status), which put six of the ten
+// readings on the same amber: a restart the operator just triggered looked
+// identical to a readiness check that had failed. One resolves itself, the
+// other needs a human. This splits them by what the operator should do, and
+// lets a hard-failed subsystem escalate the dot past what the heading word
+// alone conveys.
+export function homeStateDotTone(overallValue: unknown, health: { status: string }[] = []): HomeStateTone {
+  const value = String(overallValue || "").trim().toLowerCase();
+  // Deliberate, self-resolving states win over everything below: while a stop
+  // or restart is in flight the subsystems are legitimately down, and painting
+  // that red would cry wolf on an action the operator just asked for.
+  if (/^(starting|stopping|restarting)\b/.test(value)) return "motion";
+  if (value === "checking") return "loading";
+  if (value === "stopped") return "off";
+  if (value === "unknown" || value === "status loaded") return "nodata";
+  // Escalation. summarizeHomeStatus can report "OK" while Funcom/FLS is
+  // FAILED -- the token-mismatch branch overrides the ready override -- so the
+  // heading word alone is not the worst thing on screen.
+  if (health.some((item) => normalizeStatus(String(item.status || "")) === "fail")) return "failed";
+  if (value === "ok") return "ok";
+  return "attention";
+}
+
+// The heading reads "Battlegroup Status: <value>", but summarizeHomeStatus
+// yields "Restarting Battlegroup" while a restart is in flight, which would
+// render as "Battlegroup Status: Restarting Battlegroup". Trimmed here rather
+// than in the summary: that value is shared with homeNeedsWarmRefresh, and the
+// duplication is purely a consequence of this heading's new prefix.
+export function homeOverallHeading(value: unknown) {
+  const text = formatDisplayValue(value || "Unknown");
+  return text.replace(/\s+battlegroup$/i, "");
+}
+
+// The two identity values that are not already in the summary line above, and
+// that an operator copies rather than reads at a glance. Rendered labelled --
+// and shown even when Unknown -- because with the Server Identity band gone
+// this is the only place they appear.
+const HOME_HERO_META_LABELS = ["Server IP", "Battlegroup"];
+
+// Title/Region/Mode/population as one line under the state heading. Unknown
+// entries are dropped rather than printed: this is a summary, and a line reading
+// "Unknown · Unknown" tells an operator nothing. When nothing at all resolves the
+// line falls back to a loading sentence, so an empty identity is still visible.
+// Uptime is deliberately absent -- the Performance band below carries it on its
+// own card, and repeating it here said the same thing twice.
+function homeIdentityLine(items: { label: string; value: string }[]) {
+  const pick = (label: string) => {
+    const value = String(items.find((item) => item.label === label)?.value || "").trim();
+    return value && !/^(unknown|unavailable)$/i.test(value) ? value : "";
+  };
+  // formatHomePopulation yields "14" or "14 / 40"; either reads as a bare
+  // trailing number, so it is labelled here rather than in the summary.
+  const population = pick("Population");
+  const parts = [pick("Title"), pick("Region"), pick("Mode"), population ? `${population} online` : ""].filter(Boolean);
+  return parts.length ? parts.join(" · ") : "Server details are still loading.";
+}
+
+// Dates the status values on screen. Ticks on its own 1s interval so the
+// second-by-second re-render stays inside this element instead of re-rendering
+// every card in the panel.
+function StatusFreshness({ lastUpdatedAt, pollFailures }: { lastUpdatedAt: number; pollFailures: number }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+  if (!lastUpdatedAt) return null;
+  const stale = pollFailures >= STALE_POLL_THRESHOLD;
+  const ago = formatFreshness(lastUpdatedAt, now);
+  return <p className={stale ? "home-freshness stale" : "home-freshness"}>
+    {stale ? `Status may be stale — last updated ${ago}` : `Updated ${ago}`}
+  </p>;
+}
+
+// The six readiness subsystems as one line each, replacing the old card band.
+// A row is a button when the subsystem has somewhere to be dealt with, so a
+// warning routes to the tab that can fix it instead of being a dead end.
+function HomeSubsystemList({ items, onNavigate }: { items: { label: string; value: string; status: string; detail: string }[]; onNavigate?: (tab: Tab) => void }) {
+  return <section className="home-subsystems" aria-label="Readiness and health">
+    <h3>Readiness & Health</h3>
+    <ul className="home-subsystem-list">
+      {items.map((item) => {
+        const route = HOME_SUBSYSTEM_ROUTES[item.label];
+        const body = <>
+          <span className="home-subsystem-label">{item.label}</span>
+          <span className="home-subsystem-value">
+            {/* A healthy row's value is the literal "OK" beside a "Ready"
+                pill saying the same thing twice -- and healthy is the common
+                case. Anything else ("Warming", "Token Mismatch Detected",
+                "3 of 8 up") is the detail the pill cannot carry, so it stays. */}
+            {!/^OK$/i.test(item.value) && <span>{formatDisplayValue(item.value)}</span>}
+            <StatusPill value={item.status} />
+          </span>
+        </>;
+        return <li key={item.label} className="home-subsystem-row" title={item.detail || undefined}>
+          {route && onNavigate
+            ? <button type="button" className="home-subsystem-button" onClick={() => onNavigate(route)} aria-label={`${item.label}: ${item.value}. Open ${route}`}>{body}</button>
+            : <div className="home-subsystem-static">{body}</div>}
+        </li>;
+      })}
+    </ul>
+  </section>;
 }
 
 function PerformanceCards({ performance, error }: { performance: PerformanceSnapshot | null; error: string }) {
@@ -440,12 +658,15 @@ function PerformanceCards({ performance, error }: { performance: PerformanceSnap
     <h3>Performance</h3>
     {error && !performance && <p className="error">{error}</p>}
     <div className="health-grid health-grid-compact">
-      {cards.map((item) => <article className="status-card performance-card" key={item.label}>
-        <div className="status-card-title"><span>{item.label}</span><StatusPill value={performance ? "OK" : "INFO"} /></div>
-        <strong>{item.value}</strong>
-        <p>{item.detail}</p>
-        {item.percent !== null && <div className="metric-track" aria-hidden="true"><span style={{ width: `${clampPercent(item.percent)}%` }} /></div>}
-      </article>)}
+      {cards.map((item) => {
+        const cardStatus = performanceCardStatus(item.percent, Boolean(performance));
+        return <article className="status-card performance-card" key={item.label}>
+          <div className="status-card-title"><span>{item.label}</span>{cardStatus && <StatusPill value={cardStatus} />}</div>
+          <strong>{item.value}</strong>
+          <p>{item.detail}</p>
+          {item.percent !== null && <div className="metric-track" aria-hidden="true"><span className={performanceTrackTone(item.percent, Boolean(performance))} style={{ width: `${clampPercent(item.percent)}%` }} /></div>}
+        </article>;
+      })}
     </div>
   </section>;
 }
@@ -1226,33 +1447,6 @@ function isValidHourMinuteTime(value: string) {
 
 
 
-function HomeHealthCards({ status, readiness, readinessWarning, loading, runningAction, restartStartObserved, taskResult, funcomTokenResult }: { status: string; readiness: string; readinessWarning: string; loading: boolean; runningAction: "start" | "stop" | "restart" | ""; restartStartObserved: boolean; taskResult: HomeTaskResult | null; funcomTokenResult: HomeTaskResult | null }) {
-  const funcomTokenCheckRunning = funcomTokenResult?.status === "running";
-  const summary = summarizeHomeStatus(status, readiness, readinessWarning, loading, runningAction, taskResult, restartStartObserved, !funcomTokenCheckRunning && (isFuncomTokenAuthFailure(funcomTokenResult) || hasPersistedFuncomTokenAuthFailure()));
-  return <div className="home-health wide">
-    <section className="dashboard-band">
-      <h3>Server Identity</h3>
-      <div className="health-grid">
-        {summary.identity.map((item) => <article className="status-card" key={item.label}>
-          <div className="status-card-title"><span>{item.label}</span><StatusPill value={item.status} /></div>
-          <strong>{formatDisplayValue(item.value)}</strong>
-          {item.detail && <p>{item.detail}</p>}
-        </article>)}
-      </div>
-    </section>
-    <section className="dashboard-band">
-      <h3>Readiness & Health</h3>
-      <div className="health-grid health-grid-compact">
-        {summary.health.map((item) => <article className="status-card" key={item.label}>
-          <div className="status-card-title"><span>{item.label}</span><StatusPill value={item.status} /></div>
-          <strong>{formatDisplayValue(item.value)}</strong>
-          {item.detail && <p>{item.detail}</p>}
-        </article>)}
-      </div>
-    </section>
-  </div>;
-}
-
 function DoctorSummary({ text, readiness, loading, error, onFixBinding, onCleanupImages, onCleanupBuildCache, fixingBinding, cleanupOperation, fixDisabled }: {
   text: string;
   readiness: string;
@@ -1456,7 +1650,11 @@ function summarizeHomeStatus(status: string, readiness: string, readinessWarning
   };
 }
 
-function homeNeedsWarmRefresh(status: string, readiness: string) {
+// Exported for the regression guard in ServerPanels.homeCards.test.tsx: this
+// and isHomeActionComplete both read summarizeHomeStatus()'s identity/health
+// arrays, so a future edit that drops an entry while "just changing the
+// rendering" has to fail a test rather than silently break poll cadence.
+export function homeNeedsWarmRefresh(status: string, readiness: string) {
   if (!status && !readiness) return false;
   const summary = summarizeHomeStatus(status, readiness, "", false);
   const overall = summary.identity.find((item) => item.label === "Overall");
@@ -1780,13 +1978,22 @@ function isHomeBootStarting(status: string, readiness: string) {
   return coreStartupContainerUp || readinessStarting || (coreStartupContainerUp && containerLines.length > 0 && missingContainers > 0) || (coreStartupContainerUp && listenerLines.length > 0 && missingListeners > 0);
 }
 
-function homeOverallBadge(value: string) {
+export function homeOverallBadge(value: string) {
   const normalized = String(value || "").trim().toLowerCase();
   if (/\b(restarting|restart|stopping|starting)\b/.test(normalized)) return "WARN";
   if (/^stopped$/i.test(value)) return "WARN";
   if (/^issue(?: detected)?$/i.test(value)) return "WARN";
   if (/warming/i.test(value)) return "Info";
   if (/stopped|not running|offline/i.test(value)) return "WARN";
+  // "Readiness checked" is summarizeHomeStatus's label for a readiness run that
+  // did NOT pass -- when it passes the value is "OK". Left to inferStatus the
+  // word "checked" matches its pass list and comes back green, so a failed
+  // readiness check reported itself as healthy.
+  if (normalized === "readiness checked") return "WARN";
+  // Core subsystems are up but something is flagged. inferStatus finds no
+  // keyword and falls through to "Info", the same neutral as "Unknown" and
+  // "Checking" -- indistinguishable from "nothing known yet".
+  if (normalized === "needs review") return "WARN";
   return inferStatus(value);
 }
 

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -123,9 +123,17 @@ export function isRestartLifecycleReady(action: "start" | "stop" | "restart" | "
 export const PERFORMANCE_WARN_PERCENT = 75;
 export const PERFORMANCE_FAIL_PERCENT = 90;
 
+// `null` means "no reading available", NOT "no percentage concept" -- the API
+// returns null routinely, e.g. cpuPercent on the first sample after every API
+// start, because it needs two samples to compute a delta. That must read INFO
+// ("Sampling..."), never OK. Cards with no percentage at all (Uptime) are
+// handled by the caller, which omits the badge entirely rather than passing
+// null through here.
 export function performanceCardStatus(percent: number | null, sampled: boolean) {
-  if (percent === null) return "";
-  if (!sampled || !Number.isFinite(percent)) return "INFO";
+  if (!sampled || percent === null || !Number.isFinite(percent)) return "INFO";
+  // A negative utilisation is nonsense rather than healthy; report it as
+  // unknown instead of letting it fall through to OK.
+  if (percent < 0) return "INFO";
   if (percent > PERFORMANCE_FAIL_PERCENT) return "FAILED";
   if (percent >= PERFORMANCE_WARN_PERCENT) return "WARN";
   return "OK";
@@ -479,10 +487,20 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
   const summary = summarizeHomeStatus(status, readiness, readinessWarning, loading, runningAction, taskResult, restartStartObserved, !funcomTokenCheckRunning && (isFuncomTokenAuthFailure(funcomTokenResult) || hasPersistedFuncomTokenAuthFailure()));
   const overall = summary.identity.find((item) => item.label === "Overall");
   const identityCards = summary.identity.filter((item) => item.label !== "Overall");
+  const populationItem = identityCards.find((item) => item.label === "Population");
+  const populationWarn = /^warn$/i.test(String(populationItem?.status || ""));
+  const populationSegment = homePopulationSegment(populationItem?.value);
+  const identityLine = homeIdentityLine(identityCards);
 
   return (
     <section className="grid">
-      <article className="hero-panel wide home-hero">
+      {/* The h2 is visually hidden but structurally real: deleting the old
+          "Server Overview" heading left the page jumping h1 -> h3, and left
+          this region with no accessible name. The three h3s below it (this
+          hero's status label, Readiness & Health, Performance) are its
+          children, so the level is correct as well as present. */}
+      <article className="hero-panel wide home-hero" aria-labelledby="home-hero-heading">
+        <h2 id="home-hero-heading" className="sr-only">Server overview</h2>
         <div className="home-hero-split">
           <div className="home-hero-primary">
             {/* An h3, not a styled span: it is the peer of the "Readiness &
@@ -495,7 +513,18 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
               <span className={`home-state-dot home-state-dot-${homeStateDotTone(overall?.value, summary.health)}`} aria-hidden="true" />
               <span className="home-hero-state-value">{homeOverallHeading(overall?.value)}</span>
             </div>
-            <p className="home-hero-identity">{homeIdentityLine(identityCards)}</p>
+            {/* Population is rendered apart from the rest of the line so its
+                WARN can survive: summarizeHomeStatus flags an unreadable count
+                ("14 / ?" or "Unavailable"), and the deleted Server Identity
+                band was the only thing that showed that. Folding it into the
+                plain summary string dropped the signal silently. */}
+            <p className="home-hero-identity">
+              {identityLine || (populationSegment ? "" : "Server details are still loading.")}
+              {populationSegment && <>
+                {identityLine ? " · " : ""}
+                <span className={populationWarn ? "home-population-warn" : undefined}>{populationSegment}</span>
+              </>}
+            </p>
             <dl className="home-hero-meta">
               {HOME_HERO_META_LABELS.map((label) => <div className="home-hero-meta-item" key={label}>
                 <dt>{label}</dt>
@@ -573,11 +602,19 @@ function homeIdentityLine(items: { label: string; value: string }[]) {
     const value = String(items.find((item) => item.label === label)?.value || "").trim();
     return value && !/^(unknown|unavailable)$/i.test(value) ? value : "";
   };
-  // formatHomePopulation yields "14" or "14 / 40"; either reads as a bare
-  // trailing number, so it is labelled here rather than in the summary.
-  const population = pick("Population");
-  const parts = [pick("Title"), pick("Region"), pick("Mode"), population ? `${population} online` : ""].filter(Boolean);
-  return parts.length ? parts.join(" · ") : "Server details are still loading.";
+  const parts = [pick("Title"), pick("Region"), pick("Mode")].filter(Boolean);
+  return parts.join(" · ");
+}
+
+// formatHomePopulation yields "14", "14 / 40", "14 / ?" or "Unavailable"; any
+// of those reads as a bare trailing number without a label. "Unavailable" is
+// kept rather than dropped -- paired with the warn tone it is the signal that
+// the count could not be read, which is worth more than silence.
+function homePopulationSegment(value: unknown) {
+  const text = String(value || "").trim();
+  if (!text || /^unknown$/i.test(text)) return "";
+  if (/^unavailable$/i.test(text)) return "population unavailable";
+  return `${text} online`;
 }
 
 // Dates the status values on screen. Ticks on its own 1s interval so the
@@ -617,7 +654,11 @@ function HomeSubsystemList({ items, onNavigate }: { items: { label: string; valu
             <StatusPill value={item.status} />
           </span>
         </>;
-        return <li key={item.label} className="home-subsystem-row" title={item.detail || undefined}>
+        // No `title` attribute: every producer of a health card emits
+        // detail: "", so a tooltip would advertise a hover affordance that
+        // never has content -- and a hover-only one at that. If detail ever
+        // becomes real it belongs in the row body, not an attribute.
+        return <li key={item.label} className="home-subsystem-row">
           {route && onNavigate
             ? <button type="button" className="home-subsystem-button" onClick={() => onNavigate(route)} aria-label={`${item.label}: ${item.value}. Open ${route}`}>{body}</button>
             : <div className="home-subsystem-static">{body}</div>}
@@ -632,25 +673,31 @@ function PerformanceCards({ performance, error }: { performance: PerformanceSnap
     {
       label: "CPU Usage",
       value: performance?.cpuPercent == null ? "Sampling..." : `${performance.cpuPercent.toFixed(1)}%`,
-      percent: performance?.cpuPercent ?? 0,
+      percent: performance?.cpuPercent ?? null,
+      metered: true,
       detail: "Host Processor Load"
     },
     {
       label: "Memory",
       value: performance?.memory.percent == null ? "Unknown" : `${performance.memory.percent.toFixed(1)}%`,
-      percent: performance?.memory.percent ?? 0,
+      percent: performance?.memory.percent ?? null,
+      metered: true,
       detail: performance ? `${formatBytes(performance.memory.usedBytes)} / ${formatBytes(performance.memory.totalBytes)}` : "Waiting for Sample"
     },
     {
       label: "Disk",
       value: performance?.disk.percent == null ? "Unknown" : `${performance.disk.percent.toFixed(1)}%`,
-      percent: performance?.disk.percent ?? 0,
+      percent: performance?.disk.percent ?? null,
+      metered: true,
       detail: performance ? `${formatBytes(performance.disk.usedBytes)} / ${formatBytes(performance.disk.totalBytes)}` : "Waiting for Sample"
     },
     {
       label: "Uptime",
       value: performance?.uptime || "0d 00h 00m",
       percent: null,
+      // Not a utilisation figure at all, so it gets neither a badge nor a bar
+      // -- distinct from a metered card whose reading has not arrived yet.
+      metered: false,
       detail: "Host Uptime"
     }
   ];
@@ -659,12 +706,12 @@ function PerformanceCards({ performance, error }: { performance: PerformanceSnap
     {error && !performance && <p className="error">{error}</p>}
     <div className="health-grid health-grid-compact">
       {cards.map((item) => {
-        const cardStatus = performanceCardStatus(item.percent, Boolean(performance));
+        const cardStatus = item.metered ? performanceCardStatus(item.percent, Boolean(performance)) : "";
         return <article className="status-card performance-card" key={item.label}>
           <div className="status-card-title"><span>{item.label}</span>{cardStatus && <StatusPill value={cardStatus} />}</div>
           <strong>{item.value}</strong>
           <p>{item.detail}</p>
-          {item.percent !== null && <div className="metric-track" aria-hidden="true"><span className={performanceTrackTone(item.percent, Boolean(performance))} style={{ width: `${clampPercent(item.percent)}%` }} /></div>}
+          {item.metered && item.percent !== null && <div className="metric-track" aria-hidden="true"><span className={performanceTrackTone(item.percent, Boolean(performance))} style={{ width: `${clampPercent(item.percent)}%` }} /></div>}
         </article>;
       })}
     </div>
@@ -1978,6 +2025,12 @@ function isHomeBootStarting(status: string, readiness: string) {
   return coreStartupContainerUp || readinessStarting || (coreStartupContainerUp && containerLines.length > 0 && missingContainers > 0) || (coreStartupContainerUp && listenerLines.length > 0 && missingListeners > 0);
 }
 
+// NOTE: this no longer colours anything on screen. It produces
+// identity[0].status, and since the Server Identity band was removed the only
+// remaining consumer is homeNeedsWarmRefresh's poll-cadence check -- the hero
+// dot reads homeStateDotTone(overall.value) instead. Kept correct rather than
+// deleted because a status-badge helper that calls a failed readiness check
+// "Ready" is simply wrong, and it is still exercised by that cadence check.
 export function homeOverallBadge(value: string) {
   const normalized = String(value || "").trim().toLowerCase();
   if (/\b(restarting|restart|stopping|starting)\b/.test(normalized)) return "WARN";

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -26,6 +26,12 @@
   --danger: #a74949;
   --danger-strong: #8d3434;
   --danger-text: #ffb4a8;
+  /* For small filled indicators (an 11px status dot), where neither existing
+     danger step works: --danger-text is a pale salmon that sits right next to
+     --title's amber at that size -- measured side by side, the two were not
+     separable -- and --danger is dark enough to read as brown on the card
+     background. This is the saturated middle, only for shapes, never text. */
+  --danger-signal: #e05a4f;
   --warning: #a97932;
   background: var(--bg);
   color: var(--text);
@@ -968,6 +974,12 @@ main { padding: 22px; min-width: 0; }
 .performance-card strong { font-size: 22px; line-height: 1.15; }
 .metric-track { height: 8px; overflow: hidden; border-radius: 999px; background: #0c0e10; border: 1px solid #302b25; }
 .metric-track span { display: block; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #6f8f5f, #c68b4a); transition: width .35s ease; }
+/* The fill colour has to carry the same verdict as the card's badge -- with a
+   single gradient for every reading, a 96%-full disk looked identical to a
+   4%-full one and the bar was decoration. Same warn/danger tokens the badges
+   use, so the two cannot disagree. */
+.metric-track span.metric-track-warn { background: linear-gradient(90deg, #a97932, #d49a5c); }
+.metric-track span.metric-track-fail { background: linear-gradient(90deg, var(--danger), var(--danger-strong)); }
 .result-list { display: grid; gap: 8px; margin: 10px 0 0; padding: 0; list-style: none; }
 .result-row { border: 1px solid #302b25; border-radius: 6px; padding: 9px 10px; background: #14171a; color: #d9c8aa; }
 .result-ok { border-color: #3d8b62; color: #9be6bd; }
@@ -2130,9 +2142,93 @@ body.debug .technical-details { display: block; }
 .service-table { display: grid; gap: 10px; margin-top: 14px; }
 .service-actions, .service-card .service-actions { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; align-items: center; }
 .service-actions button, .service-actions .button-link { width: auto; white-space: nowrap; }
-.home-health { display: grid; gap: 16px; }
 .dashboard-band { display: grid; gap: 10px; }
 .dashboard-band h3 { margin: 0; color: #ffd08a; }
+
+/* The hero is the only .grid child without .wide, so before this it sat in
+   column 1 of a two-column grid and left the whole right half of row 1 empty
+   on every viewport above the 900px breakpoint. It now spans the row and uses
+   that reclaimed space for the readiness subsystems. */
+.home-hero-split { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr); gap: 20px; align-items: start; }
+.home-hero-primary { min-width: 0; }
+.home-hero-state { display: flex; align-items: center; flex-wrap: wrap; gap: 10px; }
+/* Only layout here: .home-hero-state-label is an h3, so it already picks up
+   the same size, colour and weight as the "Readiness & Health" and
+   "Performance" headings. Deliberately no font-size -- restating it would let
+   the two drift apart the next time heading sizing changes. */
+.home-hero-state-label { margin: 0; }
+/* The reading shares the heading's warm family and weight but is stepped up:
+   the label names the row, the reading is the answer. The dot carries state. */
+.home-hero-state-value { color: var(--title); font-size: 1.4em; font-weight: 700; line-height: 1.2; }
+/* Three axes, not one: hue carries severity, the pulse carries "in progress",
+   and ring-vs-fill carries "no reading yet". Anyone who cannot separate the
+   hues still gets the important distinction -- a pulsing dot is working on it,
+   a hollow one has nothing to report -- which matters on a console this
+   uniformly amber. */
+.home-state-dot { flex: 0 0 auto; width: 11px; height: 11px; border-radius: 50%; background: var(--muted); }
+.home-state-dot-ok { background: var(--success-text); }
+.home-state-dot-attention { background: var(--title); }
+.home-state-dot-failed { background: var(--danger-signal); }
+/* Off on purpose. Solid, so it still reads as a known state -- the hollow
+   ring below is reserved for "we have no reading". --text-subtle, not
+   --muted: --muted is a warm beige that sits in the same family as --title's
+   amber, so at 11px "off" and "needs attention" blurred together. */
+.home-state-dot-off { background: var(--text-subtle); }
+/* Blue is already this palette's informational hue (see .badge-info); it is
+   the one family that does not blur into the warm chrome the way another
+   amber step would. */
+.home-state-dot-motion { background: #85b7eb; animation: state-dot-pulse 1.6s ease-in-out infinite; }
+.home-state-dot-loading { background: transparent; border: 2px solid var(--text-subtle); animation: state-dot-pulse 1.6s ease-in-out infinite; }
+.home-state-dot-nodata { background: transparent; border: 2px solid var(--text-subtle); }
+@keyframes state-dot-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: .45; transform: scale(.82); }
+}
+.home-hero-identity { margin: 6px 0 0; color: var(--muted); }
+/* Server IP and Battlegroup: reference values an operator copies, so they are
+   labelled rather than folded into the "·" summary line above, and they keep
+   their own line-up when the hero narrows. */
+.home-hero-meta { display: flex; flex-wrap: wrap; gap: 8px 24px; margin: 12px 0 0; }
+.home-hero-meta-item { min-width: 0; display: grid; gap: 2px; }
+.home-hero-meta dt { color: var(--muted); font-size: 12px; }
+.home-hero-meta dd { margin: 0; color: var(--text-strong); overflow-wrap: anywhere; }
+/* Dates the values on screen. Muted at rest so it does not compete with the
+   state word; only the stale form is allowed to draw the eye. */
+.home-freshness { margin: 8px 0 0; color: var(--text-subtle); font-size: 12px; }
+.home-freshness.stale { color: var(--title); }
+
+.home-subsystems { min-width: 0; display: grid; gap: 10px; align-content: start; }
+.home-subsystems h3 { margin: 0; color: #ffd08a; }
+.home-subsystem-list { list-style: none; margin: 0; padding: 0; display: grid; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+.home-subsystem-row + .home-subsystem-row { border-top: 1px solid var(--border); }
+/* The button resets the global button styling rather than inheriting it: these
+   are full-bleed rows, not controls, so they take the row's own padding and a
+   transparent background and only light up on hover. */
+.home-subsystem-button, .home-subsystem-static {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 44px;
+  padding: 9px 12px;
+  background: var(--panel);
+  border: 0;
+  border-radius: 0;
+  color: inherit;
+  text-align: left;
+}
+.home-subsystem-button { cursor: pointer; }
+.home-subsystem-button:hover { background: #1c2024; color: var(--text-strong); }
+.home-subsystem-button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.home-subsystem-label { min-width: 0; overflow-wrap: anywhere; }
+.home-subsystem-value { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 8px; color: var(--muted); }
+
+/* Stop destroys running state; it should not read as the visual peer of a
+   read-only Refresh sitting beside it. Border and text only -- the filled
+   danger treatment is reserved for confirm dialogs. */
+.danger-button { border-color: var(--danger); color: var(--danger-text); }
+.danger-button:hover:not(:disabled) { border-color: var(--danger-strong); background: rgba(167, 73, 73, .16); }
 .health-grid-compact { grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); }
 .readiness-groups { display: grid; gap: 14px; }
 .readiness-group { display: grid; gap: 8px; }
@@ -2595,6 +2691,7 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   .sidebar-nav-heading { grid-column: 1 / -1; }
   .home-backdrop { inset: 0; }
   .grid, .two-col { grid-template-columns: 1fr; }
+  .home-hero-split { grid-template-columns: 1fr; gap: 16px; }
   .health-grid, .health-grid-compact { grid-template-columns: 1fr; }
   .live-map-layout { grid-template-columns: 1fr; }
   .live-map-view-body { grid-template-columns: 1fr; }
@@ -2604,6 +2701,9 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
 
 @media (prefers-reduced-motion: reduce) {
   .home-sand-fine, .home-sand-near, .setup-finish-celebration span { animation: none; }
+  /* The dot keeps its hue and its ring/fill, so "in progress" is still
+     distinguishable from "no reading" without the motion. */
+  .home-state-dot-motion, .home-state-dot-loading { animation: none; }
 }
 
 .toggle-row { display: flex; flex-wrap: wrap; gap: 8px; }

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2178,13 +2178,23 @@ body.debug .technical-details { display: block; }
    the one family that does not blur into the warm chrome the way another
    amber step would. */
 .home-state-dot-motion { background: #85b7eb; animation: state-dot-pulse 1.6s ease-in-out infinite; }
-.home-state-dot-loading { background: transparent; border: 2px solid var(--text-subtle); animation: state-dot-pulse 1.6s ease-in-out infinite; }
+/* Dashed vs solid, not just pulsing vs still: prefers-reduced-motion strips
+   the animation, and without a static difference "Checking" and "no reading"
+   became the same pixels for exactly the users who opted out of motion. */
+.home-state-dot-loading { background: transparent; border: 2px dashed var(--text-subtle); animation: state-dot-pulse 1.6s ease-in-out infinite; }
 .home-state-dot-nodata { background: transparent; border: 2px solid var(--text-subtle); }
 @keyframes state-dot-pulse {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: .45; transform: scale(.82); }
 }
-.home-hero-identity { margin: 6px 0 0; color: var(--muted); }
+/* overflow-wrap is load-bearing, not cosmetic: a server Title is free text and
+   can arrive with no spaces. Without it the line overflowed its grid track and
+   was painted underneath the opaque subsystem list next to it -- no scrollbar,
+   no clipping, just silently unreadable. */
+.home-hero-identity { margin: 6px 0 0; color: var(--muted); overflow-wrap: anywhere; }
+/* An unreadable player count. The rest of the line is muted prose; this one
+   segment lifts to the warn tone so the "?" is not mistaken for a real value. */
+.home-population-warn { color: var(--title); }
 /* Server IP and Battlegroup: reference values an operator copies, so they are
    labelled rather than folded into the "·" summary line above, and they keep
    their own line-up when the hero narrows. */
@@ -2202,8 +2212,10 @@ body.debug .technical-details { display: block; }
 .home-subsystem-list { list-style: none; margin: 0; padding: 0; display: grid; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
 .home-subsystem-row + .home-subsystem-row { border-top: 1px solid var(--border); }
 /* The button resets the global button styling rather than inheriting it: these
-   are full-bleed rows, not controls, so they take the row's own padding and a
-   transparent background and only light up on hover. */
+   are full-bleed rows, not controls, so they take the row's own padding and
+   only light up on hover. The fill is the opaque --panel rather than the
+   hero's frosted surface, so the list reads as one solid slab instead of six
+   translucent chips. */
 .home-subsystem-button, .home-subsystem-static {
   width: 100%;
   display: flex;
@@ -2221,8 +2233,16 @@ body.debug .technical-details { display: block; }
 .home-subsystem-button { cursor: pointer; }
 .home-subsystem-button:hover { background: #1c2024; color: var(--text-strong); }
 .home-subsystem-button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.home-subsystem-label { min-width: 0; overflow-wrap: anywhere; }
-.home-subsystem-value { flex: 0 0 auto; display: inline-flex; align-items: center; gap: 8px; color: var(--muted); }
+/* The label is a fixed short string ("Game Servers", "Funcom/FLS"); the value
+   is the variable part and can be as long as "Token Mismatch Detected". So the
+   label holds its width and the VALUE is what gives way. The previous
+   flex: 0 0 auto on the value inverted that: the value refused to shrink and
+   crushed the label to a 5px column breaking one glyph per line at ~940px. */
+.home-subsystem-label { flex: 0 0 auto; white-space: nowrap; }
+.home-subsystem-value { flex: 0 1 auto; min-width: 0; display: inline-flex; align-items: center; justify-content: flex-end; gap: 8px; color: var(--muted); text-align: right; }
+/* Only the text gives way -- the badge is already compact and must stay whole. */
+.home-subsystem-value > span:not(.badge) { min-width: 0; overflow-wrap: anywhere; }
+.home-subsystem-value > .badge { flex: 0 0 auto; }
 
 /* Stop destroys running state; it should not read as the visual peer of a
    read-only Refresh sitting beside it. Border and text only -- the filled
@@ -2701,8 +2721,8 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
 
 @media (prefers-reduced-motion: reduce) {
   .home-sand-fine, .home-sand-near, .setup-finish-celebration span { animation: none; }
-  /* The dot keeps its hue and its ring/fill, so "in progress" is still
-     distinguishable from "no reading" without the motion. */
+  /* The dot keeps its hue and its ring style (dashed for "checking", solid for
+     "no reading"), so both stay distinguishable without the motion. */
   .home-state-dot-motion, .home-state-dot-loading { animation: none; }
 }
 

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2209,7 +2209,16 @@ body.debug .technical-details { display: block; }
 
 .home-subsystems { min-width: 0; display: grid; gap: 10px; align-content: start; }
 .home-subsystems h3 { margin: 0; color: #ffd08a; }
-.home-subsystem-list { list-style: none; margin: 0; padding: 0; display: grid; border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+/* No overflow: hidden. It clipped the inset focus ring's square corners on the
+   first and last rows; the rounded slab is achieved by rounding those rows'
+   own fills instead. Logical longhands rather than the border-radius shorthand
+   so the first-child and last-child rules compose instead of overwriting each
+   other when the list holds a single row. */
+.home-subsystem-list { list-style: none; margin: 0; padding: 0; display: grid; border: 1px solid var(--border); border-radius: 8px; }
+.home-subsystem-row:first-child .home-subsystem-button,
+.home-subsystem-row:first-child .home-subsystem-static { border-start-start-radius: 7px; border-start-end-radius: 7px; }
+.home-subsystem-row:last-child .home-subsystem-button,
+.home-subsystem-row:last-child .home-subsystem-static { border-end-start-radius: 7px; border-end-end-radius: 7px; }
 .home-subsystem-row + .home-subsystem-row { border-top: 1px solid var(--border); }
 /* The button resets the global button styling rather than inheriting it: these
    are full-bleed rows, not controls, so they take the row's own padding and


### PR DESCRIPTION
The hero panel was the only `.grid` child without `.wide`, so the right half of row 1 sat empty on every viewport above the 900px breakpoint. It now spans the row, leads with the overall verdict, and uses the reclaimed space for the six readiness subsystems as rows that route to the tab handling each one.

Also in this pass:

- Performance badges and meter bars derive from each reading rather than "did a sample arrive", so a 96%-full disk no longer shows the same green pill as a 4%-full one.
- The Server Identity band is removed; it repeated the hero summary line. Server IP and Battlegroup move into the hero and render even when unknown, since that is now the only place they appear.
- The status dot splits the overloaded amber (six of ten readings) by what the operator should do: hue for severity, a pulse for in-progress, ring-vs-fill for no reading yet. It takes the worst of the overall reading and all six subsystems, so a failed Funcom/FLS shows red even while the heading reads OK.
- The three polling effects swallowed their errors, leaving stale values on screen indefinitely. The panel now dates the data and warns after consecutive misses, without blanking the last good values.
- `homeOverallBadge` no longer reports a failed readiness check as healthy — `inferStatus` was matching the word "checked" against its pass list.

Everything is rendering-only. `summarizeHomeStatus` keeps its exact shape because `isHomeActionComplete` and `homeNeedsWarmRefresh` read its `health` and `identity` arrays to drive the restart lifecycle; a regression test pins that and fails if the health array is emptied.

Verified: `tsc --noEmit` clean, 781/781 tests across 76 files with 0 skipped. Layout and colour choices were measured in the browser rather than eyeballed — the hero now matches the full grid width, and `--danger-signal` was added because at 11px `--danger-text` was not separable from `--title`'s amber.
