### PR TITLE
Fix flaky console/web tests under full-suite parallelism

### DIFF
--- a/console/web/src/features/bases/BaseInventoryTab.test.tsx
+++ b/console/web/src/features/bases/BaseInventoryTab.test.tsx
@@ -13,6 +13,15 @@ import { BaseInventoryTab } from "./BaseInventoryTab";
 // visually stay put while scrolling"), which stays a live-browser check.
 import "../../styles.css";
 
+// Raised from the 5s default for this file only. Importing the real stylesheet
+// above means jsdom runs the full cascade on every query, which makes this file
+// roughly an order of magnitude slower than the rest of the suite (~75s for its
+// tests, with csstree-match hitting its own iteration ceiling). Under full-suite
+// parallelism a single test can drift past 5s and time out while still passing
+// in isolation. Scoped here rather than set globally in vitest.config.ts so a
+// genuine hang anywhere else still fails fast.
+vi.setConfig({ testTimeout: 20000 });
+
 vi.mock("../../api/bases", () => ({
   basesApi: {
     inventory: vi.fn(),

--- a/console/web/src/features/maps/MapsPanel.matchRegion.test.tsx
+++ b/console/web/src/features/maps/MapsPanel.matchRegion.test.tsx
@@ -109,9 +109,12 @@ function renderMapsPanel() {
 
 async function openUserGameGlobalTab(api: Record<string, ReturnType<typeof vi.fn>>) {
   renderMapsPanel();
-  const modifiers = await screen.findByRole("button", { name: "Expand Interactive Modifiers" });
-  await waitFor(() => expect(modifiers).toBeEnabled());
-  fireEvent.click(modifiers);
+  // Re-queried inside the waitFor rather than captured before it: the button
+  // exists while the panel is still loading, and React can replace the node on
+  // the settle re-render instead of mutating it -- a captured reference would
+  // then never become enabled.
+  await waitFor(() => expect(screen.getByRole("button", { name: "Expand Interactive Modifiers" })).toBeEnabled());
+  fireEvent.click(screen.getByRole("button", { name: "Expand Interactive Modifiers" }));
   fireEvent.click(screen.getByRole("tab", { name: "UserGame" }));
   const targetSelect = await screen.findByLabelText("Target");
   fireEvent.change(targetSelect, { target: { value: "__global__::" } });

--- a/console/web/src/features/maps/MapsPanel.settingsAvailability.test.tsx
+++ b/console/web/src/features/maps/MapsPanel.settingsAvailability.test.tsx
@@ -99,11 +99,14 @@ describe("MapsPanel modifier availability", () => {
     renderMapsPanel();
 
     expect(await screen.findByText("Loading Maps")).toBeInTheDocument();
-    const modifiers = screen.getByRole("button", { name: "Expand Interactive Modifiers" });
-    await waitFor(() => expect(modifiers).toBeEnabled());
+    // Re-queried inside the waitFor rather than captured before it: the button
+    // exists while the panel is still loading, and React can replace the node on
+    // the settle re-render instead of mutating it -- a captured reference would
+    // then never become enabled.
+    await waitFor(() => expect(screen.getByRole("button", { name: "Expand Interactive Modifiers" })).toBeEnabled());
     expect(api.rawUserSettings).not.toHaveBeenCalled();
 
-    fireEvent.click(modifiers);
+    fireEvent.click(screen.getByRole("button", { name: "Expand Interactive Modifiers" }));
 
     expect(screen.getByRole("tab", { name: "UserEngine" })).toBeVisible();
     expect(screen.getByDisplayValue("2.0")).toBeVisible();

--- a/console/web/src/features/players/CharacterAdminUI.skills.test.tsx
+++ b/console/web/src/features/players/CharacterAdminUI.skills.test.tsx
@@ -58,8 +58,8 @@ describe("CharacterAdminUI skill live grants", () => {
     fireEvent.click(screen.getByRole("button", { name: "Skills" }));
 
     expect(await screen.findByText("The player must be online to change skills or restore starter skills.")).toBeInTheDocument();
-    const rankButton = await screen.findByRole("button", { name: "Set Energy Capsule rank 1" });
-    await waitFor(() => expect(rankButton).toBeDisabled());
+    await waitFor(() => expect(screen.getByRole("button", { name: "Set Energy Capsule rank 1" })).toBeDisabled());
+    const rankButton = screen.getByRole("button", { name: "Set Energy Capsule rank 1" });
     expect(rankButton).toHaveAttribute("title", "The player must be online to change skills");
 
     fireEvent.click(rankButton);


### PR DESCRIPTION
Two pre-existing flakes in the `console/web` suite, both only visible under full-suite parallelism.

**Stale node captures.** Three tests captured a DOM node from `findByRole`/`getByRole` and then polled that reference in `waitFor`. The node exists before the async load settles, and React can replace it on the settle re-render instead of mutating it — so the captured reference never flips state and `waitFor` times out. Each now re-queries inside the `waitFor` callback.

- `CharacterAdminUI.skills.test.tsx` — "does not let an offline player create an unsaved skill draft"
- `MapsPanel.matchRegion.test.tsx` and `MapsPanel.settingsAvailability.test.tsx` — same pattern on the Interactive Modifiers button

**Timeout.** `BaseInventoryTab.test.tsx` imports the real `styles.css`, so jsdom runs the full cascade on every query and the file runs ~75s for its 97 tests. Under parallelism a single test drifts past the 5s default while still passing in isolation. Raised to 20s for that file only, so a genuine hang elsewhere still fails fast.

Test-only changes; no production source touched.

Verified with 8 consecutive full `npx vitest run` passes: 75 files, 746 tests, 0 failed, 0 skipped. Before the fix, the same suite failed 1 in 7 runs.
