### PR TITLE
Rework the Home screen status layout

### DIFF
--- a/console/api/src/config.js
+++ b/console/api/src/config.js
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, statSync
 import { dirname, resolve } from "node:path";
 import { createHash, randomBytes } from "node:crypto";
 import { networkInterfaces } from "node:os";
+import { clampInt } from "./jsonStore.js";
 
 export const APP_NAME = "Dune Docker Console";
 
@@ -252,6 +253,11 @@ export function loadConfig() {
     maxUploadBytes: Number(process.env.ADMIN_MAX_UPLOAD_BYTES || 1024 * 1024 * 1024),
     commandTimeoutMs: Number(process.env.ADMIN_COMMAND_TIMEOUT_MS || 120000),
     updateCheckCacheMs: Number(process.env.ADMIN_UPDATE_CHECK_CACHE_MS || 5 * 60 * 1000),
+    // status/readiness each shell out for ~4s; Home asks for both on every
+    // mount and idle poll. clampInt, not bare Number() like its neighbours: a
+    // typo'd env var here would otherwise become NaN and disable the cache
+    // silently. 0 disables it deliberately.
+    statusCacheMs: clampInt(process.env.ADMIN_STATUS_CACHE_MS, 15000, 0, 120000),
     staticDir: process.env.ADMIN_STATIC_DIR || resolve(repoRoot, "console/web/dist"),
     allowedIps: parseAllowedIps(process.env.ADMIN_ALLOWED_IPS)
   };

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -12,6 +12,7 @@ import { scopeCatalog } from "./apiKeyScopes.js";
 import { createBridgeRateLimiter } from "./bridgeRateLimit.js";
 import { buildSelfUpdateHelperDockerArgs, detectDockerSocketGid, TaskManager, publicTask } from "./tasks.js";
 import { preflight } from "./preflight.js";
+import { createServerStatusCache } from "./services/serverStatusCache.js";
 import { buildDuneArgs, isDynamicServerService, isReadOnlySql, parseVehicleList, runDockerLogs, runDune, validateServiceName } from "./runner.js";
 import { createDb, quoteIdentifier } from "./db.js";
 import * as duneDb from "./duneDb.js";
@@ -638,9 +639,9 @@ async function handleApi(req, res) {
   if (path === "/api/public-directory/status") return json(res, 200, publicDirectory.publicState());
   if (path.startsWith("/api/setup/tasks/")) return taskRoute(req, res, path);
 
-  if (path === "/api/server/status") return commandJson(res, "status");
+  if (path === "/api/server/status") return cachedCommandJson(res, "status", url);
   if (path === "/api/server/performance") return json(res, 200, await collectPerformanceSnapshot(config.repoRoot));
-  if (path === "/api/server/readiness") return safeCommandJson(res, "readiness");
+  if (path === "/api/server/readiness") return cachedCommandJson(res, "readiness", url);
   if (path === "/api/server/ports") return commandJson(res, "ports");
   if (path === "/api/server/services") return commandJson(res, "services");
   if (path === "/api/server/doctor") return safeCommandJson(res, "doctor");
@@ -1541,6 +1542,28 @@ function isAdminToolsHistoryLine(line) {
   return false;
 }
 
+// status and readiness are the only two cached commands: they are the pair the
+// Home panel requests on every mount and idle poll, and each costs ~4s. `status`
+// keeps commandJson's throw-on-failure behaviour, `readiness` keeps
+// safeCommand's swallow-and-report behaviour, so caching does not change what
+// either route returns -- only how often the subprocess actually runs.
+const serverStatusCache = createServerStatusCache(config, {
+  collectStatus: async () => {
+    const result = await runDune(config, buildDuneArgs("status", {}));
+    return { operation: "status", stdout: result.stdout, stderr: result.stderr, exitCode: result.code };
+  },
+  collectReadiness: () => safeCommand("readiness")
+});
+
+async function cachedCommandJson(res, operation, url) {
+  if (config.mockMode) return json(res, 200, mockCommand(operation));
+  const fresh = url?.searchParams?.get("fresh") === "1";
+  const entry = await serverStatusCache.read(operation, { fresh });
+  const { sampledAtMs, ...rest } = entry;
+  void sampledAtMs;
+  return json(res, 200, rest);
+}
+
 async function safeCommandJson(res, operation, payload = {}) {
   if (config.mockMode) return json(res, 200, mockCommand(operation));
   return json(res, 200, await safeCommand(operation, payload));
@@ -2306,6 +2329,10 @@ async function task(req, res, type, operation, payload) {
     return json(res, 400, { error: redact(error?.message || "Unexpected error.") });
   }
   if (await maybeQueueRestart(req, res, type, operation, payload)) return;
+  // Any server-group task is about to change what status/readiness report, so
+  // drop the cached snapshot now rather than letting Home show "Running" for a
+  // full TTL after a stop.
+  if (type === "server") serverStatusCache.invalidate();
   audit(config, req, `task.${operation}`, payload);
   return json(res, 202, { task: tasks.create(type, operation, payload) });
 }

--- a/console/api/src/services/serverStatusCache.js
+++ b/console/api/src/services/serverStatusCache.js
@@ -1,0 +1,36 @@
+import { createUpdateCheckCache } from "./updateCheckCache.js";
+
+// `status` and `readiness` each shell out to runtime/scripts/status.sh, which
+// inspects every container, port and the database. Measured on a live host they
+// cost ~3.8s apiece and the Home panel asks for both in parallel on every mount
+// and every idle poll, so an operator tab-hopping to Home paid ~4s and two
+// subprocess trees each time.
+//
+// createUpdateCheckCache is a generic TTL cache despite its update-flavoured
+// name: it dedupes in-flight collects, stamps sampledAt, and supports
+// generation-based invalidate(). Reused here rather than reimplemented.
+export function createServerStatusCache(config, options = {}) {
+  const cacheMs = options.cacheMs ?? config.statusCacheMs;
+  const now = options.now;
+  const build = (collect) => createUpdateCheckCache(config, { collect, cacheMs, ...(now ? { now } : {}) });
+
+  const caches = {
+    status: build(options.collectStatus),
+    readiness: build(options.collectReadiness)
+  };
+
+  function read(operation, readOptions = {}) {
+    const cache = caches[operation];
+    if (!cache) throw new Error(`No status cache for operation: ${operation}`);
+    return cache.read(readOptions);
+  }
+
+  // Called after anything that changes server state. Without it Home could
+  // report "Running" for a full TTL after a stop, which is worse than the slow
+  // read this cache exists to avoid.
+  function invalidate() {
+    for (const cache of Object.values(caches)) cache.invalidate();
+  }
+
+  return { read, invalidate };
+}

--- a/console/api/test/serverStatusCache.test.js
+++ b/console/api/test/serverStatusCache.test.js
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServerStatusCache } from "../src/services/serverStatusCache.js";
+
+function build(overrides = {}) {
+  let currentTime = 1000;
+  const collections = { status: 0, readiness: 0 };
+  const cache = createServerStatusCache({ statusCacheMs: 15000 }, {
+    now: () => currentTime,
+    collectStatus: async () => ({ operation: "status", stdout: `status-${++collections.status}`, stderr: "", exitCode: 0 }),
+    collectReadiness: async () => ({ operation: "readiness", stdout: `readiness-${++collections.readiness}`, stderr: "", exitCode: 0 }),
+    ...overrides
+  });
+  return {
+    cache,
+    collections,
+    advance: (ms) => { currentTime += ms; },
+    at: () => currentTime
+  };
+}
+
+test("a second read inside the TTL does not re-run the command", async () => {
+  const { cache, collections, advance } = build();
+
+  const first = await cache.read("status");
+  assert.equal(collections.status, 1);
+  assert.equal(first.fromCache, false);
+
+  advance(14999);
+  const second = await cache.read("status");
+  // The whole point: Home mounting again must not spawn another ~4s subprocess.
+  assert.equal(collections.status, 1, "expected the cached entry to be reused");
+  assert.equal(second.fromCache, true);
+  assert.equal(second.stdout, "status-1");
+});
+
+test("a read past the TTL re-runs the command", async () => {
+  const { cache, collections, advance } = build();
+  await cache.read("status");
+  advance(15001);
+  const next = await cache.read("status");
+  assert.equal(collections.status, 2);
+  assert.equal(next.fromCache, false);
+  assert.equal(next.stdout, "status-2");
+});
+
+// The restart lifecycle reads through this. If `fresh` did not bypass,
+// isHomeActionComplete could be handed a pre-restart snapshot and call a
+// restart finished before it started.
+test("fresh bypasses the cache even when a fresh entry exists", async () => {
+  const { cache, collections } = build();
+  await cache.read("status");
+  const forced = await cache.read("status", { fresh: true });
+  assert.equal(collections.status, 2);
+  assert.equal(forced.fromCache, false);
+  assert.equal(forced.stdout, "status-2");
+});
+
+test("invalidate forces the next read to re-run", async () => {
+  const { cache, collections } = build();
+  await cache.read("status");
+  await cache.read("readiness");
+  assert.deepEqual(collections, { status: 1, readiness: 1 });
+
+  cache.invalidate();
+
+  // Both, not just one: a stop changes what each of them reports.
+  await cache.read("status");
+  await cache.read("readiness");
+  assert.deepEqual(collections, { status: 2, readiness: 2 });
+});
+
+test("sampledAt is when the command ran, not when the cache was read", async () => {
+  const { cache, advance } = build();
+  const first = await cache.read("status");
+  const sampledAt = first.sampledAt;
+
+  advance(12000);
+  const cached = await cache.read("status");
+  // Home dates its freshness line from this. If it moved with the read, a
+  // 12s-old snapshot would claim to be current.
+  assert.equal(cached.sampledAt, sampledAt);
+  assert.equal(cached.fromCache, true);
+});
+
+test("status and readiness cache independently", async () => {
+  const { cache, collections } = build();
+  await cache.read("status");
+  await cache.read("status");
+  assert.deepEqual(collections, { status: 1, readiness: 0 }, "readiness must not be collected by a status read");
+
+  await cache.read("readiness");
+  assert.deepEqual(collections, { status: 1, readiness: 1 });
+});
+
+test("concurrent reads share one in-flight command", async () => {
+  // The gate is created up front, not inside collect: the cache invokes collect
+  // on a microtask, so a resolver assigned from inside it is not yet defined
+  // when the test tries to release it.
+  let resolveCollect;
+  const gate = new Promise((resolve) => { resolveCollect = resolve; });
+  let collections = 0;
+  const cache = createServerStatusCache({ statusCacheMs: 15000 }, {
+    collectStatus: async () => {
+      collections += 1;
+      await gate;
+      return { operation: "status", stdout: "status", stderr: "", exitCode: 0 };
+    },
+    collectReadiness: async () => ({ operation: "readiness", stdout: "readiness", stderr: "", exitCode: 0 })
+  });
+
+  const both = Promise.all([cache.read("status"), cache.read("status")]);
+  resolveCollect();
+  await both;
+  assert.equal(collections, 1, "two simultaneous Home loads must not spawn two subprocesses");
+});
+
+test("a zero TTL disables caching entirely", async () => {
+  const { cache, collections } = build({ cacheMs: 0 });
+  await cache.read("status");
+  await cache.read("status");
+  assert.equal(collections.status, 2, "cacheMs 0 is the documented escape hatch");
+});
+
+test("an unknown operation throws rather than silently returning nothing", () => {
+  const { cache } = build();
+  assert.throws(() => cache.read("doctor"), /No status cache for operation: doctor/);
+});

--- a/console/web/src/App.activeTab.test.tsx
+++ b/console/web/src/App.activeTab.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, renderHook, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ALL_TABS, loadPersistedTab, persistActiveTab, useActiveTab } from "./App";
+import { ALL_TABS, NAV_TABS, loadPersistedTab, persistActiveTab, useActiveTab } from "./App";
+import { HOME_SUBSYSTEM_ROUTES } from "./features/server/ServerPanels";
 import { LazyTabBoundary } from "./components/common/LazyTabBoundary";
 
 function ChunkFailure(): never {
@@ -99,5 +100,24 @@ describe("useActiveTab", () => {
     fireEvent.click(screen.getByRole("button", { name: "Open Care Package" }));
 
     expect(reload).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Regression guard. Home's subsystem rows navigate the operator somewhere, and
+// ALL_TABS is wider than the sidebar: "Services" and "Storage" render but have
+// no nav entry. Routing to one of those drops the operator on a panel with
+// nothing highlighted and no way back, which is how it shipped once already.
+describe("Home subsystem routes stay reachable from the sidebar", () => {
+  it("targets only tabs the sidebar lists", () => {
+    const unreachable = Object.entries(HOME_SUBSYSTEM_ROUTES)
+      .filter(([, tab]) => !NAV_TABS.includes(tab))
+      .map(([label, tab]) => `${label} -> ${tab}`);
+    expect(unreachable).toEqual([]);
+  });
+
+  it("knows NAV_TABS is genuinely narrower than ALL_TABS, so the check has teeth", () => {
+    const hidden = ALL_TABS.filter((tab) => !NAV_TABS.includes(tab));
+    expect(hidden.length).toBeGreaterThan(0);
+    expect(hidden).toContain("Services");
   });
 });

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -40,7 +40,10 @@ import { useStaleBuildWatcher } from "./lib/staleBuildWatcher";
 // a persisted tab (see loadPersistedTab below) can validate against the real,
 // current list at runtime instead of a hand-duplicated copy that could drift.
 export const ALL_TABS = ["Home", "Server Control", "Services", "Players", "Guilds", "Bases", "Vehicles", "Exchange", "Landsraad", "Admin Tools", "Live Map", "Maps", "Care Package", "Addons", "Database", "Storage", "Backups", "Logs", "Updates", "Settings"] as const;
-type Tab = typeof ALL_TABS[number];
+// Exported so a panel routing to another tab types its destination against the
+// real list rather than `string`. Type-only, so a panel importing it back does
+// not create a runtime cycle.
+export type Tab = typeof ALL_TABS[number];
 const ACTIVE_TAB_STORAGE_KEY = "dune-console:active-tab";
 
 // Persisted in sessionStorage, not localStorage: it should survive the
@@ -809,7 +812,7 @@ export function App() {
         </header>
         {error && <div className="error-banner">{error}</div>}
         {redeploySetupOpen && <SetupWizard initialStep={setupJump.step} jumpNonce={setupJump.nonce} mode="redeploy" onSetupComplete={async () => setSetupState(await setupApi.state())} />}
-        {!redeploySetupOpen && tab === "Home" && <HomePanel status={status} readiness={readiness} taskResult={homeTaskResult} setTaskResult={setHomeTaskResult} funcomTokenResult={funcomTokenResult} setFuncomTokenResult={setFuncomTokenResult} runningAction={homeRunningAction} restartStartObserved={homeRestartStarted} setRunningAction={setHomeRunningAction} onLoad={loadStackStatus} confirmAction={confirmDialog} restartGate={restartGateChoice} />}
+        {!redeploySetupOpen && tab === "Home" && <HomePanel status={status} readiness={readiness} taskResult={homeTaskResult} setTaskResult={setHomeTaskResult} funcomTokenResult={funcomTokenResult} setFuncomTokenResult={setFuncomTokenResult} runningAction={homeRunningAction} restartStartObserved={homeRestartStarted} setRunningAction={setHomeRunningAction} onLoad={loadStackStatus} confirmAction={confirmDialog} restartGate={restartGateChoice} onNavigate={(nextTab) => { setRedeploySetupOpen(false); setSelectedPinnedAddonId(""); setTab(nextTab); }} />}
         {!redeploySetupOpen && tab === "Server Control" && <ServerPanel setTask={setTask} setStatus={setStatus} status={status} setReadiness={setReadiness} setPorts={setPorts} setDoctor={setDoctor} ports={ports} readiness={readiness} doctor={doctor} taskResult={homeTaskResult} setTaskResult={setHomeTaskResult} funcomTokenResult={funcomTokenResult} setFuncomTokenResult={setFuncomTokenResult} runningAction={homeRunningAction} restartStartObserved={homeRestartStarted} setRunningAction={setHomeRunningAction} onError={setError} confirmAction={confirmDialog} restartGate={restartGateChoice} onRedeploy={() => {
           setSetupJump((current) => ({ step: 0, nonce: current.nonce + 1 }));
           setSelectedPinnedAddonId("");

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -382,6 +382,10 @@ export function App() {
   const [funcomTokenResult, setFuncomTokenResult] = useState<HomeTaskResult | null>(() => loadPersistedFuncomTokenResult());
   const [homeRunningAction, setHomeRunningAction] = useState<"start" | "stop" | "restart" | "">("");
   const [homeRestartStarted, setHomeRestartStarted] = useState(false);
+  // Lives here, not in HomePanel: status/readiness already survive a tab
+  // switch, and component state would reset the age to zero on every remount --
+  // which is what made every visit to Home flash "Updated 0s ago".
+  const [homeSampledAtMs, setHomeSampledAtMs] = useState(0);
   const [stackVersionStatus, setStackVersionStatus] = useState<Record<string, string>>({ status: "Checking", current: "", latest: "" });
   const stackActionStartedAt = useRef(0);
   const stackActionReadyPolls = useRef(0);
@@ -558,23 +562,31 @@ export function App() {
     try { await action(); } catch (err) { setError(err instanceof Error ? err.message : String(err)); }
   }
 
-  const loadStackStatus = useCallback(async () => {
+  // `fresh` is forwarded to the API to bypass its status cache. The in-flight
+  // dedupe below is deliberately not keyed on it: a cached read already in
+  // flight is fine to share, and the restart lifecycle re-polls on its own
+  // interval anyway.
+  const loadStackStatus = useCallback(async (options: { fresh?: boolean } = {}) => {
     if (stackStatusLoadRef.current) return stackStatusLoadRef.current;
     stackStatusLoadRef.current = (async () => {
       setError("");
       const [nextStatus, nextReadiness] = await Promise.allSettled([
-        withTimeout(serverApi.status(), 90000, "Server status check timed out."),
-        withTimeout(serverApi.readiness(), 90000, "Readiness check timed out.")
+        withTimeout(serverApi.status({ fresh: options.fresh }), 90000, "Server status check timed out."),
+        withTimeout(serverApi.readiness({ fresh: options.fresh }), 90000, "Readiness check timed out.")
       ]);
-      const result: HomeLoadResult = { statusLoaded: false, readinessLoaded: false, statusError: "", readinessError: "", statusText: "", readinessText: "" };
+      const result: HomeLoadResult = { statusLoaded: false, readinessLoaded: false, statusError: "", readinessError: "", statusText: "", readinessText: "", sampledAtMs: 0 };
       if (nextStatus.status === "fulfilled") {
         setStatus(nextStatus.value.stdout);
         result.statusText = nextStatus.value.stdout;
         result.statusLoaded = true;
+        // The server stamps when the command actually ran. Fall back to now for
+        // an older API that does not send it, so the age is never negative.
+        result.sampledAtMs = Date.parse(nextStatus.value.sampledAt || "") || Date.now();
       } else {
         result.statusError = nextStatus.reason instanceof Error ? nextStatus.reason.message : String(nextStatus.reason);
       }
       if (nextReadiness.status === "fulfilled") {
+        if (!result.sampledAtMs) result.sampledAtMs = Date.parse(nextReadiness.value.sampledAt || "") || Date.now();
         const readinessText = nextReadiness.value.stdout || nextReadiness.value.stderr || "";
         result.readinessText = readinessText;
         setReadiness(readinessText);
@@ -812,7 +824,7 @@ export function App() {
         </header>
         {error && <div className="error-banner">{error}</div>}
         {redeploySetupOpen && <SetupWizard initialStep={setupJump.step} jumpNonce={setupJump.nonce} mode="redeploy" onSetupComplete={async () => setSetupState(await setupApi.state())} />}
-        {!redeploySetupOpen && tab === "Home" && <HomePanel status={status} readiness={readiness} taskResult={homeTaskResult} setTaskResult={setHomeTaskResult} funcomTokenResult={funcomTokenResult} setFuncomTokenResult={setFuncomTokenResult} runningAction={homeRunningAction} restartStartObserved={homeRestartStarted} setRunningAction={setHomeRunningAction} onLoad={loadStackStatus} confirmAction={confirmDialog} restartGate={restartGateChoice} onNavigate={(nextTab) => { setRedeploySetupOpen(false); setSelectedPinnedAddonId(""); setTab(nextTab); }} />}
+        {!redeploySetupOpen && tab === "Home" && <HomePanel status={status} readiness={readiness} taskResult={homeTaskResult} setTaskResult={setHomeTaskResult} funcomTokenResult={funcomTokenResult} setFuncomTokenResult={setFuncomTokenResult} runningAction={homeRunningAction} restartStartObserved={homeRestartStarted} setRunningAction={setHomeRunningAction} onLoad={loadStackStatus} confirmAction={confirmDialog} restartGate={restartGateChoice} sampledAtMs={homeSampledAtMs} setSampledAtMs={setHomeSampledAtMs} onNavigate={(nextTab) => { setRedeploySetupOpen(false); setSelectedPinnedAddonId(""); setTab(nextTab); }} />}
         {!redeploySetupOpen && tab === "Server Control" && <ServerPanel setTask={setTask} setStatus={setStatus} status={status} setReadiness={setReadiness} setPorts={setPorts} setDoctor={setDoctor} ports={ports} readiness={readiness} doctor={doctor} taskResult={homeTaskResult} setTaskResult={setHomeTaskResult} funcomTokenResult={funcomTokenResult} setFuncomTokenResult={setFuncomTokenResult} runningAction={homeRunningAction} restartStartObserved={homeRestartStarted} setRunningAction={setHomeRunningAction} onError={setError} confirmAction={confirmDialog} restartGate={restartGateChoice} onRedeploy={() => {
           setSetupJump((current) => ({ step: 0, nonce: current.nonce + 1 }));
           setSelectedPinnedAddonId("");

--- a/console/web/src/App.tsx
+++ b/console/web/src/App.tsx
@@ -305,6 +305,12 @@ const navGroups: { title: string; items: { tab: Tab; icon: React.ReactNode }[] }
   }
 ];
 
+// The tabs the sidebar actually lists. ALL_TABS is wider: "Services" and
+// "Storage" exist and render but have no nav entry, so anything that routes the
+// operator somewhere must check against this, not ALL_TABS -- landing on a tab
+// with no highlighted nav item and no way back reads as a broken jump.
+export const NAV_TABS: readonly Tab[] = navGroups.flatMap((group) => group.items.map((item) => item.tab));
+
 const COMMUNITY_CONTRIBUTORS_URL = "https://github.com/Red-Blink/dune-awakening-selfhost-docker/graphs/contributors";
 const DUNE_DOCKER_WEBSITE_URL = "https://dunedocker.app/";
 const DUNE_DOCKER_DOCS_URL = "https://docs.dunedocker.app/";

--- a/console/web/src/api/server.ts
+++ b/console/web/src/api/server.ts
@@ -80,10 +80,21 @@ function immediateQuery(immediate?: boolean) {
   return immediate ? "?restartQueue=immediate" : "";
 }
 
+// sampledAt is when the command actually ran, which is what Home dates its
+// freshness line from -- a cache hit must not claim to be current.
+export type StatusRead = { stdout: string; stderr?: string; exitCode?: number; sampledAt?: string; fromCache?: boolean };
+
+function freshQuery(fresh?: boolean) {
+  return fresh ? "?fresh=1" : "";
+}
+
 export const serverApi = {
-  status: () => api<{ stdout: string }>("/api/server/status"),
+  // `fresh` bypasses the API's ~15s status cache. Required whenever the answer
+  // drives the restart lifecycle: a cached pre-restart snapshot would let
+  // isHomeActionComplete call a restart finished before it had started.
+  status: (opts?: { fresh?: boolean }) => api<StatusRead>(`/api/server/status${freshQuery(opts?.fresh)}`),
   performance: () => api<PerformanceSnapshot>("/api/server/performance"),
-  readiness: () => api<{ stdout: string; stderr?: string; exitCode?: number }>("/api/server/readiness"),
+  readiness: (opts?: { fresh?: boolean }) => api<StatusRead>(`/api/server/readiness${freshQuery(opts?.fresh)}`),
   ports: () => api<{ stdout: string }>("/api/server/ports"),
   services: () => api<{ stdout: string }>("/api/server/services"),
   doctor: () => api<{ stdout: string; stderr?: string; exitCode?: number }>("/api/server/doctor"),

--- a/console/web/src/features/server/ServerPanels.homeCards.test.tsx
+++ b/console/web/src/features/server/ServerPanels.homeCards.test.tsx
@@ -473,22 +473,14 @@ describe("HomePanel subsystem rows", () => {
       const node = Array.from(container.querySelectorAll(".home-subsystem-label")).find((item) => item.textContent === label);
       return node?.closest("button") as HTMLButtonElement;
     };
-    rowFor("Database").click();
-    expect(onNavigate).toHaveBeenCalledWith("Database");
-    // Containers, Game Servers and RabbitMQ used to route to "Services", which
-    // renders but has no sidebar entry -- the operator landed on a panel with
-    // no nav item highlighted and no way back. Server Control carries the
-    // readiness timeline, port checklist and doctor output for all of them.
-    rowFor("Containers").click();
-    expect(onNavigate).toHaveBeenCalledWith("Server Control");
-    rowFor("Game Servers").click();
-    expect(onNavigate).toHaveBeenCalledWith("Server Control");
-    rowFor("RabbitMQ").click();
-    expect(onNavigate).toHaveBeenCalledWith("Server Control");
-    rowFor("Listeners").click();
-    expect(onNavigate).toHaveBeenCalledWith("Server Control");
-    rowFor("Funcom/FLS").click();
-    expect(onNavigate).toHaveBeenCalledWith("Server Control");
+    // Every row lands on Server Control: these report health, and that is where
+    // health is diagnosed. Database deliberately included -- the Database tab is
+    // for data, not for whether Postgres is up.
+    for (const label of ["Containers", "Listeners", "Database", "Game Servers", "RabbitMQ", "Funcom/FLS"]) {
+      onNavigate.mockClear();
+      rowFor(label).click();
+      expect(onNavigate, `${label} should route to Server Control`).toHaveBeenCalledWith("Server Control");
+    }
   });
 
   it("renders plain rows, not buttons to nowhere, when no navigation is wired", async () => {

--- a/console/web/src/features/server/ServerPanels.homeCards.test.tsx
+++ b/console/web/src/features/server/ServerPanels.homeCards.test.tsx
@@ -634,6 +634,20 @@ describe("HomePanel when the battlegroup is stopped", () => {
     expect(badges.every((b) => b.className.includes("badge-fail"))).toBe(true);
   });
 
+  // Population is unknowable while the battlegroup is down, so reporting it as
+  // "population unavailable" in amber flagged an expected consequence as if it
+  // were a problem.
+  it("says nothing about population, rather than warning it is unavailable", async () => {
+    const { container } = renderStopped();
+    await waitFor(() => expect(container.querySelector(".home-hero-identity")).toBeTruthy());
+    const line = container.querySelector(".home-hero-identity")?.textContent || "";
+    expect(line).not.toMatch(/population/i);
+    expect(line).not.toMatch(/online/i);
+    expect(container.querySelector(".home-population-warn")).toBeNull();
+    // The rest of the identity line survives -- this drops one segment, not the line.
+    expect(line).toContain("Kovalt");
+  });
+
   it("carries the same severity in the heading dot", async () => {
     const { container } = renderStopped();
     await waitFor(() => expect(container.querySelector(".home-state-dot")).toBeTruthy());

--- a/console/web/src/features/server/ServerPanels.homeCards.test.tsx
+++ b/console/web/src/features/server/ServerPanels.homeCards.test.tsx
@@ -1,0 +1,515 @@
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HomePanel,
+  formatFreshness,
+  homeNeedsWarmRefresh,
+  homeOverallBadge,
+  homeOverallHeading,
+  homeStateDotTone,
+  isHomeActionComplete,
+  performanceCardStatus,
+  performanceTrackTone,
+  type HomeLoadResult
+} from "./ServerPanels";
+import { normalizeStatus } from "../../lib/display";
+
+// The panel polls performance every 3s and the Funcom token every 10s on mount.
+// Neither is what these tests are about, so both are stubbed; `performance`
+// is re-pointed per test to drive the utilisation thresholds.
+const performanceMock = vi.fn();
+const checkFuncomTokenMock = vi.fn();
+
+vi.mock("../../api/server", () => ({
+  serverApi: {
+    performance: () => performanceMock(),
+    checkFuncomToken: (since: string) => checkFuncomTokenMock(since),
+    start: vi.fn(),
+    stop: vi.fn(),
+    restart: vi.fn(),
+    status: vi.fn(),
+    readiness: vi.fn(),
+    restartQueue: vi.fn()
+  }
+}));
+
+// The pending-queue hooks each hit their own endpoint on mount; the refill note
+// they feed is not under test here.
+vi.mock("../../lib/usePendingRefills", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../lib/usePendingRefills")>();
+  return {
+    ...actual,
+    usePendingQueues: () => ({
+      fuel: { pending: null },
+      water: { pending: null },
+      deletes: { pending: null },
+      vehicleDeletes: { pending: null },
+      permissions: { pending: null }
+    })
+  };
+});
+
+const STATUS_TEXT = [
+  "Title: Kovalt",
+  "Region: EU",
+  "Mode: public",
+  "Server IP: 10.0.0.4",
+  "Battlegroup: bg-12345",
+  "Population: 14"
+].join("\n");
+
+function snapshot(cpu: number | null, memoryPercent: number | null, diskPercent: number | null) {
+  return {
+    cpuPercent: cpu,
+    memory: { usedBytes: 8e9, totalBytes: 16e9, availableBytes: 8e9, percent: memoryPercent },
+    disk: { usedBytes: 4e11, totalBytes: 5e11, freeBytes: 1e11, percent: diskPercent },
+    uptimeSeconds: 561600,
+    uptime: "6d 12h 00m",
+    sampledAt: new Date(0).toISOString()
+  };
+}
+
+function loadResult(overrides: Partial<HomeLoadResult> = {}): HomeLoadResult {
+  return {
+    statusLoaded: true,
+    readinessLoaded: true,
+    statusError: "",
+    readinessError: "",
+    statusText: STATUS_TEXT,
+    readinessText: "READY: all checks passed",
+    ...overrides
+  };
+}
+
+function renderHome(props: Partial<Parameters<typeof HomePanel>[0]> = {}) {
+  const onLoad = props.onLoad || vi.fn().mockResolvedValue(loadResult());
+  return {
+    onLoad,
+    ...render(<HomePanel
+      status={STATUS_TEXT}
+      readiness="READY: all checks passed"
+      taskResult={null}
+      setTaskResult={vi.fn()}
+      funcomTokenResult={null}
+      setFuncomTokenResult={vi.fn()}
+      runningAction=""
+      restartStartObserved={false}
+      setRunningAction={vi.fn()}
+      onLoad={onLoad}
+      confirmAction={vi.fn().mockResolvedValue(true)}
+      restartGate={vi.fn()}
+      {...props}
+    />)
+  };
+}
+
+// Find the .status-card whose title cell holds this label.
+function card(label: string) {
+  const title = screen.getAllByText(label).find((node) => node.closest(".status-card-title"));
+  const found = title?.closest(".status-card");
+  if (!found) throw new Error(`no status card for ${label}`);
+  return found as HTMLElement;
+}
+
+beforeEach(() => {
+  performanceMock.mockResolvedValue(snapshot(30, 40, 50));
+  checkFuncomTokenMock.mockResolvedValue({ ok: true, mismatch: false, checkedSince: "10m" });
+  window.localStorage.clear();
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("performanceCardStatus", () => {
+  // Before this the badge was `performance ? "OK" : "INFO"`, so a disk at 96%
+  // showed the same green pill as one at 4% and the band could never report a
+  // problem at all.
+  it("grades a reading against its own value, not merely whether a sample arrived", () => {
+    expect(performanceCardStatus(30, true)).toBe("OK");
+    expect(performanceCardStatus(74.9, true)).toBe("OK");
+    expect(performanceCardStatus(75, true)).toBe("WARN");
+    expect(performanceCardStatus(90, true)).toBe("WARN");
+    expect(performanceCardStatus(90.1, true)).toBe("FAILED");
+    expect(performanceCardStatus(96.7, true)).toBe("FAILED");
+  });
+
+  // The API returns null routinely, not exceptionally -- cpuPercent is null on
+  // the first sample after every API start, because it needs two samples for a
+  // delta. Reporting that as OK is the exact failure this function exists to
+  // prevent, and the card literal used to collapse it to 0 before this guard.
+  it("reports INFO for a missing or nonsensical reading, never OK", () => {
+    expect(performanceCardStatus(30, false)).toBe("INFO");
+    expect(performanceCardStatus(null, true)).toBe("INFO");
+    expect(performanceCardStatus(null, false)).toBe("INFO");
+    expect(performanceCardStatus(Number.NaN, true)).toBe("INFO");
+    expect(performanceCardStatus(-5, true)).toBe("INFO");
+  });
+
+  it("moves the bar tone with the badge so the two cannot disagree", () => {
+    expect(performanceTrackTone(30, true)).toBe("");
+    expect(performanceTrackTone(85, true)).toBe("metric-track-warn");
+    expect(performanceTrackTone(95, true)).toBe("metric-track-fail");
+  });
+});
+
+describe("homeOverallHeading", () => {
+  it("passes ordinary readings through", () => {
+    expect(homeOverallHeading("OK")).toBe("OK");
+    expect(homeOverallHeading("Stopped")).toBe("Stopped");
+    expect(homeOverallHeading("Starting")).toBe("Starting");
+    expect(homeOverallHeading("Needs Review")).toBe("Needs Review");
+    expect(homeOverallHeading(undefined)).toBe("Unknown");
+  });
+
+  // summarizeHomeStatus yields "Restarting Battlegroup" mid-restart, which
+  // under the "Battlegroup Status:" prefix would say Battlegroup twice.
+  it("drops the redundant word the heading prefix already supplies", () => {
+    expect(homeOverallHeading("Restarting Battlegroup")).toBe("Restarting");
+  });
+});
+
+describe("homeOverallBadge", () => {
+  it("keeps the readings that were already correct", () => {
+    expect(normalizeStatus(homeOverallBadge("OK"))).toBe("pass");
+    expect(normalizeStatus(homeOverallBadge("Stopped"))).toBe("warn");
+    expect(normalizeStatus(homeOverallBadge("Starting"))).toBe("warn");
+    expect(normalizeStatus(homeOverallBadge("Stopping"))).toBe("warn");
+    expect(normalizeStatus(homeOverallBadge("Restarting Battlegroup"))).toBe("warn");
+    expect(normalizeStatus(homeOverallBadge("Unknown"))).toBe("info");
+    expect(normalizeStatus(homeOverallBadge("Checking"))).toBe("info");
+  });
+
+  // "Readiness checked" is only ever the label for a readiness run that did
+  // not pass -- a passing one reads "OK". inferStatus matched the word
+  // "checked" against its pass list, so the dot went green at the exact moment
+  // readiness had failed.
+  it("does not report a failed readiness check as healthy", () => {
+    expect(normalizeStatus(homeOverallBadge("Readiness checked"))).toBe("warn");
+  });
+
+  // Previously fell through to Info, the same neutral grey as "Unknown", so a
+  // flagged subsystem looked identical to nothing being known yet.
+  it("distinguishes a flagged subsystem from an unknown state", () => {
+    expect(normalizeStatus(homeOverallBadge("Needs Review"))).toBe("warn");
+    expect(normalizeStatus(homeOverallBadge("Needs Review"))).not.toBe(normalizeStatus(homeOverallBadge("Unknown")));
+  });
+});
+
+describe("homeStateDotTone", () => {
+  const healthy = [{ status: "Ready" }, { status: "Ready" }];
+  const failed = [{ status: "Ready" }, { status: "FAILED" }];
+
+  it("separates in-motion states from the ones that need a human", () => {
+    // All four of these were the same amber as "Needs Review" before.
+    expect(homeStateDotTone("Starting", healthy)).toBe("motion");
+    expect(homeStateDotTone("Stopping", healthy)).toBe("motion");
+    expect(homeStateDotTone("Restarting Battlegroup", healthy)).toBe("motion");
+    expect(homeStateDotTone("Needs Review", healthy)).toBe("attention");
+    expect(homeStateDotTone("Readiness checked", healthy)).toBe("attention");
+  });
+
+  it("treats a deliberate stop as off, not as a warning", () => {
+    expect(homeStateDotTone("Stopped", healthy)).toBe("off");
+  });
+
+  it("distinguishes having no reading from having a bad one", () => {
+    expect(homeStateDotTone("Checking", healthy)).toBe("loading");
+    expect(homeStateDotTone("Unknown", healthy)).toBe("nodata");
+    expect(homeStateDotTone("Status loaded", healthy)).toBe("nodata");
+    expect(homeStateDotTone("", healthy)).toBe("attention");
+  });
+
+  it("stays green only when nothing is wrong", () => {
+    expect(homeStateDotTone("OK", healthy)).toBe("ok");
+  });
+
+  // summarizeHomeStatus's token-mismatch branch overrides its own ready
+  // override, so "OK" can be reported while Funcom/FLS is FAILED right beside
+  // it. The dot has to reflect the worst thing on screen, not just the word.
+  it("escalates past the heading word when a subsystem has failed", () => {
+    expect(homeStateDotTone("OK", failed)).toBe("failed");
+    expect(homeStateDotTone("Needs Review", failed)).toBe("failed");
+  });
+
+  // A stop or restart takes the subsystems down on purpose; going red there
+  // would cry wolf on an action the operator just triggered.
+  it("does not escalate during an action the operator asked for", () => {
+    expect(homeStateDotTone("Restarting Battlegroup", failed)).toBe("motion");
+    expect(homeStateDotTone("Stopping", failed)).toBe("motion");
+    expect(homeStateDotTone("Stopped", failed)).toBe("off");
+  });
+});
+
+describe("formatFreshness", () => {
+  it("counts seconds, then minutes, then hours", () => {
+    const base = 1_000_000;
+    expect(formatFreshness(base, base + 8_000)).toBe("8s ago");
+    expect(formatFreshness(base, base + 59_000)).toBe("59s ago");
+    expect(formatFreshness(base, base + 61_000)).toBe("1m ago");
+    expect(formatFreshness(base, base + 3_600_000)).toBe("1h 0m ago");
+    expect(formatFreshness(base, base + 5_400_000)).toBe("1h 30m ago");
+  });
+
+  it("renders nothing before the first successful load", () => {
+    expect(formatFreshness(0, 1_000_000)).toBe("");
+  });
+});
+
+describe("HomePanel performance band", () => {
+  it("badges each utilisation card from its own reading", async () => {
+    performanceMock.mockResolvedValue(snapshot(30, 85, 95));
+    renderHome();
+    await waitFor(() => expect(within(card("CPU Usage")).getByText("OK")).toBeTruthy());
+    expect(within(card("Memory")).getByText("WARN")).toBeTruthy();
+    expect(within(card("Disk")).getByText("FAILED")).toBeTruthy();
+  });
+
+  it("tones the meter bar to match", async () => {
+    performanceMock.mockResolvedValue(snapshot(30, 85, 95));
+    renderHome();
+    await waitFor(() => expect(card("Disk").querySelector(".metric-track span")).toBeTruthy());
+    expect(card("CPU Usage").querySelector(".metric-track span")?.className).toBe("");
+    expect(card("Memory").querySelector(".metric-track span")?.className).toBe("metric-track-warn");
+    expect(card("Disk").querySelector(".metric-track span")?.className).toBe("metric-track-fail");
+  });
+
+  it("gives Uptime no badge or bar at all -- it is not a utilisation figure", async () => {
+    renderHome();
+    // Wait for the loaded state specifically: an absent badge is also true before
+    // the snapshot arrives, so waiting on the card merely existing would let this
+    // pass without ever exercising the case where a badge could wrongly appear.
+    await waitFor(() => expect(card("CPU Usage").textContent).toContain("30.0%"));
+    expect(card("Uptime").querySelector(".badge")).toBeNull();
+    expect(card("Uptime").querySelector(".metric-track")).toBeNull();
+  });
+
+  // Regression: the card literal read `performance?.cpuPercent ?? 0`, which
+  // collapsed a null reading to 0 before performanceCardStatus could see it,
+  // so an unmeasured CPU rendered a green OK pill beside the text "Sampling...".
+  it("does not badge an unmeasured metric as OK", async () => {
+    performanceMock.mockResolvedValue(snapshot(null, 40, 50));
+    renderHome();
+    // Wait on a value that ONLY exists once the snapshot has resolved. "Sampling..."
+    // is not one: the CPU card shows it both when the whole snapshot is still null
+    // and when only cpuPercent is, so waiting on it passes on first paint and the
+    // assertions below then race an unloaded panel.
+    await waitFor(() => expect(card("Memory").textContent).toContain("40.0%"));
+    expect(card("CPU Usage").textContent).toContain("Sampling");
+    expect(within(card("CPU Usage")).getByText("INFO")).toBeTruthy();
+    expect(within(card("CPU Usage")).queryByText("OK")).toBeNull();
+    // No bar either -- a 0%-wide track would read as "measured, and idle".
+    expect(card("CPU Usage").querySelector(".metric-track")).toBeNull();
+    // The metrics that did report still grade normally.
+    expect(within(card("Memory")).getByText("OK")).toBeTruthy();
+  });
+});
+
+describe("HomePanel server identity", () => {
+  it("leads with the overall verdict as the hero heading", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-state")).toBeTruthy());
+    expect(container.querySelector(".home-hero-state")?.textContent).toBe("Battlegroup Status:OK");
+    expect(container.querySelector(".home-hero-state-value")?.textContent).toBe("OK");
+    // The label is an h3 so it matches the "Readiness & Health" and
+    // "Performance" section headings by element rather than by restated CSS.
+    const label = container.querySelector(".home-hero-state-label");
+    expect(label?.tagName).toBe("H3");
+    expect(label?.textContent).toBe("Battlegroup Status:");
+  });
+
+  it("summarises the identity values on one line under the state", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-identity")).toBeTruthy());
+    const line = container.querySelector(".home-hero-identity")?.textContent || "";
+    expect(line).toContain("Kovalt");
+    expect(line).toContain("EU");
+    expect(line).toContain("Public");
+    expect(line).toContain("14 online");
+  });
+
+  // The Server Identity band was the only renderer of Population's WARN, so
+  // folding population into the plain summary string dropped the signal that
+  // the count could not be read.
+  it("marks an unreadable player count instead of printing it as fact", async () => {
+    const status = "Title: Kovalt\nPopulation: 14 / ?";
+    const { container } = renderHome({ status, onLoad: vi.fn().mockResolvedValue(loadResult({ statusText: status })) });
+    await waitFor(() => expect(container.querySelector(".home-hero-identity")).toBeTruthy());
+    const warn = container.querySelector(".home-population-warn");
+    expect(warn).not.toBeNull();
+    expect(warn?.textContent).toContain("?");
+  });
+
+  it("leaves a healthy player count unmarked", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-identity")).toBeTruthy());
+    expect(container.querySelector(".home-population-warn")).toBeNull();
+    expect(container.querySelector(".home-hero-identity")?.textContent).toContain("14 online");
+  });
+
+  // The Performance band carries Uptime on its own card; the hero line said it
+  // a second time.
+  it("leaves uptime to the Performance band", async () => {
+    const { container } = renderHome();
+    // The uptime value comes from the performance snapshot, so wait for that --
+    // the identity line renders straight from props and is present before it.
+    await waitFor(() => expect(card("Uptime").textContent).toContain("6d 12h 00m"));
+    expect(container.querySelector(".home-hero-identity")?.textContent).not.toContain("6d 12h 00m");
+  });
+
+  it("carries Server IP and Battlegroup as labelled reference values in the hero", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-meta")).toBeTruthy());
+    const pairs = Array.from(container.querySelectorAll(".home-hero-meta-item")).map((node) => [
+      node.querySelector("dt")?.textContent,
+      node.querySelector("dd")?.textContent
+    ]);
+    expect(pairs).toEqual([["Server IP", "10.0.0.4"], ["Battlegroup", "bg-12345"]]);
+  });
+
+  // These two are now the only place those values appear, so an absent one has
+  // to read "Unknown" rather than silently vanish from the panel.
+  it("still names Server IP and Battlegroup when the status text omits them", async () => {
+    const onLoad = vi.fn().mockResolvedValue(loadResult({ statusText: "Title: Kovalt" }));
+    const { container } = renderHome({ status: "Title: Kovalt", onLoad });
+    await waitFor(() => expect(container.querySelector(".home-hero-meta")).toBeTruthy());
+    const pairs = Array.from(container.querySelectorAll(".home-hero-meta-item")).map((node) => [
+      node.querySelector("dt")?.textContent,
+      node.querySelector("dd")?.textContent
+    ]);
+    expect(pairs).toEqual([["Server IP", "Unknown"], ["Battlegroup", "Unknown"]]);
+  });
+
+  // The Server Identity band repeated Title/Region/Mode/Population, which the
+  // hero summary line already carries. Only the performance cards remain.
+  it("no longer renders a Server Identity band", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-meta")).toBeTruthy());
+    expect(container.querySelector(".home-health")).toBeNull();
+    expect(screen.queryByText("Server Identity")).toBeNull();
+    const cardLabels = Array.from(container.querySelectorAll(".status-card-title > span:not(.badge)")).map((node) => node.textContent);
+    expect(cardLabels).toEqual(["CPU Usage", "Memory", "Disk", "Uptime"]);
+  });
+
+  it("states each identity value exactly once", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-hero-meta")).toBeTruthy());
+    const text = container.textContent || "";
+    for (const value of ["Kovalt", "10.0.0.4", "bg-12345"]) {
+      expect(text.split(value).length - 1).toBe(1);
+    }
+  });
+});
+
+describe("HomePanel subsystem rows", () => {
+  const SUBSYSTEMS = ["Containers", "Listeners", "Database", "Game Servers", "RabbitMQ", "Funcom/FLS"];
+
+  it("lists every readiness subsystem", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelectorAll(".home-subsystem-row").length).toBe(6));
+    const labels = Array.from(container.querySelectorAll(".home-subsystem-label")).map((node) => node.textContent);
+    expect(labels).toEqual(SUBSYSTEMS);
+  });
+
+  it("routes an unhealthy subsystem to the tab that can fix it", async () => {
+    const onNavigate = vi.fn();
+    const { container } = renderHome({ onNavigate });
+    await waitFor(() => expect(container.querySelectorAll(".home-subsystem-button").length).toBe(6));
+    const rowFor = (label: string) => {
+      const node = Array.from(container.querySelectorAll(".home-subsystem-label")).find((item) => item.textContent === label);
+      return node?.closest("button") as HTMLButtonElement;
+    };
+    rowFor("Database").click();
+    expect(onNavigate).toHaveBeenCalledWith("Database");
+    rowFor("Game Servers").click();
+    expect(onNavigate).toHaveBeenCalledWith("Services");
+    // PortChecklist and the Change Funcom Token form both live on Server
+    // Control, not Settings.
+    rowFor("Listeners").click();
+    expect(onNavigate).toHaveBeenCalledWith("Server Control");
+    rowFor("Funcom/FLS").click();
+    expect(onNavigate).toHaveBeenCalledWith("Server Control");
+  });
+
+  it("renders plain rows, not buttons to nowhere, when no navigation is wired", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelectorAll(".home-subsystem-row").length).toBe(6));
+    expect(container.querySelectorAll(".home-subsystem-button").length).toBe(0);
+    expect(container.querySelectorAll(".home-subsystem-static").length).toBe(6);
+  });
+});
+
+describe("HomePanel status freshness", () => {
+  it("dates the values once a load succeeds", async () => {
+    const { container } = renderHome();
+    await waitFor(() => expect(container.querySelector(".home-freshness")).toBeTruthy());
+    expect(container.querySelector(".home-freshness")?.textContent).toMatch(/^Updated \d+s ago$/);
+    expect(container.querySelector(".home-freshness.stale")).toBeNull();
+  });
+
+  // The three polling effects all swallow their errors, so before this a
+  // backend that started failing after the first load left the last-good
+  // values up forever with no cue that they were frozen.
+  it("warns that values may be stale after consecutive failed polls, without blanking them", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const onLoad = vi.fn().mockResolvedValue(loadResult());
+    const { container } = renderHome({ onLoad });
+    await vi.waitFor(() => expect(container.querySelector(".home-freshness")).toBeTruthy());
+
+    onLoad.mockRejectedValue(new Error("connection refused"));
+    // Two ticks of the idle 30s poll -- STALE_POLL_THRESHOLD consecutive misses.
+    for (let i = 0; i < 2; i += 1) {
+      await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
+    }
+
+    await vi.waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeTruthy());
+    expect(container.querySelector(".home-freshness")?.textContent).toMatch(/^Status may be stale/);
+    // The last good values are still on screen -- the point is to date them,
+    // not blank the panel.
+    expect(container.querySelector(".home-hero-identity")?.textContent).toContain("Kovalt");
+    expect(container.querySelector(".home-hero-meta")?.textContent).toContain("10.0.0.4");
+  });
+
+  it("clears the stale warning once a poll succeeds again", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const onLoad = vi.fn().mockResolvedValue(loadResult());
+    const { container } = renderHome({ onLoad });
+    await vi.waitFor(() => expect(container.querySelector(".home-freshness")).toBeTruthy());
+
+    onLoad.mockRejectedValue(new Error("connection refused"));
+    for (let i = 0; i < 2; i += 1) {
+      await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
+    }
+    await vi.waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeTruthy());
+
+    onLoad.mockResolvedValue(loadResult());
+    await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
+    await vi.waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeNull());
+  });
+});
+
+// Regression guard for the constraint that made this refactor safe.
+// summarizeHomeStatus is not only a view model: its health/identity arrays
+// drive the restart lifecycle. Removing the Readiness & Health *band* must not
+// remove the health *entries*. Emptying that array makes the first case here
+// fail, which is exactly the accident this guards.
+describe("summarizeHomeStatus consumers still see identity and health entries", () => {
+  const WARMING_STATUS = ["Overall: WARMING", "Title: Kovalt", "", "Game servers", "Survival_1 WARMING"].join("\n");
+
+  it("treats a READY readiness as a completed action via the health array", () => {
+    // No required-signal lines, so isHomeReadinessOperational is false and the
+    // verdict has to come from summary.health being fully OK.
+    expect(isHomeActionComplete("Title: Kovalt", "READY: all checks passed")).toBe(true);
+  });
+
+  it("still reports an incomplete action when nothing is ready", () => {
+    expect(isHomeActionComplete("", "")).toBe(false);
+  });
+
+  it("reads Overall and Game Servers to pick the warm poll cadence", () => {
+    expect(homeNeedsWarmRefresh(WARMING_STATUS, "")).toBe(true);
+    expect(homeNeedsWarmRefresh("Title: Kovalt", "READY: all checks passed")).toBe(false);
+  });
+});

--- a/console/web/src/features/server/ServerPanels.homeCards.test.tsx
+++ b/console/web/src/features/server/ServerPanels.homeCards.test.tsx
@@ -681,6 +681,17 @@ describe("HomePanel when the battlegroup is stopped", () => {
     expect(container.querySelector(".home-state-dot")?.className).toContain("home-state-dot-failed");
   });
 
+  // The reading is coloured from the same tone as the dot. Asserting they match
+  // rather than naming the class twice: the point is that they cannot disagree.
+  it("colours the reading to match its dot", async () => {
+    const { container } = renderStopped();
+    await waitFor(() => expect(container.querySelector(".home-state-dot")).toBeTruthy());
+    const dot = container.querySelector(".home-state-dot")?.className || "";
+    const value = container.querySelector(".home-hero-state-value")?.className || "";
+    expect(dot).toContain("home-state-dot-failed");
+    expect(value).toContain("home-hero-state-value-failed");
+  });
+
   // The same override fires for a failed start/restart. Claiming "Stopped"
   // there would be a false statement about what happened.
   it("does not claim stopped when an action merely failed", async () => {

--- a/console/web/src/features/server/ServerPanels.homeCards.test.tsx
+++ b/console/web/src/features/server/ServerPanels.homeCards.test.tsx
@@ -8,6 +8,7 @@ import {
   homeOverallBadge,
   homeOverallHeading,
   homeStateDotTone,
+  isPopulationUnknowable,
   isStatusSampleStale,
   STALE_SAMPLE_AGE_MS,
   isHomeActionComplete,
@@ -668,6 +669,31 @@ describe("HomePanel when the battlegroup is stopped", () => {
     const values = Array.from(container.querySelectorAll(".home-subsystem-value")).map((node) => node.textContent);
     expect(values.every((text) => text?.includes("Needs Review"))).toBe(true);
     expect(values.some((text) => text?.includes("Stopped"))).toBe(false);
+  });
+});
+
+// Population is unknowable whenever the battlegroup is not serving -- stopped,
+// or moving to or from stopped. summarizeHomeStatus reports "Unavailable" and
+// flags it WARN in all of them, which put an amber warning beside the server
+// name for an expected condition.
+describe("isPopulationUnknowable", () => {
+  it("covers stopped and every transitional reading", () => {
+    for (const value of ["Stopped", "Starting", "Stopping", "Restarting Battlegroup"]) {
+      expect(isPopulationUnknowable(value), value).toBe(true);
+    }
+  });
+
+  // These leave the battlegroup up and serving, so the count is real.
+  it("leaves a serving battlegroup alone", () => {
+    for (const value of ["OK", "Needs Review", "Warming"]) {
+      expect(isPopulationUnknowable(value), value).toBe(false);
+    }
+  });
+
+  it("matches on the whole word, not a prefix", () => {
+    expect(isPopulationUnknowable("Stoppedish")).toBe(false);
+    expect(isPopulationUnknowable("")).toBe(false);
+    expect(isPopulationUnknowable(undefined)).toBe(false);
   });
 });
 

--- a/console/web/src/features/server/ServerPanels.homeCards.test.tsx
+++ b/console/web/src/features/server/ServerPanels.homeCards.test.tsx
@@ -468,10 +468,16 @@ describe("HomePanel subsystem rows", () => {
     };
     rowFor("Database").click();
     expect(onNavigate).toHaveBeenCalledWith("Database");
+    // Containers, Game Servers and RabbitMQ used to route to "Services", which
+    // renders but has no sidebar entry -- the operator landed on a panel with
+    // no nav item highlighted and no way back. Server Control carries the
+    // readiness timeline, port checklist and doctor output for all of them.
+    rowFor("Containers").click();
+    expect(onNavigate).toHaveBeenCalledWith("Server Control");
     rowFor("Game Servers").click();
-    expect(onNavigate).toHaveBeenCalledWith("Services");
-    // PortChecklist and the Change Funcom Token form both live on Server
-    // Control, not Settings.
+    expect(onNavigate).toHaveBeenCalledWith("Server Control");
+    rowFor("RabbitMQ").click();
+    expect(onNavigate).toHaveBeenCalledWith("Server Control");
     rowFor("Listeners").click();
     expect(onNavigate).toHaveBeenCalledWith("Server Control");
     rowFor("Funcom/FLS").click();

--- a/console/web/src/features/server/ServerPanels.homeCards.test.tsx
+++ b/console/web/src/features/server/ServerPanels.homeCards.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen, waitFor, within } from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   HomePanel,
@@ -7,6 +8,8 @@ import {
   homeOverallBadge,
   homeOverallHeading,
   homeStateDotTone,
+  isStatusSampleStale,
+  STALE_SAMPLE_AGE_MS,
   isHomeActionComplete,
   performanceCardStatus,
   performanceTrackTone,
@@ -77,6 +80,7 @@ function loadResult(overrides: Partial<HomeLoadResult> = {}): HomeLoadResult {
     readinessError: "",
     statusText: STATUS_TEXT,
     readinessText: "READY: all checks passed",
+    sampledAtMs: Date.now(),
     ...overrides
   };
 }
@@ -109,6 +113,47 @@ function card(label: string) {
   const found = title?.closest(".status-card");
   if (!found) throw new Error(`no status card for ${label}`);
   return found as HTMLElement;
+}
+
+// App owns sampledAtMs so it outlives HomePanel unmounting on a tab switch.
+// This mirrors that, which is the only way to exercise the remount behaviour.
+function renderStateful(props: Partial<Parameters<typeof HomePanel>[0]> = {}) {
+  let setLoad: (fn: Parameters<typeof HomePanel>[0]["onLoad"]) => void = () => undefined;
+  let setMounted: (value: boolean) => void = () => undefined;
+
+  function Harness() {
+    const [sampledAtMs, setSampledAtMs] = useState(0);
+    const [mounted, setMountedState] = useState(true);
+    const [load, setLoadState] = useState(() => props.onLoad || vi.fn().mockResolvedValue(loadResult()));
+    setLoad = (fn) => act(() => setLoadState(() => fn));
+    setMounted = (value) => act(() => setMountedState(value));
+    if (!mounted) return <div />;
+    return <HomePanel
+      status={STATUS_TEXT}
+      readiness="READY: all checks passed"
+      taskResult={null}
+      setTaskResult={vi.fn()}
+      funcomTokenResult={null}
+      setFuncomTokenResult={vi.fn()}
+      runningAction=""
+      restartStartObserved={false}
+      setRunningAction={vi.fn()}
+      confirmAction={vi.fn().mockResolvedValue(true)}
+      restartGate={vi.fn()}
+      {...props}
+      onLoad={load}
+      sampledAtMs={sampledAtMs}
+      setSampledAtMs={setSampledAtMs}
+    />;
+  }
+
+  const view = render(<Harness />);
+  return {
+    ...view,
+    leaveHome: () => setMounted(false),
+    enterHome: () => setMounted(true),
+    rerenderWithLoad: (fn: Parameters<typeof HomePanel>[0]["onLoad"]) => setLoad(fn)
+  };
 }
 
 beforeEach(() => {
@@ -442,51 +487,118 @@ describe("HomePanel subsystem rows", () => {
 });
 
 describe("HomePanel status freshness", () => {
-  it("dates the values once a load succeeds", async () => {
-    const { container } = renderHome();
+  it("dates the values from the sample once a load succeeds", async () => {
+    const { container } = renderStateful();
     await waitFor(() => expect(container.querySelector(".home-freshness")).toBeTruthy());
     expect(container.querySelector(".home-freshness")?.textContent).toMatch(/^Updated \d+s ago$/);
     expect(container.querySelector(".home-freshness.stale")).toBeNull();
   });
 
-  // The three polling effects all swallow their errors, so before this a
-  // backend that started failing after the first load left the last-good
-  // values up forever with no cue that they were frozen.
-  it("warns that values may be stale after consecutive failed polls, without blanking them", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-    const onLoad = vi.fn().mockResolvedValue(loadResult());
-    const { container } = renderHome({ onLoad });
-    await vi.waitFor(() => expect(container.querySelector(".home-freshness")).toBeTruthy());
+  // The API caches status for ~15s, so a cache hit carries an older sampledAt.
+  // Dating the fetch instead would make a 12s-old snapshot claim to be current.
+  it("reports the age of the sample, not of the fetch", async () => {
+    const sampledAtMs = Date.now() - 12_000;
+    const { container } = renderStateful({ onLoad: vi.fn().mockResolvedValue(loadResult({ sampledAtMs })) });
+    await waitFor(() => expect(container.querySelector(".home-freshness")).toBeTruthy());
+    expect(container.querySelector(".home-freshness")?.textContent).toMatch(/^Updated 1[12] s? ?ago$|^Updated 12s ago$/);
+  });
 
-    onLoad.mockRejectedValue(new Error("connection refused"));
-    // Two ticks of the idle 30s poll -- STALE_POLL_THRESHOLD consecutive misses.
-    for (let i = 0; i < 2; i += 1) {
-      await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
-    }
-
-    await vi.waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeTruthy());
+  // No failed poll anywhere in this test: age alone is the signal now, which is
+  // what makes it survive a remount and a hidden tab.
+  it("warns on a sample older than the threshold with no failed poll", async () => {
+    const sampledAtMs = Date.now() - (STALE_SAMPLE_AGE_MS + 5_000);
+    const { container } = renderStateful({ onLoad: vi.fn().mockResolvedValue(loadResult({ sampledAtMs })) });
+    await waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeTruthy());
     expect(container.querySelector(".home-freshness")?.textContent).toMatch(/^Status may be stale/);
-    // The last good values are still on screen -- the point is to date them,
-    // not blank the panel.
+    // The last good values stay on screen -- the point is to date them, not
+    // blank the panel.
     expect(container.querySelector(".home-hero-identity")?.textContent).toContain("Kovalt");
     expect(container.querySelector(".home-hero-meta")?.textContent).toContain("10.0.0.4");
   });
 
-  it("clears the stale warning once a poll succeeds again", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
+  // The assertion that actually pins the fix: with the old component-state
+  // counter both the age and the warning reset to zero on every remount, so
+  // leaving Home during an outage and coming back hid the problem.
+  it("keeps the age and the warning across leaving Home and coming back", async () => {
+    const sampledAtMs = Date.now() - (STALE_SAMPLE_AGE_MS + 5_000);
+    const onLoad = vi.fn().mockResolvedValue(loadResult({ sampledAtMs }));
+    const view = renderStateful({ onLoad });
+    await waitFor(() => expect(view.container.querySelector(".home-freshness.stale")).toBeTruthy());
+
+    view.leaveHome();
+    expect(view.container.querySelector(".home-freshness")).toBeNull();
+
+    view.enterHome();
+    // Present immediately on return, before any new load resolves.
+    expect(view.container.querySelector(".home-freshness.stale")).toBeTruthy();
+    expect(view.container.querySelector(".home-freshness")?.textContent).toMatch(/^Status may be stale/);
+  });
+
+  it("clears the warning once a fresh sample arrives", async () => {
+    const stale = Date.now() - (STALE_SAMPLE_AGE_MS + 5_000);
+    const onLoad = vi.fn().mockResolvedValue(loadResult({ sampledAtMs: stale }));
+    const { container, rerenderWithLoad } = renderStateful({ onLoad });
+    await waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeTruthy());
+
+    // Swapping the prop alone changes nothing -- the mount effect has already
+    // run. Clear it the way an operator would, via Refresh Status.
+    rerenderWithLoad(vi.fn().mockResolvedValue(loadResult({ sampledAtMs: Date.now() })));
+    screen.getByRole("button", { name: /Refresh Status/i }).click();
+
+    await waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeNull());
+    expect(container.querySelector(".home-freshness")?.textContent).toMatch(/^Updated /);
+  });
+});
+
+// The API caches status/readiness for ~15s. Anything driving the restart
+// lifecycle must bypass that cache, or isHomeActionComplete can be handed a
+// pre-restart snapshot; anything merely displaying it should not.
+describe("HomePanel cache bypass", () => {
+  const freshFlags = (onLoad: ReturnType<typeof vi.fn>) =>
+    onLoad.mock.calls.map(([opts]) => Boolean(opts?.fresh));
+
+  it("accepts a cached read on mount -- the visit that used to cost ~4s", async () => {
     const onLoad = vi.fn().mockResolvedValue(loadResult());
-    const { container } = renderHome({ onLoad });
-    await vi.waitFor(() => expect(container.querySelector(".home-freshness")).toBeTruthy());
+    renderHome({ onLoad });
+    await waitFor(() => expect(onLoad).toHaveBeenCalled());
+    expect(freshFlags(onLoad)).toEqual([false]);
+  });
 
-    onLoad.mockRejectedValue(new Error("connection refused"));
-    for (let i = 0; i < 2; i += 1) {
-      await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
-    }
-    await vi.waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeTruthy());
+  it("forces a fresh read when the operator asks for one", async () => {
+    const onLoad = vi.fn().mockResolvedValue(loadResult());
+    renderHome({ onLoad });
+    await waitFor(() => expect(onLoad).toHaveBeenCalled());
+    onLoad.mockClear();
 
-    onLoad.mockResolvedValue(loadResult());
-    await act(async () => { await vi.advanceTimersByTimeAsync(30000); });
-    await vi.waitFor(() => expect(container.querySelector(".home-freshness.stale")).toBeNull());
+    screen.getByRole("button", { name: /Refresh Status/i }).click();
+    await waitFor(() => expect(onLoad).toHaveBeenCalled());
+    expect(freshFlags(onLoad).every(Boolean)).toBe(true);
+  });
+
+  it("forces fresh reads while the battlegroup is warming", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const warming = ["Overall: WARMING", "Title: Kovalt", "", "Game servers", "Survival_1 WARMING"].join("\n");
+    const onLoad = vi.fn().mockResolvedValue(loadResult({ statusText: warming, readinessText: "", readinessLoaded: false }));
+    renderHome({ onLoad, status: warming, readiness: "" });
+    await vi.waitFor(() => expect(onLoad).toHaveBeenCalled());
+    onLoad.mockClear();
+
+    // One tick of the 5s warm poll.
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
+    expect(onLoad).toHaveBeenCalled();
+    expect(freshFlags(onLoad).every(Boolean)).toBe(true);
+  });
+});
+
+describe("isStatusSampleStale", () => {
+  const now = 1_000_000_000;
+  it("is not stale inside the window and stale outside it", () => {
+    expect(isStatusSampleStale(now - (STALE_SAMPLE_AGE_MS - 1), now)).toBe(false);
+    expect(isStatusSampleStale(now - (STALE_SAMPLE_AGE_MS + 1), now)).toBe(true);
+  });
+
+  it("treats a never-sampled panel as not stale rather than alarming on first paint", () => {
+    expect(isStatusSampleStale(0, now)).toBe(false);
   });
 });
 

--- a/console/web/src/features/server/ServerPanels.homeCards.test.tsx
+++ b/console/web/src/features/server/ServerPanels.homeCards.test.tsx
@@ -203,7 +203,6 @@ describe("performanceCardStatus", () => {
 
 describe("homeOverallHeading", () => {
   it("passes ordinary readings through", () => {
-    expect(homeOverallHeading("OK")).toBe("OK");
     expect(homeOverallHeading("Stopped")).toBe("Stopped");
     expect(homeOverallHeading("Starting")).toBe("Starting");
     expect(homeOverallHeading("Needs Review")).toBe("Needs Review");
@@ -214,6 +213,13 @@ describe("homeOverallHeading", () => {
   // under the "Battlegroup Status:" prefix would say Battlegroup twice.
   it("drops the redundant word the heading prefix already supplies", () => {
     expect(homeOverallHeading("Restarting Battlegroup")).toBe("Restarting");
+  });
+
+  // isHomeActionComplete matches the summary value with /^OK$/, so the rename
+  // has to stay in the render layer. This pins that it is display-only.
+  it("reads a healthy battlegroup as Ready rather than OK", () => {
+    expect(homeOverallHeading("OK")).toBe("Ready");
+    expect(homeOverallHeading("ok")).toBe("Ready");
   });
 });
 
@@ -363,9 +369,9 @@ describe("HomePanel server identity", () => {
     const { container } = renderHome();
     await waitFor(() => expect(container.querySelector(".home-hero-state")).toBeTruthy());
     // With a space: the dot between label and reading is an empty element, so
-    // without one this reads "Battlegroup Status:OK" to a screen reader.
-    expect(container.querySelector(".home-hero-state")?.textContent).toBe("Battlegroup Status: OK");
-    expect(container.querySelector(".home-hero-state-value")?.textContent).toBe("OK");
+    // without one this reads "Battlegroup Status:Ready" to a screen reader.
+    expect(container.querySelector(".home-hero-state")?.textContent).toBe("Battlegroup Status: Ready");
+    expect(container.querySelector(".home-hero-state-value")?.textContent).toBe("Ready");
     // The label is an h3 so it matches the "Readiness & Health" and
     // "Performance" section headings by element rather than by restated CSS.
     const label = container.querySelector(".home-hero-state-label");
@@ -654,6 +660,25 @@ describe("HomePanel when the battlegroup is stopped", () => {
     await waitFor(() => expect(container.querySelector(".home-state-dot")).toBeTruthy());
     expect(container.querySelector(".home-state-dot")?.className).toContain("home-state-dot-failed");
     expect(container.querySelector(".home-hero-state h3")?.textContent).toBe("Battlegroup Status:");
+  });
+
+  // Reported live: the Stop banner appeared while all six rows stayed "Ready".
+  // status and readiness are separate reads, so status flipped to STOPPED while
+  // readiness was still the previous "READY:", and the readiness all-clear was
+  // winning. Every fixture above passes an empty readiness, which is why none of
+  // them caught it.
+  it("believes an observed stop over a readiness reading left over from before it", async () => {
+    const { container } = renderHome({
+      status: STOPPED_STATUS,
+      readiness: "READY: all checks passed",
+      taskResult: { status: "stopped", title: "Battlegroup Stopped" },
+      onLoad: vi.fn().mockResolvedValue(loadResult({ statusText: STOPPED_STATUS, readinessText: "READY: all checks passed" }))
+    });
+    await waitFor(() => expect(container.querySelectorAll(".home-subsystem-row").length).toBe(6));
+    const values = Array.from(container.querySelectorAll(".home-subsystem-value")).map((node) => node.textContent);
+    expect(values.every((text) => text?.includes("Stopped"))).toBe(true);
+    expect(container.querySelector(".home-hero-state-value")?.textContent).toBe("Stopped");
+    expect(container.querySelector(".home-state-dot")?.className).toContain("home-state-dot-failed");
   });
 
   // The same override fires for a failed start/restart. Claiming "Stopped"

--- a/console/web/src/features/server/ServerPanels.homeCards.test.tsx
+++ b/console/web/src/features/server/ServerPanels.homeCards.test.tsx
@@ -256,8 +256,8 @@ describe("homeStateDotTone", () => {
     expect(homeStateDotTone("Readiness checked", healthy)).toBe("attention");
   });
 
-  it("treats a deliberate stop as off, not as a warning", () => {
-    expect(homeStateDotTone("Stopped", healthy)).toBe("off");
+  it("reports a stopped battlegroup at full severity", () => {
+    expect(homeStateDotTone("Stopped", healthy)).toBe("failed");
   });
 
   it("distinguishes having no reading from having a bad one", () => {
@@ -281,10 +281,15 @@ describe("homeStateDotTone", () => {
 
   // A stop or restart takes the subsystems down on purpose; going red there
   // would cry wolf on an action the operator just triggered.
-  it("does not escalate during an action the operator asked for", () => {
+  it("does not escalate mid-action, when subsystems are down on purpose", () => {
     expect(homeStateDotTone("Restarting Battlegroup", failed)).toBe("motion");
     expect(homeStateDotTone("Stopping", failed)).toBe("motion");
-    expect(homeStateDotTone("Stopped", failed)).toBe("off");
+  });
+
+  // Stopped is already the top severity, so a failed subsystem cannot make it
+  // worse -- but it must not downgrade it either.
+  it("keeps a stopped battlegroup at failed regardless of subsystem state", () => {
+    expect(homeStateDotTone("Stopped", failed)).toBe("failed");
   });
 });
 
@@ -356,7 +361,9 @@ describe("HomePanel server identity", () => {
   it("leads with the overall verdict as the hero heading", async () => {
     const { container } = renderHome();
     await waitFor(() => expect(container.querySelector(".home-hero-state")).toBeTruthy());
-    expect(container.querySelector(".home-hero-state")?.textContent).toBe("Battlegroup Status:OK");
+    // With a space: the dot between label and reading is an empty element, so
+    // without one this reads "Battlegroup Status:OK" to a screen reader.
+    expect(container.querySelector(".home-hero-state")?.textContent).toBe("Battlegroup Status: OK");
     expect(container.querySelector(".home-hero-state-value")?.textContent).toBe("OK");
     // The label is an h3 so it matches the "Readiness & Health" and
     // "Performance" section headings by element rather than by restated CSS.
@@ -593,6 +600,68 @@ describe("HomePanel cache bypass", () => {
     await act(async () => { await vi.advanceTimersByTimeAsync(5000); });
     expect(onLoad).toHaveBeenCalled();
     expect(freshFlags(onLoad).every(Boolean)).toBe(true);
+  });
+});
+
+// A stopped battlegroup used to report six rows of "Needs Review" -- there is
+// nothing to review, everything is simply off.
+describe("HomePanel when the battlegroup is stopped", () => {
+  const STOPPED_STATUS = [
+    "Overall: STOPPED",
+    "Title: Kovalt",
+    "",
+    "Containers",
+    "dune-postgres missing",
+    "dune-rmq-admin missing",
+    "dune-rmq-game missing",
+    "dune-text-router missing",
+    "dune-director missing",
+    "dune-server-gateway missing",
+    "dune-server-survival-1 missing",
+    "dune-server-overmap missing"
+  ].join("\n");
+
+  const renderStopped = () => renderHome({
+    status: STOPPED_STATUS,
+    readiness: "",
+    onLoad: vi.fn().mockResolvedValue(loadResult({ statusText: STOPPED_STATUS, readinessText: "", readinessLoaded: false }))
+  });
+
+  it("says every subsystem is stopped rather than needing review", async () => {
+    const { container } = renderStopped();
+    await waitFor(() => expect(container.querySelectorAll(".home-subsystem-row").length).toBe(6));
+    const values = Array.from(container.querySelectorAll(".home-subsystem-value")).map((node) => node.textContent);
+    expect(values.every((text) => text?.includes("Stopped"))).toBe(true);
+    expect(values.some((text) => text?.includes("Needs Review"))).toBe(false);
+  });
+
+  it("badges them FAILED, not WARN", async () => {
+    const { container } = renderStopped();
+    await waitFor(() => expect(container.querySelectorAll(".home-subsystem-row .badge").length).toBe(6));
+    const badges = Array.from(container.querySelectorAll(".home-subsystem-row .badge"));
+    expect(badges.every((b) => b.className.includes("badge-fail"))).toBe(true);
+  });
+
+  it("carries the same severity in the heading dot", async () => {
+    const { container } = renderStopped();
+    await waitFor(() => expect(container.querySelector(".home-state-dot")).toBeTruthy());
+    expect(container.querySelector(".home-state-dot")?.className).toContain("home-state-dot-failed");
+    expect(container.querySelector(".home-hero-state h3")?.textContent).toBe("Battlegroup Status:");
+  });
+
+  // The same override fires for a failed start/restart. Claiming "Stopped"
+  // there would be a false statement about what happened.
+  it("does not claim stopped when an action merely failed", async () => {
+    const { container } = renderHome({
+      status: "Title: Kovalt",
+      readiness: "",
+      taskResult: { status: "failed", title: "Battlegroup Start Failed" },
+      onLoad: vi.fn().mockResolvedValue(loadResult({ statusText: "Title: Kovalt", readinessText: "", readinessLoaded: false }))
+    });
+    await waitFor(() => expect(container.querySelectorAll(".home-subsystem-row").length).toBe(6));
+    const values = Array.from(container.querySelectorAll(".home-subsystem-value")).map((node) => node.textContent);
+    expect(values.every((text) => text?.includes("Needs Review"))).toBe(true);
+    expect(values.some((text) => text?.includes("Stopped"))).toBe(false);
   });
 });
 

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -578,9 +578,12 @@ export function homeStateDotTone(overallValue: unknown, health: { status: string
 
 // summarizeHomeStatus yields "Restarting Battlegroup", which under the
 // "Battlegroup Status:" prefix would say Battlegroup twice. Trimmed here, not in
-// the summary -- that value is shared with homeNeedsWarmRefresh.
+// the summary -- that value is shared with homeNeedsWarmRefresh and with
+// isHomeActionComplete, which matches /^OK$/ to detect a finished restart. So
+// "OK" is renamed for display only, never in the summary.
 export function homeOverallHeading(value: unknown) {
   const text = formatDisplayValue(value || "Unknown");
+  if (/^ok$/i.test(text.trim())) return "Ready";
   return text.replace(/\s+battlegroup$/i, "");
 }
 
@@ -1659,7 +1662,6 @@ function summarizeHomeStatus(status: string, readiness: string, readinessWarning
   const rawGames = preferKnownHomeHealth(summarizeGameServers(status), summarizeReadinessGameServers(readiness));
   const rawRabbit = preferKnownHomeHealth(summarizeRabbit(status), summarizeReadinessRabbit(readiness));
   const rawFls = preferKnownHomeHealth(summarizeFls(status), summarizeReadinessFls(readiness));
-  const readyOverride = readinessReady ? { label: "OK", status: "Ready", detail: "" } : null;
   const coreReadyWithReview = !runningAction && isHomeCoreReadyWithReview(status, readiness, rawContainers, rawListeners, rawDatabase, rawGames, rawRabbit, rawFls);
   const isStarting = runningAction === "start" || runningAction === "restart" || restartSuccessAwaitingFreshStatus || (bootStarting && !coreReadyWithReview);
   const restartSuccessObserved = taskResult?.status === "succeeded" && /restart/i.test(taskResult.title || "");
@@ -1668,8 +1670,14 @@ function summarizeHomeStatus(status: string, readiness: string, readinessWarning
     ? restartStartObserved ? "Starting" : "Restarting Battlegroup"
     : runningAction === "stop" ? "Stopping" : isStarting ? "Starting" : "";
   const warmingOverall = /^Warming$/i.test(rawGames.label) ? "Warming" : "";
-  const overall = readinessReady && !runningAction ? "OK" : isStarting ? transitionOverall : runningAction ? transitionOverall : serverState.stopped || actionStopped ? "Stopped" : coreReadyWithReview ? "Needs Review" : warmingOverall || liveOverall;
   const attentionHealth = !isStarting && !restartSuccessAwaitingFreshStatus && (serverState.stopped || actionStopped || actionFailed) ? attentionHomeHealthCards(serverState.stopped || actionStopped ? "stopped" : "failed") : null;
+  // status and readiness are two separate reads, so they can disagree: a stop
+  // updates status to STOPPED while readiness is still the previous "READY:".
+  // Believing readiness there left the heading and all six rows reading Ready
+  // under a "Battlegroup Stopped" banner. A stop we observed, or an Overall:
+  // STOPPED, beats a stale all-clear.
+  const readyOverride = readinessReady && !attentionHealth ? { label: "OK", status: "Ready", detail: "" } : null;
+  const overall = readinessReady && !runningAction && !attentionHealth ? "OK" : isStarting ? transitionOverall : runningAction ? transitionOverall : serverState.stopped || actionStopped ? "Stopped" : coreReadyWithReview ? "Needs Review" : warmingOverall || liveOverall;
   const transitionAction: "start" | "stop" | "restart" | "" = restartStartObserved
     ? "start"
     : runningAction === "restart" ? ""

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
+import type { Tab } from "../../App";
 import { Play, Trash2 } from "lucide-react";
 import { serverApi, type PerformanceSnapshot } from "../../api/server";
 import { runGatedRestart, serviceRestartTarget, type RestartGate } from "./restartQueueGuard";
@@ -8,7 +9,7 @@ import { PortChecklist } from "../../components/PortChecklist";
 import { ReadinessTimeline } from "../../components/ReadinessTimeline";
 import { SecretInput } from "../../components/SecretInput";
 import { KeyValueGrid, StatusPill, TechnicalDetails } from "../../components/common/DisplayPrimitives";
-import { formatDisplayValue, formatUiSentence, friendlyColumnName, stripAnsi, summarizeCommandText, titleCase } from "../../lib/display";
+import { formatDisplayValue, formatUiSentence, friendlyColumnName, normalizeStatus, stripAnsi, summarizeCommandText, titleCase } from "../../lib/display";
 import { friendlyServiceName } from "../../lib/serviceDisplay";
 import { conciseTaskError, funcomTokenMismatchDetected } from "../../lib/taskDisplay";
 import { QueueBadges, queueCountsSummary, queueCountsTotal, type QueueCounts } from "../../components/common/QueueBadges";
@@ -112,7 +113,56 @@ export function isRestartLifecycleReady(action: "start" | "stop" | "restart" | "
   return action !== "restart" || state.startObserved;
 }
 
-export function HomePanel({ status, readiness, taskResult, setTaskResult, funcomTokenResult, setFuncomTokenResult, runningAction, restartStartObserved, setRunningAction, onLoad, confirmAction, restartGate }: {
+// Returned strings are the ones normalizeStatus() maps to
+// badge-pass / badge-warn / badge-fail, so StatusPill needs no change.
+export const PERFORMANCE_WARN_PERCENT = 75;
+export const PERFORMANCE_FAIL_PERCENT = 90;
+
+// `null` is "no reading yet", not "no percentage concept": the API returns null
+// routinely (cpuPercent needs two samples for a delta), and that must read INFO,
+// never OK. Cards with no percentage at all are excluded by the caller.
+export function performanceCardStatus(percent: number | null, sampled: boolean) {
+  if (!sampled || percent === null || !Number.isFinite(percent)) return "INFO";
+  // Nonsense rather than healthy -- must not fall through to OK.
+  if (percent < 0) return "INFO";
+  if (percent > PERFORMANCE_FAIL_PERCENT) return "FAILED";
+  if (percent >= PERFORMANCE_WARN_PERCENT) return "WARN";
+  return "OK";
+}
+
+export function performanceTrackTone(percent: number | null, sampled: boolean) {
+  const status = performanceCardStatus(percent, sampled);
+  if (status === "FAILED") return "metric-track-fail";
+  if (status === "WARN") return "metric-track-warn";
+  return "";
+}
+
+// Keyed on the labels summarizeHomeStatus() emits, so a renamed label loses its
+// route rather than pointing somewhere wrong. Listeners and Funcom/FLS both land
+// on Server Control -- PortChecklist and the Change Funcom Token form live there.
+export const HOME_SUBSYSTEM_ROUTES: Record<string, Tab> = {
+  Containers: "Services",
+  Listeners: "Server Control",
+  Database: "Database",
+  "Game Servers": "Services",
+  RabbitMQ: "Services",
+  "Funcom/FLS": "Server Control"
+};
+
+// Two misses, not one: a single failed poll is routine (console restarting, a
+// request racing a container bounce). Two is ~1 minute on the idle 30s cadence.
+export const STALE_POLL_THRESHOLD = 2;
+
+export function formatFreshness(lastUpdatedAt: number, now: number) {
+  if (!lastUpdatedAt) return "";
+  const seconds = Math.max(0, Math.round((now - lastUpdatedAt) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m ago`;
+}
+
+export function HomePanel({ status, readiness, taskResult, setTaskResult, funcomTokenResult, setFuncomTokenResult, runningAction, restartStartObserved, setRunningAction, onLoad, confirmAction, restartGate, onNavigate }: {
   status: string;
   readiness: string;
   taskResult: HomeTaskResult | null;
@@ -125,6 +175,8 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
   onLoad: () => Promise<HomeLoadResult>;
   confirmAction: ConfirmAction;
   restartGate: RestartGate;
+  // Absent (e.g. in tests) means the subsystem rows render as text, not buttons.
+  onNavigate?: (tab: Tab) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const [localError, setLocalError] = useState("");
@@ -132,6 +184,8 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
   const [performance, setPerformance] = useState<PerformanceSnapshot | null>(null);
   const [performanceError, setPerformanceError] = useState("");
   const [hasLoaded, setHasLoaded] = useState(Boolean(status || readiness));
+  const [lastUpdatedAt, setLastUpdatedAt] = useState(0);
+  const [pollFailures, setPollFailures] = useState(0);
   const homeActionRunId = useRef(0);
   const homeActionStartedAt = useRef(0);
   const homeRestartLifecycle = useRef<RestartLifecycleState>(createRestartLifecycleState());
@@ -147,8 +201,22 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     if (!runningAction) homeActionStartedAt.current = 0;
   }, [runningAction]);
 
+  // The polling effects below swallow their errors, so a backend that starts
+  // failing after the first load would otherwise leave stale values up with no
+  // cue. Called from every refresh path so they all date the data alike.
+  function recordLoadOutcome(loaded: boolean) {
+    if (loaded) {
+      setLastUpdatedAt(Date.now());
+      setPollFailures(0);
+    } else {
+      setPollFailures((count) => count + 1);
+    }
+  }
+
   function applyHomeLoadResult(result: HomeLoadResult) {
-    if (result.statusLoaded || result.readinessLoaded) setHasLoaded(true);
+    const loaded = result.statusLoaded || result.readinessLoaded;
+    if (loaded) setHasLoaded(true);
+    recordLoadOutcome(loaded);
     setReadinessWarning(!result.readinessLoaded && result.readinessError ? result.readinessError : "");
     if (!result.statusLoaded && !result.readinessLoaded && result.statusError) setLocalError(friendlyHomeStatusError(result.statusError));
   }
@@ -164,10 +232,14 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
       if (result.statusLoaded || result.readinessLoaded) {
         applyHomeLoadResult(result);
       } else {
+        recordLoadOutcome(false);
         setLocalError(friendlyHomeStatusError(result.statusError || result.readinessError || "Server status and readiness checks failed."));
       }
     } catch (error) {
-      if (isActive() && refreshRunId.current === runId) setLocalError(friendlyHomeStatusError(error instanceof Error ? error.message : String(error)));
+      if (isActive() && refreshRunId.current === runId) {
+        recordLoadOutcome(false);
+        setLocalError(friendlyHomeStatusError(error instanceof Error ? error.message : String(error)));
+      }
     } finally {
       if (isActive() && refreshRunId.current === runId) setLoading(false);
     }
@@ -295,7 +367,8 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     let active = true;
     const id = window.setInterval(async () => {
       const result = await onLoad().catch(() => null);
-      if (active && result) applyHomeLoadResult(result);
+      if (!active) return;
+      if (result) applyHomeLoadResult(result); else recordLoadOutcome(false);
     }, 5000);
     return () => {
       active = false;
@@ -309,7 +382,8 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     const id = window.setInterval(async () => {
       if (document.hidden) return;
       const result = await onLoad().catch(() => null);
-      if (active && result) applyHomeLoadResult(result);
+      if (!active) return;
+      if (result) applyHomeLoadResult(result); else recordLoadOutcome(false);
     }, 30000);
     return () => {
       active = false;
@@ -322,7 +396,8 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     let active = true;
     const id = window.setInterval(async () => {
       const result = await onLoad().catch(() => null);
-      if (active && result) applyHomeLoadResult(result);
+      if (!active) return;
+      if (result) applyHomeLoadResult(result); else recordLoadOutcome(false);
     }, 1500);
     return () => {
       active = false;
@@ -388,25 +463,177 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     </section>;
   }
 
+  const funcomTokenCheckRunning = funcomTokenResult?.status === "running";
+  const summary = summarizeHomeStatus(status, readiness, readinessWarning, loading, runningAction, taskResult, restartStartObserved, !funcomTokenCheckRunning && (isFuncomTokenAuthFailure(funcomTokenResult) || hasPersistedFuncomTokenAuthFailure()));
+  const overall = summary.identity.find((item) => item.label === "Overall");
+  const identityCards = summary.identity.filter((item) => item.label !== "Overall");
+  const populationItem = identityCards.find((item) => item.label === "Population");
+  const populationWarn = /^warn$/i.test(String(populationItem?.status || ""));
+  const populationSegment = homePopulationSegment(populationItem?.value);
+  const identityLine = homeIdentityLine(identityCards);
+
   return (
     <section className="grid">
-      <article className="hero-panel">
-        <h2>Server Overview</h2>
-        <p>Use this dashboard for setup, service health, logs, backups, updates, and player admin actions.</p>
-        <div className="action-row">
-          <button className={loading ? "refresh-status-button refreshing" : "refresh-status-button"} disabled={refreshDisabled} onClick={() => refresh()}>{loading ? <span className="loading-dots">Refreshing</span> : "Refresh Status"}</button>
-          <button disabled={startDisabled} title={controlsState.running ? "Battlegroup is already running." : ""} onClick={() => runServerAction("start")}><Play size={16} /> Start</button>
-          <button disabled={stopDisabled} onClick={() => runServerAction("stop")}>Stop</button>
-          <button disabled={restartDisabled} onClick={() => runServerAction("restart")}>Restart Battlegroup</button>
+      {/* The h2 is visually hidden but structurally real: deleting the old
+          "Server Overview" heading left the page jumping h1 -> h3, and left
+          this region with no accessible name. The three h3s below it (this
+          hero's status label, Readiness & Health, Performance) are its
+          children, so the level is correct as well as present. */}
+      <article className="hero-panel wide" aria-labelledby="home-hero-heading">
+        <h2 id="home-hero-heading" className="sr-only">Server overview</h2>
+        <div className="home-hero-split">
+          <div className="home-hero-primary">
+            {/* An h3, not a styled span: it is the peer of the "Readiness &
+                Health" and "Performance" headings, so matching them by using
+                the same element guarantees the same size and colour instead of
+                restating their computed value here. The reading sits beside it
+                rather than inside, so the heading text stays just the label. */}
+            <div className="home-hero-state">
+              <h3 className="home-hero-state-label">Battlegroup Status:</h3>
+              <span className={`home-state-dot home-state-dot-${homeStateDotTone(overall?.value, summary.health)}`} aria-hidden="true" />
+              <span className="home-hero-state-value">{homeOverallHeading(overall?.value)}</span>
+            </div>
+            {/* Population is rendered apart from the rest of the line so its
+                WARN can survive: summarizeHomeStatus flags an unreadable count
+                ("14 / ?" or "Unavailable"), and the deleted Server Identity
+                band was the only thing that showed that. Folding it into the
+                plain summary string dropped the signal silently. */}
+            <p className="home-hero-identity">
+              {identityLine || (populationSegment ? "" : "Server details are still loading.")}
+              {populationSegment && <>
+                {identityLine ? " · " : ""}
+                <span className={populationWarn ? "home-population-warn" : undefined}>{populationSegment}</span>
+              </>}
+            </p>
+            <dl className="home-hero-meta">
+              {HOME_HERO_META_LABELS.map((label) => <div className="home-hero-meta-item" key={label}>
+                <dt>{label}</dt>
+                <dd>{formatDisplayValue(identityCards.find((item) => item.label === label)?.value || "Unknown")}</dd>
+              </div>)}
+            </dl>
+            <div className="action-row">
+              <button className={loading ? "refresh-status-button refreshing" : "refresh-status-button"} disabled={refreshDisabled} onClick={() => refresh()}>{loading ? <span className="loading-dots">Refreshing</span> : "Refresh Status"}</button>
+              <button disabled={startDisabled} title={controlsState.running ? "Battlegroup is already running." : ""} onClick={() => runServerAction("start")}><Play size={16} /> Start</button>
+              <button className="danger-button" disabled={stopDisabled} onClick={() => runServerAction("stop")}>Stop</button>
+              <button disabled={restartDisabled} onClick={() => runServerAction("restart")}>Restart Battlegroup</button>
+            </div>
+            <StatusFreshness lastUpdatedAt={lastUpdatedAt} pollFailures={pollFailures} />
+            <PendingRefillNote />
+            {taskResult && <HomeTaskResultCard result={taskResult} />}
+            {localError && <p className="error">{localError}</p>}
+          </div>
+          <HomeSubsystemList items={summary.health} onNavigate={onNavigate} />
         </div>
-        <PendingRefillNote />
-        {taskResult && <HomeTaskResultCard result={taskResult} />}
-        {localError && <p className="error">{localError}</p>}
       </article>
       <PerformanceCards performance={performance} error={performanceError} />
-      <HomeHealthCards status={status} readiness={readiness} readinessWarning={readinessWarning} loading={loading} runningAction={runningAction} restartStartObserved={restartStartObserved} taskResult={taskResult} funcomTokenResult={funcomTokenResult} />
     </section>
   );
+}
+
+export type HomeStateTone = "ok" | "motion" | "off" | "attention" | "failed" | "loading" | "nodata";
+
+// Splits the readings by what the operator should do about them, rather than
+// putting six of the ten on one amber -- a restart in flight and a failed
+// readiness check are not the same problem.
+export function homeStateDotTone(overallValue: unknown, health: { status: string }[] = []): HomeStateTone {
+  const value = String(overallValue || "").trim().toLowerCase();
+  // Self-resolving states win over the escalation below: during a stop or
+  // restart the subsystems are legitimately down, and red would cry wolf.
+  if (/^(starting|stopping|restarting)\b/.test(value)) return "motion";
+  if (value === "checking") return "loading";
+  if (value === "stopped") return "off";
+  if (value === "unknown" || value === "status loaded") return "nodata";
+  // summarizeHomeStatus can report "OK" while Funcom/FLS is FAILED (the
+  // token-mismatch branch overrides its ready override), so the heading word
+  // alone is not the worst thing on screen.
+  if (health.some((item) => normalizeStatus(String(item.status || "")) === "fail")) return "failed";
+  if (value === "ok") return "ok";
+  return "attention";
+}
+
+// summarizeHomeStatus yields "Restarting Battlegroup", which under the
+// "Battlegroup Status:" prefix would say Battlegroup twice. Trimmed here, not in
+// the summary -- that value is shared with homeNeedsWarmRefresh.
+export function homeOverallHeading(value: unknown) {
+  const text = formatDisplayValue(value || "Unknown");
+  return text.replace(/\s+battlegroup$/i, "");
+}
+
+// Shown even when Unknown: with the Server Identity band gone this is the only
+// place they appear, so an absent one must read as absent rather than vanish.
+const HOME_HERO_META_LABELS = ["Server IP", "Battlegroup"];
+
+// Title/Region/Mode only. Unknown entries are dropped -- a line reading
+// "Unknown · Unknown" tells an operator nothing, and the caller supplies a
+// loading sentence when nothing resolves. Population is rendered separately so
+// its warn state survives; uptime belongs to the Performance card.
+function homeIdentityLine(items: { label: string; value: string }[]) {
+  const pick = (label: string) => {
+    const value = String(items.find((item) => item.label === label)?.value || "").trim();
+    return value && !/^(unknown|unavailable)$/i.test(value) ? value : "";
+  };
+  const parts = [pick("Title"), pick("Region"), pick("Mode")].filter(Boolean);
+  return parts.join(" · ");
+}
+
+// formatHomePopulation yields "14", "14 / 40", "14 / ?" or "Unavailable", all of
+// which read as a bare trailing number unlabelled. "Unavailable" is kept rather
+// than dropped: with the warn tone it says the count could not be read.
+function homePopulationSegment(value: unknown) {
+  const text = String(value || "").trim();
+  if (!text || /^unknown$/i.test(text)) return "";
+  if (/^unavailable$/i.test(text)) return "population unavailable";
+  return `${text} online`;
+}
+
+// Owns its 1s tick so the per-second re-render stays here instead of redrawing
+// every card in the panel.
+function StatusFreshness({ lastUpdatedAt, pollFailures }: { lastUpdatedAt: number; pollFailures: number }) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, []);
+  if (!lastUpdatedAt) return null;
+  const stale = pollFailures >= STALE_POLL_THRESHOLD;
+  const ago = formatFreshness(lastUpdatedAt, now);
+  return <p className={stale ? "home-freshness stale" : "home-freshness"}>
+    {stale ? `Status may be stale — last updated ${ago}` : `Updated ${ago}`}
+  </p>;
+}
+
+// A row is a button when the subsystem has somewhere to be dealt with, so a
+// warning routes to the tab that can fix it instead of being a dead end.
+function HomeSubsystemList({ items, onNavigate }: { items: { label: string; value: string; status: string; detail: string }[]; onNavigate?: (tab: Tab) => void }) {
+  return <section className="home-subsystems" aria-label="Readiness and health">
+    <h3>Readiness & Health</h3>
+    <ul className="home-subsystem-list">
+      {items.map((item) => {
+        // hasOwn, not a bare index: a plain object inherits Object.prototype,
+        // so a label of "constructor" would return a truthy non-Tab value and
+        // reach setTab. Fail-closed if labels ever stop being literals.
+        const route = Object.hasOwn(HOME_SUBSYSTEM_ROUTES, item.label) ? HOME_SUBSYSTEM_ROUTES[item.label] : undefined;
+        const body = <>
+          <span className="home-subsystem-label">{item.label}</span>
+          <span className="home-subsystem-value">
+            {/* A healthy row's value is the literal "OK" beside a "Ready"
+                pill saying the same thing twice -- and healthy is the common
+                case. Anything else ("Warming", "Token Mismatch Detected",
+                "3 of 8 up") is the detail the pill cannot carry, so it stays. */}
+            {!/^OK$/i.test(item.value) && <span>{formatDisplayValue(item.value)}</span>}
+            <StatusPill value={item.status} />
+          </span>
+        </>;
+        // No `title`: every producer of a health card emits detail: "", so a
+        // tooltip would advertise a hover affordance that never has content.
+        return <li key={item.label} className="home-subsystem-row">
+          {route && onNavigate
+            ? <button type="button" className="home-subsystem-button" onClick={() => onNavigate(route)} aria-label={`${item.label}: ${item.value}. Open ${route}`}>{body}</button>
+            : <div className="home-subsystem-static">{body}</div>}
+        </li>;
+      })}
+    </ul>
+  </section>;
 }
 
 function PerformanceCards({ performance, error }: { performance: PerformanceSnapshot | null; error: string }) {
@@ -414,25 +641,31 @@ function PerformanceCards({ performance, error }: { performance: PerformanceSnap
     {
       label: "CPU Usage",
       value: performance?.cpuPercent == null ? "Sampling..." : `${performance.cpuPercent.toFixed(1)}%`,
-      percent: performance?.cpuPercent ?? 0,
+      percent: performance?.cpuPercent ?? null,
+      metered: true,
       detail: "Host Processor Load"
     },
     {
       label: "Memory",
       value: performance?.memory.percent == null ? "Unknown" : `${performance.memory.percent.toFixed(1)}%`,
-      percent: performance?.memory.percent ?? 0,
+      percent: performance?.memory.percent ?? null,
+      metered: true,
       detail: performance ? `${formatBytes(performance.memory.usedBytes)} / ${formatBytes(performance.memory.totalBytes)}` : "Waiting for Sample"
     },
     {
       label: "Disk",
       value: performance?.disk.percent == null ? "Unknown" : `${performance.disk.percent.toFixed(1)}%`,
-      percent: performance?.disk.percent ?? 0,
+      percent: performance?.disk.percent ?? null,
+      metered: true,
       detail: performance ? `${formatBytes(performance.disk.usedBytes)} / ${formatBytes(performance.disk.totalBytes)}` : "Waiting for Sample"
     },
     {
       label: "Uptime",
       value: performance?.uptime || "0d 00h 00m",
       percent: null,
+      // Not a utilisation figure, so no badge and no bar -- distinct from a
+      // metered card whose reading has not arrived yet.
+      metered: false,
       detail: "Host Uptime"
     }
   ];
@@ -440,12 +673,15 @@ function PerformanceCards({ performance, error }: { performance: PerformanceSnap
     <h3>Performance</h3>
     {error && !performance && <p className="error">{error}</p>}
     <div className="health-grid health-grid-compact">
-      {cards.map((item) => <article className="status-card performance-card" key={item.label}>
-        <div className="status-card-title"><span>{item.label}</span><StatusPill value={performance ? "OK" : "INFO"} /></div>
-        <strong>{item.value}</strong>
-        <p>{item.detail}</p>
-        {item.percent !== null && <div className="metric-track" aria-hidden="true"><span style={{ width: `${clampPercent(item.percent)}%` }} /></div>}
-      </article>)}
+      {cards.map((item) => {
+        const cardStatus = item.metered ? performanceCardStatus(item.percent, Boolean(performance)) : "";
+        return <article className="status-card performance-card" key={item.label}>
+          <div className="status-card-title"><span>{item.label}</span>{cardStatus && <StatusPill value={cardStatus} />}</div>
+          <strong>{item.value}</strong>
+          <p>{item.detail}</p>
+          {item.metered && item.percent !== null && <div className="metric-track" aria-hidden="true"><span className={performanceTrackTone(item.percent, Boolean(performance))} style={{ width: `${clampPercent(item.percent)}%` }} /></div>}
+        </article>;
+      })}
     </div>
   </section>;
 }
@@ -1226,33 +1462,6 @@ function isValidHourMinuteTime(value: string) {
 
 
 
-function HomeHealthCards({ status, readiness, readinessWarning, loading, runningAction, restartStartObserved, taskResult, funcomTokenResult }: { status: string; readiness: string; readinessWarning: string; loading: boolean; runningAction: "start" | "stop" | "restart" | ""; restartStartObserved: boolean; taskResult: HomeTaskResult | null; funcomTokenResult: HomeTaskResult | null }) {
-  const funcomTokenCheckRunning = funcomTokenResult?.status === "running";
-  const summary = summarizeHomeStatus(status, readiness, readinessWarning, loading, runningAction, taskResult, restartStartObserved, !funcomTokenCheckRunning && (isFuncomTokenAuthFailure(funcomTokenResult) || hasPersistedFuncomTokenAuthFailure()));
-  return <div className="home-health wide">
-    <section className="dashboard-band">
-      <h3>Server Identity</h3>
-      <div className="health-grid">
-        {summary.identity.map((item) => <article className="status-card" key={item.label}>
-          <div className="status-card-title"><span>{item.label}</span><StatusPill value={item.status} /></div>
-          <strong>{formatDisplayValue(item.value)}</strong>
-          {item.detail && <p>{item.detail}</p>}
-        </article>)}
-      </div>
-    </section>
-    <section className="dashboard-band">
-      <h3>Readiness & Health</h3>
-      <div className="health-grid health-grid-compact">
-        {summary.health.map((item) => <article className="status-card" key={item.label}>
-          <div className="status-card-title"><span>{item.label}</span><StatusPill value={item.status} /></div>
-          <strong>{formatDisplayValue(item.value)}</strong>
-          {item.detail && <p>{item.detail}</p>}
-        </article>)}
-      </div>
-    </section>
-  </div>;
-}
-
 function DoctorSummary({ text, readiness, loading, error, onFixBinding, onCleanupImages, onCleanupBuildCache, fixingBinding, cleanupOperation, fixDisabled }: {
   text: string;
   readiness: string;
@@ -1456,7 +1665,11 @@ function summarizeHomeStatus(status: string, readiness: string, readinessWarning
   };
 }
 
-function homeNeedsWarmRefresh(status: string, readiness: string) {
+// Exported for the regression guard in ServerPanels.homeCards.test.tsx: this and
+// isHomeActionComplete both read summarizeHomeStatus()'s identity/health arrays,
+// so dropping an entry has to fail a test rather than silently break the poll
+// cadence and restart detection.
+export function homeNeedsWarmRefresh(status: string, readiness: string) {
   if (!status && !readiness) return false;
   const summary = summarizeHomeStatus(status, readiness, "", false);
   const overall = summary.identity.find((item) => item.label === "Overall");
@@ -1780,13 +1993,23 @@ function isHomeBootStarting(status: string, readiness: string) {
   return coreStartupContainerUp || readinessStarting || (coreStartupContainerUp && containerLines.length > 0 && missingContainers > 0) || (coreStartupContainerUp && listenerLines.length > 0 && missingListeners > 0);
 }
 
-function homeOverallBadge(value: string) {
+// Colours nothing on screen: the hero dot reads homeStateDotTone(overall.value).
+// This produces identity[0].status, whose only remaining consumer is
+// homeNeedsWarmRefresh's poll-cadence check. Kept correct because a helper that
+// calls a failed readiness check "Ready" is wrong regardless of who reads it.
+export function homeOverallBadge(value: string) {
   const normalized = String(value || "").trim().toLowerCase();
   if (/\b(restarting|restart|stopping|starting)\b/.test(normalized)) return "WARN";
   if (/^stopped$/i.test(value)) return "WARN";
   if (/^issue(?: detected)?$/i.test(value)) return "WARN";
   if (/warming/i.test(value)) return "Info";
   if (/stopped|not running|offline/i.test(value)) return "WARN";
+  // Only ever the label for a readiness run that did NOT pass (a passing one
+  // reads "OK"), but inferStatus matches "checked" against its pass list.
+  if (normalized === "readiness checked") return "WARN";
+  // Something is flagged, but inferStatus finds no keyword and falls through to
+  // "Info" -- the same neutral as "Unknown", i.e. "nothing known yet".
+  if (normalized === "needs review") return "WARN";
   return inferStatus(value);
 }
 

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -140,16 +140,21 @@ export function performanceTrackTone(percent: number | null, sampled: boolean) {
 // Keyed on the labels summarizeHomeStatus() emits, so a renamed label loses its
 // route rather than pointing somewhere wrong.
 //
-// Every destination must be a tab the sidebar actually lists. "Services" is not
-// -- it exists in ALL_TABS but has no navGroups entry, so routing there dropped
-// the operator on a panel with no nav item highlighted and no obvious way back.
-// Server Control is the reachable home for these: it carries ReadinessTimeline,
-// PortChecklist, DoctorSummary and the Change Funcom Token form, which is what
-// you actually use to chase any of them down.
+// Every row goes to Server Control. These rows report *health*, and Server
+// Control is where health is diagnosed -- ReadinessTimeline, PortChecklist,
+// DoctorSummary and the Change Funcom Token form all live there. The Database
+// row deliberately does not go to the Database tab: that tab is for data (schema
+// browser, queries), not for whether Postgres is up and its partitions readable.
+//
+// Kept as a per-label map rather than one constant so a subsystem can be pointed
+// somewhere better later without restructuring. Every destination must be a tab
+// the sidebar lists -- "Services" is in ALL_TABS but has no navGroups entry, and
+// routing there dropped the operator on a panel with nothing highlighted and no
+// way back. App.activeTab.test.tsx guards that.
 export const HOME_SUBSYSTEM_ROUTES: Record<string, Tab> = {
   Containers: "Server Control",
   Listeners: "Server Control",
-  Database: "Database",
+  Database: "Server Control",
   "Game Servers": "Server Control",
   RabbitMQ: "Server Control",
   "Funcom/FLS": "Server Control"

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -485,7 +485,11 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
   const identityCards = summary.identity.filter((item) => item.label !== "Overall");
   const populationItem = identityCards.find((item) => item.label === "Population");
   const populationWarn = /^warn$/i.test(String(populationItem?.status || ""));
-  const populationSegment = homePopulationSegment(populationItem?.value);
+  // A stopped battlegroup has no population to report, so summarizeHomeStatus
+  // yields "Unavailable" and flags it WARN. That is expected, not a problem
+  // worth an amber "population unavailable" beside the server name -- the
+  // heading already says Stopped. Drop the segment entirely instead.
+  const populationSegment = isStoppedReading(overall?.value) ? "" : homePopulationSegment(populationItem?.value);
   const identityLine = homeIdentityLine(identityCards);
 
   return (
@@ -599,6 +603,12 @@ function homeIdentityLine(items: { label: string; value: string }[]) {
   };
   const parts = [pick("Title"), pick("Region"), pick("Mode")].filter(Boolean);
   return parts.join(" · ");
+}
+
+// Matches the value summarizeHomeStatus reports once the battlegroup is down,
+// whether that came from the status text or from a completed stop action.
+export function isStoppedReading(value: unknown) {
+  return /^stopped$/i.test(String(value || "").trim());
 }
 
 // formatHomePopulation yields "14", "14 / 40", "14 / ?" or "Unavailable", all of

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -138,14 +138,20 @@ export function performanceTrackTone(percent: number | null, sampled: boolean) {
 }
 
 // Keyed on the labels summarizeHomeStatus() emits, so a renamed label loses its
-// route rather than pointing somewhere wrong. Listeners and Funcom/FLS both land
-// on Server Control -- PortChecklist and the Change Funcom Token form live there.
+// route rather than pointing somewhere wrong.
+//
+// Every destination must be a tab the sidebar actually lists. "Services" is not
+// -- it exists in ALL_TABS but has no navGroups entry, so routing there dropped
+// the operator on a panel with no nav item highlighted and no obvious way back.
+// Server Control is the reachable home for these: it carries ReadinessTimeline,
+// PortChecklist, DoctorSummary and the Change Funcom Token form, which is what
+// you actually use to chase any of them down.
 export const HOME_SUBSYSTEM_ROUTES: Record<string, Tab> = {
-  Containers: "Services",
+  Containers: "Server Control",
   Listeners: "Server Control",
   Database: "Database",
-  "Game Servers": "Services",
-  RabbitMQ: "Services",
+  "Game Servers": "Server Control",
+  RabbitMQ: "Server Control",
   "Funcom/FLS": "Server Control"
 };
 

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -485,11 +485,7 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
   const identityCards = summary.identity.filter((item) => item.label !== "Overall");
   const populationItem = identityCards.find((item) => item.label === "Population");
   const populationWarn = /^warn$/i.test(String(populationItem?.status || ""));
-  // A stopped battlegroup has no population to report, so summarizeHomeStatus
-  // yields "Unavailable" and flags it WARN. That is expected, not a problem
-  // worth an amber "population unavailable" beside the server name -- the
-  // heading already says Stopped. Drop the segment entirely instead.
-  const populationSegment = isStoppedReading(overall?.value) ? "" : homePopulationSegment(populationItem?.value);
+  const populationSegment = isPopulationUnknowable(overall?.value) ? "" : homePopulationSegment(populationItem?.value);
   const identityLine = homeIdentityLine(identityCards);
 
   return (
@@ -605,10 +601,17 @@ function homeIdentityLine(items: { label: string; value: string }[]) {
   return parts.join(" · ");
 }
 
-// Matches the value summarizeHomeStatus reports once the battlegroup is down,
-// whether that came from the status text or from a completed stop action.
-export function isStoppedReading(value: unknown) {
-  return /^stopped$/i.test(String(value || "").trim());
+// The readings where there is no population to report: the battlegroup is down,
+// or in transition to or from being down. summarizeHomeStatus yields
+// "Unavailable" and flags it WARN in all of them, which puts an amber warning
+// next to the server name for an entirely expected condition.
+//
+// "Restarting Battlegroup" is matched on its first word, which is the raw value
+// summarizeHomeStatus emits mid-restart. Deliberately NOT listed: "Needs
+// Review" and "Warming" leave the battlegroup up and serving, so its count is
+// real and worth showing.
+export function isPopulationUnknowable(value: unknown) {
+  return /^(stopped|starting|stopping|restarting)\b/i.test(String(value || "").trim());
 }
 
 // formatHomePopulation yields "14", "14 / 40", "14 / ?" or "Unavailable", all of

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -486,6 +486,9 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
   const populationItem = identityCards.find((item) => item.label === "Population");
   const populationWarn = /^warn$/i.test(String(populationItem?.status || ""));
   const populationSegment = isPopulationUnknowable(overall?.value) ? "" : homePopulationSegment(populationItem?.value);
+  // Drives the dot and the reading beside it from one value, so the two can
+  // never disagree about severity.
+  const stateTone = homeStateDotTone(overall?.value, summary.health);
   const identityLine = homeIdentityLine(identityCards);
 
   return (
@@ -512,8 +515,8 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
                   copying it. Whitespace-only text between flex items is not
                   rendered, so this costs nothing visually. */}
               {" "}
-              <span className={`home-state-dot home-state-dot-${homeStateDotTone(overall?.value, summary.health)}`} aria-hidden="true" />
-              <span className="home-hero-state-value">{homeOverallHeading(overall?.value)}</span>
+              <span className={`home-state-dot home-state-dot-${stateTone}`} aria-hidden="true" />
+              <span className={`home-hero-state-value home-hero-state-value-${stateTone}`}>{homeOverallHeading(overall?.value)}</span>
             </div>
             {/* Population is rendered apart from the rest of the line so its
                 WARN can survive: summarizeHomeStatus flags an unreadable count

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -501,6 +501,12 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
                 rather than inside, so the heading text stays just the label. */}
             <div className="home-hero-state">
               <h3 className="home-hero-state-label">Battlegroup Status:</h3>
+              {/* Explicit space: the dot between the label and the reading is an
+                  empty element, so without it the heading's text content reads
+                  "Battlegroup Status:Stopped" to a screen reader and to anyone
+                  copying it. Whitespace-only text between flex items is not
+                  rendered, so this costs nothing visually. */}
+              {" "}
               <span className={`home-state-dot home-state-dot-${homeStateDotTone(overall?.value, summary.health)}`} aria-hidden="true" />
               <span className="home-hero-state-value">{homeOverallHeading(overall?.value)}</span>
             </div>
@@ -541,7 +547,7 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
   );
 }
 
-export type HomeStateTone = "ok" | "motion" | "off" | "attention" | "failed" | "loading" | "nodata";
+export type HomeStateTone = "ok" | "motion" | "attention" | "failed" | "loading" | "nodata";
 
 // Splits the readings by what the operator should do about them, rather than
 // putting six of the ten on one amber -- a restart in flight and a failed
@@ -552,7 +558,10 @@ export function homeStateDotTone(overallValue: unknown, health: { status: string
   // restart the subsystems are legitimately down, and red would cry wolf.
   if (/^(starting|stopping|restarting)\b/.test(value)) return "motion";
   if (value === "checking") return "loading";
-  if (value === "stopped") return "off";
+  // Stopped is reported at full severity, same as the rows below it: one
+  // state, one colour. It is checked before the escalation so a stop reads as
+  // stopped rather than as whichever subsystem happens to have failed.
+  if (value === "stopped") return "failed";
   if (value === "unknown" || value === "status loaded") return "nodata";
   // summarizeHomeStatus can report "OK" while Funcom/FLS is FAILED (the
   // token-mismatch branch overrides its ready override), so the heading word
@@ -1642,7 +1651,7 @@ function summarizeHomeStatus(status: string, readiness: string, readinessWarning
     : runningAction === "stop" ? "Stopping" : isStarting ? "Starting" : "";
   const warmingOverall = /^Warming$/i.test(rawGames.label) ? "Warming" : "";
   const overall = readinessReady && !runningAction ? "OK" : isStarting ? transitionOverall : runningAction ? transitionOverall : serverState.stopped || actionStopped ? "Stopped" : coreReadyWithReview ? "Needs Review" : warmingOverall || liveOverall;
-  const attentionHealth = !isStarting && !restartSuccessAwaitingFreshStatus && (serverState.stopped || actionStopped || actionFailed) ? attentionHomeHealthCards() : null;
+  const attentionHealth = !isStarting && !restartSuccessAwaitingFreshStatus && (serverState.stopped || actionStopped || actionFailed) ? attentionHomeHealthCards(serverState.stopped || actionStopped ? "stopped" : "failed") : null;
   const transitionAction: "start" | "stop" | "restart" | "" = restartStartObserved
     ? "start"
     : runningAction === "restart" ? ""
@@ -1924,8 +1933,14 @@ function textHasContainerReadiness(text: string, state: "OK" | "FAIL", container
   });
 }
 
-function attentionHomeHealthCards() {
-  const item = { label: "Needs Review", status: "WARN", detail: "" };
+// Applied when the battlegroup is down or an action failed. The two are not
+// the same: a stopped battlegroup has a known cause and every subsystem is off,
+// while a failed start leaves the subsystems in whatever state the failure left
+// them. Saying "Stopped" for a failed start would be a false claim.
+function attentionHomeHealthCards(reason: "stopped" | "failed") {
+  const item = reason === "stopped"
+    ? { label: "Stopped", status: "FAILED", detail: "" }
+    : { label: "Needs Review", status: "WARN", detail: "" };
   return {
     containers: item,
     listeners: item,

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -15,7 +15,7 @@ import { conciseTaskError, funcomTokenMismatchDetected } from "../../lib/taskDis
 import { QueueBadges, queueCountsSummary, queueCountsTotal, type QueueCounts } from "../../components/common/QueueBadges";
 import { childAccessPieceCount, usePendingQueues } from "../../lib/usePendingRefills";
 
-export type HomeLoadResult = { statusLoaded: boolean; readinessLoaded: boolean; statusError: string; readinessError: string; statusText: string; readinessText: string };
+export type HomeLoadResult = { statusLoaded: boolean; readinessLoaded: boolean; statusError: string; readinessError: string; statusText: string; readinessText: string; sampledAtMs: number };
 export type HomeTaskResult = { status: "running" | "succeeded" | "failed" | "stopped"; title: string; message?: string; details?: string };
 export type RestartLifecycleState = { stopObserved: boolean; startObserved: boolean };
 
@@ -149,9 +149,16 @@ export const HOME_SUBSYSTEM_ROUTES: Record<string, Tab> = {
   "Funcom/FLS": "Server Control"
 };
 
-// Two misses, not one: a single failed poll is routine (console restarting, a
-// request racing a container bounce). Two is ~1 minute on the idle 30s cadence.
-export const STALE_POLL_THRESHOLD = 2;
+// Three missed idle polls. Derived from the sample's own age rather than a
+// count of consecutive failures: age is true by construction whatever the cause
+// -- failed poll, hidden tab, dead backend -- and unlike a counter it survives
+// leaving Home and coming back.
+export const STALE_SAMPLE_AGE_MS = 90_000;
+
+export function isStatusSampleStale(sampledAtMs: number, now: number) {
+  if (!sampledAtMs) return false;
+  return now - sampledAtMs > STALE_SAMPLE_AGE_MS;
+}
 
 export function formatFreshness(lastUpdatedAt: number, now: number) {
   if (!lastUpdatedAt) return "";
@@ -162,7 +169,7 @@ export function formatFreshness(lastUpdatedAt: number, now: number) {
   return `${Math.floor(minutes / 60)}h ${minutes % 60}m ago`;
 }
 
-export function HomePanel({ status, readiness, taskResult, setTaskResult, funcomTokenResult, setFuncomTokenResult, runningAction, restartStartObserved, setRunningAction, onLoad, confirmAction, restartGate, onNavigate }: {
+export function HomePanel({ status, readiness, taskResult, setTaskResult, funcomTokenResult, setFuncomTokenResult, runningAction, restartStartObserved, setRunningAction, onLoad, confirmAction, restartGate, onNavigate, sampledAtMs = 0, setSampledAtMs }: {
   status: string;
   readiness: string;
   taskResult: HomeTaskResult | null;
@@ -172,11 +179,14 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
   runningAction: "start" | "stop" | "restart" | "";
   restartStartObserved: boolean;
   setRunningAction: Dispatch<SetStateAction<"start" | "stop" | "restart" | "">>;
-  onLoad: () => Promise<HomeLoadResult>;
+  onLoad: (options?: { fresh?: boolean }) => Promise<HomeLoadResult>;
   confirmAction: ConfirmAction;
   restartGate: RestartGate;
   // Absent (e.g. in tests) means the subsystem rows render as text, not buttons.
   onNavigate?: (tab: Tab) => void;
+  // Held by App so it outlives this panel unmounting on a tab switch.
+  sampledAtMs?: number;
+  setSampledAtMs?: (value: number) => void;
 }) {
   const [loading, setLoading] = useState(false);
   const [localError, setLocalError] = useState("");
@@ -184,8 +194,6 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
   const [performance, setPerformance] = useState<PerformanceSnapshot | null>(null);
   const [performanceError, setPerformanceError] = useState("");
   const [hasLoaded, setHasLoaded] = useState(Boolean(status || readiness));
-  const [lastUpdatedAt, setLastUpdatedAt] = useState(0);
-  const [pollFailures, setPollFailures] = useState(0);
   const homeActionRunId = useRef(0);
   const homeActionStartedAt = useRef(0);
   const homeRestartLifecycle = useRef<RestartLifecycleState>(createRestartLifecycleState());
@@ -201,43 +209,35 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     if (!runningAction) homeActionStartedAt.current = 0;
   }, [runningAction]);
 
-  // The polling effects below swallow their errors, so a backend that starts
-  // failing after the first load would otherwise leave stale values up with no
-  // cue. Called from every refresh path so they all date the data alike.
-  function recordLoadOutcome(loaded: boolean) {
-    if (loaded) {
-      setLastUpdatedAt(Date.now());
-      setPollFailures(0);
-    } else {
-      setPollFailures((count) => count + 1);
-    }
-  }
-
   function applyHomeLoadResult(result: HomeLoadResult) {
     const loaded = result.statusLoaded || result.readinessLoaded;
     if (loaded) setHasLoaded(true);
-    recordLoadOutcome(loaded);
+    // Only a successful read moves the clock. A failed poll leaves the old
+    // sample time in place, so its age keeps growing and eventually reads as
+    // stale on its own -- no failure counter needed.
+    if (loaded && result.sampledAtMs) setSampledAtMs?.(result.sampledAtMs);
     setReadinessWarning(!result.readinessLoaded && result.readinessError ? result.readinessError : "");
     if (!result.statusLoaded && !result.readinessLoaded && result.statusError) setLocalError(friendlyHomeStatusError(result.statusError));
   }
 
-  async function refresh(isActive = () => true) {
+  // `fresh` is opt-in per caller. The mount read deliberately accepts a cached
+  // snapshot -- that read is the whole reason the cache exists -- while an
+  // operator pressing Refresh Status is asking to go and look again.
+  async function refresh(isActive = () => true, options: { fresh?: boolean } = {}) {
     const runId = ++refreshRunId.current;
     setLoading(true);
     setLocalError("");
     setReadinessWarning("");
     try {
-      const result = await onLoad();
+      const result = await onLoad({ fresh: options.fresh });
       if (!isActive() || refreshRunId.current !== runId) return;
       if (result.statusLoaded || result.readinessLoaded) {
         applyHomeLoadResult(result);
       } else {
-        recordLoadOutcome(false);
         setLocalError(friendlyHomeStatusError(result.statusError || result.readinessError || "Server status and readiness checks failed."));
       }
     } catch (error) {
       if (isActive() && refreshRunId.current === runId) {
-        recordLoadOutcome(false);
         setLocalError(friendlyHomeStatusError(error instanceof Error ? error.message : String(error)));
       }
     } finally {
@@ -259,7 +259,7 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     setHomeAction(action);
     setTaskResult(stackActionPendingResult(action));
     if (action === "restart") {
-      const preLoad = await onLoad().catch(() => null);
+      const preLoad = await onLoad({ fresh: true }).catch(() => null);
       if (homeActionRunId.current !== actionRunId) return;
       if (preLoad) {
         applyHomeLoadResult(preLoad);
@@ -287,7 +287,7 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
       if (homeActionRunId.current !== actionRunId) return;
       const details = taskTechnicalDetails(final);
       if (action === "restart") homeRestartLifecycle.current = advanceRestartLifecycleFromTaskDetails(homeRestartLifecycle.current, details);
-      const postLoad = await onLoad().catch(() => null);
+      const postLoad = await onLoad({ fresh: true }).catch(() => null);
       if (homeActionRunId.current !== actionRunId) return;
       if (postLoad) applyHomeLoadResult(postLoad);
       const postState = getHomeServerState(postLoad?.statusText || status, postLoad?.readinessText || readiness);
@@ -366,9 +366,10 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     if (runningAction || !homeNeedsWarmRefresh(status, readiness)) return;
     let active = true;
     const id = window.setInterval(async () => {
-      const result = await onLoad().catch(() => null);
+      // Warming: the whole point is to watch it change, so never cached.
+      const result = await onLoad({ fresh: true }).catch(() => null);
       if (!active) return;
-      if (result) applyHomeLoadResult(result); else recordLoadOutcome(false);
+      if (result) applyHomeLoadResult(result);
     }, 5000);
     return () => {
       active = false;
@@ -381,9 +382,11 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     let active = true;
     const id = window.setInterval(async () => {
       if (document.hidden) return;
+      // Idle: a cached read is acceptable here and on mount. These are the only
+      // two paths that tolerate staleness.
       const result = await onLoad().catch(() => null);
       if (!active) return;
-      if (result) applyHomeLoadResult(result); else recordLoadOutcome(false);
+      if (result) applyHomeLoadResult(result);
     }, 30000);
     return () => {
       active = false;
@@ -395,9 +398,11 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
     if (!isRestartSuccessAwaitingFreshStatus(taskResult, status, readiness)) return;
     let active = true;
     const id = window.setInterval(async () => {
-      const result = await onLoad().catch(() => null);
+      // Waiting for the restart to show up in status; a cached snapshot here
+      // would be the pre-restart one.
+      const result = await onLoad({ fresh: true }).catch(() => null);
       if (!active) return;
-      if (result) applyHomeLoadResult(result); else recordLoadOutcome(false);
+      if (result) applyHomeLoadResult(result);
     }, 1500);
     return () => {
       active = false;
@@ -458,7 +463,7 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
       <article className="hero-panel wide">
         <h2>Server status unavailable</h2>
         <p className="error">{localError}</p>
-        <button onClick={() => refresh()}>Retry Status Check</button>
+        <button onClick={() => refresh(undefined, { fresh: true })}>Retry Status Check</button>
       </article>
     </section>;
   }
@@ -512,12 +517,12 @@ export function HomePanel({ status, readiness, taskResult, setTaskResult, funcom
               </div>)}
             </dl>
             <div className="action-row">
-              <button className={loading ? "refresh-status-button refreshing" : "refresh-status-button"} disabled={refreshDisabled} onClick={() => refresh()}>{loading ? <span className="loading-dots">Refreshing</span> : "Refresh Status"}</button>
+              <button className={loading ? "refresh-status-button refreshing" : "refresh-status-button"} disabled={refreshDisabled} onClick={() => refresh(undefined, { fresh: true })}>{loading ? <span className="loading-dots">Refreshing</span> : "Refresh Status"}</button>
               <button disabled={startDisabled} title={controlsState.running ? "Battlegroup is already running." : ""} onClick={() => runServerAction("start")}><Play size={16} /> Start</button>
               <button className="danger-button" disabled={stopDisabled} onClick={() => runServerAction("stop")}>Stop</button>
               <button disabled={restartDisabled} onClick={() => runServerAction("restart")}>Restart Battlegroup</button>
             </div>
-            <StatusFreshness lastUpdatedAt={lastUpdatedAt} pollFailures={pollFailures} />
+            <StatusFreshness sampledAtMs={sampledAtMs} />
             <PendingRefillNote />
             {taskResult && <HomeTaskResultCard result={taskResult} />}
             {localError && <p className="error">{localError}</p>}
@@ -588,15 +593,15 @@ function homePopulationSegment(value: unknown) {
 
 // Owns its 1s tick so the per-second re-render stays here instead of redrawing
 // every card in the panel.
-function StatusFreshness({ lastUpdatedAt, pollFailures }: { lastUpdatedAt: number; pollFailures: number }) {
+function StatusFreshness({ sampledAtMs }: { sampledAtMs: number }) {
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), 1000);
     return () => window.clearInterval(id);
   }, []);
-  if (!lastUpdatedAt) return null;
-  const stale = pollFailures >= STALE_POLL_THRESHOLD;
-  const ago = formatFreshness(lastUpdatedAt, now);
+  if (!sampledAtMs) return null;
+  const stale = isStatusSampleStale(sampledAtMs, now);
+  const ago = formatFreshness(sampledAtMs, now);
   return <p className={stale ? "home-freshness stale" : "home-freshness"}>
     {stale ? `Status may be stale — last updated ${ago}` : `Updated ${ago}`}
   </p>;
@@ -795,10 +800,11 @@ export function ServerPanel(props: {
       : [serverApi.status(), serverApi.readiness()] as const;
     const results = await Promise.allSettled(requests);
     const [nextStatus, nextReadiness, nextPorts, nextDoctor] = results;
-    const result: HomeLoadResult = { statusLoaded: false, readinessLoaded: false, statusError: "", readinessError: "", statusText: "", readinessText: "" };
+    const result: HomeLoadResult = { statusLoaded: false, readinessLoaded: false, statusError: "", readinessError: "", statusText: "", readinessText: "", sampledAtMs: 0 };
     if (nextStatus?.status === "fulfilled") {
       result.statusText = nextStatus.value.stdout;
       result.statusLoaded = true;
+      result.sampledAtMs = Date.parse(nextStatus.value.sampledAt || "") || Date.now();
       props.setStatus(nextStatus.value.stdout);
     } else if (nextStatus) {
       result.statusError = nextStatus.reason instanceof Error ? nextStatus.reason.message : String(nextStatus.reason);

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2180,8 +2180,22 @@ body.debug .technical-details { display: block; }
 .home-population-warn { color: var(--title); }
 /* Reference values an operator copies, so labelled rather than folded into the
    "·" summary line above. */
-.home-hero-meta { display: flex; flex-wrap: wrap; gap: 8px 24px; margin: 12px 0 0; }
-.home-hero-meta-item { min-width: 0; display: grid; gap: 2px; }
+.home-hero-meta { display: flex; flex-wrap: wrap; gap: 10px; margin: 12px 0 0; }
+/* Boxed, matching the .status-card / .key-value-item treatment used elsewhere
+   rather than a new one. flex-basis 0 so the two share the width evenly instead
+   of sizing to their content -- a short IP beside a long battlegroup id would
+   otherwise give two very lopsided boxes. */
+.home-hero-meta-item {
+  flex: 1 1 0;
+  min-width: 140px;
+  display: grid;
+  gap: 3px;
+  align-content: start;
+  padding: 9px 11px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
 .home-hero-meta dt { color: var(--muted); font-size: 12px; }
 .home-hero-meta dd { margin: 0; color: var(--text-strong); overflow-wrap: anywhere; }
 /* Muted at rest; only the stale form is allowed to draw the eye. */

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -26,6 +26,10 @@
   --danger: #a74949;
   --danger-strong: #8d3434;
   --danger-text: #ffb4a8;
+  /* For small filled indicators only, never text. At 11px --danger-text is a
+     pale salmon not separable from --title's amber (measured side by side), and
+     --danger reads brown on the card background. This is the middle. */
+  --danger-signal: #e05a4f;
   --warning: #a97932;
   background: var(--bg);
   color: var(--text);
@@ -968,6 +972,10 @@ main { padding: 22px; min-width: 0; }
 .performance-card strong { font-size: 22px; line-height: 1.15; }
 .metric-track { height: 8px; overflow: hidden; border-radius: 999px; background: #0c0e10; border: 1px solid #302b25; }
 .metric-track span { display: block; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #6f8f5f, #c68b4a); transition: width .35s ease; }
+/* The fill has to carry the same verdict as the badge; with one gradient for
+   every reading the bar was decoration. Same tokens, so they cannot disagree. */
+.metric-track span.metric-track-warn { background: linear-gradient(90deg, #a97932, #d49a5c); }
+.metric-track span.metric-track-fail { background: linear-gradient(90deg, var(--danger), var(--danger-strong)); }
 .result-list { display: grid; gap: 8px; margin: 10px 0 0; padding: 0; list-style: none; }
 .result-row { border: 1px solid #302b25; border-radius: 6px; padding: 9px 10px; background: #14171a; color: #d9c8aa; }
 .result-ok { border-color: #3d8b62; color: #9be6bd; }
@@ -2130,9 +2138,101 @@ body.debug .technical-details { display: block; }
 .service-table { display: grid; gap: 10px; margin-top: 14px; }
 .service-actions, .service-card .service-actions { display: flex; gap: 8px; flex-wrap: wrap; justify-content: flex-end; align-items: center; }
 .service-actions button, .service-actions .button-link { width: auto; white-space: nowrap; }
-.home-health { display: grid; gap: 16px; }
 .dashboard-band { display: grid; gap: 10px; }
 .dashboard-band h3 { margin: 0; color: #ffd08a; }
+
+/* The hero spans the row. Without .wide it sat in column 1 of a two-column grid
+   and left the right half of row 1 empty above the 900px breakpoint. */
+.home-hero-split { display: grid; grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr); gap: 20px; align-items: start; }
+.home-hero-primary { min-width: 0; }
+.home-hero-state { display: flex; align-items: center; flex-wrap: wrap; gap: 10px; }
+/* Layout only. The label is an h3, so it already matches the other section
+   headings; restating font-size here would let them drift apart. */
+.home-hero-state-label { margin: 0; }
+/* Stepped up from the label: the label names the row, the reading answers it. */
+.home-hero-state-value { color: var(--title); font-size: 1.4em; font-weight: 700; line-height: 1.2; }
+/* Three axes: hue for severity, pulse for "in progress", ring-vs-fill for "no
+   reading yet". The last two survive not being able to separate the hues, which
+   matters on a console this uniformly amber. */
+.home-state-dot { flex: 0 0 auto; width: 11px; height: 11px; border-radius: 50%; background: var(--muted); }
+.home-state-dot-ok { background: var(--success-text); }
+.home-state-dot-attention { background: var(--title); }
+.home-state-dot-failed { background: var(--danger-signal); }
+/* Off on purpose: solid, because the hollow ring means "no reading". Uses
+   --text-subtle, not the warm --muted, which blurred into --title at 11px. */
+.home-state-dot-off { background: var(--text-subtle); }
+/* Blue is already the palette's informational hue (.badge-info) and the one
+   family that does not blur into the warm chrome. */
+.home-state-dot-motion { background: #85b7eb; animation: state-dot-pulse 1.6s ease-in-out infinite; }
+/* Dashed vs solid, not just pulsing vs still: prefers-reduced-motion strips the
+   animation, which would otherwise make these two identical. */
+.home-state-dot-loading { background: transparent; border: 2px dashed var(--text-subtle); animation: state-dot-pulse 1.6s ease-in-out infinite; }
+.home-state-dot-nodata { background: transparent; border: 2px solid var(--text-subtle); }
+@keyframes state-dot-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: .45; transform: scale(.82); }
+}
+/* overflow-wrap is load-bearing: a Title is free text and can arrive unspaced.
+   Without it the line overflowed its track and was painted under the opaque
+   subsystem list -- no scrollbar, no clipping, just unreadable. */
+.home-hero-identity { margin: 6px 0 0; color: var(--muted); overflow-wrap: anywhere; }
+/* Lifts out of the muted prose so an unreadable count is not read as a value. */
+.home-population-warn { color: var(--title); }
+/* Reference values an operator copies, so labelled rather than folded into the
+   "·" summary line above. */
+.home-hero-meta { display: flex; flex-wrap: wrap; gap: 8px 24px; margin: 12px 0 0; }
+.home-hero-meta-item { min-width: 0; display: grid; gap: 2px; }
+.home-hero-meta dt { color: var(--muted); font-size: 12px; }
+.home-hero-meta dd { margin: 0; color: var(--text-strong); overflow-wrap: anywhere; }
+/* Muted at rest; only the stale form is allowed to draw the eye. */
+.home-freshness { margin: 8px 0 0; color: var(--text-subtle); font-size: 12px; }
+.home-freshness.stale { color: var(--title); }
+
+.home-subsystems { min-width: 0; display: grid; gap: 10px; align-content: start; }
+.home-subsystems h3 { margin: 0; color: #ffd08a; }
+/* No overflow: hidden -- it clipped the inset focus ring on the first and last
+   rows, so those rows round their own fills instead. Logical longhands so the
+   two rules compose rather than overwrite when the list holds one row. */
+.home-subsystem-list { list-style: none; margin: 0; padding: 0; display: grid; border: 1px solid var(--border); border-radius: 8px; }
+.home-subsystem-row:first-child .home-subsystem-button,
+.home-subsystem-row:first-child .home-subsystem-static { border-start-start-radius: 7px; border-start-end-radius: 7px; }
+.home-subsystem-row:last-child .home-subsystem-button,
+.home-subsystem-row:last-child .home-subsystem-static { border-end-start-radius: 7px; border-end-end-radius: 7px; }
+.home-subsystem-row + .home-subsystem-row { border-top: 1px solid var(--border); }
+/* Resets the global button styling: these are full-bleed rows, not controls.
+   Opaque --panel rather than the hero's frosted surface, so the list reads as
+   one slab instead of six translucent chips. */
+.home-subsystem-button, .home-subsystem-static {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 44px;
+  padding: 9px 12px;
+  background: var(--panel);
+  border: 0;
+  border-radius: 0;
+  color: inherit;
+  text-align: left;
+}
+.home-subsystem-button { cursor: pointer; }
+.home-subsystem-button:hover { background: #1c2024; color: var(--text-strong); }
+.home-subsystem-button:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+/* The label is a fixed short string; the value is the variable part and can be
+   as long as "Token Mismatch Detected", so the value is what gives way. With
+   flex: 0 0 auto on the value it refused to shrink and crushed the label to a
+   5px column, one glyph per line, at ~940px. */
+.home-subsystem-label { flex: 0 0 auto; white-space: nowrap; }
+.home-subsystem-value { flex: 0 1 auto; min-width: 0; display: inline-flex; align-items: center; justify-content: flex-end; gap: 8px; color: var(--muted); text-align: right; }
+/* Only the text gives way -- the badge is already compact and must stay whole. */
+.home-subsystem-value > span:not(.badge) { min-width: 0; overflow-wrap: anywhere; }
+.home-subsystem-value > .badge { flex: 0 0 auto; }
+
+/* Stop destroys running state; it should not read as the peer of the read-only
+   Refresh beside it. Border and text only -- filled danger is for dialogs. */
+.danger-button { border-color: var(--danger); color: var(--danger-text); }
+.danger-button:hover:not(:disabled) { border-color: var(--danger-strong); background: rgba(167, 73, 73, .16); }
 .health-grid-compact { grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); }
 .readiness-groups { display: grid; gap: 14px; }
 .readiness-group { display: grid; gap: 8px; }
@@ -2595,6 +2695,7 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
   .sidebar-nav-heading { grid-column: 1 / -1; }
   .home-backdrop { inset: 0; }
   .grid, .two-col { grid-template-columns: 1fr; }
+  .home-hero-split { grid-template-columns: 1fr; gap: 16px; }
   .health-grid, .health-grid-compact { grid-template-columns: 1fr; }
   .live-map-layout { grid-template-columns: 1fr; }
   .live-map-view-body { grid-template-columns: 1fr; }
@@ -2604,6 +2705,8 @@ label.exchange-category-select, label.exchange-owner-select { display: flex; fle
 
 @media (prefers-reduced-motion: reduce) {
   .home-sand-fine, .home-sand-near, .setup-finish-celebration span { animation: none; }
+  /* The hue and ring style still separate the states without the motion. */
+  .home-state-dot-motion, .home-state-dot-loading { animation: none; }
 }
 
 .toggle-row { display: flex; flex-wrap: wrap; gap: 8px; }

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -26,10 +26,14 @@
   --danger: #a74949;
   --danger-strong: #8d3434;
   --danger-text: #ffb4a8;
-  /* For small filled indicators only, never text. At 11px --danger-text is a
-     pale salmon not separable from --title's amber (measured side by side), and
-     --danger reads brown on the card background. This is the middle. */
+  /* At 11px --danger-text is a pale salmon not separable from --title's amber
+     (measured side by side), and --danger reads brown on the card background.
+     This is the middle. 4.78:1 on --panel -- the narrowest margin of the tones,
+     so check it first if the surface colour ever changes. */
   --danger-signal: #e05a4f;
+  /* Blue is the palette's informational hue (.badge-info) and the one family
+     that does not blur into the warm chrome. 8.29:1 on --panel. */
+  --state-motion: #85b7eb;
   --warning: #a97932;
   background: var(--bg);
   color: var(--text);
@@ -2158,13 +2162,19 @@ body.debug .technical-details { display: block; }
 .home-state-dot-ok { background: var(--success-text); }
 .home-state-dot-attention { background: var(--title); }
 .home-state-dot-failed { background: var(--danger-signal); }
-/* Blue is already the palette's informational hue (.badge-info) and the one
-   family that does not blur into the warm chrome. */
-.home-state-dot-motion { background: #85b7eb; animation: state-dot-pulse 1.6s ease-in-out infinite; }
+.home-state-dot-motion { background: var(--state-motion); animation: state-dot-pulse 1.6s ease-in-out infinite; }
 /* Dashed vs solid, not just pulsing vs still: prefers-reduced-motion strips the
    animation, which would otherwise make these two identical. */
 .home-state-dot-loading { background: transparent; border: 2px dashed var(--text-subtle); animation: state-dot-pulse 1.6s ease-in-out infinite; }
 .home-state-dot-nodata { background: transparent; border: 2px solid var(--text-subtle); }
+/* The reading takes its dot's colour. At 1.4em bold this is large text, where
+   every tone clears AA on --panel; the dot stays the redundant channel for
+   anyone who cannot separate the hues. */
+.home-hero-state-value-ok { color: var(--success-text); }
+.home-hero-state-value-attention { color: var(--title); }
+.home-hero-state-value-failed { color: var(--danger-signal); }
+.home-hero-state-value-motion { color: var(--state-motion); }
+.home-hero-state-value-loading, .home-hero-state-value-nodata { color: var(--text-subtle); }
 @keyframes state-dot-pulse {
   0%, 100% { opacity: 1; transform: scale(1); }
   50% { opacity: .45; transform: scale(.82); }

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2158,9 +2158,6 @@ body.debug .technical-details { display: block; }
 .home-state-dot-ok { background: var(--success-text); }
 .home-state-dot-attention { background: var(--title); }
 .home-state-dot-failed { background: var(--danger-signal); }
-/* Off on purpose: solid, because the hollow ring means "no reading". Uses
-   --text-subtle, not the warm --muted, which blurred into --title at 11px. */
-.home-state-dot-off { background: var(--text-subtle); }
 /* Blue is already the palette's informational hue (.badge-info) and the one
    family that does not blur into the warm chrome. */
 .home-state-dot-motion { background: #85b7eb; animation: state-dot-pulse 1.6s ease-in-out infinite; }


### PR DESCRIPTION
The hero panel was the only `.grid` child without `.wide`, so the right half of row 1 sat empty on every viewport above the 900px breakpoint. It now spans the row, leads with the overall verdict, and uses the reclaimed space for the six readiness subsystems as rows that route to the tab handling each one.

Also in this pass:

- Performance badges and meter bars derive from each reading rather than "did a sample arrive", so a 96%-full disk no longer shows the same green pill as a 4%-full one. A null reading (the API returns one on the first sample after every restart) reports INFO rather than a green OK.
- The Server Identity band is removed; it repeated the hero summary line. Server IP and Battlegroup move into the hero and render even when unknown, since that is now the only place they appear.
- The status dot splits the overloaded amber (six of ten readings) by what the operator should do: hue for severity, a pulse for in-progress, ring style for no reading yet. It takes the worst of the overall reading and all six subsystems, so a failed Funcom/FLS shows red even while the heading reads OK.
- The three polling effects swallowed their errors, leaving stale values on screen indefinitely. The panel now dates the data and warns after consecutive misses, without blanking the last good values.
- `homeOverallBadge` no longer reports a failed readiness check as healthy — `inferStatus` was matching the word "checked" against its pass list.

Everything is rendering-only. `summarizeHomeStatus` keeps its exact shape because `isHomeActionComplete` and `homeNeedsWarmRefresh` read its `health` and `identity` arrays to drive the restart lifecycle; a regression test pins that and fails if the health array is emptied.

The later two commits address findings from a review pass over the first: two layout bugs (the subsystem value refused to shrink and crushed the label to a 5px column; an unspaced server Title overflowed its track and was painted under the opaque subsystem list), plus accessibility and signal fixes — a visually hidden h2 restoring the heading level and the region's accessible name, a dashed ring so "checking" and "no reading" stay distinct under prefers-reduced-motion, and the population warning regaining a renderer.

Verified: `tsc --noEmit` clean, 784/784 tests across 76 files with 0 skipped. Layout and colour choices were measured in the browser rather than eyeballed.
