### PR TITLE
Console IAM: split coarse actions, validate policy names, per-action key scopes

### DIFF
--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -219,8 +219,17 @@ export const ROUTE_ACTIONS = {
   // --- Storage (read) ---
   "GET /api/storage":                          "storage:read",
 
-  // --- Blueprints (read) ---
+  // --- Blueprints ---
   "GET /api/blueprints":                       "blueprints:read",
+  // POST-shaped but read-only in effect: blueprintBulkExportRoute only calls
+  // exportBlueprint() per id and zips the results, and GET
+  // /api/blueprints/{id}/export already resolves to blueprints:read. It is
+  // still NOT folded into blueprints:read, deliberately -- one call can pull
+  // 500 blueprints, so an operator who granted read-only access to the
+  // blueprint list did not thereby agree to bulk extraction. Its own action
+  // lets them grant that separately, and nobody's existing read grant widens.
+  "POST /api/blueprints/export":               "blueprints:export",
+  "POST /api/blueprints/import":               "blueprints:import",
 
   // --- Admin Tools ---
   "GET /api/admin/items/catalog":              "admin:items:read",
@@ -440,15 +449,21 @@ export const REGEX_ACTIONS_BY_METHOD = {
 
   "POST /api/storage/":    "storage:mutate",
 
-  "POST /api/addons/":     "addons:mutate",
-  "DELETE /api/addons/":   "addons:mutate",
+  // Fail-closed sentinel, as for players/guilds above: REGEX_ACTIONS has a
+  // method-agnostic "/api/addons/installed/" -> addons:read fallback, so
+  // dropping these would let an unclassified addon mutation run under a
+  // read-only grant.
+  "POST /api/addons/":     "addons:unclassified",
+  "DELETE /api/addons/":   "addons:unclassified",
 
   "PATCH /api/maps/spicefields/": "maps:write-config",
 
   "DELETE /api/backups/":  "backups:delete",
 
-  "POST /api/blueprints/": "blueprints:mutate",
-  "DELETE /api/blueprints/":"blueprints:mutate",
+  // Same fail-closed sentinel: "/api/blueprints/" -> blueprints:read sits
+  // beneath this tier in REGEX_ACTIONS.
+  "POST /api/blueprints/": "blueprints:unclassified",
+  "DELETE /api/blueprints/":"blueprints:unclassified",
 
   "PATCH /api/database/tables/": "database:mutate",
 };
@@ -690,7 +705,36 @@ export const REGEX_ACTIONS_BY_METHOD_PATTERN = [
   { method: "POST",   pattern: /^\/api\/guilds\/[^/]+\/members$/, action: "guilds:membership" },
   { method: "POST",   pattern: /^\/api\/guilds\/[^/]+\/members\/[^/]+\/promote$/, action: "guilds:rank" },
   { method: "POST",   pattern: /^\/api\/guilds\/[^/]+\/members\/[^/]+\/demote$/, action: "guilds:rank" },
-  { method: "DELETE", pattern: /^\/api\/guilds\/[^/]+$/, action: "guilds:disband" }
+  { method: "DELETE", pattern: /^\/api\/guilds\/[^/]+$/, action: "guilds:disband" },
+
+  // ---- Blueprints ----
+  //
+  // blueprints:mutate covered bulk export (a read), import (creation) and
+  // delete (destruction) with one grant. Anchored so it cannot swallow
+  // /api/blueprints/{id}/export, which stays blueprints:read.
+  { method: "DELETE", pattern: /^\/api\/blueprints\/[^/]+$/, action: "blueprints:delete" },
+
+  // ---- Addons ----
+  //
+  // addons:mutate covered removing an installed addon, enabling/disabling one,
+  // AND the bridge -- the route that executes whatever the addon's manifest
+  // declares, including SQL. Lifecycle control and "run the addon's code" are
+  // not the same privilege and should never have been the same action.
+  //
+  //   addons:remove  uninstall an installed addon
+  //   addons:toggle  enable/disable, the reversible lifecycle switch
+  //   addons:bridge  the manifest-authorized action channel. Authorizes
+  //                  against the INSTALLED ADDON's declared permission rather
+  //                  than the caller (see server.js addonBridgeRoute), which is
+  //                  exactly why it deserves to be withheld separately.
+  //
+  // API keys cannot reach any of these regardless: `addons` is in
+  // KEY_WRITE_DENIED_NAMESPACES, and the bridge additionally refuses key
+  // principals outright.
+  { method: "DELETE", pattern: /^\/api\/addons\/installed\/[^/]+$/, action: "addons:remove" },
+  { method: "POST",   pattern: /^\/api\/addons\/installed\/[^/]+\/bridge$/, action: "addons:bridge" },
+  { method: "POST",   pattern: /^\/api\/addons\/installed\/[^/]+\/enable$/, action: "addons:toggle" },
+  { method: "POST",   pattern: /^\/api\/addons\/installed\/[^/]+\/disable$/, action: "addons:toggle" }
 ];
 
 // ---- Content-conditional actions ----

--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -762,6 +762,51 @@ export const CONTENT_CONDITIONAL_ACTIONS = [
   "database:execute",
 ];
 
+// ---- Removed actions, and what they became ----
+//
+// Splitting the coarse *:mutate actions is not a no-op for a policy that
+// already named one. policy.js's own header teaches the idiom
+//
+//     { "Effect": "Deny",  "Action": ["players:mutate"] },
+//     { "Effect": "Allow", "Action": ["players:*"] }
+//
+// and deleting players:mutate outright turns that document inside out: the Deny
+// matches nothing, the surviving wildcard matches all ten successors, and an
+// upgrade silently converts "no player mutations" into "every player mutation".
+// Measured on a real document during review: a tier GAINED 22 actions and lost
+// none, including addons:bridge and guilds:disband.
+//
+// So the old names keep their MEANING at evaluation time -- a Deny on
+// players:mutate still denies everything it used to deny -- while
+// setPolicies refuses them on save, so an operator is pushed to migrate on
+// their next edit rather than being silently re-interpreted. Aliases affect
+// matchAction only; they are NOT in the catalog and cannot be granted to an
+// API key.
+//
+// Each list is exactly the set of actions the routes that used to resolve to
+// the old name now resolve to -- no more. players:kick-all is deliberately
+// ABSENT: it was already its own action before the split (an exact
+// ROUTE_ACTIONS entry for POST /api/players/kick-all-online), so it was never
+// part of players:mutate and must not be handed over by an alias. The
+// *:unclassified sentinels ARE included, because the old *:mutate names were
+// themselves the catch-all for unmapped mutating routes.
+export const REMOVED_ACTION_ALIASES = Object.freeze({
+  "players:mutate": Object.freeze([
+    "players:moderate", "players:teleport", "players:give-item", "players:grant",
+    "players:reset", "players:delete-item", "players:edit-item", "players:repair",
+    "players:recover", "players:unclassified"
+  ]),
+  "guilds:mutate": Object.freeze([
+    "guilds:disband", "guilds:membership", "guilds:rank", "guilds:unclassified"
+  ]),
+  "blueprints:mutate": Object.freeze([
+    "blueprints:export", "blueprints:import", "blueprints:delete", "blueprints:unclassified"
+  ]),
+  "addons:mutate": Object.freeze([
+    "addons:remove", "addons:toggle", "addons:bridge", "addons:unclassified"
+  ])
+});
+
 // ---- Action resolution ----
 //
 // Returns the action string for a given route path and HTTP method.

--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -407,37 +407,22 @@ export const REGEX_ACTIONS_BY_METHOD = {
   "PUT /api/settings/api-keys/":    "settings:write",
   "DELETE /api/settings/api-keys/": "settings:write",
 
-  // Catch-all for a player mutation route that nobody has classified into one
-  // of the players:* actions in REGEX_ACTIONS_BY_METHOD_PATTERN below. Every
-  // route that exists today IS classified, and rbacParity.test.js asserts that
-  // none of them lands here -- so adding a route without giving it an action
-  // fails CI rather than silently inheriting a broad grant.
+  // ---- *:unclassified sentinels ----
   //
-  // These three lines cannot simply be deleted, though it is tempting now that
-  // every route is named. REGEX_ACTIONS has a method-agnostic
-  // "/api/players/" -> players:read fallback underneath this tier, so with no
-  // method-aware rule here an unclassified POST or DELETE would resolve to
-  // players:read and be authorized by a READ-ONLY grant. Failing to
-  // players:unclassified fails closed for every tier that has not been handed
-  // players:* ; falling through to players:read fails open. Same trap the
-  // vehicles:system-custodian entry below documents.
+  // DO NOT DELETE THESE, even though every route that exists today is named in
+  // REGEX_ACTIONS_BY_METHOD_PATTERN and rbacParity.test.js proves it. They are
+  // the fail-closed floor: REGEX_ACTIONS underneath this tier is
+  // method-agnostic and maps "/api/<ns>/" to <ns>:read, so an unnamed POST or
+  // DELETE with no sentinel here resolves to a READ action and runs under a
+  // read-only grant. Same trap the vehicles:system-custodian entry documents.
   //
-  // Deliberately NOT named players:mutate any more. That name is now absent
-  // from the catalog entirely, so a hand-authored policy still granting it is
-  // refused by setPolicies and warned about at startup (see policy.js
-  // unknownActions) instead of quietly continuing to mean something. An
-  // operator who had players:mutate must now pick the narrower actions they
-  // actually want.
+  // Coverage is per method and currently uneven: players has POST/DELETE/PATCH,
+  // guilds/addons/blueprints have POST/DELETE, and no namespace has PUT.
   "POST /api/players/":    "players:unclassified",
   "DELETE /api/players/":  "players:unclassified",
   "PATCH /api/players/":   "players:unclassified",
 
-  // Same fail-closed sentinel as players:unclassified above, for the same
-  // reason: REGEX_ACTIONS has a method-agnostic "/api/guilds/" -> guilds:read
-  // fallback beneath this tier, so deleting these two lines would make an
-  // unclassified guild mutation resolve to a READ action. guilds:mutate is gone
-  // from the catalog, so a policy still naming it is refused on save and warned
-  // about at startup rather than silently meaning less than it used to.
+  // Sentinel; see *:unclassified above.
   "POST /api/guilds/":     "guilds:unclassified",
   "DELETE /api/guilds/":   "guilds:unclassified",
 
@@ -449,10 +434,7 @@ export const REGEX_ACTIONS_BY_METHOD = {
 
   "POST /api/storage/":    "storage:mutate",
 
-  // Fail-closed sentinel, as for players/guilds above: REGEX_ACTIONS has a
-  // method-agnostic "/api/addons/installed/" -> addons:read fallback, so
-  // dropping these would let an unclassified addon mutation run under a
-  // read-only grant.
+  // Sentinel; see *:unclassified above.
   "POST /api/addons/":     "addons:unclassified",
   "DELETE /api/addons/":   "addons:unclassified",
 
@@ -460,8 +442,7 @@ export const REGEX_ACTIONS_BY_METHOD = {
 
   "DELETE /api/backups/":  "backups:delete",
 
-  // Same fail-closed sentinel: "/api/blueprints/" -> blueprints:read sits
-  // beneath this tier in REGEX_ACTIONS.
+  // Sentinel; see *:unclassified above.
   "POST /api/blueprints/": "blueprints:unclassified",
   "DELETE /api/blueprints/":"blueprints:unclassified",
 
@@ -585,46 +566,35 @@ export const REGEX_ACTIONS_BY_METHOD_PATTERN = [
 
   // ---- Players ----
   //
-  // These 41 method+path pairs all resolved to a single players:mutate until
-  // 2026-08-29. That one grant covered kicking, banning, wiping a character's
-  // progression, deleting items out of their inventory, minting currency and
-  // handing out max-level specializations -- so there was no way to let someone
-  // kick and ban without also letting them destroy or fabricate. Every other
-  // namespace with a destructive operation (bases, vehicles) had already been
-  // carved up on exactly this argument; players, the namespace where the
-  // operations act on a person's saved character, had not.
-  //
-  // Grouped by consequence, because that is what an operator delegates on:
+  // 41 method+path pairs, split by consequence -- that is the unit an operator
+  // delegates on. Previously all one players:mutate, which made kicking
+  // inseparable from wiping a character.
   //
   //   players:moderate    session/account control. No economy or progression
   //                       effect. The natural moderator grant.
-  //   players:teleport    moving someone. Disruptive, but nothing is created,
-  //                       destroyed, or spent.
-  //   players:give-item   putting items (and vehicles) into the world. The
+  //   players:teleport    moving someone. Disruptive; creates and destroys
+  //                       nothing.
+  //   players:give-item   items and vehicles into the world. The
   //                       economy-inflation surface.
   //   players:grant       currency, XP, reputation, unlocks, specializations,
   //                       skill points, faction, journey/tutorial completion.
   //                       Progression handed out rather than earned.
   //   players:reset       progression destroyed: full reset, journey, tutorials,
-  //                       specializations, keystones, and clean-inventory.
+  //                       specializations, keystones, clean-inventory.
   //                       Irreversible from the player's side.
-  //   players:delete-item destroying one inventory row. Own action for the same
-  //                       reason bases:delete-item is: item destruction is not
-  //                       something a broad mutation grant can be read as
-  //                       consent for.
-  //   players:edit-item   editing one inventory row in place (quantity, etc).
-  //                       Separate from deletion so neither implies the other.
-  //   players:repair      fixing broken state -- gear durability, decayed
-  //                       vehicles, a stuck login queue, water/fuel top-ups.
-  //                       Low blast radius, high day-to-day utility, which is
-  //                       exactly why it should be grantable on its own.
-  //   players:recover     character recovery. Restores/rewrites a character,
+  //   players:delete-item destroying one inventory row. Separate for the same
+  //                       reason bases:delete-item is.
+  //   players:edit-item   editing one inventory row in place (quantity, etc),
+  //                       separate from deletion so neither implies the other.
+  //   players:repair      gear durability, decayed vehicles, a stuck login
+  //                       queue, water/fuel top-ups. Low blast radius, high
+  //                       day-to-day utility.
+  //   players:recover     character recovery -- restores/rewrites a character,
   //                       so it stands apart from both grant and repair.
   //
-  // Naming follows the issue #351 rule: no action here is a string prefix of
-  // another, so no "X*" or "X-*" wildcard can bridge two of them by accident.
-  // In particular delete-item and edit-item share no prefix, and there is no
-  // players:delete-items for a "players:delete-item*" pattern to catch.
+  // Issue #351 rule: no action may be a string prefix of another, or an "X*"
+  // wildcard bridges the two. delete-item/edit-item share no prefix, and there
+  // is no players:delete-items for "players:delete-item*" to catch.
   { method: "POST",   pattern: /^\/api\/players\/[^/]+\/kick$/, action: "players:moderate" },
   { method: "POST",   pattern: /^\/api\/players\/[^/]+\/ban$/, action: "players:moderate" },
   // The one path that multiplexes on method: GET reads ban state (and falls
@@ -680,27 +650,22 @@ export const REGEX_ACTIONS_BY_METHOD_PATTERN = [
 
   // ---- Guilds ----
   //
-  // DELETE /api/guilds/{guildId} is DISBAND -- it destroys the guild. It shared
-  // guilds:mutate with promoting a member until 2026-08-29, so there was no way
-  // to let someone fix a roster without also letting them delete the guild
-  // outright. That is precisely the reversible-vs-irreversible split that
-  // bases:delete and vehicles:delete already got; guilds had been missed.
+  // DELETE /api/guilds/{guildId} is DISBAND. It shared guilds:mutate with
+  // promoting a member, so fixing a roster and destroying the guild were one
+  // grant -- the reversible-vs-irreversible split bases and vehicles already
+  // had.
   //
   //   guilds:disband     destroys the guild. Irreversible.
-  //   guilds:membership  who is in the guild -- add and remove. Removal costs a
-  //                      player their guild-derived access, so it sits above
-  //                      rank changes and below disbanding.
-  //   guilds:rank        promote/demote within the guild. Rank only; nobody
-  //                      joins or leaves.
+  //   guilds:membership  add and remove. Removal costs a player their
+  //                      guild-derived access, so it sits above rank and below
+  //                      disband. Add/remove stay one action: two directions of
+  //                      the same roster knob. Split if a one-way case appears.
+  //   guilds:rank        promote/demote. Rank only; nobody joins or leaves.
   //
-  // Add and remove stay one action deliberately: they are two directions of the
-  // same roster knob, and an operator doing roster management needs both. Split
-  // them if a real case for one-way membership editing turns up.
-  //
-  // Both DELETE patterns are anchored, so "/api/guilds/{id}" (the guild) and
-  // "/api/guilds/{id}/members/{playerId}" (one member) cannot be confused --
-  // the same reason bases:delete needs a real regex rather than a startsWith
-  // prefix, since the variable segment comes before the distinguishing part.
+  // Both DELETE patterns are anchored so "/api/guilds/{id}" and
+  // "/api/guilds/{id}/members/{playerId}" cannot be confused -- the variable
+  // segment comes before the distinguishing part, so a startsWith prefix (as
+  // bases:delete also found) is not enough.
   { method: "DELETE", pattern: /^\/api\/guilds\/[^/]+\/members\/[^/]+$/, action: "guilds:membership" },
   { method: "POST",   pattern: /^\/api\/guilds\/[^/]+\/members$/, action: "guilds:membership" },
   { method: "POST",   pattern: /^\/api\/guilds\/[^/]+\/members\/[^/]+\/promote$/, action: "guilds:rank" },
@@ -716,17 +681,16 @@ export const REGEX_ACTIONS_BY_METHOD_PATTERN = [
 
   // ---- Addons ----
   //
-  // addons:mutate covered removing an installed addon, enabling/disabling one,
-  // AND the bridge -- the route that executes whatever the addon's manifest
-  // declares, including SQL. Lifecycle control and "run the addon's code" are
-  // not the same privilege and should never have been the same action.
+  // addons:mutate covered lifecycle AND the bridge -- the route that executes
+  // whatever the addon's manifest declares, including SQL. Lifecycle control
+  // and "run the addon's code" are not the same privilege.
   //
   //   addons:remove  uninstall an installed addon
   //   addons:toggle  enable/disable, the reversible lifecycle switch
   //   addons:bridge  the manifest-authorized action channel. Authorizes
-  //                  against the INSTALLED ADDON's declared permission rather
-  //                  than the caller (see server.js addonBridgeRoute), which is
-  //                  exactly why it deserves to be withheld separately.
+  //                  against the INSTALLED ADDON's declared permission, not the
+  //                  caller (server.js addonBridgeRoute) -- which is why it is
+  //                  withheld separately.
   //
   // API keys cannot reach any of these regardless: `addons` is in
   // KEY_WRITE_DENIED_NAMESPACES, and the bridge additionally refuses key
@@ -745,50 +709,42 @@ export const REGEX_ACTIONS_BY_METHOD_PATTERN = [
 // enforced by a second check inside the handler (server.js requireAction) once
 // the body is parsed.
 //
-// They are listed here so allKnownActions() sees them. That set is what the
-// API-key scope catalog and any policy-authoring tool read, so an action
-// missing from it is invisible to every tool an operator has — it could be
-// denied in a policy document and no UI would ever offer it.
+// Listed here so allKnownActions() sees them: that set feeds the API-key scope
+// catalog and any policy-authoring tool, so an action missing from it is
+// invisible to every tool an operator has.
 //
-//   database:execute -- POST /api/database/query resolves to database:query at
-//     the route level. That name is read-shaped, and the default admin policy
-//     granted it on that reading while explicitly denying database:mutate (the
-//     narrow, structured single-cell edit) and database:write-config. But the
-//     same route also accepts write SQL — UPDATE, DELETE, DROP — so admin's
-//     Deny on the narrow path was defeated by the raw-SQL path it still held.
-//     database:execute covers that write half, and the default admin policy
-//     denies it.
+//   database:execute -- the write half of POST /api/database/query, which
+//     resolves to the read-shaped database:query at the route level. Admin is
+//     granted database:query while denied database:mutate (the narrow
+//     single-cell edit) and database:write-config, so without this the raw-SQL
+//     path defeated the Deny on the structured one. Denied to admin by default.
+//     Selection is best-effort (see duneDb.runSql); the read path is enforced
+//     by Postgres, not by this action.
 export const CONTENT_CONDITIONAL_ACTIONS = [
   "database:execute",
 ];
 
 // ---- Removed actions, and what they became ----
 //
-// Splitting the coarse *:mutate actions is not a no-op for a policy that
-// already named one. policy.js's own header teaches the idiom
+// Deleting a split action ESCALATES an existing policy rather than narrowing
+// it. policy.js's header teaches the idiom
 //
 //     { "Effect": "Deny",  "Action": ["players:mutate"] },
 //     { "Effect": "Allow", "Action": ["players:*"] }
 //
-// and deleting players:mutate outright turns that document inside out: the Deny
-// matches nothing, the surviving wildcard matches all ten successors, and an
-// upgrade silently converts "no player mutations" into "every player mutation".
-// Measured on a real document during review: a tier GAINED 22 actions and lost
-// none, including addons:bridge and guilds:disband.
+// With the name gone the Deny matches nothing and the wildcard matches all ten
+// successors, turning "no player mutations" into "every player mutation" -- 22
+// actions gained on upgrade, including addons:bridge and guilds:disband.
 //
-// So the old names keep their MEANING at evaluation time -- a Deny on
-// players:mutate still denies everything it used to deny -- while
-// setPolicies refuses them on save, so an operator is pushed to migrate on
-// their next edit rather than being silently re-interpreted. Aliases affect
-// matchAction only; they are NOT in the catalog and cannot be granted to an
-// API key.
+// So the old names keep their MEANING in matchAction (a Deny still denies what
+// it denied, an Allow still grants what it granted) while setPolicies refuses
+// them on save, naming the successors. Aliases are NOT in the catalog and
+// cannot be granted to an API key.
 //
-// Each list is exactly the set of actions the routes that used to resolve to
-// the old name now resolve to -- no more. players:kick-all is deliberately
-// ABSENT: it was already its own action before the split (an exact
-// ROUTE_ACTIONS entry for POST /api/players/kick-all-online), so it was never
-// part of players:mutate and must not be handed over by an alias. The
-// *:unclassified sentinels ARE included, because the old *:mutate names were
+// Each list is exactly what the old name's routes resolve to now, no more.
+// players:kick-all is ABSENT: it was already its own ROUTE_ACTIONS entry
+// (POST /api/players/kick-all-online), so it was never part of players:mutate.
+// The *:unclassified sentinels ARE included -- the old *:mutate names were
 // themselves the catch-all for unmapped mutating routes.
 export const REMOVED_ACTION_ALIASES = Object.freeze({
   "players:mutate": Object.freeze([

--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -398,12 +398,39 @@ export const REGEX_ACTIONS_BY_METHOD = {
   "PUT /api/settings/api-keys/":    "settings:write",
   "DELETE /api/settings/api-keys/": "settings:write",
 
-  "POST /api/players/":    "players:mutate",
-  "DELETE /api/players/":  "players:mutate",
-  "PATCH /api/players/":   "players:mutate",
+  // Catch-all for a player mutation route that nobody has classified into one
+  // of the players:* actions in REGEX_ACTIONS_BY_METHOD_PATTERN below. Every
+  // route that exists today IS classified, and rbacParity.test.js asserts that
+  // none of them lands here -- so adding a route without giving it an action
+  // fails CI rather than silently inheriting a broad grant.
+  //
+  // These three lines cannot simply be deleted, though it is tempting now that
+  // every route is named. REGEX_ACTIONS has a method-agnostic
+  // "/api/players/" -> players:read fallback underneath this tier, so with no
+  // method-aware rule here an unclassified POST or DELETE would resolve to
+  // players:read and be authorized by a READ-ONLY grant. Failing to
+  // players:unclassified fails closed for every tier that has not been handed
+  // players:* ; falling through to players:read fails open. Same trap the
+  // vehicles:system-custodian entry below documents.
+  //
+  // Deliberately NOT named players:mutate any more. That name is now absent
+  // from the catalog entirely, so a hand-authored policy still granting it is
+  // refused by setPolicies and warned about at startup (see policy.js
+  // unknownActions) instead of quietly continuing to mean something. An
+  // operator who had players:mutate must now pick the narrower actions they
+  // actually want.
+  "POST /api/players/":    "players:unclassified",
+  "DELETE /api/players/":  "players:unclassified",
+  "PATCH /api/players/":   "players:unclassified",
 
-  "POST /api/guilds/":     "guilds:mutate",
-  "DELETE /api/guilds/":   "guilds:mutate",
+  // Same fail-closed sentinel as players:unclassified above, for the same
+  // reason: REGEX_ACTIONS has a method-agnostic "/api/guilds/" -> guilds:read
+  // fallback beneath this tier, so deleting these two lines would make an
+  // unclassified guild mutation resolve to a READ action. guilds:mutate is gone
+  // from the catalog, so a policy still naming it is refused on save and warned
+  // about at startup rather than silently meaning less than it used to.
+  "POST /api/guilds/":     "guilds:unclassified",
+  "DELETE /api/guilds/":   "guilds:unclassified",
 
   "POST /api/bases/":      "bases:mutate",
   "DELETE /api/bases/":    "bases:mutate",
@@ -539,7 +566,156 @@ export const REGEX_ACTIONS_BY_METHOD_PATTERN = [
   // can bridge.
   { method: "DELETE", pattern: /^\/api\/vehicles\/[^/]+\/storage\/items\/[^/]+$/, action: "vehicles:delete-item" },
   { method: "DELETE", pattern: /^\/api\/vehicles\/[^/]+\/storage\/items$/, action: "vehicles:bulk-delete-items" },
-  { method: "DELETE", pattern: /^\/api\/vehicles\/[^/]+\/storage\/all-items$/, action: "vehicles:bulk-delete-items" }
+  { method: "DELETE", pattern: /^\/api\/vehicles\/[^/]+\/storage\/all-items$/, action: "vehicles:bulk-delete-items" },
+
+  // ---- Players ----
+  //
+  // These 41 method+path pairs all resolved to a single players:mutate until
+  // 2026-08-29. That one grant covered kicking, banning, wiping a character's
+  // progression, deleting items out of their inventory, minting currency and
+  // handing out max-level specializations -- so there was no way to let someone
+  // kick and ban without also letting them destroy or fabricate. Every other
+  // namespace with a destructive operation (bases, vehicles) had already been
+  // carved up on exactly this argument; players, the namespace where the
+  // operations act on a person's saved character, had not.
+  //
+  // Grouped by consequence, because that is what an operator delegates on:
+  //
+  //   players:moderate    session/account control. No economy or progression
+  //                       effect. The natural moderator grant.
+  //   players:teleport    moving someone. Disruptive, but nothing is created,
+  //                       destroyed, or spent.
+  //   players:give-item   putting items (and vehicles) into the world. The
+  //                       economy-inflation surface.
+  //   players:grant       currency, XP, reputation, unlocks, specializations,
+  //                       skill points, faction, journey/tutorial completion.
+  //                       Progression handed out rather than earned.
+  //   players:reset       progression destroyed: full reset, journey, tutorials,
+  //                       specializations, keystones, and clean-inventory.
+  //                       Irreversible from the player's side.
+  //   players:delete-item destroying one inventory row. Own action for the same
+  //                       reason bases:delete-item is: item destruction is not
+  //                       something a broad mutation grant can be read as
+  //                       consent for.
+  //   players:edit-item   editing one inventory row in place (quantity, etc).
+  //                       Separate from deletion so neither implies the other.
+  //   players:repair      fixing broken state -- gear durability, decayed
+  //                       vehicles, a stuck login queue, water/fuel top-ups.
+  //                       Low blast radius, high day-to-day utility, which is
+  //                       exactly why it should be grantable on its own.
+  //   players:recover     character recovery. Restores/rewrites a character,
+  //                       so it stands apart from both grant and repair.
+  //
+  // Naming follows the issue #351 rule: no action here is a string prefix of
+  // another, so no "X*" or "X-*" wildcard can bridge two of them by accident.
+  // In particular delete-item and edit-item share no prefix, and there is no
+  // players:delete-items for a "players:delete-item*" pattern to catch.
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/kick$/, action: "players:moderate" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/ban$/, action: "players:moderate" },
+  // The one path that multiplexes on method: GET reads ban state (and falls
+  // through to the players:read prefix rule), POST bans, DELETE unbans. Both
+  // mutating methods need naming here or DELETE would land on the
+  // players:unclassified catch-all instead of the moderation grant.
+  { method: "DELETE", pattern: /^\/api\/players\/[^/]+\/ban$/, action: "players:moderate" },
+
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/teleport$/, action: "players:teleport" },
+
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/give-item$/, action: "players:give-item" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/give-item-id$/, action: "players:give-item" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/give-items$/, action: "players:give-item" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/augment-item$/, action: "players:give-item" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/spawn-vehicle$/, action: "players:give-item" },
+
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/add-currency$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/add-xp$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/add-intel$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/add-faction-reputation$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/faction$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/set-skill-points$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/set-skill-module$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/building-unlocks\/grant$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/customizations\/grant$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/crafting-recipes\/unlock$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/research-items\/unlock$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/specializations\/add-xp$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/specializations\/grant-max$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/specializations\/keystones\/grant-all$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/journey\/complete$/, action: "players:grant" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/tutorials\/complete$/, action: "players:grant" },
+
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/reset-progression$/, action: "players:reset" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/clean-inventory$/, action: "players:reset" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/journey\/reset$/, action: "players:reset" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/tutorials\/reset$/, action: "players:reset" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/specializations\/reset$/, action: "players:reset" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/specializations\/keystones\/reset-all$/, action: "players:reset" },
+
+  { method: "DELETE", pattern: /^\/api\/players\/[^/]+\/inventory\/[^/]+$/, action: "players:delete-item" },
+  { method: "PATCH",  pattern: /^\/api\/players\/[^/]+\/inventory\/[^/]+$/, action: "players:edit-item" },
+
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/repair-gear$/, action: "players:repair" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/repair-faction-reputation$/, action: "players:repair" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/repair-landsraad-quests$/, action: "players:repair" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/repair-login-queue$/, action: "players:repair" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/repair-vehicle-decay$/, action: "players:repair" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/refuel-vehicle$/, action: "players:repair" },
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/refill-water$/, action: "players:repair" },
+
+  { method: "POST",   pattern: /^\/api\/players\/[^/]+\/character-recovery$/, action: "players:recover" },
+
+  // ---- Guilds ----
+  //
+  // DELETE /api/guilds/{guildId} is DISBAND -- it destroys the guild. It shared
+  // guilds:mutate with promoting a member until 2026-08-29, so there was no way
+  // to let someone fix a roster without also letting them delete the guild
+  // outright. That is precisely the reversible-vs-irreversible split that
+  // bases:delete and vehicles:delete already got; guilds had been missed.
+  //
+  //   guilds:disband     destroys the guild. Irreversible.
+  //   guilds:membership  who is in the guild -- add and remove. Removal costs a
+  //                      player their guild-derived access, so it sits above
+  //                      rank changes and below disbanding.
+  //   guilds:rank        promote/demote within the guild. Rank only; nobody
+  //                      joins or leaves.
+  //
+  // Add and remove stay one action deliberately: they are two directions of the
+  // same roster knob, and an operator doing roster management needs both. Split
+  // them if a real case for one-way membership editing turns up.
+  //
+  // Both DELETE patterns are anchored, so "/api/guilds/{id}" (the guild) and
+  // "/api/guilds/{id}/members/{playerId}" (one member) cannot be confused --
+  // the same reason bases:delete needs a real regex rather than a startsWith
+  // prefix, since the variable segment comes before the distinguishing part.
+  { method: "DELETE", pattern: /^\/api\/guilds\/[^/]+\/members\/[^/]+$/, action: "guilds:membership" },
+  { method: "POST",   pattern: /^\/api\/guilds\/[^/]+\/members$/, action: "guilds:membership" },
+  { method: "POST",   pattern: /^\/api\/guilds\/[^/]+\/members\/[^/]+\/promote$/, action: "guilds:rank" },
+  { method: "POST",   pattern: /^\/api\/guilds\/[^/]+\/members\/[^/]+\/demote$/, action: "guilds:rank" },
+  { method: "DELETE", pattern: /^\/api\/guilds\/[^/]+$/, action: "guilds:disband" }
+];
+
+// ---- Content-conditional actions ----
+//
+// Actions that no entry above resolves to, because the action depends on the
+// request BODY rather than on its method and path. actionForRoute runs in the
+// gate, before any body is read, so these cannot be resolved there; they are
+// enforced by a second check inside the handler (server.js requireAction) once
+// the body is parsed.
+//
+// They are listed here so allKnownActions() sees them. That set is what the
+// API-key scope catalog and any policy-authoring tool read, so an action
+// missing from it is invisible to every tool an operator has — it could be
+// denied in a policy document and no UI would ever offer it.
+//
+//   database:execute -- POST /api/database/query resolves to database:query at
+//     the route level. That name is read-shaped, and the default admin policy
+//     granted it on that reading while explicitly denying database:mutate (the
+//     narrow, structured single-cell edit) and database:write-config. But the
+//     same route also accepts write SQL — UPDATE, DELETE, DROP — so admin's
+//     Deny on the narrow path was defeated by the raw-SQL path it still held.
+//     database:execute covers that write half, and the default admin policy
+//     denies it.
+export const CONTENT_CONDITIONAL_ACTIONS = [
+  "database:execute",
 ];
 
 // ---- Action resolution ----

--- a/console/api/src/apiKeyScopes.js
+++ b/console/api/src/apiKeyScopes.js
@@ -144,19 +144,13 @@ export function normalizeScopes(input) {
   for (const [namespace, value] of Object.entries(input)) {
     if (!allowed.has(namespace)) continue;
 
-    // An explicit action list, the precise form. Granting `players: "write"`
-    // hands over all twelve player actions at once -- kicking, banning,
-    // wiping progression, deleting inventory -- which is the whole reason the
-    // players:* and guilds:* actions were split. A list lets a key be given
-    // exactly players:read and players:moderate and nothing else.
+    // An explicit action list -- the precise form. `players: "write"` hands
+    // over all twelve player actions at once, which is what the splits exist to
+    // avoid; a list can grant exactly players:read and players:moderate.
     //
-    // The trade-off, and it is a real one: a level auto-covers actions added
-    // later (that is why levels are stored rather than expanded, see the file
-    // header), while a list does not. A read route added next release is
-    // reachable by `players: "read"` and NOT by an explicit list. That is the
-    // point -- you opted into a fixed set -- but it means a list needs
-    // revisiting when the catalog grows. Levels remain available and remain
-    // the right default for broad, trusted keys.
+    // The trade: a level auto-covers actions added in a later release (see the
+    // file header), a list does not. A list therefore needs revisiting when the
+    // catalog grows, and levels stay the right default for broad, trusted keys.
     if (Array.isArray(value)) {
       const grantable = new Set(grantableActions(namespace));
       const actions = [...new Set(value.filter((action) => grantable.has(action)))].sort();

--- a/console/api/src/apiKeyScopes.js
+++ b/console/api/src/apiKeyScopes.js
@@ -127,22 +127,70 @@ export function scopeCatalog() {
 // misspelled level ("readonly") all become None rather than falling back to
 // read. There is no default level and no merge with a previous value; the
 // caller passes the complete desired map, so removing a namespace revokes it.
+// Every action a namespace can be granted, read and write buckets together.
+// Write-denied namespaces contribute no write actions, because
+// actionsByNamespace() already omits them from the catalog -- so membership in
+// this set is the only check an explicit action list needs.
+export function grantableActions(namespace) {
+  const entry = actionsByNamespace().get(namespace);
+  if (!entry) return [];
+  return [...entry.read, ...entry.write];
+}
+
 export function normalizeScopes(input) {
   const scopes = {};
   if (!input || typeof input !== "object" || Array.isArray(input)) return scopes;
   const allowed = new Set(selectableNamespaces());
-  for (const [namespace, level] of Object.entries(input)) {
+  for (const [namespace, value] of Object.entries(input)) {
     if (!allowed.has(namespace)) continue;
-    if (!SCOPE_LEVELS.includes(level)) continue;
-    if (level === "write" && !namespaceHasWriteActions(namespace)) {
+
+    // An explicit action list, the precise form. Granting `players: "write"`
+    // hands over all twelve player actions at once -- kicking, banning,
+    // wiping progression, deleting inventory -- which is the whole reason the
+    // players:* and guilds:* actions were split. A list lets a key be given
+    // exactly players:read and players:moderate and nothing else.
+    //
+    // The trade-off, and it is a real one: a level auto-covers actions added
+    // later (that is why levels are stored rather than expanded, see the file
+    // header), while a list does not. A read route added next release is
+    // reachable by `players: "read"` and NOT by an explicit list. That is the
+    // point -- you opted into a fixed set -- but it means a list needs
+    // revisiting when the catalog grows. Levels remain available and remain
+    // the right default for broad, trusted keys.
+    if (Array.isArray(value)) {
+      const grantable = new Set(grantableActions(namespace));
+      const actions = [...new Set(value.filter((action) => grantable.has(action)))].sort();
+      // Nothing recognised means None, never a fallback to a level -- same
+      // drop-rather-than-coerce rule the level branch below follows.
+      if (actions.length) scopes[namespace] = actions;
+      continue;
+    }
+
+    if (!SCOPE_LEVELS.includes(value)) continue;
+    if (value === "write" && !namespaceHasWriteActions(namespace)) {
       // logs has no write action, and updates' writes are denied. In both
       // cases store read rather than a level that resolves to the same thing.
       scopes[namespace] = "read";
       continue;
     }
-    scopes[namespace] = level;
+    scopes[namespace] = value;
   }
   return scopes;
+}
+
+// Does this stored scope value reach this action? The single place the two
+// scope forms are interpreted, so keyAllows() and any UI preview cannot drift.
+export function scopeAllowsAction(namespace, value, action) {
+  if (Array.isArray(value)) {
+    if (!value.includes(action)) return false;
+    // Defensive, for a hand-edited api-keys.json that lists a write action in
+    // a write-denied namespace: normalizeScopes drops those on save, and this
+    // is the check that also covers a file edited behind its back.
+    return !KEY_WRITE_DENIED_NAMESPACES.has(namespace) || isReadAction(action);
+  }
+  if (value !== "read" && value !== "write") return false;
+  if (value === "write" && !KEY_WRITE_DENIED_NAMESPACES.has(namespace)) return true;
+  return isReadAction(action);
 }
 
 export function scopesGrantAnything(scopes) {

--- a/console/api/src/apiKeys.js
+++ b/console/api/src/apiKeys.js
@@ -14,6 +14,7 @@ import {
   isReadAction,
   namespaceOf,
   normalizeScopes,
+  scopeAllowsAction,
   scopesGrantAnything
 } from "./apiKeyScopes.js";
 
@@ -90,13 +91,12 @@ export function keyAllows(key, action) {
   // granting `settings: write` still cannot mint keys.
   if (KEY_DENIED_NAMESPACES.has(namespace)) return false;
   const scopes = key.scopes && typeof key.scopes === "object" ? key.scopes : {};
-  const level = scopes[namespace];
-  if (level !== "read" && level !== "write") return false;   // absent, or anything else, is None
-  // A stored "write" on a write-denied namespace (updates) degrades to read
-  // rather than being honoured. normalizeScopes already coerces it on save;
-  // this is the check that also covers a hand-edited api-keys.json.
-  if (level === "write" && !KEY_WRITE_DENIED_NAMESPACES.has(namespace)) return true;
-  return isReadAction(action);
+  // A namespace holds either a level ("read"/"write") or an explicit list of
+  // actions. Absent, or anything else, is None. scopeAllowsAction is the one
+  // place both forms are interpreted -- including the write-denied degrade
+  // that normalizeScopes applies on save and this re-applies for a
+  // hand-edited api-keys.json.
+  return scopeAllowsAction(namespace, scopes[namespace], action);
 }
 
 function badRequest(message) {
@@ -142,7 +142,13 @@ export function publicKey(record, expired = false) {
     id: record.id,
     name: record.name,
     prefix: record.prefix,
-    scopes: { ...record.scopes },
+    // Copied one level deeper than a spread, because a scope value may now be
+    // an ARRAY of actions. `{ ...record.scopes }` would hand every caller a
+    // reference to the stored array, so anything mutating what it got back --
+    // a sort in the UI layer, a push in a future caller -- would be editing
+    // the live key's grant in place.
+    scopes: Object.fromEntries(Object.entries(record.scopes || {})
+      .map(([namespace, value]) => [namespace, Array.isArray(value) ? [...value] : value])),
     enabled: record.enabled !== false,
     createdAt: record.createdAt,
     expiresAt: record.expiresAt || null,

--- a/console/api/src/apiKeys.js
+++ b/console/api/src/apiKeys.js
@@ -142,11 +142,9 @@ export function publicKey(record, expired = false) {
     id: record.id,
     name: record.name,
     prefix: record.prefix,
-    // Copied one level deeper than a spread, because a scope value may now be
-    // an ARRAY of actions. `{ ...record.scopes }` would hand every caller a
-    // reference to the stored array, so anything mutating what it got back --
-    // a sort in the UI layer, a push in a future caller -- would be editing
-    // the live key's grant in place.
+    // One level deeper than a spread: a scope value may be an ARRAY, and
+    // `{ ...record.scopes }` would share that array with every caller, so any
+    // sort or push downstream would edit the live key's grant in place.
     scopes: Object.fromEntries(Object.entries(record.scopes || {})
       .map(([namespace, value]) => [namespace, Array.isArray(value) ? [...value] : value])),
     enabled: record.enabled !== false,

--- a/console/api/src/db.js
+++ b/console/api/src/db.js
@@ -153,10 +153,14 @@ export function isReadOnlySql(query) {
 // enough to reject them. Callers use this first so obviously-empty input is a
 // 400 instead of a pg_dump.
 //
-// Only ever rejects input that is entirely comments, semicolons and whitespace.
-// The comment stripping is naive about string literals -- SELECT '--' strips to
-// "SELECT '" -- but that can only leave MORE text behind, never less, so it
-// cannot turn a real statement into a false rejection.
+// The comment stripping is naive about string literals. That cuts both ways:
+// SELECT '--' strips to "SELECT '" (more text left behind), but
+// SELECT '/*' as a, '*/' as b strips to "select ' ' as b" -- 14 characters of
+// real SQL removed. So "it can only leave more behind" is NOT true, and this
+// function is safe for a different reason: it only ever decides whether
+// SOMETHING remains, and every case above still leaves a non-empty string. No
+// statement has been found that it falsely rejects, and the corpus in
+// databaseQueryAuthz.test.js pins the ones that were tried.
 export function hasExecutableStatement(query) {
   return stripSqlComments(query).replace(/;/g, "").trim().length > 0;
 }

--- a/console/api/src/db.js
+++ b/console/api/src/db.js
@@ -146,21 +146,16 @@ export function isReadOnlySql(query) {
 
 // True when there is something here Postgres would actually run.
 //
-// The SQL routes classify with isReadOnlySql, which answers "does this START
-// with a read keyword" -- so "" , "   ", ";", and a fully commented-out block
-// all answer NO and were therefore treated as WRITES. That sent them down the
-// write path, which takes a full pre-write backup before duneDb.runSql gets far
-// enough to reject them. Callers use this first so obviously-empty input is a
-// 400 instead of a pg_dump.
+// isReadOnlySql answers "does this START with a read keyword", so "", "   ",
+// ";" and a fully commented-out block all answer NO and classify as WRITES --
+// down the write path, which takes a full pre-write backup. Callers check this
+// first so obviously-empty input is a 400 rather than a pg_dump.
 //
-// The comment stripping is naive about string literals. That cuts both ways:
-// SELECT '--' strips to "SELECT '" (more text left behind), but
-// SELECT '/*' as a, '*/' as b strips to "select ' ' as b" -- 14 characters of
-// real SQL removed. So "it can only leave more behind" is NOT true, and this
-// function is safe for a different reason: it only ever decides whether
-// SOMETHING remains, and every case above still leaves a non-empty string. No
-// statement has been found that it falsely rejects, and the corpus in
-// databaseQueryAuthz.test.js pins the ones that were tried.
+// The comment stripping is naive about string literals, and it can remove real
+// SQL: `SELECT '/*' as a, '*/' as b` strips to `select ' ' as b`. That is safe
+// here only because this decides whether ANYTHING remains, and every such case
+// still leaves a non-empty string. Do not reuse it where the stripped text
+// itself matters. The corpus in databaseQueryAuthz.test.js pins the cases tried.
 export function hasExecutableStatement(query) {
   return stripSqlComments(query).replace(/;/g, "").trim().length > 0;
 }

--- a/console/api/src/db.js
+++ b/console/api/src/db.js
@@ -131,13 +131,34 @@ export function bigintParam(value, label, min = 1n, max = 9223372036854775807n) 
   return n.toString();
 }
 
-export function isReadOnlySql(query) {
-  const stripped = String(query || "")
+export function stripSqlComments(query) {
+  return String(query || "")
     .replace(/\/\*[\s\S]*?\*\//g, " ")
     .replace(/--[^\n]*/g, " ")
     .trim();
+}
+
+export function isReadOnlySql(query) {
+  const stripped = stripSqlComments(query);
   return /^(select|with|show|explain)\b/i.test(stripped) &&
     !/\b(insert|update|delete|drop|alter|truncate|create|grant|revoke|copy\s+.*\s+from)\b/i.test(stripped);
+}
+
+// True when there is something here Postgres would actually run.
+//
+// The SQL routes classify with isReadOnlySql, which answers "does this START
+// with a read keyword" -- so "" , "   ", ";", and a fully commented-out block
+// all answer NO and were therefore treated as WRITES. That sent them down the
+// write path, which takes a full pre-write backup before duneDb.runSql gets far
+// enough to reject them. Callers use this first so obviously-empty input is a
+// 400 instead of a pg_dump.
+//
+// Only ever rejects input that is entirely comments, semicolons and whitespace.
+// The comment stripping is naive about string literals -- SELECT '--' strips to
+// "SELECT '" -- but that can only leave MORE text behind, never less, so it
+// cannot turn a real statement into a false rejection.
+export function hasExecutableStatement(query) {
+  return stripSqlComments(query).replace(/;/g, "").trim().length > 0;
 }
 
 function normalizeQueryResult(result) {

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -839,27 +839,23 @@ export async function runSql(db, query, allowDestructive = false, { enforceReadO
   const readOnly = isReadOnlySql(sql);
   if (!allowDestructive && !readOnly) throw new Error("Only read-only SQL is allowed without destructive confirmation");
 
-  // POSTGRES refuses the write, rather than isReadOnlySql being trusted to have
-  // spotted it.
+  // POSTGRES refuses the write; isReadOnlySql is not trusted to have spotted it.
   //
-  // The classifier only asks "does this start with a read keyword and avoid a
-  // blacklist". Every privileged mutation in this application is shaped
-  // `select dune.<fn>(...)` -- disband_guild, delete_actors,
-  // adjust_player_virtual_currency_balance -- so the whole mutation surface
-  // walked straight through, and the blacklist cannot be repaired to cover it
-  // (\bdelete\b does not match delete_actors, and the schema ships hundreds of
-  // functions). `SELECT ... INTO` and `select 1; select mutating_fn()` walked
-  // through by other routes again.
+  // The classifier only asks "starts with a read keyword and avoids a
+  // blacklist". Every privileged mutation here is shaped `select dune.<fn>(...)`
+  // -- disband_guild, delete_actors, adjust_player_virtual_currency_balance --
+  // so the entire mutation surface passes, and the blacklist cannot be repaired
+  // to catch it (\bdelete\b does not match delete_actors, across hundreds of
+  // shipped functions). `SELECT ... INTO` and `select 1; select fn()` pass too.
   //
-  // That left every guard built on the classifier -- the database:execute
-  // permission, the pre-write backup, the mutation rate limiter -- decorative
-  // for exactly the statements that matter most. Asking the database is the
-  // only check that cannot be talked around.
+  // So every guard built on the classifier -- the database:execute permission,
+  // the pre-write backup, the mutation rate limiter -- is decorative for
+  // exactly the statements that matter most. Asking the database is the only
+  // check that cannot be talked around.
   if (enforceReadOnly && !allowDestructive) {
     const result = await db.transaction(async (tx) => {
-      // Must be the first statement in the transaction, and it covers every
-      // statement in `sql` -- including later ones in a multi-statement string,
-      // which is how `select 1; select mutating_fn()` got through.
+      // Must be first in the transaction. Covers every statement in `sql`,
+      // including later ones in a multi-statement string.
       await tx.query("set transaction read only");
       return tx.query(sql);
     });

--- a/console/api/src/duneDb.js
+++ b/console/api/src/duneDb.js
@@ -828,11 +828,44 @@ export async function searchDatabase(db, q) {
   return result.rows;
 }
 
-export async function runSql(db, query, allowDestructive = false) {
+// enforceReadOnly is for CALLER-SUPPLIED SQL only -- the console's Run Query
+// route and the addon bridge. Internal callers build their own SQL and pass it
+// with enforceReadOnly off, both because their statements are not attacker
+// controlled and because their mocked `db` objects in tests have no usable
+// transaction().
+export async function runSql(db, query, allowDestructive = false, { enforceReadOnly = false } = {}) {
   const sql = String(query || "").trim();
   if (!sql) throw new Error("SQL query is required");
   const readOnly = isReadOnlySql(sql);
   if (!allowDestructive && !readOnly) throw new Error("Only read-only SQL is allowed without destructive confirmation");
+
+  // POSTGRES refuses the write, rather than isReadOnlySql being trusted to have
+  // spotted it.
+  //
+  // The classifier only asks "does this start with a read keyword and avoid a
+  // blacklist". Every privileged mutation in this application is shaped
+  // `select dune.<fn>(...)` -- disband_guild, delete_actors,
+  // adjust_player_virtual_currency_balance -- so the whole mutation surface
+  // walked straight through, and the blacklist cannot be repaired to cover it
+  // (\bdelete\b does not match delete_actors, and the schema ships hundreds of
+  // functions). `SELECT ... INTO` and `select 1; select mutating_fn()` walked
+  // through by other routes again.
+  //
+  // That left every guard built on the classifier -- the database:execute
+  // permission, the pre-write backup, the mutation rate limiter -- decorative
+  // for exactly the statements that matter most. Asking the database is the
+  // only check that cannot be talked around.
+  if (enforceReadOnly && !allowDestructive) {
+    const result = await db.transaction(async (tx) => {
+      // Must be the first statement in the transaction, and it covers every
+      // statement in `sql` -- including later ones in a multi-statement string,
+      // which is how `select 1; select mutating_fn()` got through.
+      await tx.query("set transaction read only");
+      return tx.query(sql);
+    });
+    return rowsResult(result);
+  }
+
   const result = readOnly
     ? await db.query(sql)
     : await withKnownLiveRefresh(db, () => db.query(sql), { features: liveRefreshFeaturesForSql(sql) });

--- a/console/api/src/policy.js
+++ b/console/api/src/policy.js
@@ -12,17 +12,11 @@
 //       { "Effect": "Allow", "Action": ["bases:*", "server:read"] }
 //     ]}
 //
-// Every Action here must be a REAL action, or a wildcard matching at least one.
-// This example used to read "Deny players:reset-progression" -- a string no
-// route resolves to, so it denied nothing while looking like it withheld
-// progression resets. The route actually resolves to players:reset.
-// setPolicies now refuses such a pattern instead of storing it;
-// unknownActions() is the check.
-//
-// A name the catalog USED to have is a different case, handled by
-// REMOVED_ACTION_ALIASES: it keeps its old meaning when evaluated, so an
-// upgrade cannot silently re-interpret a policy, but setPolicies still refuses
-// it on save so the operator migrates.
+// Every Action must be a REAL action, or a wildcard matching at least one; a
+// name matching nothing denies nothing while reading like a restriction.
+// setPolicies refuses those (unknownActions). A name the catalog USED to have
+// is a separate case: REMOVED_ACTION_ALIASES keeps its old meaning at
+// evaluation time, and setPolicies refuses it on save so the operator migrates.
 //
 // Evaluation: for each statement in order,
 //   if action matches statement AND Effect=Deny  → DENY immediately
@@ -54,20 +48,16 @@ export function matchAction(pattern, action) {
     const regex = new RegExp("^" + pattern.replace(/\*/g, ".*") + "$");
     return regex.test(action);
   }
-  // A name this catalog used to have. Checked LAST, so it can never shadow a
-  // live action, and it exists so that splitting a coarse action does not
-  // silently re-interpret a policy that already named it -- a Deny on
-  // players:mutate still denies every action players:mutate used to cover.
-  // See REMOVED_ACTION_ALIASES in actions.js for why this is not simply a
-  // deletion. setPolicies still refuses these on save.
+  // A name this catalog used to have. Checked LAST so it can never shadow a
+  // live action. See REMOVED_ACTION_ALIASES in actions.js for why a split
+  // cannot simply delete the old name.
   const successors = REMOVED_ACTION_ALIASES[pattern];
   if (successors) return successors.includes(action);
   return false;
 }
 
-// Patterns naming an action this catalog used to have. Distinct from
-// unknownActions: these still MEAN something (matchAction honours them), but an
-// operator saving a policy should be told to name the successors explicitly.
+// Patterns naming an action the catalog used to have. Unlike unknownActions
+// these still mean something, but a save should name the successors explicitly.
 export function deprecatedActions(docs) {
   const found = [];
   for (const [tier, document] of Object.entries(docs || {})) {
@@ -133,12 +123,10 @@ export function loadPolicies(repoRoot = null) {
       const parsed = JSON.parse(raw);
       if (validPolicyStore(parsed)) {
         _policies = parsed;
-        // Loaded even when it names actions that do not exist, and reported
-        // rather than rejected. setPolicies refuses those on save, so a stored
-        // file can only acquire one by hand-editing -- and throwing the whole
-        // document away would silently revert an operator's entire policy to
-        // defaults, a far bigger surprise than the dead pattern itself. The
-        // caller logs what is returned here.
+        // Reported, not rejected: discarding the document would silently
+        // revert the operator's whole policy to defaults, a bigger surprise
+        // than the dead pattern. setPolicies refuses these on save, so a stored
+        // file can only acquire one by hand-editing. The caller logs this.
         return { source: "file", path: filePath, unknownActions: unknownActions(parsed), deprecatedActions: deprecatedActions(parsed) };
       }
       _policies = DEFAULT_POLICIES;
@@ -203,19 +191,17 @@ export function getAllPolicies(policies = null) {
 }
 
 // Every Action pattern that matches NO action in the catalog, as
-// [{ tier, pattern }]. Such a pattern is dead weight in an Allow and a silent
-// lie in a Deny: "Deny players:reset-progression" looks like it withholds
-// progression resets, but no route resolves to that string (the real one is
-// players:reset), so it withholds nothing and the policy reads as safe.
+// [{ tier, pattern }]. Dead weight in an Allow; a silent lie in a Deny.
+// "Deny players:reset-progression" is the shape -- no route resolves to it
+// (players:reset does), so it withholds nothing while the policy reads as safe.
 //
-// A name the catalog used to have is NOT reported here -- matchAction still
-// honours it, so it matches successors and is not dead. deprecatedActions()
-// reports those separately, because the fix is migration rather than a typo.
+// Removed names are NOT reported here: matchAction still honours them, so they
+// are not dead. deprecatedActions() reports those, since the fix is migration
+// rather than a typo.
 //
-// Wildcards are legal and must stay legal, so the test is "does this pattern
-// match at least one real action", not "is this string in the catalog" --
-// evaluated with the same matchAction the engine uses, so a pattern accepted
-// here behaves at runtime exactly as it did during validation.
+// The test is "does this pattern match at least one real action", not "is this
+// string in the catalog", so wildcards stay legal -- and it runs through the
+// same matchAction the engine uses, so validation and runtime cannot disagree.
 export function unknownActions(docs) {
   const known = [...allKnownActions()];
   const dead = [];
@@ -238,15 +224,15 @@ export function setPolicies(docs, repoRoot = null) {
   if (!evaluate({ tier: "owner" }, "settings:write", docs)) {
     return { ok: false, error: "The owner policy must retain settings:write access." };
   }
-  // Refused rather than warned about: the dangerous case is a misspelled Deny,
-  // and a save that "succeeded with warnings" is exactly how an operator ends
-  // up believing a restriction is in force when it is not.
-  // Refused on SAVE even though matchAction still honours them at evaluation
-  // time. That asymmetry is the whole design: an existing document keeps its
-  // meaning through an upgrade, and the operator is pushed to migrate the next
-  // time they edit it, rather than being silently re-interpreted OR having the
-  // console refuse to start. The message names the successors so the edit is
-  // mechanical.
+  // Both checks REFUSE rather than warn. A save that "succeeded with warnings"
+  // is how an operator ends up believing a restriction is in force when it is
+  // not.
+  //
+  // Deprecated names are refused on save even though matchAction still honours
+  // them at evaluation time. That asymmetry is deliberate: a stored document
+  // keeps its meaning through an upgrade, and the operator migrates on their
+  // next edit instead of the console refusing to start. The message names the
+  // successors so the edit is mechanical.
   const deprecated = deprecatedActions(docs);
   if (deprecated.length) {
     const listed = deprecated
@@ -331,20 +317,15 @@ const DEFAULT_POLICIES = {
         "settings:*",
         "database:write-config",
         "database:mutate",
-        // The write half of POST /api/database/query -- the reason the two
-        // denials above were decorative: database:query is granted just
-        // above, and that one route accepts UPDATE/DELETE/DROP as readily as
-        // SELECT, so admin kept arbitrary write access to the whole database
-        // through it. See CONTENT_CONDITIONAL_ACTIONS in actions.js.
+        // The write half of POST /api/database/query, without which the two
+        // denials above are decorative: database:query is granted just above
+        // and that route takes UPDATE/DELETE/DROP as readily as SELECT.
         //
-        // What actually closes that hole is the requireAction("database:execute")
-        // call in server.js's databaseQuery, not this line: the Allow list
-        // above names database:read/query/export individually rather than
-        // database:*, so default-deny already refuses database:execute and
-        // removing this line changes nothing today. It is here for the edit
-        // that widens the Allow to database:* -- a plausible tidy-up that
-        // would otherwise silently hand admin the write half back. Covered by
-        // "the deny survives a widened allow list" in databaseQueryAuthz.test.js.
+        // Redundant today -- the Allow list names database:read/query/export
+        // individually, so default-deny already refuses this. It is here for
+        // the plausible tidy-up that widens the Allow to database:*, which
+        // would otherwise hand the write half back. Pinned by "the deny
+        // survives a widened allow list" in databaseQueryAuthz.test.js.
         "database:execute",
       ]}
     ]

--- a/console/api/src/policy.js
+++ b/console/api/src/policy.js
@@ -15,9 +15,14 @@
 // Every Action here must be a REAL action, or a wildcard matching at least one.
 // This example used to read "Deny players:reset-progression" -- a string no
 // route resolves to, so it denied nothing while looking like it withheld
-// progression resets (the actual action is players:mutate, which covers every
-// player mutation at once). setPolicies now refuses such a pattern instead of
-// storing it; unknownActions() is the check.
+// progression resets. The route actually resolves to players:reset.
+// setPolicies now refuses such a pattern instead of storing it;
+// unknownActions() is the check.
+//
+// A name the catalog USED to have is a different case, handled by
+// REMOVED_ACTION_ALIASES: it keeps its old meaning when evaluated, so an
+// upgrade cannot silently re-interpret a policy, but setPolicies still refuses
+// it on save so the operator migrates.
 //
 // Evaluation: for each statement in order,
 //   if action matches statement AND Effect=Deny  → DENY immediately
@@ -26,7 +31,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { ROUTE_ACTIONS, REGEX_ACTIONS, REGEX_ACTIONS_BY_METHOD, REGEX_ACTIONS_BY_METHOD_PATTERN, CONTENT_CONDITIONAL_ACTIONS } from "./actions.js";
+import { ROUTE_ACTIONS, REGEX_ACTIONS, REGEX_ACTIONS_BY_METHOD, REGEX_ACTIONS_BY_METHOD_PATTERN, CONTENT_CONDITIONAL_ACTIONS, REMOVED_ACTION_ALIASES } from "./actions.js";
 import { writeJsonAtomic } from "./jsonStore.js";
 
 // ---- Policy evaluation ----
@@ -49,7 +54,32 @@ export function matchAction(pattern, action) {
     const regex = new RegExp("^" + pattern.replace(/\*/g, ".*") + "$");
     return regex.test(action);
   }
+  // A name this catalog used to have. Checked LAST, so it can never shadow a
+  // live action, and it exists so that splitting a coarse action does not
+  // silently re-interpret a policy that already named it -- a Deny on
+  // players:mutate still denies every action players:mutate used to cover.
+  // See REMOVED_ACTION_ALIASES in actions.js for why this is not simply a
+  // deletion. setPolicies still refuses these on save.
+  const successors = REMOVED_ACTION_ALIASES[pattern];
+  if (successors) return successors.includes(action);
   return false;
+}
+
+// Patterns naming an action this catalog used to have. Distinct from
+// unknownActions: these still MEAN something (matchAction honours them), but an
+// operator saving a policy should be told to name the successors explicitly.
+export function deprecatedActions(docs) {
+  const found = [];
+  for (const [tier, document] of Object.entries(docs || {})) {
+    for (const statement of document?.statements || []) {
+      const patterns = Array.isArray(statement.Action) ? statement.Action : [statement.Action];
+      for (const pattern of patterns) {
+        if (typeof pattern !== "string") continue;
+        if (REMOVED_ACTION_ALIASES[pattern]) found.push({ tier, pattern, successors: [...REMOVED_ACTION_ALIASES[pattern]] });
+      }
+    }
+  }
+  return found;
 }
 
 export function evaluate(session, action, policies = null) {
@@ -109,19 +139,19 @@ export function loadPolicies(repoRoot = null) {
         // document away would silently revert an operator's entire policy to
         // defaults, a far bigger surprise than the dead pattern itself. The
         // caller logs what is returned here.
-        return { source: "file", path: filePath, unknownActions: unknownActions(parsed) };
+        return { source: "file", path: filePath, unknownActions: unknownActions(parsed), deprecatedActions: deprecatedActions(parsed) };
       }
       _policies = DEFAULT_POLICIES;
-      return { source: "defaults", path: filePath, invalid: true, unknownActions: [] };
+      return { source: "defaults", path: filePath, invalid: true, unknownActions: [], deprecatedActions: [] };
     } catch {
       _policies = DEFAULT_POLICIES;
-      return { source: "defaults", path: filePath, invalid: true, unknownActions: [] };
+      return { source: "defaults", path: filePath, invalid: true, unknownActions: [], deprecatedActions: [] };
     }
   }
 
   // Hardcoded fallback defaults
   _policies = DEFAULT_POLICIES;
-  return { source: "defaults", unknownActions: [] };
+  return { source: "defaults", unknownActions: [], deprecatedActions: [] };
 }
 
 let _allowedActions = {};
@@ -176,7 +206,11 @@ export function getAllPolicies(policies = null) {
 // [{ tier, pattern }]. Such a pattern is dead weight in an Allow and a silent
 // lie in a Deny: "Deny players:reset-progression" looks like it withholds
 // progression resets, but no route resolves to that string (the real one is
-// players:mutate), so it withholds nothing and the policy reads as safe.
+// players:reset), so it withholds nothing and the policy reads as safe.
+//
+// A name the catalog used to have is NOT reported here -- matchAction still
+// honours it, so it matches successors and is not dead. deprecatedActions()
+// reports those separately, because the fix is migration rather than a typo.
 //
 // Wildcards are legal and must stay legal, so the test is "does this pattern
 // match at least one real action", not "is this string in the catalog" --
@@ -207,6 +241,24 @@ export function setPolicies(docs, repoRoot = null) {
   // Refused rather than warned about: the dangerous case is a misspelled Deny,
   // and a save that "succeeded with warnings" is exactly how an operator ends
   // up believing a restriction is in force when it is not.
+  // Refused on SAVE even though matchAction still honours them at evaluation
+  // time. That asymmetry is the whole design: an existing document keeps its
+  // meaning through an upgrade, and the operator is pushed to migrate the next
+  // time they edit it, rather than being silently re-interpreted OR having the
+  // console refuse to start. The message names the successors so the edit is
+  // mechanical.
+  const deprecated = deprecatedActions(docs);
+  if (deprecated.length) {
+    const listed = deprecated
+      .map(({ tier, pattern, successors }) => `${tier}: ${pattern} (now ${successors.join(", ")})`)
+      .join("; ");
+    return {
+      ok: false,
+      error: `These actions were split and no longer exist. Name the actions you actually want instead: ${listed}.`,
+      deprecatedActions: deprecated
+    };
+  }
+
   const dead = unknownActions(docs);
   if (dead.length) {
     const listed = dead.map(({ tier, pattern }) => `${tier}: ${pattern}`).join(", ");

--- a/console/api/src/policy.js
+++ b/console/api/src/policy.js
@@ -8,9 +8,16 @@
 // Policy document format (per tier):
 //   { "version": 1, "tier": "moderator",
 //     "statements": [
-//       { "Effect": "Deny",  "Action": ["players:reset-progression"] },
-//       { "Effect": "Allow", "Action": ["players:*", "server:read"] }
+//       { "Effect": "Deny",  "Action": ["bases:delete"] },
+//       { "Effect": "Allow", "Action": ["bases:*", "server:read"] }
 //     ]}
+//
+// Every Action here must be a REAL action, or a wildcard matching at least one.
+// This example used to read "Deny players:reset-progression" -- a string no
+// route resolves to, so it denied nothing while looking like it withheld
+// progression resets (the actual action is players:mutate, which covers every
+// player mutation at once). setPolicies now refuses such a pattern instead of
+// storing it; unknownActions() is the check.
 //
 // Evaluation: for each statement in order,
 //   if action matches statement AND Effect=Deny  → DENY immediately
@@ -19,7 +26,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { ROUTE_ACTIONS, REGEX_ACTIONS, REGEX_ACTIONS_BY_METHOD, REGEX_ACTIONS_BY_METHOD_PATTERN } from "./actions.js";
+import { ROUTE_ACTIONS, REGEX_ACTIONS, REGEX_ACTIONS_BY_METHOD, REGEX_ACTIONS_BY_METHOD_PATTERN, CONTENT_CONDITIONAL_ACTIONS } from "./actions.js";
 import { writeJsonAtomic } from "./jsonStore.js";
 
 // ---- Policy evaluation ----
@@ -88,21 +95,33 @@ export function loadPolicies(repoRoot = null) {
     ? resolve(repoRoot, "runtime/generated/iam-policies.json")
     : resolve(process.cwd(), "../..", "runtime/generated/iam-policies.json");
 
+  _allowedActions = {};
+
   if (existsSync(filePath)) {
     try {
       const raw = readFileSync(filePath, "utf8");
       const parsed = JSON.parse(raw);
       if (validPolicyStore(parsed)) {
         _policies = parsed;
-        return;
+        // Loaded even when it names actions that do not exist, and reported
+        // rather than rejected. setPolicies refuses those on save, so a stored
+        // file can only acquire one by hand-editing -- and throwing the whole
+        // document away would silently revert an operator's entire policy to
+        // defaults, a far bigger surprise than the dead pattern itself. The
+        // caller logs what is returned here.
+        return { source: "file", path: filePath, unknownActions: unknownActions(parsed) };
       }
+      _policies = DEFAULT_POLICIES;
+      return { source: "defaults", path: filePath, invalid: true, unknownActions: [] };
     } catch {
-      // Fall through to defaults
+      _policies = DEFAULT_POLICIES;
+      return { source: "defaults", path: filePath, invalid: true, unknownActions: [] };
     }
   }
 
   // Hardcoded fallback defaults
   _policies = DEFAULT_POLICIES;
+  return { source: "defaults", unknownActions: [] };
 }
 
 let _allowedActions = {};
@@ -112,11 +131,16 @@ let _allowedActions = {};
 // other tiers instead (see actions.js). bases:delete is the reason this
 // enumerates all four: it exists only in REGEX_ACTIONS_BY_METHOD_PATTERN, so
 // a version of this that only read ROUTE_ACTIONS would never surface it.
+//
+// CONTENT_CONDITIONAL_ACTIONS is the fifth source and the only one no route
+// resolves to: those actions are decided from the request body inside the
+// handler, so nothing in the four route tables above mentions them.
 export function allKnownActions() {
   const actions = new Set(Object.values(ROUTE_ACTIONS));
   for (const [, action] of REGEX_ACTIONS) actions.add(action);
   for (const action of Object.values(REGEX_ACTIONS_BY_METHOD)) actions.add(action);
   for (const { action } of REGEX_ACTIONS_BY_METHOD_PATTERN) actions.add(action);
+  for (const action of CONTENT_CONDITIONAL_ACTIONS) actions.add(action);
   return actions;
 }
 
@@ -148,12 +172,49 @@ export function getAllPolicies(policies = null) {
   return { ...store };
 }
 
+// Every Action pattern that matches NO action in the catalog, as
+// [{ tier, pattern }]. Such a pattern is dead weight in an Allow and a silent
+// lie in a Deny: "Deny players:reset-progression" looks like it withholds
+// progression resets, but no route resolves to that string (the real one is
+// players:mutate), so it withholds nothing and the policy reads as safe.
+//
+// Wildcards are legal and must stay legal, so the test is "does this pattern
+// match at least one real action", not "is this string in the catalog" --
+// evaluated with the same matchAction the engine uses, so a pattern accepted
+// here behaves at runtime exactly as it did during validation.
+export function unknownActions(docs) {
+  const known = [...allKnownActions()];
+  const dead = [];
+  for (const [tier, document] of Object.entries(docs || {})) {
+    for (const statement of document?.statements || []) {
+      const patterns = Array.isArray(statement.Action) ? statement.Action : [statement.Action];
+      for (const pattern of patterns) {
+        if (typeof pattern !== "string") continue;
+        if (!known.some((action) => matchAction(pattern, action))) dead.push({ tier, pattern });
+      }
+    }
+  }
+  return dead;
+}
+
 export function setPolicies(docs, repoRoot = null) {
   if (!validPolicyStore(docs)) {
     return { ok: false, error: "Policies must contain valid tier documents and Allow/Deny statements." };
   }
   if (!evaluate({ tier: "owner" }, "settings:write", docs)) {
     return { ok: false, error: "The owner policy must retain settings:write access." };
+  }
+  // Refused rather than warned about: the dangerous case is a misspelled Deny,
+  // and a save that "succeeded with warnings" is exactly how an operator ends
+  // up believing a restriction is in force when it is not.
+  const dead = unknownActions(docs);
+  if (dead.length) {
+    const listed = dead.map(({ tier, pattern }) => `${tier}: ${pattern}`).join(", ");
+    return {
+      ok: false,
+      error: `These actions do not exist and would have no effect: ${listed}. Check GET /api/settings/iam/policies for the full list of valid actions.`,
+      unknownActions: dead
+    };
   }
   _policies = docs;
   _allowedActions = {};
@@ -218,6 +279,21 @@ const DEFAULT_POLICIES = {
         "settings:*",
         "database:write-config",
         "database:mutate",
+        // The write half of POST /api/database/query -- the reason the two
+        // denials above were decorative: database:query is granted just
+        // above, and that one route accepts UPDATE/DELETE/DROP as readily as
+        // SELECT, so admin kept arbitrary write access to the whole database
+        // through it. See CONTENT_CONDITIONAL_ACTIONS in actions.js.
+        //
+        // What actually closes that hole is the requireAction("database:execute")
+        // call in server.js's databaseQuery, not this line: the Allow list
+        // above names database:read/query/export individually rather than
+        // database:*, so default-deny already refuses database:execute and
+        // removing this line changes nothing today. It is here for the edit
+        // that widens the Allow to database:* -- a plausible tidy-up that
+        // would otherwise silently hand admin the write half back. Covered by
+        // "the deny survives a widened allow list" in databaseQueryAuthz.test.js.
+        "database:execute",
       ]}
     ]
   },

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -14,13 +14,12 @@ import { buildSelfUpdateHelperDockerArgs, detectDockerSocketGid, TaskManager, pu
 import { preflight } from "./preflight.js";
 import { buildDuneArgs, isDynamicServerService, parseVehicleList, runDockerLogs, runDune, validateServiceName } from "./runner.js";
 // isReadOnlySql comes from db.js, NOT runner.js. runner's copy tests the raw
-// string, so a genuinely read-only SELECT with a leading `-- note` or `/* */`
-// header does not start with a read keyword and was classified a WRITE --
-// which since database:execute exists means a 403 for admin on ordinary
-// pasted SQL. db.js strips comments first (substituting a space, so it cannot
-// fuse tokens or hide a leading `delete`). Using one classifier here and in
-// duneDb.runSql also removes the divergence between the authorization
-// decision and the execution decision.
+// string, so a read-only SELECT behind a leading `-- note` or `/* */` header
+// does not start with a read keyword and classifies as a WRITE -- a 403 for
+// admin on ordinary pasted SQL. db.js strips comments first, substituting a
+// space so it cannot fuse tokens or hide a leading `delete`. Sharing one
+// classifier with duneDb.runSql also keeps the authorization decision and the
+// execution decision from diverging.
 import { createDb, hasExecutableStatement, isReadOnlySql, quoteIdentifier } from "./db.js";
 import * as duneDb from "./duneDb.js";
 import { audit, recordAdminHistory } from "./audit.js";
@@ -559,22 +558,17 @@ function dockerPsNames() {
   });
 }
 
-// Second authorization gate, for a route whose real action depends on the
-// request body rather than on its method and path. actionForRoute runs in
-// handleApi's gate with no body in hand, so a route that does two different
-// things at two different blast radii (POST /api/database/query: SELECT vs
-// DROP) can only resolve to the safer of the two there. The handler calls this
-// afterwards with the narrower action, and it re-runs BOTH checks the gate ran
-// -- the policy engine, then the key's own scope map -- so a body-decided
-// action is constrained exactly as a routed one would be.
+// Second authorization gate, for a route whose action depends on the request
+// BODY. actionForRoute runs in handleApi's gate with no body in hand, so a
+// route spanning two blast radii (POST /api/database/query: SELECT vs DROP)
+// resolves to the safer one there; the handler calls this afterwards with the
+// narrower action. Re-runs BOTH gate checks -- policy engine, then the key's
+// scope map. Additive only: it can narrow access, never widen it.
 //
-// Deliberately additive: the route-level action is already authorized by the
-// time a handler runs, so this only ever narrows access, never widens it.
-//
-// Returns true when the principal may proceed. On false it has ALREADY written
-// the 403, and the caller must return without doing any further work — in
-// particular without the rate-limit tick or the pre-write backup, both of which
-// are side effects an unauthorized caller must not be able to trigger.
+// Returns true when the principal may proceed. On false the 403 is ALREADY
+// written and the caller must return immediately -- in particular before the
+// rate-limit tick and the pre-write backup, side effects an unauthorized
+// caller must not be able to trigger.
 function requireAction(req, res, action) {
   const session = req.authSession;
   if (!session || !evaluate(session, action)) {
@@ -880,10 +874,10 @@ async function handleApi(req, res) {
     const testAction = String(body?.action || "").trim();
     const testTier = String(body?.tier || "").trim();
     if (!testAction || !testTier) return json(res, 400, { error: "Both action and tier are required." });
-    // `known` is the difference between "denied" and "not a thing". Testing a
-    // misspelled action returns allowed:false -- which reads as "my Deny works"
-    // and is the single most misleading answer this endpoint can give, since a
-    // misspelled Deny is precisely the mistake an operator comes here to check.
+    // `known` separates "denied" from "not a thing". A misspelled action
+    // returns allowed:false, which reads as "my Deny works" -- the most
+    // misleading answer this endpoint can give, since a misspelled Deny is
+    // exactly what an operator comes here to check.
     return json(res, 200, {
       action: testAction,
       tier: testTier,
@@ -1371,10 +1365,8 @@ async function addonBridgeRoute(req, res, path) {
   if (action.startsWith("scheduler.")) return addonSchedulerBridgeAction(req, res, id, action, body);
   if (action === "database.query" || action === "database.execute") {
     const query = String(body.query || "");
-    // Same guard, and for the same reason, as databaseQuery: an empty or
-    // comments-only body classifies as a write and reaches the backup spawn
-    // below. database.query happened to be shielded by its own read-only 400;
-    // database.execute was not.
+    // Same guard as databaseQuery: empty or comments-only input classifies as
+    // a write and reaches the backup spawn below.
     if (!hasExecutableStatement(query)) {
       return json(res, 400, { error: "No SQL statement to run." });
     }
@@ -2016,12 +2008,10 @@ async function safeCommand(operation, payload = {}) {
 async function databaseQuery(req, res) {
   const body = await readJson(req);
   const query = String(body.query || "");
-  // BEFORE the classification below, because isReadOnlySql answers "does this
-  // start with a read keyword" -- so an empty string answers no and used to be
-  // classified as a WRITE, taking a full pre-write backup before duneDb.runSql
-  // got far enough to reject it with "SQL query is required". Submitting "" in
-  // a loop made the host run pg_dump 20 times a minute per session, the
-  // mutation limiter's ceiling, for input that could never execute.
+  // BEFORE the classification below: isReadOnlySql answers "does this start
+  // with a read keyword", so "" answers no and classifies as a WRITE, taking a
+  // full pre-write backup before runSql rejects it. Empty input submitted in a
+  // loop therefore ran pg_dump at the mutation limiter's ceiling.
   if (!hasExecutableStatement(query)) {
     return json(res, 400, { error: "Enter a SQL query to run." });
   }
@@ -2039,17 +2029,13 @@ async function databaseQuery(req, res) {
     await runDune(config, buildDuneArgs("backupCreate"), { env: { DB_BACKUP_ORIGIN: "destructive-sql" } });
   }
   audit(config, req, "database.query", { readOnly, destructive: !readOnly });
-  // !readOnly, not the unconditional `true` this passed before: a request
-  // authorized as read-only is now also EXECUTED with writes refused, so
-  // duneDb.runSql's own classifier has to agree before anything can write.
-  // Safe as a second opinion because runner.js's isReadOnlySql (used above) is
-  // strictly the more conservative of the two -- it tests the raw string where
-  // db.js's strips comments first, so anything it calls read-only db.js calls
-  // read-only too. It can never reject a query this route just authorized.
-  // enforceReadOnly: the read path executes inside a READ ONLY transaction, so
-  // a statement the classifier called read-only cannot write even if it was
-  // wrong -- which for `select dune.<fn>(...)`, the shape every privileged
-  // mutation in this app uses, it always was.
+  // !readOnly rather than the unconditional `true` this used to pass, so a
+  // request authorized as read-only is also EXECUTED with writes refused.
+  // runSql re-classifies with the same db.js function used above, so the two
+  // decisions cannot disagree.
+  //
+  // enforceReadOnly is the actual guarantee: the read path runs inside a READ
+  // ONLY transaction, so Postgres refuses a write the classifier got wrong.
   return dbJson(res, () => duneDb.runSql(db, query, !readOnly, { enforceReadOnly: true }));
 }
 

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -13,7 +13,7 @@ import { createBridgeRateLimiter } from "./bridgeRateLimit.js";
 import { buildSelfUpdateHelperDockerArgs, detectDockerSocketGid, TaskManager, publicTask } from "./tasks.js";
 import { preflight } from "./preflight.js";
 import { buildDuneArgs, isDynamicServerService, isReadOnlySql, parseVehicleList, runDockerLogs, runDune, validateServiceName } from "./runner.js";
-import { createDb, quoteIdentifier } from "./db.js";
+import { createDb, hasExecutableStatement, quoteIdentifier } from "./db.js";
 import * as duneDb from "./duneDb.js";
 import { audit, recordAdminHistory } from "./audit.js";
 import { redact } from "./redact.js";
@@ -38,7 +38,7 @@ import { handleDiscordAdapterRoute, isDiscordAdapterRoute } from "./integrations
 import { discordAdapterEnabled } from "./integrations/discord/adapter.js";
 import { initializeDiscordAdapterSchema } from "./integrations/discord/schema.js";
 import { actionForRoute, ROUTE_ACTIONS } from "./actions.js";
-import { evaluate, loadPolicies, getAllPolicies, setPolicies } from "./policy.js";
+import { evaluate, loadPolicies, getAllPolicies, setPolicies, allKnownActions } from "./policy.js";
 import { liveItemGrantOk, liveItemGrantWarning } from "./grantResults.js";
 import { primeMessageOfTheDayOnlineState, readMessageOfTheDay, recordMessageOfTheDayScanFailure, restoreMessageOfTheDay, runMessageOfTheDayScan, saveMessageOfTheDay } from "./services/messageOfTheDay.js";
 import { primePlayerAnnouncementOnlineState, readPlayerAnnouncements, restorePlayerAnnouncements, runPlayerAnnouncementScan, savePlayerAnnouncements } from "./services/playerAnnouncements.js";
@@ -90,7 +90,16 @@ try {
   // bridge available for this process and retry the migration next startup.
   console.warn(`EDA Exchange Bot retirement deferred: ${redact(error?.message || "Unexpected error.")}`);
 }
-loadPolicies(config.repoRoot);
+const policyLoad = loadPolicies(config.repoRoot);
+if (policyLoad.invalid) {
+  console.warn(`IAM policy file at ${policyLoad.path} is not a valid policy store; using built-in defaults.`);
+}
+for (const { tier, pattern } of policyLoad.unknownActions) {
+  // Loaded anyway (see loadPolicies), but an operator who hand-edited a Deny
+  // into the file needs to know it matches no real action and is withholding
+  // nothing. Silence here is how a policy comes to look safer than it is.
+  console.warn(`IAM policy warning: ${tier} names "${pattern}", which matches no known action and has no effect.`);
+}
 const auth = createAuth(config);
 const qaUpdates = createQaUpdates(config);
 const loginRateLimiter = createLoginRateLimiter();
@@ -537,6 +546,35 @@ function dockerPsNames() {
   });
 }
 
+// Second authorization gate, for a route whose real action depends on the
+// request body rather than on its method and path. actionForRoute runs in
+// handleApi's gate with no body in hand, so a route that does two different
+// things at two different blast radii (POST /api/database/query: SELECT vs
+// DROP) can only resolve to the safer of the two there. The handler calls this
+// afterwards with the narrower action, and it re-runs BOTH checks the gate ran
+// -- the policy engine, then the key's own scope map -- so a body-decided
+// action is constrained exactly as a routed one would be.
+//
+// Deliberately additive: the route-level action is already authorized by the
+// time a handler runs, so this only ever narrows access, never widens it.
+//
+// Returns true when the principal may proceed. On false it has ALREADY written
+// the 403, and the caller must return without doing any further work — in
+// particular without the rate-limit tick or the pre-write backup, both of which
+// are side effects an unauthorized caller must not be able to trigger.
+function requireAction(req, res, action) {
+  const session = req.authSession;
+  if (!session || !evaluate(session, action)) {
+    json(res, 403, { error: "Your account does not have permission to access this resource." });
+    return false;
+  }
+  if (req.authApiKey && !apiKeys.allows(req.authApiKey, action)) {
+    json(res, 403, { error: "This API key is not permitted to use this endpoint." });
+    return false;
+  }
+  return true;
+}
+
 async function handleApi(req, res) {
   const url = new URL(req.url, "http://localhost");
   const path = url.pathname;
@@ -613,6 +651,11 @@ async function handleApi(req, res) {
   const session = bearer?.session || auth.requireAuth(req, res);
   if (!session) return;
   req.authSession = session;
+  // Stashed for requireAction(), the second gate a body-dependent route runs
+  // once it knows its narrower action. It carries the authenticated record
+  // itself rather than an id to look up again, so the second check cannot
+  // resolve to a different (or newly revoked) key than the first one did.
+  req.authApiKey = bearer?.key || null;
 
   const action = actionForRoute(path, req.method);
   if (!action || !evaluate(session, action)) {
@@ -799,7 +842,10 @@ async function handleApi(req, res) {
   if (path === "/api/settings/admin-password" && req.method === "POST") return adminPasswordRoute(req, res);
   if (path === "/api/settings/web-port" && req.method === "POST") return webPortRoute(req, res);
   if (path === "/api/settings/iam/policies" && req.method === "GET") {
-    return json(res, 200, { policies: getAllPolicies() });
+    // The catalog rides along because policies are hand-authored JSON with no
+    // editor UI: without it the only way to learn the vocabulary is to read
+    // actions.js, which is how misspelled actions get written in the first place.
+    return json(res, 200, { policies: getAllPolicies(), actions: [...allKnownActions()].sort() });
   }
   if (path === "/api/settings/iam/policy" && req.method === "PUT") {
     const body = await readJson(req);
@@ -821,7 +867,16 @@ async function handleApi(req, res) {
     const testAction = String(body?.action || "").trim();
     const testTier = String(body?.tier || "").trim();
     if (!testAction || !testTier) return json(res, 400, { error: "Both action and tier are required." });
-    return json(res, 200, { action: testAction, tier: testTier, allowed: evaluate({ tier: testTier }, testAction) });
+    // `known` is the difference between "denied" and "not a thing". Testing a
+    // misspelled action returns allowed:false -- which reads as "my Deny works"
+    // and is the single most misleading answer this endpoint can give, since a
+    // misspelled Deny is precisely the mistake an operator comes here to check.
+    return json(res, 200, {
+      action: testAction,
+      tier: testTier,
+      allowed: evaluate({ tier: testTier }, testAction),
+      known: allKnownActions().has(testAction)
+    });
   }
 
   if (path === "/api/players") return dbJson(res, () => duneDb.listPlayers(db, {
@@ -1303,6 +1358,13 @@ async function addonBridgeRoute(req, res, path) {
   if (action.startsWith("scheduler.")) return addonSchedulerBridgeAction(req, res, id, action, body);
   if (action === "database.query" || action === "database.execute") {
     const query = String(body.query || "");
+    // Same guard, and for the same reason, as databaseQuery: an empty or
+    // comments-only body classifies as a write and reaches the backup spawn
+    // below. database.query happened to be shielded by its own read-only 400;
+    // database.execute was not.
+    if (!hasExecutableStatement(query)) {
+      return json(res, 400, { error: "No SQL statement to run." });
+    }
     const readOnly = isReadOnlySql(query);
     const requiredPermission = readOnly ? "database:read" : "database:write";
     if (action === "database.query" && !readOnly) return json(res, 400, { error: "database.query accepts read-only SQL only. Use database.execute with database:write permission for write SQL." });
@@ -1941,13 +2003,37 @@ async function safeCommand(operation, payload = {}) {
 async function databaseQuery(req, res) {
   const body = await readJson(req);
   const query = String(body.query || "");
+  // BEFORE the classification below, because isReadOnlySql answers "does this
+  // start with a read keyword" -- so an empty string answers no and used to be
+  // classified as a WRITE, taking a full pre-write backup before duneDb.runSql
+  // got far enough to reject it with "SQL query is required". Submitting "" in
+  // a loop made the host run pg_dump 20 times a minute per session, the
+  // mutation limiter's ceiling, for input that could never execute.
+  if (!hasExecutableStatement(query)) {
+    return json(res, 400, { error: "Enter a SQL query to run." });
+  }
+  // Classified ONCE, and every decision below reads this one value. Calling
+  // isReadOnlySql again per decision would let the authorization answer and the
+  // execution answer disagree about the same string.
   const readOnly = isReadOnlySql(query);
+  // The route resolved to database:query, which is read-shaped and granted as
+  // such. Write SQL down this same route is a different privilege and needs
+  // database:execute on top. First, so an unauthorized write never reaches the
+  // rate-limit tick or the backup spawn below.
+  if (!readOnly && !requireAction(req, res, "database:execute")) return;
   if (!readOnly && !applyMutationRateLimit(req, res, "database.query.write")) return;
   if (!config.mockMode && !readOnly) {
     await runDune(config, buildDuneArgs("backupCreate"), { env: { DB_BACKUP_ORIGIN: "destructive-sql" } });
   }
   audit(config, req, "database.query", { readOnly, destructive: !readOnly });
-  return dbJson(res, () => duneDb.runSql(db, query, true));
+  // !readOnly, not the unconditional `true` this passed before: a request
+  // authorized as read-only is now also EXECUTED with writes refused, so
+  // duneDb.runSql's own classifier has to agree before anything can write.
+  // Safe as a second opinion because runner.js's isReadOnlySql (used above) is
+  // strictly the more conservative of the two -- it tests the raw string where
+  // db.js's strips comments first, so anything it calls read-only db.js calls
+  // read-only too. It can never reject a query this route just authorized.
+  return dbJson(res, () => duneDb.runSql(db, query, !readOnly));
 }
 
 async function databaseExport(req, res) {

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -12,8 +12,16 @@ import { scopeCatalog } from "./apiKeyScopes.js";
 import { createBridgeRateLimiter } from "./bridgeRateLimit.js";
 import { buildSelfUpdateHelperDockerArgs, detectDockerSocketGid, TaskManager, publicTask } from "./tasks.js";
 import { preflight } from "./preflight.js";
-import { buildDuneArgs, isDynamicServerService, isReadOnlySql, parseVehicleList, runDockerLogs, runDune, validateServiceName } from "./runner.js";
-import { createDb, hasExecutableStatement, quoteIdentifier } from "./db.js";
+import { buildDuneArgs, isDynamicServerService, parseVehicleList, runDockerLogs, runDune, validateServiceName } from "./runner.js";
+// isReadOnlySql comes from db.js, NOT runner.js. runner's copy tests the raw
+// string, so a genuinely read-only SELECT with a leading `-- note` or `/* */`
+// header does not start with a read keyword and was classified a WRITE --
+// which since database:execute exists means a 403 for admin on ordinary
+// pasted SQL. db.js strips comments first (substituting a space, so it cannot
+// fuse tokens or hide a leading `delete`). Using one classifier here and in
+// duneDb.runSql also removes the divergence between the authorization
+// decision and the execution decision.
+import { createDb, hasExecutableStatement, isReadOnlySql, quoteIdentifier } from "./db.js";
 import * as duneDb from "./duneDb.js";
 import { audit, recordAdminHistory } from "./audit.js";
 import { redact } from "./redact.js";
@@ -93,6 +101,11 @@ try {
 const policyLoad = loadPolicies(config.repoRoot);
 if (policyLoad.invalid) {
   console.warn(`IAM policy file at ${policyLoad.path} is not a valid policy store; using built-in defaults.`);
+}
+for (const { tier, pattern, successors } of policyLoad.deprecatedActions || []) {
+  // Still enforced with its original meaning (see REMOVED_ACTION_ALIASES), so
+  // this is a migration notice, not a warning that access changed.
+  console.warn(`IAM policy notice: ${tier} names "${pattern}", which was split into ${successors.join(", ")}. It still applies as before; name the successors to silence this.`);
 }
 for (const { tier, pattern } of policyLoad.unknownActions) {
   // Loaded anyway (see loadPolicies), but an operator who hand-edited a Deny
@@ -1373,7 +1386,7 @@ async function addonBridgeRoute(req, res, path) {
     if (!readOnly && !config.mockMode) {
       await runDune(config, buildDuneArgs("backupCreate"), { env: { DB_BACKUP_ORIGIN: `addon-${addon.id}` } });
     }
-    const result = await duneDb.runSql(db, query, !readOnly);
+    const result = await duneDb.runSql(db, query, !readOnly, { enforceReadOnly: true });
     audit(config, req, "addons.bridge", { id: addon.id, action, permission: addon.permission, readOnly, rowCount: result.rowCount, command: result.command, ok: true });
     return json(res, 200, { ok: true, result });
   }
@@ -2033,7 +2046,11 @@ async function databaseQuery(req, res) {
   // strictly the more conservative of the two -- it tests the raw string where
   // db.js's strips comments first, so anything it calls read-only db.js calls
   // read-only too. It can never reject a query this route just authorized.
-  return dbJson(res, () => duneDb.runSql(db, query, !readOnly));
+  // enforceReadOnly: the read path executes inside a READ ONLY transaction, so
+  // a statement the classifier called read-only cannot write even if it was
+  // wrong -- which for `select dune.<fn>(...)`, the shape every privileged
+  // mutation in this app uses, it always was.
+  return dbJson(res, () => duneDb.runSql(db, query, !readOnly, { enforceReadOnly: true }));
 }
 
 async function databaseExport(req, res) {

--- a/console/api/test/actionSplits.test.js
+++ b/console/api/test/actionSplits.test.js
@@ -1,0 +1,331 @@
+// players:mutate and guilds:mutate, split by consequence.
+//
+// One action used to cover all 41 mutating method+path pairs under
+// /api/players/ -- kick, ban, wipe a character's progression, delete items out
+// of their inventory, mint currency, hand out max-level specializations. There
+// was no way to grant kicking without also granting destruction, which is the
+// exact argument that had already carved up bases: and vehicles: .
+//
+// The table below IS the specification. It is written out in full rather than
+// derived from actions.js, so that a change to the mapping has to be made
+// twice, deliberately -- deriving it from the thing under test would assert
+// nothing.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { actionForRoute } from "../src/actions.js";
+import { allKnownActions, evaluate } from "../src/policy.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverSrc = readFileSync(join(__dirname, "../src/server.js"), "utf8");
+
+const ID = "12345";
+const p = (suffix) => `/api/players/${ID}${suffix}`;
+
+const EXPECTED = [
+  ["POST", p("/kick"), "players:moderate"],
+  ["POST", p("/ban"), "players:moderate"],
+  ["DELETE", p("/ban"), "players:moderate"],
+
+  ["POST", p("/teleport"), "players:teleport"],
+
+  ["POST", p("/give-item"), "players:give-item"],
+  ["POST", p("/give-item-id"), "players:give-item"],
+  ["POST", p("/give-items"), "players:give-item"],
+  ["POST", p("/augment-item"), "players:give-item"],
+  ["POST", p("/spawn-vehicle"), "players:give-item"],
+
+  ["POST", p("/add-currency"), "players:grant"],
+  ["POST", p("/add-xp"), "players:grant"],
+  ["POST", p("/add-intel"), "players:grant"],
+  ["POST", p("/add-faction-reputation"), "players:grant"],
+  ["POST", p("/faction"), "players:grant"],
+  ["POST", p("/set-skill-points"), "players:grant"],
+  ["POST", p("/set-skill-module"), "players:grant"],
+  ["POST", p("/building-unlocks/grant"), "players:grant"],
+  ["POST", p("/customizations/grant"), "players:grant"],
+  ["POST", p("/crafting-recipes/unlock"), "players:grant"],
+  ["POST", p("/research-items/unlock"), "players:grant"],
+  ["POST", p("/specializations/add-xp"), "players:grant"],
+  ["POST", p("/specializations/grant-max"), "players:grant"],
+  ["POST", p("/specializations/keystones/grant-all"), "players:grant"],
+  ["POST", p("/journey/complete"), "players:grant"],
+  ["POST", p("/tutorials/complete"), "players:grant"],
+
+  ["POST", p("/reset-progression"), "players:reset"],
+  ["POST", p("/clean-inventory"), "players:reset"],
+  ["POST", p("/journey/reset"), "players:reset"],
+  ["POST", p("/tutorials/reset"), "players:reset"],
+  ["POST", p("/specializations/reset"), "players:reset"],
+  ["POST", p("/specializations/keystones/reset-all"), "players:reset"],
+
+  ["DELETE", p("/inventory/999"), "players:delete-item"],
+  ["PATCH", p("/inventory/999"), "players:edit-item"],
+
+  ["POST", p("/repair-gear"), "players:repair"],
+  ["POST", p("/repair-faction-reputation"), "players:repair"],
+  ["POST", p("/repair-landsraad-quests"), "players:repair"],
+  ["POST", p("/repair-login-queue"), "players:repair"],
+  ["POST", p("/repair-vehicle-decay"), "players:repair"],
+  ["POST", p("/refuel-vehicle"), "players:repair"],
+  ["POST", p("/refill-water"), "players:repair"],
+
+  ["POST", p("/character-recovery"), "players:recover"]
+];
+
+// ---- The mapping ----
+
+test("players: every mutation resolves to its own narrow action", () => {
+  for (const [method, path, action] of EXPECTED) {
+    assert.equal(actionForRoute(path, method), action, `${method} ${path}`);
+  }
+});
+
+test("players: no mutation falls through to the unclassified catch-all", () => {
+  for (const [method, path] of EXPECTED) {
+    assert.notEqual(actionForRoute(path, method), "players:unclassified", `${method} ${path} is unclassified`);
+  }
+});
+
+test("players: the old players:mutate no longer exists", () => {
+  // Removed rather than repurposed, so a hand-authored policy still naming it
+  // is refused by setPolicies and warned about at startup, instead of quietly
+  // continuing to mean something narrower than the operator intended.
+  assert.ok(!allKnownActions().has("players:mutate"));
+  const resolved = new Set(EXPECTED.map(([m, path]) => actionForRoute(path, m)));
+  assert.ok(!resolved.has("players:mutate"));
+});
+
+// ---- The catch-all has to stay, and has to fail CLOSED ----
+
+test("players: an unclassified mutation fails closed, not to players:read", () => {
+  // The trap: REGEX_ACTIONS has a method-agnostic "/api/players/" ->
+  // players:read fallback beneath the method-aware tier. Delete the method-aware
+  // catch-all now that every route is named, and an unclassified POST resolves
+  // to players:read -- authorizing a mutation under a READ-ONLY grant.
+  for (const method of ["POST", "DELETE", "PATCH"]) {
+    const action = actionForRoute(p("/some-route-added-later"), method);
+    assert.equal(action, "players:unclassified", `${method} should hit the catch-all`);
+    assert.notEqual(action, "players:read", `${method} must never resolve to a read action`);
+  }
+  // Reads still resolve to reads.
+  assert.equal(actionForRoute(p("/ban"), "GET"), "players:read");
+  assert.equal(actionForRoute(p("/inventory"), "GET"), "players:read");
+});
+
+test("players: no tier below admin can reach the catch-all", () => {
+  for (const tier of ["moderator", "player", "observer"]) {
+    assert.equal(evaluate({ tier }, "players:unclassified"), false);
+  }
+});
+
+// ---- New routes cannot be added without classifying them ----
+
+test("players: server.js has no mutation missing from the table", () => {
+  // Extracts the dispatch lines rather than trusting the table to be complete.
+  // A new POST/DELETE/PATCH route under /api/players/ fails here until it is
+  // given an action and listed above.
+  const found = new Set();
+  const re = /path\.match\(\/\^(.*?)\$?\/\)([^\n]{0,120})/g;
+  let m;
+  while ((m = re.exec(serverSrc)) !== null) {
+    const raw = m[1].split("\\/").join("/");
+    if (!raw.startsWith("/api/players/")) continue;
+    const method = /req\.method\s*===\s*"([A-Z]+)"/.exec(m[2])?.[1];
+    if (!method || !["POST", "DELETE", "PATCH"].includes(method)) continue;
+    found.add(`${method} ${raw.split("[^/]+").join("{id}")}`);
+  }
+
+  const listed = new Set(EXPECTED.map(([method, path]) =>
+    `${method} ${path.replace(ID, "{id}").replace("/inventory/999", "/inventory/{id}")}`));
+
+  // /ban carries no method in its dispatch condition (playerBanRoute switches
+  // internally), so it never appears in `found` and is asserted separately.
+  listed.delete("POST /api/players/{id}/ban");
+  listed.delete("DELETE /api/players/{id}/ban");
+
+  const missing = [...found].filter((route) => !listed.has(route));
+  assert.deepEqual(missing, [], `player mutations in server.js with no entry in EXPECTED: ${missing.join(", ")}`);
+  // Guards against the extraction silently matching nothing, which would make
+  // the assertion above pass vacuously and stop covering new routes entirely.
+  // Not hypothetical: the guilds copy of this loop shipped briefly with a
+  // damaged escape (split("\/") rather than split("\\/"), which is identity in
+  // JS) and found zero routes. 39, not 41: /ban carries no method in its
+  // dispatch and is asserted separately.
+  assert.equal(found.size, 39, "route extraction found an unexpected number of player mutations");
+});
+
+test("players: the ban route still multiplexes three methods on one path", () => {
+  // If this dispatch ever grows an explicit method, the special-case above is
+  // stale and the extraction test would silently stop covering it.
+  assert.match(serverSrc, /if \(path\.match\(\/\^\\\/api\\\/players\\\/\[\^\/\]\+\\\/ban\$\/\)\) return playerBanRoute/);
+  assert.match(serverSrc, /\["GET", "POST", "DELETE"\]\.includes\(req\.method \|\| "GET"\)/);
+});
+
+// ---- Naming (issue #351) ----
+
+test("players: no action is a string prefix of another", () => {
+  // policy.js matchAction supports an "X*" style where a pattern matches any
+  // action starting with it. Two actions sharing a prefix mean a policy author
+  // aiming at the narrower one can silently be granted the broader.
+  const actions = [...allKnownActions()].filter((a) => a.startsWith("players:"));
+  for (const a of actions) {
+    for (const b of actions) {
+      if (a === b) continue;
+      assert.ok(!b.startsWith(a), `${b} starts with ${a}; a "${a}*" pattern would match both`);
+    }
+  }
+});
+
+// ---- Default policies are unchanged in effect ----
+
+test("players: owner and admin still reach every action", () => {
+  for (const action of [...allKnownActions()].filter((a) => a.startsWith("players:"))) {
+    assert.equal(evaluate({ tier: "owner" }, action), true, `owner ${action}`);
+    assert.equal(evaluate({ tier: "admin" }, action), true, `admin ${action}`);
+  }
+});
+
+test("players: the split did not widen any tier below admin", () => {
+  // moderator/player/observer held players:read (+ players:kick-all for
+  // moderator) before the split and must hold exactly that after it. A refactor
+  // of the vocabulary must not hand anyone a new capability.
+  const playerActions = [...allKnownActions()].filter((a) => a.startsWith("players:"));
+  const reachable = (tier) => playerActions.filter((a) => evaluate({ tier }, a)).sort();
+  assert.deepEqual(reachable("moderator"), ["players:kick-all", "players:read"]);
+  assert.deepEqual(reachable("player"), ["players:read"]);
+  assert.deepEqual(reachable("observer"), ["players:read"]);
+});
+
+test("players: the narrow actions are independently grantable", () => {
+  // The point of the whole change: kicking without destroying.
+  const docs = {
+    owner: { version: 1, tier: "owner", statements: [{ Effect: "Allow", Action: "*" }] },
+    moderator: {
+      version: 1,
+      tier: "moderator",
+      statements: [{ Effect: "Allow", Action: ["players:read", "players:moderate", "players:repair"] }]
+    }
+  };
+  const can = (action) => evaluate({ tier: "moderator" }, action, docs);
+  assert.equal(can("players:moderate"), true);
+  assert.equal(can("players:repair"), true);
+  for (const withheld of ["players:reset", "players:delete-item", "players:edit-item",
+                          "players:give-item", "players:grant", "players:recover",
+                          "players:teleport", "players:unclassified"]) {
+    assert.equal(can(withheld), false, `${withheld} must not ride along`);
+  }
+});
+
+// ============================ guilds ============================
+//
+// DELETE /api/guilds/{guildId} is DISBAND -- it destroys the guild -- and it
+// shared guilds:mutate with promoting a member. No way to let someone fix a
+// roster without also letting them delete the guild.
+
+const G = "guild-77";
+const P = "player-42";
+
+const GUILD_EXPECTED = [
+  ["DELETE", `/api/guilds/${G}`, "guilds:disband"],
+  ["POST", `/api/guilds/${G}/members`, "guilds:membership"],
+  ["DELETE", `/api/guilds/${G}/members/${P}`, "guilds:membership"],
+  ["POST", `/api/guilds/${G}/members/${P}/promote`, "guilds:rank"],
+  ["POST", `/api/guilds/${G}/members/${P}/demote`, "guilds:rank"]
+];
+
+test("guilds: every mutation resolves to its own narrow action", () => {
+  for (const [method, path, action] of GUILD_EXPECTED) {
+    assert.equal(actionForRoute(path, method), action, `${method} ${path}`);
+  }
+});
+
+test("guilds: disband is distinguished from removing one member", () => {
+  // Both are DELETE under /api/guilds/, and the variable segment comes BEFORE
+  // the part that tells them apart -- so a startsWith prefix rule cannot
+  // separate them and anchored regexes are required. Same shape as bases:delete.
+  assert.equal(actionForRoute(`/api/guilds/${G}`, "DELETE"), "guilds:disband");
+  assert.equal(actionForRoute(`/api/guilds/${G}/members/${P}`, "DELETE"), "guilds:membership");
+  assert.notEqual(actionForRoute(`/api/guilds/${G}`, "DELETE"),
+    actionForRoute(`/api/guilds/${G}/members/${P}`, "DELETE"));
+});
+
+test("guilds: the old guilds:mutate no longer exists", () => {
+  assert.ok(!allKnownActions().has("guilds:mutate"));
+  const resolved = new Set(GUILD_EXPECTED.map(([m, path]) => actionForRoute(path, m)));
+  assert.ok(!resolved.has("guilds:mutate"));
+});
+
+test("guilds: an unclassified mutation fails closed, not to guilds:read", () => {
+  for (const method of ["POST", "DELETE"]) {
+    const action = actionForRoute(`/api/guilds/${G}/some-route-added-later`, method);
+    assert.equal(action, "guilds:unclassified", `${method} should hit the catch-all`);
+    assert.notEqual(action, "guilds:read", `${method} must never resolve to a read action`);
+  }
+  assert.equal(actionForRoute(`/api/guilds/${G}/members`, "GET"), "guilds:read");
+  assert.equal(actionForRoute(`/api/guilds/${G}`, "GET"), "guilds:read");
+});
+
+test("guilds: server.js has no mutation missing from the table", () => {
+  const found = new Set();
+  const re = /path\.match\(\/\^(.*?)\$?\/\)([^\n]{0,120})/g;
+  let m;
+  while ((m = re.exec(serverSrc)) !== null) {
+    const raw = m[1].split("\\/").join("/");
+    if (!raw.startsWith("/api/guilds/")) continue;
+    const method = /req\.method\s*===\s*"([A-Z]+)"/.exec(m[2])?.[1];
+    if (!method || !["POST", "DELETE", "PATCH", "PUT"].includes(method)) continue;
+    found.add(`${method} ${raw.split("[^/]+").join("{id}")}`);
+  }
+  const listed = new Set(GUILD_EXPECTED.map(([method, path]) =>
+    `${method} ${path.split(G).join("{id}").split(P).join("{id}")}`));
+  const missing = [...found].filter((route) => !listed.has(route));
+  assert.deepEqual(missing, [], `guild mutations in server.js with no entry: ${missing.join(", ")}`);
+  assert.equal(found.size, 5, "expected exactly 5 mutating guild routes");
+});
+
+test("guilds: no action is a string prefix of another", () => {
+  // guilds:rank and guilds:read share "guilds:r" but neither prefixes the
+  // other, so no "guilds:r*" pattern can be written aiming at one and silently
+  // catch both by prefix matching.
+  const actions = [...allKnownActions()].filter((a) => a.startsWith("guilds:"));
+  for (const a of actions) {
+    for (const b of actions) {
+      if (a === b) continue;
+      assert.ok(!b.startsWith(a), `${b} starts with ${a}`);
+    }
+  }
+});
+
+test("guilds: the split did not widen any tier below admin", () => {
+  const guildActions = [...allKnownActions()].filter((a) => a.startsWith("guilds:"));
+  const reachable = (tier) => guildActions.filter((a) => evaluate({ tier }, a)).sort();
+  for (const tier of ["moderator", "player", "observer"]) {
+    assert.deepEqual(reachable(tier), ["guilds:read"], tier);
+  }
+  for (const action of guildActions) {
+    assert.equal(evaluate({ tier: "owner" }, action), true, `owner ${action}`);
+    assert.equal(evaluate({ tier: "admin" }, action), true, `admin ${action}`);
+  }
+});
+
+test("guilds: roster management is grantable without disbanding", () => {
+  // The point of the change.
+  const docs = {
+    owner: { version: 1, tier: "owner", statements: [{ Effect: "Allow", Action: "*" }] },
+    moderator: {
+      version: 1,
+      tier: "moderator",
+      statements: [{ Effect: "Allow", Action: ["guilds:read", "guilds:membership", "guilds:rank"] }]
+    }
+  };
+  const can = (action) => evaluate({ tier: "moderator" }, action, docs);
+  assert.equal(can("guilds:membership"), true);
+  assert.equal(can("guilds:rank"), true);
+  assert.equal(can("guilds:disband"), false, "disband must not ride along with roster edits");
+  assert.equal(can("guilds:unclassified"), false);
+});

--- a/console/api/test/actionSplits.test.js
+++ b/console/api/test/actionSplits.test.js
@@ -19,6 +19,7 @@ import { fileURLToPath } from "node:url";
 
 import { actionForRoute } from "../src/actions.js";
 import { allKnownActions, evaluate } from "../src/policy.js";
+import { keyAllows } from "../src/apiKeys.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const serverSrc = readFileSync(join(__dirname, "../src/server.js"), "utf8");
@@ -328,4 +329,153 @@ test("guilds: roster management is grantable without disbanding", () => {
   assert.equal(can("guilds:rank"), true);
   assert.equal(can("guilds:disband"), false, "disband must not ride along with roster edits");
   assert.equal(can("guilds:unclassified"), false);
+});
+
+// ============================ blueprints ============================
+//
+// blueprints:mutate covered bulk export (a read), import (creation) and delete
+// (destruction) with one grant.
+
+const B = "bp-9";
+
+const BLUEPRINT_EXPECTED = [
+  ["POST", "/api/blueprints/export", "blueprints:export"],
+  ["POST", "/api/blueprints/import", "blueprints:import"],
+  ["DELETE", `/api/blueprints/${B}`, "blueprints:delete"]
+];
+
+test("blueprints: every mutation resolves to its own narrow action", () => {
+  for (const [method, path, action] of BLUEPRINT_EXPECTED) {
+    assert.equal(actionForRoute(path, method), action, `${method} ${path}`);
+  }
+  assert.ok(!allKnownActions().has("blueprints:mutate"));
+});
+
+test("blueprints: bulk export is not folded into the read grant", () => {
+  // blueprintBulkExportRoute only reads (exportBlueprint per id, zipped), so it
+  // was wrong to call it a mutation -- but one call pulls up to 500 blueprints,
+  // so it is not blueprints:read either. Its own action, and blueprints:read
+  // stays exactly as wide as it was.
+  assert.equal(actionForRoute("/api/blueprints/export", "POST"), "blueprints:export");
+  assert.notEqual(actionForRoute("/api/blueprints/export", "POST"), "blueprints:read");
+  const docs = {
+    owner: { version: 1, tier: "owner", statements: [{ Effect: "Allow", Action: "*" }] },
+    player: { version: 1, tier: "player", statements: [{ Effect: "Allow", Action: ["blueprints:read"] }] }
+  };
+  assert.equal(evaluate({ tier: "player" }, "blueprints:export", docs), false,
+    "a read-only grant must not gain bulk extraction");
+  // The single-blueprint export stays a read, as it already was.
+  assert.equal(actionForRoute(`/api/blueprints/${B}/export`, "GET"), "blueprints:read");
+});
+
+test("blueprints: delete is distinguished from a sub-resource path", () => {
+  assert.equal(actionForRoute(`/api/blueprints/${B}`, "DELETE"), "blueprints:delete");
+  assert.equal(actionForRoute(`/api/blueprints/${B}/parts/p1`, "DELETE"), "blueprints:unclassified");
+});
+
+test("blueprints: an unclassified mutation fails closed, not to blueprints:read", () => {
+  for (const method of ["POST", "DELETE"]) {
+    const action = actionForRoute(`/api/blueprints/${B}/added-later`, method);
+    assert.equal(action, "blueprints:unclassified");
+    assert.notEqual(action, "blueprints:read");
+  }
+});
+
+// ============================ addons ============================
+//
+// addons:mutate covered uninstalling, enabling/disabling, AND the bridge --
+// the route that runs whatever the addon's manifest declares, including SQL.
+
+const A = "addon-x";
+
+const ADDON_EXPECTED = [
+  ["DELETE", `/api/addons/installed/${A}`, "addons:remove"],
+  ["POST", `/api/addons/installed/${A}/bridge`, "addons:bridge"],
+  ["POST", `/api/addons/installed/${A}/enable`, "addons:toggle"],
+  ["POST", `/api/addons/installed/${A}/disable`, "addons:toggle"]
+];
+
+test("addons: every mutation resolves to its own narrow action", () => {
+  for (const [method, path, action] of ADDON_EXPECTED) {
+    assert.equal(actionForRoute(path, method), action, `${method} ${path}`);
+  }
+  assert.ok(!allKnownActions().has("addons:mutate"));
+});
+
+test("addons: the bridge is withheld separately from lifecycle control", () => {
+  // The bridge authorizes against the installed addon's declared permission
+  // rather than the caller, so "may enable an addon" must not imply "may run
+  // whatever that addon declared".
+  const docs = {
+    owner: { version: 1, tier: "owner", statements: [{ Effect: "Allow", Action: "*" }] },
+    admin: {
+      version: 1,
+      tier: "admin",
+      statements: [{ Effect: "Allow", Action: ["addons:read", "addons:toggle", "addons:remove"] }]
+    }
+  };
+  assert.equal(evaluate({ tier: "admin" }, "addons:toggle", docs), true);
+  assert.equal(evaluate({ tier: "admin" }, "addons:remove", docs), true);
+  assert.equal(evaluate({ tier: "admin" }, "addons:bridge", docs), false, "the bridge must not ride along");
+});
+
+test("addons: install and update keep their existing actions", () => {
+  assert.equal(actionForRoute("/api/addons/community/install", "POST"), "addons:install");
+  assert.equal(actionForRoute("/api/addons/community/update", "POST"), "addons:update");
+});
+
+test("addons: an unclassified mutation fails closed, not to addons:read", () => {
+  for (const method of ["POST", "DELETE"]) {
+    const action = actionForRoute(`/api/addons/installed/${A}/added-later`, method);
+    assert.equal(action, "addons:unclassified");
+    assert.notEqual(action, "addons:read");
+  }
+  assert.equal(actionForRoute(`/api/addons/installed/${A}/content/app.js`, "GET"), "addons:read");
+});
+
+test("addons: no key can reach any addon write, bridge included", () => {
+  // `addons` is write-denied for keys, so none of the new actions are grantable
+  // to one. Asserted here so a future split cannot quietly open that door.
+  for (const [, , action] of ADDON_EXPECTED) {
+    assert.equal(keyAllows({ scopes: { addons: "write" } }, action), false, action);
+  }
+  assert.equal(keyAllows({ scopes: { addons: "read" } }, "addons:read"), true);
+});
+
+// ---- Shared invariants across every split namespace ----
+
+test("no action in a split namespace is a string prefix of another", () => {
+  for (const ns of ["players", "guilds", "blueprints", "addons"]) {
+    const actions = [...allKnownActions()].filter((a) => a.startsWith(`${ns}:`));
+    for (const a of actions) {
+      for (const b of actions) {
+        if (a === b) continue;
+        assert.ok(!b.startsWith(a), `${b} starts with ${a}`);
+      }
+    }
+  }
+});
+
+test("every split namespace kept its unclassified sentinel out of the lower tiers", () => {
+  for (const ns of ["players", "guilds", "blueprints", "addons"]) {
+    for (const tier of ["moderator", "player", "observer"]) {
+      assert.equal(evaluate({ tier }, `${ns}:unclassified`), false, `${tier} ${ns}`);
+    }
+    assert.equal(evaluate({ tier: "owner" }, `${ns}:unclassified`), true, `owner ${ns}`);
+  }
+});
+
+test("no *:mutate action survives anywhere in the catalog", () => {
+  // The four remaining :mutate actions are listed explicitly rather than
+  // asserting "none", so this cannot pass by accident if a split regresses.
+  // Each is a deliberate bucket, not an un-split leftover:
+  //   bases:mutate     refills and permission edits; every destructive base
+  //                    operation is already carved out around it
+  //   vehicles:mutate  roster/custodian/refuel/repair; delete and item removal
+  //                    are already separate
+  //   database:mutate  the structured single-cell row edit, distinct from the
+  //                    raw-SQL database:query / database:execute pair
+  //   storage:mutate   POST /api/storage/{id}/give-item, the only storage write
+  const mutates = [...allKnownActions()].filter((a) => a.endsWith(":mutate")).sort();
+  assert.deepEqual(mutates, ["bases:mutate", "database:mutate", "storage:mutate", "vehicles:mutate"]);
 });

--- a/console/api/test/actionSplits.test.js
+++ b/console/api/test/actionSplits.test.js
@@ -151,12 +151,10 @@ test("players: server.js has no mutation missing from the table", () => {
 
   const missing = [...found].filter((route) => !listed.has(route));
   assert.deepEqual(missing, [], `player mutations in server.js with no entry in EXPECTED: ${missing.join(", ")}`);
-  // Guards against the extraction silently matching nothing, which would make
-  // the assertion above pass vacuously and stop covering new routes entirely.
-  // Not hypothetical: the guilds copy of this loop shipped briefly with a
-  // damaged escape (split("\/") rather than split("\\/"), which is identity in
-  // JS) and found zero routes. 39, not 41: /ban carries no method in its
-  // dispatch and is asserted separately.
+  // Without this the assertion above passes vacuously if the extraction stops
+  // matching -- a damaged escape in the split pattern makes it find zero routes
+  // and cover nothing. 39, not 41: /ban carries no method in its dispatch and
+  // is asserted separately.
   assert.equal(found.size, 39, "route extraction found an unexpected number of player mutations");
 });
 

--- a/console/api/test/apiKeyAuthWiring.test.js
+++ b/console/api/test/apiKeyAuthWiring.test.js
@@ -15,7 +15,50 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const source = readFileSync(join(__dirname, "../src/server.js"), "utf8");
+const rawSource = readFileSync(join(__dirname, "../src/server.js"), "utf8");
+
+// Every assertion in this file reads server.js as TEXT, so a comment that
+// happens to mention a call reads to indexOf exactly like the call itself.
+// Both failure modes were reproduced against this file before it was changed:
+//
+//   false FAILURE  adding a comment above the gate that names
+//                  apiKeys.allows(bearer.key, action) broke the ordering test
+//                  while the code was still correct.
+//   false PASS     deleting the isDiscordAdapterRoute(path) fork and leaving a
+//                  comment that names it kept "the gate sits after ... the
+//                  Discord adapter fork" green -- the test went on asserting a
+//                  property that no longer existed.
+//
+// The second is the dangerous one, so comments are removed before anything is
+// matched. String-aware on purpose: handleApi contains
+// `new URL(req.url, "http://localhost")`, and a naive //-stripper truncates
+// that line mid-body and shifts every index after it.
+function stripComments(text) {
+  let out = "";
+  let quote = null;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (quote) {
+      out += ch;
+      if (ch === "\\") { out += next ?? ""; i++; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") { quote = ch; out += ch; continue; }
+    if (ch === "/" && next === "/") { while (i < text.length && text[i] !== "\n") i++; out += "\n"; continue; }
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      i++;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+const source = stripComments(rawSource);
 
 function handleApiBody() {
   const match = source.match(/async function handleApi\(req,\s*res\)\s*\{/);
@@ -42,6 +85,34 @@ const at = (needle) => {
 // a bare indexOf("auth.requireAuth") would match the wrong one and make these
 // ordering assertions pass vacuously.
 const GATE = "const session = bearer?.session || auth.requireAuth(req, res);";
+
+test("the comment stripper this file depends on actually works", () => {
+  // Everything below asserts against stripped text, so a stripper that quietly
+  // mangles server.js would degrade every other test in this file into
+  // something weaker without failing. Checked against the real source, not a
+  // toy string.
+  assert.ok(rawSource.includes('new URL(req.url, "http://localhost")'), "precondition: the URL line exists");
+  assert.ok(source.includes('new URL(req.url, "http://localhost")'),
+    "a // inside a string literal was treated as a comment");
+  assert.ok(rawSource.includes("// The main gate") || rawSource.includes("// Stashed for requireAction"),
+    "precondition: server.js has line comments");
+  assert.ok(!source.includes("// Stashed for requireAction"), "line comments are not removed");
+  assert.ok(!/\/\*[\s\S]*?\*\//.test(source), "block comments are not removed");
+  // Code either side of a stripped comment must survive intact.
+  assert.ok(source.includes("req.authApiKey = bearer?.key || null;"));
+  assert.ok(source.includes(GATE));
+
+  const sample = stripComments([
+    'const a = "http://x"; // trailing',
+    "/* block */ const b = `t${1}`;",
+    "const c = 'it\\'s';"
+  ].join("\n"));
+  assert.ok(sample.includes('const a = "http://x";'));
+  assert.ok(!sample.includes("trailing"));
+  assert.ok(!sample.includes("block"));
+  assert.ok(sample.includes("const b = `t${1}`;"));
+  assert.ok(sample.includes("const c = 'it\\'s';"), "an escaped quote ended the string early");
+});
 
 test("api key authentication runs before the session/CSRF gate", () => {
   assert.ok(

--- a/console/api/test/apiKeyScopes.test.js
+++ b/console/api/test/apiKeyScopes.test.js
@@ -125,10 +125,16 @@ test("scopeCatalog reports write support for the UI", () => {
   assert.ok(byName.get("updates").readActions.includes("updates:check"));
   assert.equal(byName.get("setup"), undefined);
   assert.ok(byName.get("players").readActions.includes("players:read"));
-  // Individual kicks resolve through the "POST /api/players/" prefix rule to
-  // players:mutate; players:kick appears only in an actions.js example comment.
-  assert.ok(byName.get("players").writeActions.includes("players:mutate"));
+  // players:mutate was split by consequence (see playersActionSplit.test.js):
+  // an individual kick now resolves to players:moderate, and players:unclassified
+  // is all that remains of the "POST /api/players/" prefix rule.
+  for (const action of ["players:moderate", "players:teleport", "players:give-item", "players:grant",
+                        "players:reset", "players:delete-item", "players:edit-item",
+                        "players:repair", "players:recover", "players:unclassified"]) {
+    assert.ok(byName.get("players").writeActions.includes(action), `missing ${action}`);
+  }
   assert.ok(byName.get("players").writeActions.includes("players:kick-all"));
+  assert.ok(!byName.get("players").writeActions.includes("players:mutate"));
 });
 
 test("normalizeScopes drops rather than coerces anything unrecognised", () => {

--- a/console/api/test/apiKeyScopes.test.js
+++ b/console/api/test/apiKeyScopes.test.js
@@ -13,6 +13,7 @@ import {
   KEY_DENIED_NAMESPACES,
   KEY_WRITE_DENIED_NAMESPACES,
   actionsByNamespace,
+  grantableActions,
   isReadAction,
   namespaceHasWriteActions,
   namespaceOf,
@@ -20,7 +21,9 @@ import {
   scopeCatalog,
   selectableNamespaces
 } from "../src/apiKeyScopes.js";
-import { keyAllows } from "../src/apiKeys.js";
+import { createApiKeyStore, keyAllows } from "../src/apiKeys.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 
 test("every catalog action classifies as exactly one of read or write", () => {
   for (const action of allKnownActions()) {
@@ -263,4 +266,187 @@ test("the uncached self-update check is out of reach of every key", () => {
   }
   // The cached game check stays reachable -- that is the point of the grant.
   assert.equal(keyAllows({ scopes: { updates: "read" } }, "updates:check"), true);
+});
+
+// ---- Per-action scopes ----
+//
+// A namespace level is coarse by construction: `players: "write"` hands over
+// all twelve player actions at once -- kicking, banning, wiping progression,
+// deleting inventory -- which is exactly what splitting players:mutate was
+// meant to make separable. Every carve-out was invisible to a key, the
+// principal most likely to be handed to a third party. A namespace may now
+// hold an explicit list of actions instead of a level.
+
+test("an explicit action list grants exactly what it lists", () => {
+  const key = { scopes: { players: ["players:read", "players:moderate"] } };
+  assert.equal(keyAllows(key, "players:read"), true);
+  assert.equal(keyAllows(key, "players:moderate"), true);
+  for (const withheld of ["players:reset", "players:delete-item", "players:give-item",
+                          "players:grant", "players:recover", "players:teleport",
+                          "players:kick-all", "players:unclassified"]) {
+    assert.equal(keyAllows(key, withheld), false, withheld);
+  }
+});
+
+test("a list does not imply the read actions of its namespace", () => {
+  // No implicit floor: listing one write action grants that action only.
+  const key = { scopes: { players: ["players:moderate"] } };
+  assert.equal(keyAllows(key, "players:moderate"), true);
+  assert.equal(keyAllows(key, "players:read"), false);
+});
+
+test("levels keep working exactly as before", () => {
+  // The stored form is not migrated, so every existing key must behave
+  // identically. This is the compatibility guarantee.
+  assert.equal(keyAllows({ scopes: { players: "write" } }, "players:reset"), true);
+  assert.equal(keyAllows({ scopes: { players: "write" } }, "players:read"), true);
+  assert.equal(keyAllows({ scopes: { players: "read" } }, "players:read"), true);
+  assert.equal(keyAllows({ scopes: { players: "read" } }, "players:reset"), false);
+  assert.equal(keyAllows({ scopes: {} }, "players:read"), false);
+});
+
+test("the two forms can be mixed across namespaces", () => {
+  const key = { scopes: { players: ["players:read"], bases: "read", server: "write" } };
+  assert.equal(keyAllows(key, "players:read"), true);
+  assert.equal(keyAllows(key, "players:reset"), false);
+  assert.equal(keyAllows(key, "bases:read"), true);
+  assert.equal(keyAllows(key, "bases:delete"), false);
+  assert.equal(keyAllows(key, "server:restart"), true);
+});
+
+test("a denied namespace is unreachable by an action list", () => {
+  // The namespace denial is checked before the scope lookup, so listing the
+  // action by name cannot route around it.
+  for (const scopes of [{ settings: ["settings:write"] }, { database: ["database:read"] },
+                        { setup: ["setup:read"] }]) {
+    const [[namespace, actions]] = Object.entries(scopes);
+    assert.equal(keyAllows({ scopes }, actions[0]), false, namespace);
+  }
+});
+
+test("a write-denied namespace refuses a write action in a list", () => {
+  // updates and addons are read-only for keys. normalizeScopes drops these on
+  // save; keyAllows re-checks for a hand-edited api-keys.json.
+  assert.equal(keyAllows({ scopes: { updates: ["updates:apply"] } }, "updates:apply"), false);
+  assert.equal(keyAllows({ scopes: { updates: ["updates:read"] } }, "updates:read"), true);
+  assert.equal(keyAllows({ scopes: { addons: ["addons:bridge"] } }, "addons:bridge"), false);
+  assert.equal(keyAllows({ scopes: { addons: ["addons:read"] } }, "addons:read"), true);
+});
+
+test("the POST-shaped read exceptions are grantable by name", () => {
+  assert.equal(keyAllows({ scopes: { exchange: ["exchange:market"] } }, "exchange:market"), true);
+  assert.equal(keyAllows({ scopes: { exchange: ["exchange:market"] } }, "exchange:market-write"), false);
+});
+
+// ---- normalizeScopes on the list form ----
+
+test("normalizeScopes keeps only real actions of that namespace", () => {
+  const scopes = normalizeScopes({
+    players: ["players:read", "players:moderate", "players:not-a-thing", "bases:read", 42, null]
+  });
+  assert.deepEqual(scopes, { players: ["players:moderate", "players:read"] });
+});
+
+test("normalizeScopes deduplicates and sorts a list", () => {
+  const scopes = normalizeScopes({ players: ["players:read", "players:moderate", "players:read"] });
+  assert.deepEqual(scopes.players, ["players:moderate", "players:read"]);
+});
+
+test("a list that survives nothing becomes None, never a level", () => {
+  // Same drop-rather-than-coerce rule the level form follows: an unrecognised
+  // grant must not fall back to read.
+  assert.deepEqual(normalizeScopes({ players: [] }), {});
+  assert.deepEqual(normalizeScopes({ players: ["nonsense"] }), {});
+  assert.deepEqual(normalizeScopes({ players: ["bases:read"] }), {});
+});
+
+test("normalizeScopes strips write actions from a write-denied namespace", () => {
+  assert.deepEqual(normalizeScopes({ updates: ["updates:read", "updates:apply"] }), { updates: ["updates:read"] });
+  // Nothing but writes leaves nothing, so the namespace drops entirely.
+  assert.deepEqual(normalizeScopes({ updates: ["updates:apply"] }), {});
+});
+
+test("normalizeScopes drops a list on a denied namespace", () => {
+  assert.deepEqual(normalizeScopes({ database: ["database:read"], settings: ["settings:read"] }), {});
+});
+
+test("normalizeScopes does not collapse a full list into a level", () => {
+  // Equivalent today, but NOT the same going forward: a level auto-covers
+  // actions added later, a list does not. Collapsing would silently widen the
+  // key at the next release.
+  const all = grantableActions("logs");
+  const scopes = normalizeScopes({ logs: all });
+  assert.ok(Array.isArray(scopes.logs), "a complete list must stay a list");
+  assert.deepEqual(scopes.logs, [...all].sort());
+});
+
+test("a list is stored as given, so a later action is NOT auto-covered", () => {
+  // The documented trade-off, asserted rather than described. A level covers a
+  // hypothetical new read action; a list does not.
+  const level = { scopes: { players: "read" } };
+  const list = { scopes: { players: ["players:read"] } };
+  const futureReadAction = "players:vitals:read";
+  assert.equal(isReadAction(futureReadAction), true, "precondition: this is read-shaped");
+  assert.equal(keyAllows(level, futureReadAction), true, "a level covers a new read action");
+  assert.equal(keyAllows(list, futureReadAction), false, "a list does not");
+});
+
+// ---- Round-tripping through the store ----
+
+test("a key created with an action list authenticates against exactly it", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "api-keys-actions-"));
+  try {
+    const store = createApiKeyStore({ file: join(dir, "api-keys.json") });
+    const { key } = await store.create({ name: "narrow", scopes: { players: ["players:read", "players:moderate"] } });
+    assert.deepEqual(key.scopes.players, ["players:moderate", "players:read"]);
+    const stored = store.get(key.id);
+    assert.equal(store.allows(stored, "players:moderate"), true);
+    assert.equal(store.allows(stored, "players:reset"), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the scopes a key hands back cannot alias the stored grant", async () => {
+  // publicKey copies one level deeper than a spread now that a value may be an
+  // array; without that, mutating what you got back would edit the live key.
+  const dir = mkdtempSync(join(tmpdir(), "api-keys-alias-"));
+  try {
+    const store = createApiKeyStore({ file: join(dir, "api-keys.json") });
+    const { key } = await store.create({ name: "alias", scopes: { players: ["players:read"] } });
+    key.scopes.players.push("players:reset");
+    const reread = store.get(key.id);
+    assert.deepEqual(reread.scopes.players, ["players:read"], "the stored grant was mutated from outside");
+    assert.equal(store.allows(reread, "players:reset"), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("updating scopes replaces wholesale for lists too", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "api-keys-update-"));
+  try {
+    const store = createApiKeyStore({ file: join(dir, "api-keys.json") });
+    const { key } = await store.create({ name: "swap", scopes: { players: ["players:read", "players:moderate"] } });
+    const updated = await store.update(key.id, { scopes: { players: ["players:read"] } });
+    assert.deepEqual(updated.scopes.players, ["players:read"]);
+    assert.equal(store.allows(store.get(key.id), "players:moderate"), false);
+    // And a list can be swapped back to a level.
+    const relevelled = await store.update(key.id, { scopes: { players: "read" } });
+    assert.equal(relevelled.scopes.players, "read");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("every action in the catalog is grantable by name", () => {
+  // Guards the list form against a namespace whose actions cannot be named --
+  // e.g. if grantableActions ever stopped including the write bucket.
+  for (const entry of scopeCatalog()) {
+    const grantable = grantableActions(entry.namespace);
+    for (const action of [...entry.readActions, ...entry.writeActions]) {
+      assert.ok(grantable.includes(action), `${action} is in the catalog but not grantable`);
+      assert.equal(keyAllows({ scopes: { [entry.namespace]: [action] } }, action), true, action);
+    }
+  }
 });

--- a/console/api/test/apiKeyScopes.test.js
+++ b/console/api/test/apiKeyScopes.test.js
@@ -128,7 +128,7 @@ test("scopeCatalog reports write support for the UI", () => {
   assert.ok(byName.get("updates").readActions.includes("updates:check"));
   assert.equal(byName.get("setup"), undefined);
   assert.ok(byName.get("players").readActions.includes("players:read"));
-  // players:mutate was split by consequence (see playersActionSplit.test.js):
+  // players:mutate was split by consequence (see actionSplits.test.js):
   // an individual kick now resolves to players:moderate, and players:unclassified
   // is all that remains of the "POST /api/players/" prefix rule.
   for (const action of ["players:moderate", "players:teleport", "players:give-item", "players:grant",

--- a/console/api/test/databaseQueryAuthz.test.js
+++ b/console/api/test/databaseQueryAuthz.test.js
@@ -172,11 +172,32 @@ test("the SQL is classified once and reused", () => {
 
 test("a read-only request is executed with writes refused", () => {
   // Previously an unconditional `true`, which meant the read-only path ran with
-  // destructive SQL permitted anyway -- the classifier was the only thing
-  // standing between a SELECT grant and a DROP.
-  assert.match(body, /duneDb\.runSql\(db, query, !readOnly\)/);
+  // destructive SQL permitted anyway.
+  //
+  // The classifier is no longer what stands between a SELECT grant and a DROP:
+  // review showed `select dune.<fn>(...)` -- the shape every privileged
+  // mutation in this app uses -- classifies read-only and sailed through. The
+  // real enforcement is `enforceReadOnly`, which runs the read path inside a
+  // `set transaction read only` transaction so Postgres refuses the write.
+  //
+  // This assertion only proves the CALL SHAPE. That the enforcement actually
+  // works is proved behaviourally, against a real Postgres, in
+  // databaseReadOnlyEnforcement.integration.test.js -- a source-text assertion
+  // like this one would pass unchanged if the transaction did nothing.
+  assert.match(body, /duneDb\.runSql\(db, query, !readOnly, \{ enforceReadOnly: true \}\)/);
   assert.ok(!/duneDb\.runSql\(db, query, true\)/.test(body),
     "runSql must not be called with an unconditional allowDestructive");
+});
+
+test("both caller-supplied SQL routes opt into read-only enforcement", () => {
+  // enforceReadOnly defaults to OFF, so a route that forgets it silently gets
+  // the old, bypassable behaviour. Internal callers pass server-built SQL and
+  // deliberately do not enforce; these two take it from the caller and must.
+  const query = codeOf(functionBody("databaseQuery"));
+  const bridge = codeOf(functionBody("addonBridgeRoute"));
+  for (const [name, fn] of [["databaseQuery", query], ["addonBridgeRoute", bridge]]) {
+    assert.match(fn, /enforceReadOnly: true/, `${name} must enforce read-only on the read path`);
+  }
 });
 
 test("requireAction re-runs both gates and fails closed", () => {

--- a/console/api/test/databaseQueryAuthz.test.js
+++ b/console/api/test/databaseQueryAuthz.test.js
@@ -44,8 +44,35 @@ function functionBody(name) {
 // not evidence: an ordering check that reads raw source can be satisfied (or
 // broken) by a comment that happens to mention the call it is looking for,
 // which is exactly what happened while writing this file.
+// String-aware, not a pair of regexes: server.js contains
+// `new URL(req.url, "http://localhost")`, and treating the // inside a string
+// literal as a comment truncates that line and shifts every index after it.
+// The bodies stripped here happen to contain no URLs today, so a naive version
+// was correct by luck. apiKeyAuthWiring.test.js documents both failure modes
+// this guards against, with the reproduction.
 function codeOf(text) {
-  return text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/[^\n]*/g, " ");
+  let out = "";
+  let quote = null;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    const next = text[i + 1];
+    if (quote) {
+      out += ch;
+      if (ch === "\\") { out += next ?? ""; i++; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") { quote = ch; out += ch; continue; }
+    if (ch === "/" && next === "/") { while (i < text.length && text[i] !== "\n") i++; out += "\n"; continue; }
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (i < text.length && !(text[i] === "*" && text[i + 1] === "/")) i++;
+      i++;
+      continue;
+    }
+    out += ch;
+  }
+  return out;
 }
 
 const body = codeOf(functionBody("databaseQuery"));

--- a/console/api/test/databaseQueryAuthz.test.js
+++ b/console/api/test/databaseQueryAuthz.test.js
@@ -1,0 +1,277 @@
+// POST /api/database/query authorizes on the SQL it was given, not just on its
+// route.
+//
+// The route resolves to database:query, a read-shaped name the default admin
+// policy grants. That same route also accepts UPDATE/DELETE/DROP, so before the
+// split it made admin's explicit Deny on database:mutate and
+// database:write-config decorative -- the narrow structured cell-edit was
+// denied while arbitrary write SQL stayed reachable. Write SQL now needs
+// database:execute on top, checked inside the handler once the body is parsed.
+//
+// server.js starts a listener on import, so handleApi and databaseQuery cannot
+// be called from a test; the ordering assertions below are static analysis, the
+// precedent set by apiKeyAuthWiring.test.js. The classifier invariant they rest
+// on IS executed for real.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { isReadOnlySql as gateClassifier } from "../src/runner.js";
+import { isReadOnlySql as executionClassifier, hasExecutableStatement } from "../src/db.js";
+import { allKnownActions, evaluate } from "../src/policy.js";
+import { actionForRoute, CONTENT_CONDITIONAL_ACTIONS } from "../src/actions.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(join(__dirname, "../src/server.js"), "utf8");
+
+function functionBody(name) {
+  const match = source.match(new RegExp(`(?:async )?function ${name}\\([^)]*\\)\\s*\\{`));
+  assert.ok(match, `${name} not found in server.js`);
+  const start = match.index + match[0].length;
+  let depth = 1;
+  for (let i = start; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") depth--;
+    if (depth === 0) return source.slice(start, i);
+  }
+  assert.fail(`${name} body not closed`);
+}
+
+// Every assertion below runs against the body with comments REMOVED. Prose is
+// not evidence: an ordering check that reads raw source can be satisfied (or
+// broken) by a comment that happens to mention the call it is looking for,
+// which is exactly what happened while writing this file.
+function codeOf(text) {
+  return text.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/\/\/[^\n]*/g, " ");
+}
+
+const body = codeOf(functionBody("databaseQuery"));
+const at = (needle) => {
+  const index = body.indexOf(needle);
+  assert.ok(index >= 0, `expected to find ${needle} in databaseQuery`);
+  return index;
+};
+
+// ---- The catalog ----
+
+test("database:execute is in the action catalog", () => {
+  // Not reachable from any route table, so allKnownActions has to pick it up
+  // from CONTENT_CONDITIONAL_ACTIONS. An action missing from that set is
+  // invisible to the API-key scope catalog and to any policy-authoring tool --
+  // it could be named in a policy document with nothing to offer or validate it.
+  assert.ok(CONTENT_CONDITIONAL_ACTIONS.includes("database:execute"));
+  assert.ok(allKnownActions().has("database:execute"));
+});
+
+test("no route resolves to database:execute", () => {
+  // The whole point of the split: the route stays database:query, and the
+  // narrower action is reached only through the in-handler check. If some
+  // future route table starts resolving to it, this design note is stale.
+  assert.equal(actionForRoute("/api/database/query", "POST"), "database:query");
+});
+
+// ---- The default policies ----
+
+test("owner may run write SQL, admin may not", () => {
+  assert.equal(evaluate({ tier: "owner" }, "database:execute"), true);
+  assert.equal(evaluate({ tier: "admin" }, "database:execute"), false);
+});
+
+test("admin keeps read SQL and export", () => {
+  // The split must not cost admin the read half it legitimately had.
+  assert.equal(evaluate({ tier: "admin" }, "database:query"), true);
+  assert.equal(evaluate({ tier: "admin" }, "database:read"), true);
+  assert.equal(evaluate({ tier: "admin" }, "database:export"), true);
+});
+
+test("the deny survives a widened allow list", () => {
+  // The Deny on database:execute is redundant against the shipped admin Allow
+  // list, which names database:read/query/export individually -- default-deny
+  // already refuses it. Its value is against the tidy-up that collapses those
+  // three into database:*. This asserts the Deny still wins in that world, so
+  // the line is not dropped later as dead weight.
+  const widened = {
+    admin: {
+      version: 1,
+      tier: "admin",
+      statements: [
+        { Effect: "Allow", Action: ["database:*"] },
+        { Effect: "Deny", Action: ["database:execute"] }
+      ]
+    }
+  };
+  assert.equal(evaluate({ tier: "admin" }, "database:query", widened), true);
+  assert.equal(evaluate({ tier: "admin" }, "database:execute", widened), false);
+});
+
+test("the tiers below admin reach no part of the database namespace", () => {
+  for (const tier of ["moderator", "player", "observer"]) {
+    for (const action of ["database:read", "database:query", "database:execute", "database:export"]) {
+      assert.equal(evaluate({ tier }, action), false, `${tier} should not hold ${action}`);
+    }
+  }
+});
+
+// ---- The handler ----
+
+test("write SQL is authorized against database:execute", () => {
+  assert.match(body, /if \(!readOnly && !requireAction\(req, res, "database:execute"\)\) return;/);
+});
+
+test("the authorization check runs before any side effect", () => {
+  // An unauthorized write must not be able to tick the mutation rate limiter
+  // (which would let a caller with no write permission starve one who has it)
+  // or spawn the pre-write database backup (an unauthenticated-in-effect way to
+  // make the host do expensive work on demand).
+  const authzAt = at('requireAction(req, res, "database:execute")');
+  assert.ok(authzAt < at('applyMutationRateLimit(req, res, "database.query.write")'),
+    "the rate limiter must not tick for a caller that is about to be refused");
+  assert.ok(authzAt < at('buildDuneArgs("backupCreate")'),
+    "an unauthorized write must not trigger a full database backup");
+  assert.ok(authzAt < at('audit(config, req, "database.query"'));
+  assert.ok(authzAt < at("duneDb.runSql"));
+});
+
+test("the SQL is classified once and reused", () => {
+  // Two calls could disagree about the same string, letting the authorization
+  // answer and the execution answer diverge.
+  const calls = body.match(/isReadOnlySql\(/g) || [];
+  assert.equal(calls.length, 1, "databaseQuery must classify the query exactly once");
+  assert.match(body, /const readOnly = isReadOnlySql\(query\);/);
+});
+
+test("a read-only request is executed with writes refused", () => {
+  // Previously an unconditional `true`, which meant the read-only path ran with
+  // destructive SQL permitted anyway -- the classifier was the only thing
+  // standing between a SELECT grant and a DROP.
+  assert.match(body, /duneDb\.runSql\(db, query, !readOnly\)/);
+  assert.ok(!/duneDb\.runSql\(db, query, true\)/.test(body),
+    "runSql must not be called with an unconditional allowDestructive");
+});
+
+test("requireAction re-runs both gates and fails closed", () => {
+  const helper = codeOf(functionBody("requireAction"));
+  assert.match(helper, /!evaluate\(session, action\)/, "the policy engine must be re-run");
+  assert.match(helper, /apiKeys\.allows\(req\.authApiKey, action\)/, "the key scope map must be re-run");
+  // A handler reached with no session at all must be refused, not waved through.
+  assert.match(helper, /if \(!session \|\| !evaluate\(session, action\)\)/);
+  assert.match(helper, /return false;/);
+  // The gate has to have stashed the key for the second check to find it.
+  assert.match(codeOf(source), /req\.authApiKey = bearer\?\.key \|\| null;/);
+});
+
+// ---- The invariant the handler's two classifiers rest on ----
+
+test("the gate's classifier is never laxer than the execution classifier", () => {
+  // databaseQuery decides with runner.js's isReadOnlySql and then hands
+  // `!readOnly` to duneDb.runSql, which re-derives the answer with db.js's.
+  // If runner's could ever call something read-only that db.js's calls a write,
+  // runSql would throw on a query the route had just authorized. Asserted
+  // functionally over a corpus rather than argued from reading the two regexes.
+  const corpus = [
+    "select 1",
+    "SELECT * FROM dune.players",
+    "  \n select 1",
+    "with x as (select 1) select * from x",
+    "show all",
+    "explain select 1",
+    "SeLeCt 1",
+    // comments, the only place the two implementations actually differ
+    "/* note */ select 1",
+    "-- note\nselect 1",
+    "select 1 -- delete",
+    "select 1 /* delete from t */",
+    "/* delete */ select 1",
+    "select 1; -- drop table t",
+    // writes
+    "delete from dune.players",
+    "update dune.players set name = 'x'",
+    "drop table dune.players",
+    "insert into t values (1)",
+    "truncate t",
+    "alter table t add column c int",
+    "grant all on t to public",
+    "copy t from '/tmp/x'",
+    "with x as (insert into t values (1) returning *) select * from x",
+    "select 1; drop table t",
+    // degenerate
+    "",
+    "   ",
+    "not sql at all"
+  ];
+
+  for (const query of corpus) {
+    if (gateClassifier(query)) {
+      assert.equal(
+        executionClassifier(query),
+        true,
+        `gate authorized as read-only but execution would refuse: ${JSON.stringify(query)}`
+      );
+    }
+  }
+});
+
+// ---- Input with nothing to execute never reaches the backup ----
+
+test("hasExecutableStatement rejects exactly the inputs with nothing to run", () => {
+  for (const empty of ["", "   ", "\n\t ", ";", ";;;", " ; ; ", "-- just a note", "/* commented out */",
+                       "/* a */ /* b */", "-- one\n-- two", "/* x */ ; -- y"]) {
+    assert.equal(hasExecutableStatement(empty), false, `should have nothing to run: ${JSON.stringify(empty)}`);
+  }
+  // Anything with a real token survives, including the cases the naive comment
+  // stripping mangles but must never reject.
+  for (const real of ["select 1", "delete from t", "SELECT '--'", "select '/* not a comment */'",
+                      "-- lead\nselect 1", "/* lead */ delete from t", "select 1;", "vacuum", "do $$ begin end $$"]) {
+    assert.equal(hasExecutableStatement(real), true, `should be runnable: ${JSON.stringify(real)}`);
+  }
+});
+
+test("every input with nothing to run would otherwise have been treated as a write", () => {
+  // This is the whole point: these classify as NOT read-only, so before the
+  // guard they took the write path and spawned a pre-write backup.
+  for (const empty of ["", "   ", ";", "-- just a note", "/* commented out */"]) {
+    assert.equal(gateClassifier(empty), false);
+    assert.equal(hasExecutableStatement(empty), false);
+  }
+});
+
+test("both SQL routes guard before classifying", () => {
+  // databaseQuery and the addon bridge each take a backup on the write path;
+  // the guard has to come first in both, not just the one that was reported.
+  for (const name of ["databaseQuery", "addonBridgeRoute"]) {
+    const fn = codeOf(functionBody(name));
+    const guardAt = fn.indexOf("hasExecutableStatement(query)");
+    assert.ok(guardAt >= 0, `${name} is missing the empty-statement guard`);
+    assert.ok(guardAt < fn.indexOf("isReadOnlySql(query)"), `${name} must guard before classifying`);
+    assert.ok(guardAt < fn.indexOf('buildDuneArgs("backupCreate")'), `${name} must guard before the backup`);
+  }
+});
+
+test("the isReadOnlySql refactor did not change any verdict", () => {
+  // stripSqlComments was factored out of db.js's isReadOnlySql to be shared
+  // with hasExecutableStatement. That function decides whether runSql permits
+  // a write, so its verdicts are pinned here rather than assumed unchanged.
+  const expected = [
+    ["select 1", true], ["  select 1", true], ["/* c */ select 1", true], ["-- c\nselect 1", true],
+    ["select 1 -- delete", true], ["with x as (select 1) select * from x", true],
+    ["show all", true], ["explain select 1", true], ["SeLeCt 1", true],
+    ["delete from t", false], ["update t set a=1", false], ["drop table t", false],
+    ["insert into t values (1)", false], ["truncate t", false], ["alter table t add c int", false],
+    ["grant all on t to public", false], ["revoke all on t from public", false],
+    ["copy t from '/tmp/x'", false], ["with x as (insert into t values (1) returning *) select * from x", false],
+    ["select 1; drop table t", false], ["", false], ["   ", false], ["vacuum", false]
+  ];
+  for (const [query, verdict] of expected) {
+    assert.equal(executionClassifier(query), verdict, `db.js isReadOnlySql changed for ${JSON.stringify(query)}`);
+  }
+});
+
+test("the corpus actually exercises both verdicts", () => {
+  // Guards the test above against passing vacuously if gateClassifier ever
+  // started returning false for everything.
+  const verdicts = new Set(["select 1", "delete from t"].map((q) => gateClassifier(q)));
+  assert.deepEqual([...verdicts].sort(), [false, true]);
+});

--- a/console/api/test/databaseReadOnlyEnforcement.integration.test.js
+++ b/console/api/test/databaseReadOnlyEnforcement.integration.test.js
@@ -1,0 +1,133 @@
+// The read path is enforced by POSTGRES, not by isReadOnlySql.
+//
+// A four-way review of the database:execute split found the permission was
+// decorative. isReadOnlySql only asks "does this start with a read keyword and
+// avoid a blacklist", and every privileged mutation in this application is
+// shaped `select dune.<fn>(...)`, so the whole mutation surface classified as
+// read-only: no database:execute demanded, no pre-write backup, no mutation
+// rate-limit tick, and an audit row saying readOnly:true. Confirmed against a
+// restored production dump by mutating a real currency balance.
+//
+// The blacklist cannot be repaired to cover it -- \bdelete\b does not match
+// delete_actors, and the schema ships hundreds of functions. So runSql now
+// wraps the read path in `set transaction read only`.
+//
+// These tests are BEHAVIOURAL on purpose. The existing coverage in
+// databaseQueryAuthz.test.js asserts on server.js source text, which would pass
+// unchanged if requireAction always returned true and could never have caught
+// this. Everything below executes real SQL against a real Postgres.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createDb } from "../src/db.js";
+import { runSql } from "../src/duneDb.js";
+
+const HOST = process.env.DUNE_DB_HOST || "";
+const skip = HOST ? false : "no DUNE_DB_HOST — needs the containerised Postgres";
+
+const db = HOST
+  ? createDb({
+      host: HOST,
+      port: Number(process.env.DUNE_DB_PORT || 5432),
+      database: process.env.DUNE_DB_NAME || "dune",
+      user: process.env.DUNE_DB_USER || "dune",
+      password: process.env.DUNE_DB_PASSWORD || "dune"
+    })
+  : null;
+
+const SCHEMA = "roenf";
+
+// EXACTLY how server.js databaseQuery and the addon bridge call it. Calling
+// runSql bare is what the first version of this file did, which silently
+// exercised the UNENFORCED path and reported the writes as succeeding -- the
+// enforcement is opt-in, so a test that forgets the option tests nothing.
+const runUserSql = (sql, allowWrite = false) => runSql(db, sql, allowWrite, { enforceReadOnly: true });
+
+test("read-only enforcement", { skip }, async (t) => {
+  await db.query(`drop schema if exists ${SCHEMA} cascade`);
+  await db.query(`create schema ${SCHEMA}`);
+  await db.query(`create table ${SCHEMA}.balances (id int primary key, amount bigint)`);
+  await db.query(`insert into ${SCHEMA}.balances values (1, 100)`);
+  // The shape that defeated the classifier: a writing function called through
+  // SELECT. Named with an underscore on purpose -- \bdelete\b does not match
+  // delete_actors, which is why a keyword blacklist can never cover this.
+  await db.query(`
+    create function ${SCHEMA}.delete_actors_and_pay(delta bigint) returns bigint
+    language sql as $$
+      update ${SCHEMA}.balances set amount = amount + delta where id = 1 returning amount;
+    $$`);
+
+  const amount = async () => {
+    const rows = await db.query(`select amount from ${SCHEMA}.balances where id = 1`);
+    return String(rows.rows[0].amount);
+  };
+
+  t.after(async () => {
+    await db.query(`drop schema if exists ${SCHEMA} cascade`);
+    await db.close();
+  });
+
+  await t.test("a mutating function called through SELECT cannot write on the read path", async () => {
+    const before = await amount();
+    await assert.rejects(
+      () => runUserSql(`select ${SCHEMA}.delete_actors_and_pay(500)`),
+      /read-only transaction/i,
+      "Postgres must refuse the write"
+    );
+    assert.equal(await amount(), before, "the balance changed despite the read-only path");
+  });
+
+  await t.test("SELECT ... INTO cannot create a table on the read path", async () => {
+    await assert.rejects(
+      () => runUserSql(`select * into ${SCHEMA}.stolen from ${SCHEMA}.balances`),
+      /read-only transaction/i
+    );
+    const found = await db.query(
+      `select count(*)::int as n from pg_tables where schemaname = $1 and tablename = 'stolen'`, [SCHEMA]);
+    assert.equal(found.rows[0].n, 0, "SELECT INTO created a table on the read path");
+  });
+
+  await t.test("a benign leading statement does not smuggle a write through", async () => {
+    // `select 1; select mutating_fn()` classified read-only and ran both.
+    // The transaction covers every statement in the string, not just the first.
+    const before = await amount();
+    await assert.rejects(
+      () => runUserSql(`select 1; select ${SCHEMA}.delete_actors_and_pay(700)`),
+      /read-only transaction/i
+    );
+    assert.equal(await amount(), before);
+  });
+
+  await t.test("ordinary reads still work on the read path", async () => {
+    const result = await runUserSql(`select amount from ${SCHEMA}.balances where id = 1`);
+    assert.equal(String(result.rows[0].amount), "100");
+  });
+
+  await t.test("a SELECT with a leading comment is a read, not a 403", async () => {
+    // Regression introduced by the database:execute split and caught in review:
+    // runner.js tested the raw string, so a header comment meant the statement
+    // did not start with a read keyword, classified as a WRITE, and demanded a
+    // permission admin is denied. Pasted SQL very often carries a header.
+    for (const sql of [
+      `-- daily balance\nselect amount from ${SCHEMA}.balances where id = 1`,
+      `/* daily balance */ select amount from ${SCHEMA}.balances where id = 1`
+    ]) {
+      const result = await runUserSql(sql);
+      assert.equal(String(result.rows[0].amount), "100", sql);
+    }
+  });
+
+  await t.test("the write path still writes when it is authorized", async () => {
+    // allowDestructive is what requireAction("database:execute") gates on. The
+    // hardening must not break the legitimate owner path.
+    const before = Number(await amount());
+    await runUserSql(`update ${SCHEMA}.balances set amount = amount + 5 where id = 1`, true);
+    assert.equal(Number(await amount()), before + 5);
+  });
+
+  await t.test("a mutating function DOES write when the write path is authorized", async () => {
+    const before = Number(await amount());
+    await runUserSql(`select ${SCHEMA}.delete_actors_and_pay(11)`, true);
+    assert.equal(Number(await amount()), before + 11, "the write path must still reach writing functions");
+  });
+});

--- a/console/api/test/databaseReadOnlyEnforcement.integration.test.js
+++ b/console/api/test/databaseReadOnlyEnforcement.integration.test.js
@@ -37,10 +37,9 @@ const db = HOST
 
 const SCHEMA = "roenf";
 
-// EXACTLY how server.js databaseQuery and the addon bridge call it. Calling
-// runSql bare is what the first version of this file did, which silently
-// exercised the UNENFORCED path and reported the writes as succeeding -- the
-// enforcement is opt-in, so a test that forgets the option tests nothing.
+// EXACTLY how server.js databaseQuery and the addon bridge call it. Enforcement
+// is opt-in, so calling runSql bare exercises the UNENFORCED path and reports
+// writes as succeeding -- a test that omits the option tests nothing.
 const runUserSql = (sql, allowWrite = false) => runSql(db, sql, allowWrite, { enforceReadOnly: true });
 
 test("read-only enforcement", { skip }, async (t) => {

--- a/console/api/test/policyActionValidation.test.js
+++ b/console/api/test/policyActionValidation.test.js
@@ -142,9 +142,12 @@ test("a valid policy still saves, and the structural checks still run first", ()
 
 test("a refused save does not change the active policy", () => {
   restoreDefaults();
-  const before = evaluate({ tier: "admin" }, "players:mutate");
+  // Probes a live catalog action, not players:mutate: that name is now a
+  // removed-action alias, so evaluating it measures alias resolution rather
+  // than the active document this test is about.
+  const before = evaluate({ tier: "admin" }, "players:reset");
   setPolicies(withAdmin([{ Effect: "Deny", Action: ["players:reset-progression"] }]));
-  assert.equal(evaluate({ tier: "admin" }, "players:mutate"), before,
+  assert.equal(evaluate({ tier: "admin" }, "players:reset"), before,
     "a rejected document must not be partially applied");
   restoreDefaults();
 });

--- a/console/api/test/policyActionValidation.test.js
+++ b/console/api/test/policyActionValidation.test.js
@@ -67,11 +67,10 @@ test("the trap was real: that Deny would have withheld nothing", () => {
     { Effect: "Allow", Action: ["players:*"] }
   ]);
   assert.equal(evaluate({ tier: "admin" }, "players:reset-progression", docs), false);
-  // ...and the route resolves to a real action that the Allow above DOES grant,
-  // so the reset stayed reachable. That action was players:mutate when this
-  // trap was found; the players:mutate split made it players:reset. Read from
-  // actionForRoute rather than hardcoded, so a further split cannot make this
-  // test quietly stop describing the live route.
+  // ...while the route resolves to a real action the Allow above DOES grant, so
+  // the reset stays reachable. Read from actionForRoute rather than hardcoded,
+  // so a future split cannot make this test quietly stop describing the live
+  // route.
   const realAction = actionForRoute("/api/players/12345/reset-progression", "POST");
   assert.ok(realAction && realAction !== "players:reset-progression");
   assert.equal(evaluate({ tier: "admin" }, realAction, docs), true);

--- a/console/api/test/policyActionValidation.test.js
+++ b/console/api/test/policyActionValidation.test.js
@@ -23,8 +23,10 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { allKnownActions, evaluate, getAllPolicies, matchAction, setPolicies, unknownActions, loadPolicies } from "../src/policy.js";
-import { actionForRoute } from "../src/actions.js";
+import { allKnownActions, deprecatedActions, evaluate, getAllPolicies, matchAction, setPolicies, unknownActions, loadPolicies } from "../src/policy.js";
+import { actionForRoute, REMOVED_ACTION_ALIASES } from "../src/actions.js";
+import { normalizeScopes } from "../src/apiKeyScopes.js";
+import { keyAllows } from "../src/apiKeys.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const policySrc = readFileSync(join(__dirname, "../src/policy.js"), "utf8");
@@ -229,4 +231,135 @@ test("the policies endpoint hands back the vocabulary", () => {
   const handler = serverSrc.slice(serverSrc.indexOf('path === "/api/settings/iam/policies"'));
   const body = handler.slice(0, handler.indexOf("\n  }\n"));
   assert.match(body, /actions: \[\.\.\.allKnownActions\(\)\]\.sort\(\)/);
+});
+
+// ---- Removed action aliases ----
+//
+// Splitting the coarse *:mutate actions is not a no-op for a policy that
+// already named one. Deleting the name outright turned the idiom this file's
+// header teaches inside out: `Deny players:mutate` + `Allow players:*` went
+// from "no player mutations" to "every player mutation", because the Deny
+// matched nothing and the wildcard matched all ten successors. Review measured
+// a tier GAINING 22 actions and losing none, silently, on upgrade.
+
+const escalationDoc = () => ({
+  owner: ownerAllowAll,
+  moderator: {
+    version: 1,
+    tier: "moderator",
+    statements: [
+      { Effect: "Deny", Action: ["players:mutate", "guilds:mutate", "addons:mutate", "blueprints:mutate"] },
+      { Effect: "Allow", Action: ["players:*", "guilds:*", "addons:*", "blueprints:*"] }
+    ]
+  }
+});
+
+test("a Deny on a removed action still denies everything it used to", () => {
+  // The regression this exists to prevent, asserted over every successor of
+  // every alias rather than a sample.
+  const docs = escalationDoc();
+  for (const [alias, successors] of Object.entries(REMOVED_ACTION_ALIASES)) {
+    for (const action of successors) {
+      assert.equal(evaluate({ tier: "moderator" }, action, docs), false,
+        `${action} leaked past a Deny on ${alias}`);
+    }
+  }
+});
+
+test("an Allow on a removed action still grants everything it used to", () => {
+  for (const [alias, successors] of Object.entries(REMOVED_ACTION_ALIASES)) {
+    const docs = {
+      owner: ownerAllowAll,
+      moderator: { version: 1, tier: "moderator", statements: [{ Effect: "Allow", Action: [alias] }] }
+    };
+    for (const action of successors) {
+      assert.equal(evaluate({ tier: "moderator" }, action, docs), true, `${alias} should still grant ${action}`);
+    }
+  }
+});
+
+test("an alias sweeps in no more than it used to cover", () => {
+  // players:kick-all was ALREADY its own action before the split (an exact
+  // ROUTE_ACTIONS entry for POST /api/players/kick-all-online), so it was never
+  // part of players:mutate. An alias that over-reaches would silently widen the
+  // very policies it exists to preserve.
+  assert.ok(!REMOVED_ACTION_ALIASES["players:mutate"].includes("players:kick-all"));
+  const docs = {
+    owner: ownerAllowAll,
+    moderator: { version: 1, tier: "moderator", statements: [{ Effect: "Allow", Action: ["players:mutate"] }] }
+  };
+  assert.equal(evaluate({ tier: "moderator" }, "players:kick-all", docs), false);
+  assert.equal(evaluate({ tier: "moderator" }, "players:read", docs), false, "an alias must not grant reads either");
+});
+
+test("every alias names only real, current actions", () => {
+  const known = allKnownActions();
+  for (const [alias, successors] of Object.entries(REMOVED_ACTION_ALIASES)) {
+    assert.ok(successors.length, `${alias} has no successors`);
+    for (const action of successors) {
+      assert.ok(known.has(action), `${alias} points at ${action}, which is not in the catalog`);
+    }
+    assert.ok(!known.has(alias), `${alias} is still in the catalog, so it is not actually removed`);
+  }
+});
+
+test("an alias cannot shadow a live action", () => {
+  // matchAction consults aliases LAST. If a future split reused a name that is
+  // both an alias and a live action, the live meaning must win.
+  for (const action of allKnownActions()) {
+    assert.ok(!REMOVED_ACTION_ALIASES[action], `${action} is both live and an alias`);
+  }
+  // And an alias pattern matches nothing outside its own successor list.
+  assert.equal(matchAction("players:mutate", "bases:delete"), false);
+  assert.equal(matchAction("players:mutate", "players:read"), false);
+});
+
+test("setPolicies refuses a removed action and names its successors", () => {
+  const result = setPolicies(escalationDoc());
+  assert.equal(result.ok, false);
+  assert.match(result.error, /were split and no longer exist/);
+  assert.match(result.error, /players:mutate \(now players:moderate/);
+  assert.ok(result.deprecatedActions.some((entry) => entry.pattern === "players:mutate"));
+  restoreDefaults();
+});
+
+test("a removed action is reported separately from one that never existed", () => {
+  // Different problems, different fixes: one needs migrating, the other is a
+  // typo that has never done anything.
+  const docs = withAdmin([{ Effect: "Deny", Action: ["players:mutate", "players:reset-progression"] }]);
+  assert.deepEqual(deprecatedActions(docs).map((e) => e.pattern), ["players:mutate"]);
+  assert.deepEqual(unknownActions(docs).map((e) => e.pattern), ["players:reset-progression"]);
+});
+
+test("a stored policy naming a removed action loads, keeps its meaning, and says so", () => {
+  // The upgrade path: accepted on load (so the operator's document is not
+  // thrown away and not re-interpreted), refused on save (so they migrate).
+  const root = writePolicyFile(escalationDoc());
+  try {
+    const result = loadPolicies(root);
+    assert.equal(result.source, "file");
+    assert.deepEqual(result.unknownActions, [], "a removed action is not an unknown action");
+    assert.ok(result.deprecatedActions.some((e) => e.pattern === "guilds:mutate"));
+    assert.ok(result.deprecatedActions[0].successors.length, "the notice must carry the successors");
+    // Still enforced with its original meaning, from the file on disk.
+    assert.equal(evaluate({ tier: "moderator" }, "guilds:disband"), false);
+    assert.equal(evaluate({ tier: "moderator" }, "players:reset"), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    restoreDefaults();
+  }
+});
+
+test("server.js reports removed actions at startup", () => {
+  assert.match(serverSrc, /for \(const \{ tier, pattern, successors \} of policyLoad\.deprecatedActions \|\| \[\]\)/);
+  assert.match(serverSrc, /which was split into/);
+});
+
+test("an alias cannot be granted to an API key", () => {
+  // Aliases live outside the catalog on purpose, so the key scope model never
+  // offers one and normalizeScopes drops it.
+  for (const alias of Object.keys(REMOVED_ACTION_ALIASES)) {
+    assert.deepEqual(normalizeScopes({ [alias.split(":")[0]]: [alias] }), {}, alias);
+    assert.equal(keyAllows({ scopes: { players: [alias] } }, "players:reset"), false);
+  }
 });

--- a/console/api/test/policyActionValidation.test.js
+++ b/console/api/test/policyActionValidation.test.js
@@ -1,0 +1,232 @@
+// A policy may only name actions that exist.
+//
+// The trap this closes: a misspelled or invented action in an ALLOW fails
+// closed and grants nothing, which is harmless. The same string in a DENY
+// withholds nothing while reading exactly like a restriction. policy.js's own
+// header documented
+//
+//     { "Effect": "Deny", "Action": ["players:reset-progression"] }
+//
+// as the canonical example -- and no route resolves to that string. The route
+// resolves to players:reset (players:mutate, before that action was split), so
+// an operator following the documented example believed progression resets
+// were blocked for admin while they were fully reachable.
+//
+// Worse, POST /api/settings/iam/policy/test answered allowed:false for it,
+// which reads as confirmation that the Deny works. The `known` field exists so
+// that answer can be told apart from a real denial.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { allKnownActions, evaluate, getAllPolicies, matchAction, setPolicies, unknownActions, loadPolicies } from "../src/policy.js";
+import { actionForRoute } from "../src/actions.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const policySrc = readFileSync(join(__dirname, "../src/policy.js"), "utf8");
+const serverSrc = readFileSync(join(__dirname, "../src/server.js"), "utf8");
+
+const ownerAllowAll = { version: 1, tier: "owner", statements: [{ Effect: "Allow", Action: "*" }] };
+const withAdmin = (statements) => ({
+  owner: ownerAllowAll,
+  admin: { version: 1, tier: "admin", statements }
+});
+
+// Restore the shipped defaults after any test that swaps them in, so ordering
+// between this file's tests cannot matter.
+function restoreDefaults() {
+  loadPolicies(join(__dirname, "__no_such_repo_root__"));
+}
+
+// ---- The reported trap, reproduced then closed ----
+
+test("the exact documented example is now refused", () => {
+  const result = setPolicies(withAdmin([
+    { Effect: "Deny", Action: ["players:reset-progression"] },
+    { Effect: "Allow", Action: ["players:*"] }
+  ]));
+  assert.equal(result.ok, false);
+  assert.match(result.error, /do not exist/);
+  assert.match(result.error, /players:reset-progression/);
+  assert.deepEqual(result.unknownActions, [{ tier: "admin", pattern: "players:reset-progression" }]);
+  restoreDefaults();
+});
+
+test("the trap was real: that Deny would have withheld nothing", () => {
+  // Evaluated directly against the document, bypassing setPolicies, to show
+  // what the old code stored. The Deny does not fire and the route's actual
+  // action stays allowed -- a policy that looks restrictive and is not.
+  const docs = withAdmin([
+    { Effect: "Deny", Action: ["players:reset-progression"] },
+    { Effect: "Allow", Action: ["players:*"] }
+  ]);
+  assert.equal(evaluate({ tier: "admin" }, "players:reset-progression", docs), false);
+  // ...and the route resolves to a real action that the Allow above DOES grant,
+  // so the reset stayed reachable. That action was players:mutate when this
+  // trap was found; the players:mutate split made it players:reset. Read from
+  // actionForRoute rather than hardcoded, so a further split cannot make this
+  // test quietly stop describing the live route.
+  const realAction = actionForRoute("/api/players/12345/reset-progression", "POST");
+  assert.ok(realAction && realAction !== "players:reset-progression");
+  assert.equal(evaluate({ tier: "admin" }, realAction, docs), true);
+  assert.ok(!allKnownActions().has("players:reset-progression"));
+});
+
+test("policy.js no longer documents a nonexistent action", () => {
+  assert.ok(!policySrc.includes('"Action": ["players:reset-progression"]'),
+    "the header example still shows an action that does not exist");
+  // Every quoted namespace:action inside the header block comment must be real
+  // (or a wildcard that matches something real) -- a fixed example that drifts
+  // is the same bug again.
+  const header = policySrc.slice(0, policySrc.indexOf("import "));
+  const known = [...allKnownActions()];
+  for (const quoted of header.match(/"[a-z][a-z-]*:[a-zA-Z0-9:*-]+"/g) || []) {
+    const pattern = quoted.slice(1, -1);
+    assert.ok(known.some((action) => matchAction(pattern, action)),
+      `policy.js header names ${pattern}, which matches no known action`);
+  }
+});
+
+// ---- unknownActions ----
+
+test("unknownActions flags dead patterns and leaves real ones alone", () => {
+  const dead = unknownActions(withAdmin([
+    { Effect: "Allow", Action: ["players:read", "player:*", "bases:*", "bases:delete-nonsense"] },
+    { Effect: "Deny", Action: "totally:invented" }
+  ]));
+  assert.deepEqual(dead.map((entry) => entry.pattern).sort(),
+    ["bases:delete-nonsense", "player:*", "totally:invented"]);
+  assert.ok(dead.every((entry) => entry.tier === "admin"));
+});
+
+test("wildcards stay legal, including the prefix-star style", () => {
+  // The validator asks "does this match at least one real action", not "is this
+  // string in the catalog" -- otherwise it would reject every wildcard policy,
+  // including the shipped ones.
+  for (const pattern of ["*", "players:*", "bases:delete-*", "bases:delete-item*", "database:*"]) {
+    assert.deepEqual(unknownActions(withAdmin([{ Effect: "Allow", Action: pattern }])), [],
+      `${pattern} should be accepted`);
+  }
+});
+
+test("a wildcard that matches nothing is still refused", () => {
+  // The dangerous near-miss: plausible shape, no matches.
+  for (const pattern of ["player:*", "base:*", "players:reset-*", "settings:*:write"]) {
+    const dead = unknownActions(withAdmin([{ Effect: "Deny", Action: pattern }]));
+    assert.deepEqual(dead, [{ tier: "admin", pattern }], `${pattern} should be refused`);
+  }
+});
+
+test("every shipped default policy passes its own validator", () => {
+  restoreDefaults();
+  assert.deepEqual(unknownActions(getAllPolicies()), []);
+});
+
+// ---- setPolicies ----
+
+test("a valid policy still saves, and the structural checks still run first", () => {
+  assert.equal(setPolicies(withAdmin([{ Effect: "Allow", Action: ["players:read", "bases:*"] }])).ok, true);
+  // An unknown action must not mask the two older failures.
+  assert.match(setPolicies({ owner: { tier: "owner", statements: [{ Effect: "Maybe", Action: "nope:nope" }] } }).error,
+    /valid tier documents/);
+  assert.match(setPolicies({ owner: { tier: "owner", statements: [{ Effect: "Deny", Action: "settings:write" }] } }).error,
+    /settings:write/);
+  restoreDefaults();
+});
+
+test("a refused save does not change the active policy", () => {
+  restoreDefaults();
+  const before = evaluate({ tier: "admin" }, "players:mutate");
+  setPolicies(withAdmin([{ Effect: "Deny", Action: ["players:reset-progression"] }]));
+  assert.equal(evaluate({ tier: "admin" }, "players:mutate"), before,
+    "a rejected document must not be partially applied");
+  restoreDefaults();
+});
+
+// ---- loadPolicies ----
+
+function writePolicyFile(docs) {
+  const root = mkdtempSync(join(tmpdir(), "iam-policies-"));
+  mkdirSync(join(root, "runtime", "generated"), { recursive: true });
+  writeFileSync(join(root, "runtime/generated/iam-policies.json"), JSON.stringify(docs));
+  return root;
+}
+
+test("a hand-edited file with a dead pattern loads, and says so", () => {
+  // Reported, NOT discarded. setPolicies refuses these on save, so a stored
+  // file can only acquire one by hand-editing -- and throwing the whole
+  // document away would silently revert the operator's entire policy to
+  // defaults, a far bigger surprise than the dead pattern itself.
+  const root = writePolicyFile(withAdmin([
+    { Effect: "Deny", Action: ["players:reset-progression"] },
+    { Effect: "Allow", Action: ["players:read", "bases:*"] }
+  ]));
+  try {
+    const result = loadPolicies(root);
+    assert.equal(result.source, "file", "the operator's document must still be in force");
+    assert.deepEqual(result.unknownActions, [{ tier: "admin", pattern: "players:reset-progression" }]);
+    // The rest of their policy really is applied, not replaced by defaults.
+    assert.equal(evaluate({ tier: "admin" }, "players:read"), true);
+    assert.equal(evaluate({ tier: "admin" }, "settings:write"), false,
+      "the file's admin policy is active, not the built-in default");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    restoreDefaults();
+  }
+});
+
+test("a structurally invalid file falls back to defaults and reports it", () => {
+  const root = writePolicyFile({ owner: { tier: "owner", statements: [{ Effect: "Maybe", Action: "*" }] } });
+  try {
+    const result = loadPolicies(root);
+    assert.equal(result.source, "defaults");
+    assert.equal(result.invalid, true);
+    assert.equal(evaluate({ tier: "owner" }, "settings:write"), true, "defaults must be in force");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    restoreDefaults();
+  }
+});
+
+test("a clean file loads with nothing to report", () => {
+  const root = writePolicyFile(withAdmin([{ Effect: "Allow", Action: ["players:read", "bases:*"] }]));
+  try {
+    const result = loadPolicies(root);
+    assert.equal(result.source, "file");
+    assert.deepEqual(result.unknownActions, []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    restoreDefaults();
+  }
+});
+
+test("a missing policy file reports defaults and no dead patterns", () => {
+  const result = loadPolicies(join(__dirname, "__no_such_repo_root__"));
+  assert.equal(result.source, "defaults");
+  assert.deepEqual(result.unknownActions, []);
+});
+
+test("server.js warns about every dead pattern at startup", () => {
+  assert.match(serverSrc, /const policyLoad = loadPolicies\(config\.repoRoot\);/);
+  assert.match(serverSrc, /for \(const \{ tier, pattern \} of policyLoad\.unknownActions\)/);
+  assert.match(serverSrc, /matches no known action and has no effect/);
+});
+
+// ---- The endpoints ----
+
+test("the policy test endpoint reports whether the action is real", () => {
+  const handler = serverSrc.slice(serverSrc.indexOf('path === "/api/settings/iam/policy/test"'));
+  const body = handler.slice(0, handler.indexOf("\n  }\n"));
+  assert.match(body, /known: allKnownActions\(\)\.has\(testAction\)/,
+    "allowed:false alone cannot distinguish a denial from a typo");
+});
+
+test("the policies endpoint hands back the vocabulary", () => {
+  const handler = serverSrc.slice(serverSrc.indexOf('path === "/api/settings/iam/policies"'));
+  const body = handler.slice(0, handler.indexOf("\n  }\n"));
+  assert.match(body, /actions: \[\.\.\.allKnownActions\(\)\]\.sort\(\)/);
+});

--- a/console/web/src/api/apiKeys.ts
+++ b/console/web/src/api/apiKeys.ts
@@ -110,16 +110,11 @@ export function keyStatus(key: ApiKey): "Active" | "Disabled" | "Expired" {
   return key.enabled ? "Active" : "Disabled";
 }
 
-// Record<string, ScopeLevel> models a missing key as ScopeLevel rather than
-// undefined, and ScopeLevel has no falsy member, so `scopes[ns] ?? "none"`
-// narrows straight back to ScopeLevel at the call site. A declared return type
+// Record<string, ScopeValue> models a missing key as ScopeValue rather than
+// undefined, and ScopeValue has no falsy member, so `scopes[ns] ?? "none"`
+// narrows straight back to ScopeValue at the call site. A declared return type
 // is not narrowed that way, and the hasOwnProperty guard makes the lookup
 // honest about a namespace that was never granted.
-export function scopeLevelOf(scopes: ApiKeyScopes, namespace: string): ScopeLevel | undefined {
-  const value = scopeValueOf(scopes, namespace);
-  return Array.isArray(value) ? undefined : value;
-}
-
 export function scopeValueOf(scopes: ApiKeyScopes, namespace: string): ScopeValue | undefined {
   return Object.prototype.hasOwnProperty.call(scopes || {}, namespace) ? scopes[namespace] : undefined;
 }

--- a/console/web/src/api/apiKeys.ts
+++ b/console/web/src/api/apiKeys.ts
@@ -4,7 +4,11 @@ import { api, post } from "./client";
 // no "none" level to store, and the server treats anything it does not
 // recognise as None rather than falling back to read.
 export type ScopeLevel = "read" | "write";
-export type ApiKeyScopes = Record<string, ScopeLevel>;
+// A namespace holds either a level or an explicit list of action names. A level
+// auto-covers actions added in a later release; a list grants exactly what it
+// names and nothing else. See docs/console/api-keys.md.
+export type ScopeValue = ScopeLevel | string[];
+export type ApiKeyScopes = Record<string, ScopeValue>;
 
 export type ApiKey = {
   id: string;
@@ -32,6 +36,20 @@ export type ScopeCatalogEntry = {
   // None/Read control for such a namespace.
   supportsWrite: boolean;
 };
+
+// Every action a namespace can be granted individually, reads first. Derived
+// from the catalog rather than fetched separately, so it cannot disagree with
+// what the server will accept.
+export function grantableActions(entry: ScopeCatalogEntry): string[] {
+  return [...entry.readActions, ...entry.writeActions];
+}
+
+// Custom is only meaningful where there is more than one action to choose
+// between -- `logs` has exactly one, so a Custom segment there would be Read
+// under another name.
+export function supportsCustom(entry: ScopeCatalogEntry): boolean {
+  return grantableActions(entry).length > 1;
+}
 
 export type CreateApiKeyInput = {
   name: string;
@@ -98,11 +116,30 @@ export function keyStatus(key: ApiKey): "Active" | "Disabled" | "Expired" {
 // is not narrowed that way, and the hasOwnProperty guard makes the lookup
 // honest about a namespace that was never granted.
 export function scopeLevelOf(scopes: ApiKeyScopes, namespace: string): ScopeLevel | undefined {
+  const value = scopeValueOf(scopes, namespace);
+  return Array.isArray(value) ? undefined : value;
+}
+
+export function scopeValueOf(scopes: ApiKeyScopes, namespace: string): ScopeValue | undefined {
   return Object.prototype.hasOwnProperty.call(scopes || {}, namespace) ? scopes[namespace] : undefined;
 }
 
+// The actions a namespace grants right now, whichever form it is stored in.
+// A level is expanded against the catalog for display only -- what gets SENT
+// stays a level, so its auto-covering behaviour is preserved.
+export function selectedActions(scopes: ApiKeyScopes, entry: ScopeCatalogEntry): string[] {
+  const value = scopeValueOf(scopes, entry.namespace);
+  if (Array.isArray(value)) return value;
+  if (value === "write") return grantableActions(entry);
+  if (value === "read") return [...entry.readActions];
+  return [];
+}
+
+// Namespaces that actually grant something. A Custom row with nothing ticked
+// is an empty array, which the server drops on save -- counting it would leave
+// Create enabled for a key that reaches nothing.
 export function grantedCount(scopes: ApiKeyScopes) {
-  return Object.keys(scopes || {}).length;
+  return Object.values(scopes || {}).filter((value) => !Array.isArray(value) || value.length > 0).length;
 }
 
 const SCOPE_LABELS: Record<string, string> = {
@@ -135,6 +172,9 @@ export function describeScopes(scopes: ApiKeyScopes) {
   if (!entries.length) return "No access";
   return entries
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([namespace, level]) => `${scopeLabel(namespace)} ${level === "write" ? "RW" : "R"}`)
+    .map(([namespace, value]) => {
+      if (Array.isArray(value)) return `${scopeLabel(namespace)} ${value.length} action${value.length === 1 ? "" : "s"}`;
+      return `${scopeLabel(namespace)} ${value === "write" ? "RW" : "R"}`;
+    })
     .join(", ");
 }

--- a/console/web/src/features/settings/ApiKeysSection.test.tsx
+++ b/console/web/src/features/settings/ApiKeysSection.test.tsx
@@ -267,12 +267,10 @@ describe("the create form", () => {
   });
 
   test("an empty Custom row is not highlighted as granted", async () => {
-    // The .granted class and grantedCount have to agree. They did not: the
-    // class was keyed off "the level is not None", so a Custom row with
-    // nothing ticked lit up as reached while the same row was excluded from
-    // the count that enables Create -- the grid claimed access the key would
-    // not have. Asserted through the class because that is what paints it;
-    // jsdom has no layout engine, so the colour itself is a browser check.
+    // The .granted class and grantedCount must agree, or the grid claims
+    // access the key does not have. Asserted through the class because that is
+    // what paints it -- jsdom has no layout engine, so the rendered colour
+    // stays a browser check.
     renderSection([]);
     await openCreateForm();
 

--- a/console/web/src/features/settings/ApiKeysSection.test.tsx
+++ b/console/web/src/features/settings/ApiKeysSection.test.tsx
@@ -266,6 +266,34 @@ describe("the create form", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: /Create Key/i })).toBeEnabled());
   });
 
+  test("an empty Custom row is not highlighted as granted", async () => {
+    // The .granted class and grantedCount have to agree. They did not: the
+    // class was keyed off "the level is not None", so a Custom row with
+    // nothing ticked lit up as reached while the same row was excluded from
+    // the count that enables Create -- the grid claimed access the key would
+    // not have. Asserted through the class because that is what paints it;
+    // jsdom has no layout engine, so the colour itself is a browser check.
+    renderSection([]);
+    await openCreateForm();
+
+    const row = () => screen.getByLabelText("Access level for players").closest(".api-key-scope-row")!;
+
+    fireEvent.click(screen.getByLabelText("Read players"));
+    expect(row().className).toContain("granted");
+
+    // Custom seeds from the level it replaces, so this arrives with
+    // players:read already ticked -- still granted, now as a list.
+    fireEvent.click(screen.getByLabelText("Custom actions for players"));
+    expect(screen.getByRole("checkbox", { name: "players:read" })).toBeChecked();
+    expect(row().className).toContain("granted");
+
+    // Untick the only seeded action: still Custom, but reaching nothing.
+    fireEvent.click(screen.getByRole("checkbox", { name: "players:read" }));
+    expect(screen.getByText(/0 of 4 actions selected/i)).toBeInTheDocument();
+    expect(row().className).not.toContain("granted");
+    expect(screen.getByRole("button", { name: /Create Key/i })).toBeDisabled();
+  });
+
   test("switching a Custom namespace back to a level sends the level", async () => {
     renderSection([]);
     await openCreateForm();

--- a/console/web/src/features/settings/ApiKeysSection.test.tsx
+++ b/console/web/src/features/settings/ApiKeysSection.test.tsx
@@ -22,7 +22,7 @@ vi.mock("../../lib/clipboard", () => ({ copyText: vi.fn().mockResolvedValue(true
 import { apiKeysApi } from "../../api/apiKeys";
 
 const CATALOG: ScopeCatalogEntry[] = [
-  { namespace: "players", readActions: ["players:read"], writeActions: ["players:mutate"], supportsWrite: true },
+  { namespace: "players", readActions: ["players:read"], writeActions: ["players:moderate", "players:reset", "players:delete-item"], supportsWrite: true },
   { namespace: "bases", readActions: ["bases:read"], writeActions: ["bases:mutate"], supportsWrite: true },
   // logs has no write action; updates has several but they are denied to keys.
   // Both must render two segments, not three.
@@ -121,12 +121,29 @@ describe("the create form", () => {
     for (const namespace of ["logs", "updates"]) {
       const group = screen.getByLabelText(`Access level for ${namespace}`);
       expect(within(group).queryByLabelText(new RegExp(`Read\\+write for ${namespace}`, "i"))).toBeNull();
-      expect(within(group).getAllByRole("radio")).toHaveLength(2);
     }
 
     const players = screen.getByLabelText("Access level for players");
     expect(within(players).getByLabelText(/Read\+write for players/i)).toBeInTheDocument();
-    expect(within(players).getAllByRole("radio")).toHaveLength(3);
+  });
+
+  test("offers Custom only where there is more than one action to choose between", async () => {
+    renderSection([]);
+    await openCreateForm();
+
+    // logs has exactly one action, so Custom there would be Read under another
+    // name -- the same catalog-driven rule that hides Read+write.
+    const logs = screen.getByLabelText("Access level for logs");
+    expect(within(logs).queryByLabelText(/Custom actions for logs/i)).toBeNull();
+    expect(within(logs).getAllByRole("radio")).toHaveLength(2);
+
+    // updates has two read actions and no writes: no Read+write segment, but
+    // Custom is still meaningful.
+    const updates = screen.getByLabelText("Access level for updates");
+    expect(within(updates).getByLabelText(/Custom actions for updates/i)).toBeInTheDocument();
+    expect(within(updates).getAllByRole("radio")).toHaveLength(3);
+
+    expect(within(screen.getByLabelText("Access level for players")).getAllByRole("radio")).toHaveLength(4);
   });
 
   test("sends only the granted namespaces, with None as absence", async () => {
@@ -171,6 +188,112 @@ describe("the create form", () => {
     renderSection([]);
     await openCreateForm();
     expect(screen.queryByRole("button", { name: /set all|grant all|select all/i })).toBeNull();
+  });
+
+  test("Custom seeds from the level it replaces, so switching does not drop access", async () => {
+    renderSection([]);
+    await openCreateForm();
+
+    fireEvent.click(screen.getByLabelText(/Read\+write for players/i));
+    fireEvent.click(screen.getByLabelText("Custom actions for players"));
+
+    // Seeded from Read+write, which is every action in the namespace.
+    for (const action of ["players:read", "players:moderate", "players:reset", "players:delete-item"]) {
+      expect(screen.getByRole("checkbox", { name: action })).toBeChecked();
+    }
+    expect(screen.getByText(/4 of 4 actions selected/i)).toBeInTheDocument();
+  });
+
+  test("Custom seeded from Read carries only the read actions", async () => {
+    renderSection([]);
+    await openCreateForm();
+
+    fireEvent.click(screen.getByLabelText("Read players"));
+    fireEvent.click(screen.getByLabelText("Custom actions for players"));
+
+    expect(screen.getByRole("checkbox", { name: "players:read" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "players:moderate" })).not.toBeChecked();
+    expect(screen.getByText(/1 of 4 actions selected/i)).toBeInTheDocument();
+  });
+
+  test("a Custom namespace sends the ticked actions, not a level", async () => {
+    renderSection([]);
+    await openCreateForm();
+
+    fireEvent.change(screen.getByLabelText(/^Name/i), { target: { value: "moderation bot" } });
+    fireEvent.click(screen.getByLabelText("Custom actions for players"));
+    fireEvent.click(screen.getByRole("checkbox", { name: "players:read" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "players:moderate" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /Create Key/i }));
+
+    await waitFor(() => expect(mocked.create).toHaveBeenCalled());
+    const [sent] = mocked.create.mock.calls[0];
+    // The whole point: the destructive actions are absent, not merely unticked.
+    expect(sent.scopes.players).toEqual(["players:moderate", "players:read"]);
+  });
+
+  test("unticking an action removes it from what is sent", async () => {
+    renderSection([]);
+    await openCreateForm();
+
+    fireEvent.change(screen.getByLabelText(/^Name/i), { target: { value: "narrower" } });
+    fireEvent.click(screen.getByLabelText(/Read\+write for players/i));
+    fireEvent.click(screen.getByLabelText("Custom actions for players"));
+    fireEvent.click(screen.getByRole("checkbox", { name: "players:reset" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "players:delete-item" }));
+
+    fireEvent.click(screen.getByRole("button", { name: /Create Key/i }));
+
+    await waitFor(() => expect(mocked.create).toHaveBeenCalled());
+    const [sent] = mocked.create.mock.calls[0];
+    expect(sent.scopes.players).toEqual(["players:moderate", "players:read"]);
+  });
+
+  test("a Custom row with nothing ticked does not count as a grant", async () => {
+    // The server drops an empty action list, so Create must not be enabled for
+    // a key that would reach nothing.
+    renderSection([]);
+    await openCreateForm();
+
+    fireEvent.change(screen.getByLabelText(/^Name/i), { target: { value: "empty" } });
+    fireEvent.click(screen.getByLabelText("Custom actions for players"));
+
+    expect(screen.getByText(/0 of 4 actions selected/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Create Key/i })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "players:read" }));
+    await waitFor(() => expect(screen.getByRole("button", { name: /Create Key/i })).toBeEnabled());
+  });
+
+  test("switching a Custom namespace back to a level sends the level", async () => {
+    renderSection([]);
+    await openCreateForm();
+
+    fireEvent.change(screen.getByLabelText(/^Name/i), { target: { value: "relevelled" } });
+    fireEvent.click(screen.getByLabelText("Custom actions for players"));
+    fireEvent.click(screen.getByRole("checkbox", { name: "players:read" }));
+    fireEvent.click(screen.getByLabelText("Read players"));
+
+    // The checklist is gone and the stored value is a level again, so the key
+    // keeps the auto-covering behaviour a level carries.
+    expect(screen.queryByRole("checkbox", { name: "players:read" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Create Key/i }));
+    await waitFor(() => expect(mocked.create).toHaveBeenCalled());
+    expect(mocked.create.mock.calls[0][0].scopes.players).toBe("read");
+  });
+
+  test("Clear All removes a Custom selection too", async () => {
+    renderSection([]);
+    await openCreateForm();
+
+    fireEvent.click(screen.getByLabelText("Custom actions for players"));
+    fireEvent.click(screen.getByRole("checkbox", { name: "players:moderate" }));
+    fireEvent.click(screen.getByRole("button", { name: /Clear All/i }));
+
+    expect(screen.queryByRole("checkbox", { name: "players:moderate" })).toBeNull();
+    expect(screen.getByRole("button", { name: /Create Key/i })).toBeDisabled();
   });
 });
 

--- a/console/web/src/features/settings/ApiKeysSection.tsx
+++ b/console/web/src/features/settings/ApiKeysSection.tsx
@@ -372,7 +372,13 @@ export function ApiKeysSection({ confirmAction }: { confirmAction: ConfirmAction
           // be Read under another name.
           if (supportsCustom(entry)) options.push({ value: "custom", label: "Custom", ariaLabel: `Custom actions for ${entry.namespace}` });
           const actions = grantableActions(entry);
-          return <div className={`api-key-scope-row${level === "none" ? "" : " granted"}`} key={entry.namespace}>
+          // Matches grantedCount, which drops an empty action list because the
+          // server does. Keying the styling off `level !== "none"` instead lit
+          // a Custom row with nothing ticked up as granted while the same row
+          // was not counted towards enabling Create -- the grid said the
+          // namespace was reached and the button said the key reached nothing.
+          const granted = level === "custom" ? chosen.length > 0 : level !== "none";
+          return <div className={`api-key-scope-row${granted ? " granted" : ""}`} key={entry.namespace}>
             <span className="api-key-scope-name">{scopeLabel(entry.namespace)}</span>
             <SegmentedControl
               name={`api-key-scope-${entry.namespace}`}

--- a/console/web/src/features/settings/ApiKeysSection.tsx
+++ b/console/web/src/features/settings/ApiKeysSection.tsx
@@ -127,16 +127,14 @@ export function ApiKeysSection({ confirmAction }: { confirmAction: ConfirmAction
       // key carrying a level that means nothing.
       if (level === "none") { delete next[namespace]; return next; }
       if (level !== "custom") { next[namespace] = level; return next; }
-      // Switching to Custom seeds the list from whatever the namespace grants
-      // right now, so the control opens showing the access the operator
-      // already chose rather than silently dropping it back to nothing. An
-      // empty seed (coming from None) stays an empty array: the row is
-      // "Custom, nothing ticked yet", which createKey refuses to send.
+      // Custom seeds from what the namespace grants right now, so switching
+      // does not silently drop the operator's existing choice. An empty seed
+      // (from None) stays an empty array -- "Custom, nothing ticked yet",
+      // which createKey refuses to send.
       const entry = catalog.find((candidate) => candidate.namespace === namespace);
-      // Sorted, like toggleAction below and like the server stores it. Seeding
-      // in catalog order instead made what got SENT depend on how the operator
-      // arrived at the selection, and made the draft reorder itself the moment
-      // the saved key came back.
+      // Sorted, like toggleAction below and like the server stores it.
+      // Catalog order would make what gets SENT depend on how the operator
+      // reached the selection, and reorder the draft when the key came back.
       next[namespace] = entry ? [...selectedActions(current, entry)].sort() : [];
       return next;
     });
@@ -367,16 +365,12 @@ export function ApiKeysSection({ confirmAction }: { confirmAction: ConfirmAction
             { value: "read", label: "Read", ariaLabel: `Read ${entry.namespace}` }
           ];
           if (entry.supportsWrite) options.push({ value: "write", label: "Read+Write", ariaLabel: `Read+Write for ${entry.namespace}` });
-          // Same catalog-driven rule as supportsWrite above: a namespace with a
-          // single action has nothing to choose between, so Custom there would
-          // be Read under another name.
+          // Catalog-driven, like supportsWrite above. See supportsCustom.
           if (supportsCustom(entry)) options.push({ value: "custom", label: "Custom", ariaLabel: `Custom actions for ${entry.namespace}` });
           const actions = grantableActions(entry);
-          // Matches grantedCount, which drops an empty action list because the
-          // server does. Keying the styling off `level !== "none"` instead lit
-          // a Custom row with nothing ticked up as granted while the same row
-          // was not counted towards enabling Create -- the grid said the
-          // namespace was reached and the button said the key reached nothing.
+          // Must match grantedCount, which drops an empty action list because
+          // the server does. `level !== "none"` alone paints an empty Custom
+          // row as reached while Create stays disabled.
           const granted = level === "custom" ? chosen.length > 0 : level !== "none";
           return <div className={`api-key-scope-row${granted ? " granted" : ""}`} key={entry.namespace}>
             <span className="api-key-scope-name">{scopeLabel(entry.namespace)}</span>

--- a/console/web/src/features/settings/ApiKeysSection.tsx
+++ b/console/web/src/features/settings/ApiKeysSection.tsx
@@ -6,8 +6,11 @@ import {
   grantedCount,
   endOfLocalDayIso,
   keyStatus,
+  grantableActions,
   scopeLabel,
-  scopeLevelOf,
+  scopeValueOf,
+  selectedActions,
+  supportsCustom,
   type ApiKey,
   type ApiKeyScopes,
   type ScopeCatalogEntry,
@@ -25,7 +28,7 @@ type ConfirmAction = (
 
 // "none" exists only in the UI. It is the absence of a scope entry, never a
 // stored value -- see toScopes below.
-type SegmentValue = ScopeLevel | "none";
+type SegmentValue = ScopeLevel | "none" | "custom";
 
 // The server rejects a past expiry; `min` stops the picker offering one in the
 // first place, so the operator finds out before submitting rather than after.
@@ -122,8 +125,31 @@ export function ApiKeysSection({ confirmAction }: { confirmAction: ConfirmAction
       const next = { ...current };
       // None is stored as absence, so the operator can never end up with a
       // key carrying a level that means nothing.
-      if (level === "none") delete next[namespace];
-      else next[namespace] = level;
+      if (level === "none") { delete next[namespace]; return next; }
+      if (level !== "custom") { next[namespace] = level; return next; }
+      // Switching to Custom seeds the list from whatever the namespace grants
+      // right now, so the control opens showing the access the operator
+      // already chose rather than silently dropping it back to nothing. An
+      // empty seed (coming from None) stays an empty array: the row is
+      // "Custom, nothing ticked yet", which createKey refuses to send.
+      const entry = catalog.find((candidate) => candidate.namespace === namespace);
+      // Sorted, like toggleAction below and like the server stores it. Seeding
+      // in catalog order instead made what got SENT depend on how the operator
+      // arrived at the selection, and made the draft reorder itself the moment
+      // the saved key came back.
+      next[namespace] = entry ? [...selectedActions(current, entry)].sort() : [];
+      return next;
+    });
+  }
+
+  function toggleAction(namespace: string, action: string, checked: boolean) {
+    setDraftScopes((current) => {
+      const value = current[namespace];
+      const actions = Array.isArray(value) ? value : [];
+      const next = { ...current };
+      next[namespace] = checked
+        ? [...new Set([...actions, action])].sort()
+        : actions.filter((candidate) => candidate !== action);
       return next;
     });
   }
@@ -325,7 +351,9 @@ export function ApiKeysSection({ confirmAction }: { confirmAction: ConfirmAction
 
       <div className="api-key-scope-grid">
         {catalog.map((entry) => {
-          const level: SegmentValue = scopeLevelOf(draftScopes, entry.namespace) ?? "none";
+          const stored = scopeValueOf(draftScopes, entry.namespace);
+          const level: SegmentValue = Array.isArray(stored) ? "custom" : stored ?? "none";
+          const chosen = Array.isArray(stored) ? stored : [];
           // logs has no write action and updates' writes are denied to keys, so
           // offering a third segment there would be a control that changes
           // nothing. Driven off the catalog, not a hardcoded name.
@@ -339,6 +367,11 @@ export function ApiKeysSection({ confirmAction }: { confirmAction: ConfirmAction
             { value: "read", label: "Read", ariaLabel: `Read ${entry.namespace}` }
           ];
           if (entry.supportsWrite) options.push({ value: "write", label: "Read+Write", ariaLabel: `Read+Write for ${entry.namespace}` });
+          // Same catalog-driven rule as supportsWrite above: a namespace with a
+          // single action has nothing to choose between, so Custom there would
+          // be Read under another name.
+          if (supportsCustom(entry)) options.push({ value: "custom", label: "Custom", ariaLabel: `Custom actions for ${entry.namespace}` });
+          const actions = grantableActions(entry);
           return <div className={`api-key-scope-row${level === "none" ? "" : " granted"}`} key={entry.namespace}>
             <span className="api-key-scope-name">{scopeLabel(entry.namespace)}</span>
             <SegmentedControl
@@ -350,6 +383,21 @@ export function ApiKeysSection({ confirmAction }: { confirmAction: ConfirmAction
               onChange={(next) => setLevel(entry.namespace, next)}
               groupClassName="segmented-control api-key-scope-segments"
             />
+            {level === "custom" && <fieldset className="api-key-scope-actions">
+              <legend className="muted">
+                {chosen.length} of {actions.length} actions selected
+                {!chosen.length && " — tick at least one, or switch back to None"}
+              </legend>
+              {actions.map((action) => <label key={action} className="api-key-scope-action">
+                <input
+                  type="checkbox"
+                  checked={chosen.includes(action)}
+                  disabled={creating}
+                  onChange={(event) => toggleAction(entry.namespace, action, event.target.checked)}
+                />
+                <code>{action}</code>
+              </label>)}
+            </fieldset>}
           </div>;
         })}
       </div>

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -6780,19 +6780,42 @@ td :where(.service-actions, .action-row, .map-action-buttons) { max-width: 100%;
 /* The Custom action checklist. The row is display: contents, so this fieldset
    is a direct item of .api-key-scope-grid and must be told to span BOTH
    columns -- left to itself it would drop into the name column and squeeze
-   against the 1fr track. */
+   against the 1fr track.
+
+   Spanning both columns is what the checklist needs (12 actions across three
+   auto-fill tracks rather than one long single-column list), but it also means
+   the band starts at the same x as the namespace names above and below it, so
+   the first column stops reading as "namespace" for one row. The left rule and
+   indent are what re-subordinate it: it reads as a detail panel hanging off the
+   row that opened it, not as another cell in the name column. Same idiom as
+   .dirty-note and .database-tunnel-security-note (both 3px var(--accent)),
+   without their tinted background -- this is structure, not a warning.
+
+   --accent, not --border-strong: the rule has to be SEEN to do the grouping,
+   and --border-strong is 1.86:1 against --panel-muted, under the 3:1 WCAG
+   1.4.11 asks of a boundary that carries meaning. --accent is 6.38:1.
+   --border (1.33:1) and #62513d (2.45:1) fail the same way. */
 .api-key-scope-actions {
   grid-column: 1 / -1;
   border: 0;
+  border-left: 3px solid var(--accent);
   border-bottom: 1px solid #241f1a;
   margin: 0;
-  padding: 2px 0 8px;
+  padding: 2px 0 8px 12px;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
   column-gap: 16px;
   row-gap: 4px;
 }
 .api-key-scope-row:last-child > .api-key-scope-actions { border-bottom: 0; }
+/* A row that owns a checklist must not be separated from it. .api-key-scope-row
+   is display: contents, so the separator lives on each CELL -- which drew a
+   full-width rule between the namespace and its own action list, grouping the
+   list with the row beneath instead. Only the fieldset closes the group. */
+.api-key-scope-row:has(> .api-key-scope-actions) > .api-key-scope-name,
+.api-key-scope-row:has(> .api-key-scope-actions) > .api-key-scope-segments {
+  border-bottom: 0;
+}
 /* Spans the grid rather than sitting in the first cell: a legend is not a grid
    item by default in every engine, so it is placed explicitly. */
 .api-key-scope-actions legend {
@@ -6861,6 +6884,14 @@ td :where(.service-actions, .action-row, .map-action-buttons) { max-width: 100%;
   .api-key-scope-row > * { padding: 0; border-bottom: 0; }
   .api-key-scope-row:last-child { border-bottom: 0; }
   .api-key-scope-segments { justify-self: stretch; grid-auto-columns: minmax(0, 1fr); }
+  /* The rule above zeroes padding on every cell, the fieldset included, which
+     stripped the checklist of the indent and gutter that make it read as a
+     group -- at the width where the rows have already lost their columns and
+     the grouping is carrying all of the structure. Same specificity as that
+     rule, so this has to come after it. Only padding is restored: that rule
+     resets border-BOTTOM, so the left rule is still inherited from the
+     unconditional declaration above. */
+  .api-key-scope-actions { padding: 2px 0 4px 12px; }
 }
 
 .api-key-reveal {

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -6777,6 +6777,54 @@ td :where(.service-actions, .action-row, .map-action-buttons) { max-width: 100%;
   justify-self: start;
 }
 .api-key-scope-segments .segmented-control-segment { min-height: 30px; padding: 0 6px; font-size: 11px; }
+/* The Custom action checklist. The row is display: contents, so this fieldset
+   is a direct item of .api-key-scope-grid and must be told to span BOTH
+   columns -- left to itself it would drop into the name column and squeeze
+   against the 1fr track. */
+.api-key-scope-actions {
+  grid-column: 1 / -1;
+  border: 0;
+  border-bottom: 1px solid #241f1a;
+  margin: 0;
+  padding: 2px 0 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr));
+  column-gap: 16px;
+  row-gap: 4px;
+}
+.api-key-scope-row:last-child > .api-key-scope-actions { border-bottom: 0; }
+/* Spans the grid rather than sitting in the first cell: a legend is not a grid
+   item by default in every engine, so it is placed explicitly. */
+.api-key-scope-actions legend {
+  grid-column: 1 / -1;
+  float: left;
+  width: 100%;
+  padding: 0 0 4px;
+  font-size: 12px;
+}
+.api-key-scope-action {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-size: 12px;
+  color: var(--muted-warm);
+  cursor: pointer;
+}
+/* accent-color is set per component in this stylesheet -- there is no global
+   checkbox rule -- so without this the ticks render in the browser default
+   blue/purple, which reads as foreign in an amber console. Matches the
+   blueprint row-select checkboxes. */
+.api-key-scope-action input { margin: 0; flex: none; accent-color: var(--accent); }
+.api-key-scope-action code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+}
+/* Ticked actions read as the granted ones, matching how .granted lifts a
+   namespace name out of the muted default. */
+.api-key-scope-action:has(input:checked) { color: var(--text-strong); }
 
 /* Declared AFTER the unconditional .api-key-scope-row / .api-key-scope-segments
    rules above: same specificity, so source order decides. Placed before them it

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -6815,7 +6815,22 @@ td :where(.service-actions, .action-row, .map-action-buttons) { max-width: 100%;
    checkbox rule -- so without this the ticks render in the browser default
    blue/purple, which reads as foreign in an amber console. Matches the
    blueprint row-select checkboxes. */
-.api-key-scope-action input { margin: 0; flex: none; accent-color: var(--accent); }
+/* An explicit size is REQUIRED, not cosmetic: the global
+   `input, select, textarea { width: 100% }` near the top of this file applies
+   to checkboxes too, and with flex: none the box cannot shrink -- it takes the
+   whole flex line and squeezes the action name to 0px, so every label in the
+   checklist renders blank. Every other checkbox rule here sets a size for the
+   same reason (.blueprint-row-select, .bases-child-access-row, .checkbox-line).
+   min-height: 0 overrides the 44px touch minimum from the pointer:coarse block. */
+.api-key-scope-action input {
+  width: 16px;
+  height: 16px;
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+  flex: none;
+  accent-color: var(--accent);
+}
 .api-key-scope-action code {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ by nature, so it gets its own.
 ## Console (`console/api`, `console/web`)
 
 - [API-REFERENCE.md](console/API-REFERENCE.md) — Current. Full HTTP API reference for every console endpoint.
-- [api-keys.md](console/api-keys.md) — Current. Named, revocable API keys for external callers: per-namespace Read/Read+write scopes that default to no access, the `settings`/`database`/`setup` namespaces no key can ever reach and the write-denied `updates` and `addons`, hash-only storage with a one-time reveal, and per-key expiry, disable and rate limits.
+- [api-keys.md](console/api-keys.md) — Current. Named, revocable API keys for external callers: per-namespace Read/Read+write, or an explicit list of actions scopes that default to no access, the `settings`/`database`/`setup` namespaces no key can ever reach and the write-denied `updates` and `addons`, hash-only storage with a one-time reveal, and per-key expiry, disable and rate limits.
 - [blueprints.md](console/blueprints.md) — Current. Blueprint import/export developer documentation.
 - [PRE-AUGMENTED-GEAR.md](console/PRE-AUGMENTED-GEAR.md) — Current. API reference for granting gear with augments pre-applied.
 - [generator-fuel-burn-rates.md](console/generator-fuel-burn-rates.md) — Current. Per-generator fuel burn constants and where they live in code.

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ by nature, so it gets its own.
 ## Console (`console/api`, `console/web`)
 
 - [API-REFERENCE.md](console/API-REFERENCE.md) — Current. Full HTTP API reference for every console endpoint.
-- [api-keys.md](console/api-keys.md) — Current. Named, revocable API keys for external callers: per-namespace Read/Read+write, or an explicit list of actions scopes that default to no access, the `settings`/`database`/`setup` namespaces no key can ever reach and the write-denied `updates` and `addons`, hash-only storage with a one-time reveal, and per-key expiry, disable and rate limits.
+- [api-keys.md](console/api-keys.md) — Current. Named, revocable API keys for external callers: scopes that default to no access, given per namespace as Read/Read+write or as an explicit list of actions, the `settings`/`database`/`setup` namespaces no key can ever reach and the write-denied `updates` and `addons`, hash-only storage with a one-time reveal, and per-key expiry, disable and rate limits.
 - [blueprints.md](console/blueprints.md) — Current. Blueprint import/export developer documentation.
 - [PRE-AUGMENTED-GEAR.md](console/PRE-AUGMENTED-GEAR.md) — Current. API reference for granting gear with augments pre-applied.
 - [generator-fuel-burn-rates.md](console/generator-fuel-burn-rates.md) — Current. Per-generator fuel burn constants and where they live in code.

--- a/docs/console-iam.md
+++ b/docs/console-iam.md
@@ -22,7 +22,7 @@ The Web Console applies an IAM action to every authenticated API route. Public a
 
 **The permission is not what enforces this.** `database:execute` is chosen by `isReadOnlySql`, which only asks whether the statement starts with a read keyword and avoids a blacklist — and every privileged mutation in this application is shaped `select dune.<fn>(...)`, which passes that test. `SELECT ... INTO` and `select 1; select fn()` pass it too. A keyword blacklist cannot be repaired to cover them (`delete` does not match `delete_actors`, and the schema ships hundreds of functions).
 
-So the read path executes inside a `set transaction read only` transaction: **Postgres** refuses the write, whatever the classifier concluded. `database:execute` decides which path a statement takes and whether a pre-write backup is taken; the transaction is what makes the read path actually read-only. Verified behaviourally in `databaseReadOnlyEnforcement.integration.test.js` against a real database. The check runs before the mutation rate limiter and before the pre-write backup, so a refused caller triggers neither side effect.
+So the read path executes inside a `set transaction read only` transaction: **Postgres** refuses the write, whatever the classifier concluded. `database:execute` decides which path a statement takes and whether a pre-write backup is taken; the transaction is what makes the read path actually read-only (`databaseReadOnlyEnforcement.integration.test.js` covers this against a real database). The check runs before the mutation rate limiter and before the pre-write backup, so a refused caller triggers neither side effect.
 
 Adding one: put the action in `CONTENT_CONDITIONAL_ACTIONS`, call `requireAction(req, res, action)` at the top of the handler, and decide its place in the default policies. `databaseQueryAuthz.test.js` is the pattern to copy for coverage.
 
@@ -72,7 +72,7 @@ This exists because the failure is asymmetric. A misspelled action in an **Allow
 { "Effect": "Deny", "Action": ["players:reset-progression"] }
 ```
 
-No route resolves to `players:reset-progression` — the route resolves to `players:reset` — so that statement denied nothing at all. It was this document's own example until 2026-08-28.
+No route resolves to `players:reset-progression` — the route resolves to `players:reset` — so that statement denies nothing at all. It was this document's own example.
 
 `GET /api/settings/iam/policies` returns an `actions` array alongside the policies: the full catalog, sorted. Policies are hand-authored JSON with no editor UI, so that response is the vocabulary to author against.
 
@@ -90,7 +90,7 @@ Updates that remove the owner's `settings:write` access are rejected so the loca
 
 ## The split namespaces
 
-`players:mutate` was one action covering all 41 mutating method+path pairs under `/api/players/` — kick, ban, wipe a character's progression, delete items from their inventory, mint currency, hand out max-level specializations. It was split on 2026-08-29, grouped by consequence:
+`players:mutate` was one action covering all 41 mutating method+path pairs under `/api/players/` — kick, ban, wipe a character's progression, delete items from their inventory, mint currency, hand out max-level specializations. It is split by consequence:
 
 | Action | Covers |
 |---|---|
@@ -106,7 +106,7 @@ Updates that remove the owner's `settings:write` access are rejected so the loca
 
 **`players:mutate` is no longer in the catalog, but it still means what it meant.** See [Upgrading a policy that names a removed action](#upgrading-a-policy-that-names-a-removed-action) below. Shipped defaults are unchanged — `owner` (`*`) and `admin` (`players:*`) still reach everything, and `moderator`/`player`/`observer` are untouched.
 
-`guilds:mutate` was split the same day and for the same reason. `DELETE /api/guilds/{guildId}` is **disband** — it destroys the guild — and it shared one action with promoting a member, so a roster fix and a deletion were the same grant.
+`guilds:mutate` was split for the same reason. `DELETE /api/guilds/{guildId}` is **disband** — it destroys the guild — and it shared one action with promoting a member, so a roster fix and a deletion were the same grant.
 
 | Action | Covers |
 |---|---|
@@ -142,7 +142,7 @@ Splitting a coarse action is not a no-op for a policy that already named one. Th
 { "Effect": "Allow", "Action": ["players:*"] }
 ```
 
-and simply deleting `players:mutate` turns that inside out: the `Deny` matches nothing, the surviving wildcard matches all ten successors, and the upgrade converts "no player mutations" into "every player mutation". Measured on a real document, a tier gained 22 actions and lost none — including `addons:bridge` and `guilds:disband`.
+and simply deleting `players:mutate` turns that inside out: the `Deny` matches nothing, the surviving wildcard matches all ten successors, and the upgrade converts "no player mutations" into "every player mutation" — 22 actions gained and none lost, including `addons:bridge` and `guilds:disband`.
 
 So the removed names are kept as **aliases**. `players:mutate`, `guilds:mutate`, `blueprints:mutate` and `addons:mutate` each resolve to exactly the actions the routes that used to resolve to them now resolve to:
 

--- a/docs/console-iam.md
+++ b/docs/console-iam.md
@@ -84,7 +84,7 @@ The policy API is owner-only under the default policy:
 
 Updates that remove the owner's `settings:write` access are rejected so the local-password recovery path remains available.
 
-## The players and guilds actions
+## The split namespaces
 
 `players:mutate` was one action covering all 41 mutating method+path pairs under `/api/players/` — kick, ban, wipe a character's progression, delete items from their inventory, mint currency, hand out max-level specializations. It was split on 2026-08-29, grouped by consequence:
 
@@ -112,7 +112,22 @@ Updates that remove the owner's `settings:write` access are rejected so the loca
 
 Add and remove stay one action deliberately: two directions of the same roster knob. Both `DELETE` patterns are anchored regexes rather than prefix rules, because `/api/guilds/{id}` and `/api/guilds/{id}/members/{playerId}` share a prefix and the variable segment comes before the part that distinguishes them — the same reason `bases:delete` needs a real regex.
 
-`players:unclassified` is a fail-closed sentinel, not something to grant. The three `POST`/`DELETE`/`PATCH /api/players/` prefix rules resolve to it so that a route nobody has classified yet cannot fall through to the method-agnostic `players:read` fallback and be authorized by a read-only grant. `actionSplits.test.js` asserts no route in `server.js` actually lands on it (`guilds:unclassified` likewise), so a new route fails CI until it is given a real action.
+`blueprints:mutate` and `addons:mutate` were split on the same grounds.
+
+| Action | Covers |
+|---|---|
+| `blueprints:export` | bulk export (`POST /api/blueprints/export`) |
+| `blueprints:import` | import |
+| `blueprints:delete` | delete one blueprint |
+| `addons:remove` | uninstall an installed addon |
+| `addons:toggle` | enable, disable |
+| `addons:bridge` | the manifest-authorized action channel |
+
+Bulk export is read-only in effect — it only reads each blueprint and zips the results, and `GET /api/blueprints/{id}/export` is already `blueprints:read`. It is deliberately **not** folded into `blueprints:read`: one call pulls up to 500 blueprints, so granting read access to the list is not consent to bulk extraction. No existing read grant widens.
+
+`addons:bridge` is separate from lifecycle control because the bridge authorizes against the **installed addon's** declared permission rather than the caller — so "may enable an addon" must not imply "may run whatever that addon declared". API keys cannot reach any addon write regardless: `addons` is write-denied for keys, and the bridge refuses key principals outright.
+
+`players:unclassified` is a fail-closed sentinel, not something to grant. The three `POST`/`DELETE`/`PATCH /api/players/` prefix rules resolve to it so that a route nobody has classified yet cannot fall through to the method-agnostic `players:read` fallback and be authorized by a read-only grant. `actionSplits.test.js` asserts no route in `server.js` actually lands on it (and likewise for `guilds:`, `blueprints:` and `addons:`), so a new route fails CI until it is given a real action.
 
 ## Route maintenance
 

--- a/docs/console-iam.md
+++ b/docs/console-iam.md
@@ -8,6 +8,19 @@ The Web Console applies an IAM action to every authenticated API route. Public a
 2. `actions.js` maps the request method and path to one action such as `players:read` or `server:restart`.
 3. `policy.js` evaluates the session tier using explicit-deny precedence: Deny, then Allow, then default Deny.
 4. An unmapped authenticated route is denied. `rbacParity.test.js` prevents new routes from being merged without a mapping.
+5. A handler whose privilege depends on the request *body* runs a second check, `requireAction`, once the body is parsed. It re-runs both gates above against a narrower action, so it can only narrow access, never widen it.
+
+## Content-conditional actions
+
+`actionForRoute` sees a method and a path, never a body. A route that does two things at two different blast radii therefore resolves to the safer of the two, and the handler narrows it afterwards. These actions are listed in `CONTENT_CONDITIONAL_ACTIONS` in `actions.js` so `allKnownActions()` — the set the API key scope catalog and any policy-authoring tool read — still sees them.
+
+| Action | Route | Reached when |
+|---|---|---|
+| `database:execute` | `POST /api/database/query` | the SQL is not read-only |
+
+`POST /api/database/query` resolves to `database:query`, a read-shaped name, and accepts write SQL down the same route. Before the split that made the default admin policy's `Deny` on `database:mutate` and `database:write-config` decorative: the narrow structured cell-edit was denied while arbitrary `UPDATE`/`DELETE`/`DROP` stayed reachable through the raw-SQL path admin still held. The write half is now `database:execute`, denied to `admin` by default. The check runs before the mutation rate limiter and before the pre-write backup, so a refused caller triggers neither side effect.
+
+Adding one: put the action in `CONTENT_CONDITIONAL_ACTIONS`, call `requireAction(req, res, action)` at the top of the handler, and decide its place in the default policies. `databaseQueryAuthz.test.js` is the pattern to copy for coverage.
 
 ## API key principals
 
@@ -45,13 +58,61 @@ Policy documents use this shape:
 
 `Action` may be one string or an array. Exact actions, namespace wildcards such as `players:*`, and `*` are supported. Explicit Deny statements override Allow statements for every tier, including owner.
 
+### Every action must exist
+
+`PUT /api/settings/iam/policy` refuses a document naming an action that does not exist, listing the offenders. The test is *does this pattern match at least one action in the catalog*, so wildcards stay legal — `players:*` and `bases:delete-*` are fine, `player:*` and `players:reset-*` are refused because they match nothing.
+
+This exists because the failure is asymmetric. A misspelled action in an **Allow** fails closed and grants nothing. The same string in a **Deny** withholds nothing while reading exactly like a restriction:
+
+```json
+{ "Effect": "Deny", "Action": ["players:reset-progression"] }
+```
+
+No route resolves to `players:reset-progression` — the real action is `players:mutate`, which covers every player mutation at once — so that statement denied nothing at all. It was this document's own example until 2026-08-28.
+
+`GET /api/settings/iam/policies` returns an `actions` array alongside the policies: the full catalog, sorted. Policies are hand-authored JSON with no editor UI, so that response is the vocabulary to author against.
+
+A file at `runtime/generated/iam-policies.json` that already names a dead action is **loaded, not discarded** — the Console logs one warning per pattern at startup and keeps the operator's policy in force. Rejecting the document would silently revert their whole policy to defaults, a bigger surprise than the dead pattern.
+
+`POST /api/settings/iam/policy/test` returns `known` alongside `allowed`. A misspelled action answers `allowed: false`, which reads as "my Deny works" — `known: false` is what distinguishes a real denial from a typo.
+
 The policy API is owner-only under the default policy:
 
-- `GET /api/settings/iam/policies` returns the active policy store.
+- `GET /api/settings/iam/policies` returns the active policy store plus `actions`, the full catalog of valid action names.
 - `PUT /api/settings/iam/policy` validates and atomically saves the complete policy store to `runtime/generated/iam-policies.json`.
-- `POST /api/settings/iam/policy/test` evaluates an action for a tier without changing policy.
+- `POST /api/settings/iam/policy/test` evaluates an action for a tier without changing policy, and reports whether the action exists (`known`).
 
 Updates that remove the owner's `settings:write` access are rejected so the local-password recovery path remains available.
+
+## The players and guilds actions
+
+`players:mutate` was one action covering all 41 mutating method+path pairs under `/api/players/` — kick, ban, wipe a character's progression, delete items from their inventory, mint currency, hand out max-level specializations. It was split on 2026-08-29, grouped by consequence:
+
+| Action | Covers |
+|---|---|
+| `players:moderate` | kick, ban, unban |
+| `players:teleport` | teleport |
+| `players:give-item` | give-item(s), give-item-id, augment-item, spawn-vehicle |
+| `players:grant` | currency, XP, intel, faction reputation, faction, skill points/module, building & customization & recipe & research unlocks, specialization XP/grant-max/keystones, journey & tutorial completion |
+| `players:reset` | reset-progression, clean-inventory, journey/tutorials/specializations/keystones resets |
+| `players:delete-item` | delete one inventory row |
+| `players:edit-item` | edit one inventory row in place |
+| `players:repair` | gear, faction reputation, landsraad quests, login queue, vehicle decay, refuel, refill water |
+| `players:recover` | character recovery |
+
+**`players:mutate` no longer exists.** A hand-authored policy still naming it is refused by `PUT /api/settings/iam/policy` and warned about at startup, rather than silently continuing to mean something narrower than intended. Replace it with the narrower actions you actually want. Policies using `players:*` are unaffected, as are the shipped defaults — `owner` (`*`) and `admin` (`players:*`) still reach everything, and `moderator`/`player`/`observer` are unchanged.
+
+`guilds:mutate` was split the same day and for the same reason. `DELETE /api/guilds/{guildId}` is **disband** — it destroys the guild — and it shared one action with promoting a member, so a roster fix and a deletion were the same grant.
+
+| Action | Covers |
+|---|---|
+| `guilds:disband` | delete the guild |
+| `guilds:membership` | add a member, remove a member |
+| `guilds:rank` | promote, demote |
+
+Add and remove stay one action deliberately: two directions of the same roster knob. Both `DELETE` patterns are anchored regexes rather than prefix rules, because `/api/guilds/{id}` and `/api/guilds/{id}/members/{playerId}` share a prefix and the variable segment comes before the part that distinguishes them — the same reason `bases:delete` needs a real regex.
+
+`players:unclassified` is a fail-closed sentinel, not something to grant. The three `POST`/`DELETE`/`PATCH /api/players/` prefix rules resolve to it so that a route nobody has classified yet cannot fall through to the method-agnostic `players:read` fallback and be authorized by a read-only grant. `actionSplits.test.js` asserts no route in `server.js` actually lands on it (`guilds:unclassified` likewise), so a new route fails CI until it is given a real action.
 
 ## Route maintenance
 
@@ -59,7 +120,7 @@ When adding an authenticated API route, add its method/path mapping to `actions.
 
 ```bash
 cd console/api
-node --test test/rbacParity.test.js test/policy.test.js test/auth.test.js
+node --test test/rbacParity.test.js test/policy.test.js test/auth.test.js test/databaseQueryAuthz.test.js test/policyActionValidation.test.js test/actionSplits.test.js
 ```
 
 Parameterized routes use the method-aware and prefix mappings at the bottom of `actions.js`. Prefer exact mappings whenever the route has a fixed path.

--- a/docs/console-iam.md
+++ b/docs/console-iam.md
@@ -18,7 +18,11 @@ The Web Console applies an IAM action to every authenticated API route. Public a
 |---|---|---|
 | `database:execute` | `POST /api/database/query` | the SQL is not read-only |
 
-`POST /api/database/query` resolves to `database:query`, a read-shaped name, and accepts write SQL down the same route. Before the split that made the default admin policy's `Deny` on `database:mutate` and `database:write-config` decorative: the narrow structured cell-edit was denied while arbitrary `UPDATE`/`DELETE`/`DROP` stayed reachable through the raw-SQL path admin still held. The write half is now `database:execute`, denied to `admin` by default. The check runs before the mutation rate limiter and before the pre-write backup, so a refused caller triggers neither side effect.
+`POST /api/database/query` resolves to `database:query`, a read-shaped name, and accepts write SQL down the same route. Before the split that made the default admin policy's `Deny` on `database:mutate` and `database:write-config` decorative: the narrow structured cell-edit was denied while arbitrary `UPDATE`/`DELETE`/`DROP` stayed reachable through the raw-SQL path admin still held. The write half is now `database:execute`, denied to `admin` by default.
+
+**The permission is not what enforces this.** `database:execute` is chosen by `isReadOnlySql`, which only asks whether the statement starts with a read keyword and avoids a blacklist — and every privileged mutation in this application is shaped `select dune.<fn>(...)`, which passes that test. `SELECT ... INTO` and `select 1; select fn()` pass it too. A keyword blacklist cannot be repaired to cover them (`delete` does not match `delete_actors`, and the schema ships hundreds of functions).
+
+So the read path executes inside a `set transaction read only` transaction: **Postgres** refuses the write, whatever the classifier concluded. `database:execute` decides which path a statement takes and whether a pre-write backup is taken; the transaction is what makes the read path actually read-only. Verified behaviourally in `databaseReadOnlyEnforcement.integration.test.js` against a real database. The check runs before the mutation rate limiter and before the pre-write backup, so a refused caller triggers neither side effect.
 
 Adding one: put the action in `CONTENT_CONDITIONAL_ACTIONS`, call `requireAction(req, res, action)` at the top of the handler, and decide its place in the default policies. `databaseQueryAuthz.test.js` is the pattern to copy for coverage.
 
@@ -68,7 +72,7 @@ This exists because the failure is asymmetric. A misspelled action in an **Allow
 { "Effect": "Deny", "Action": ["players:reset-progression"] }
 ```
 
-No route resolves to `players:reset-progression` — the real action is `players:mutate`, which covers every player mutation at once — so that statement denied nothing at all. It was this document's own example until 2026-08-28.
+No route resolves to `players:reset-progression` — the route resolves to `players:reset` — so that statement denied nothing at all. It was this document's own example until 2026-08-28.
 
 `GET /api/settings/iam/policies` returns an `actions` array alongside the policies: the full catalog, sorted. Policies are hand-authored JSON with no editor UI, so that response is the vocabulary to author against.
 
@@ -100,7 +104,7 @@ Updates that remove the owner's `settings:write` access are rejected so the loca
 | `players:repair` | gear, faction reputation, landsraad quests, login queue, vehicle decay, refuel, refill water |
 | `players:recover` | character recovery |
 
-**`players:mutate` no longer exists.** A hand-authored policy still naming it is refused by `PUT /api/settings/iam/policy` and warned about at startup, rather than silently continuing to mean something narrower than intended. Replace it with the narrower actions you actually want. Policies using `players:*` are unaffected, as are the shipped defaults — `owner` (`*`) and `admin` (`players:*`) still reach everything, and `moderator`/`player`/`observer` are unchanged.
+**`players:mutate` is no longer in the catalog, but it still means what it meant.** See [Upgrading a policy that names a removed action](#upgrading-a-policy-that-names-a-removed-action) below. Shipped defaults are unchanged — `owner` (`*`) and `admin` (`players:*`) still reach everything, and `moderator`/`player`/`observer` are untouched.
 
 `guilds:mutate` was split the same day and for the same reason. `DELETE /api/guilds/{guildId}` is **disband** — it destroys the guild — and it shared one action with promoting a member, so a roster fix and a deletion were the same grant.
 
@@ -129,13 +133,42 @@ Bulk export is read-only in effect — it only reads each blueprint and zips the
 
 `players:unclassified` is a fail-closed sentinel, not something to grant. The three `POST`/`DELETE`/`PATCH /api/players/` prefix rules resolve to it so that a route nobody has classified yet cannot fall through to the method-agnostic `players:read` fallback and be authorized by a read-only grant. `actionSplits.test.js` asserts no route in `server.js` actually lands on it (and likewise for `guilds:`, `blueprints:` and `addons:`), so a new route fails CI until it is given a real action.
 
+## Upgrading a policy that names a removed action
+
+Splitting a coarse action is not a no-op for a policy that already named one. This document teaches the idiom
+
+```json
+{ "Effect": "Deny",  "Action": ["players:mutate"] },
+{ "Effect": "Allow", "Action": ["players:*"] }
+```
+
+and simply deleting `players:mutate` turns that inside out: the `Deny` matches nothing, the surviving wildcard matches all ten successors, and the upgrade converts "no player mutations" into "every player mutation". Measured on a real document, a tier gained 22 actions and lost none — including `addons:bridge` and `guilds:disband`.
+
+So the removed names are kept as **aliases**. `players:mutate`, `guilds:mutate`, `blueprints:mutate` and `addons:mutate` each resolve to exactly the actions the routes that used to resolve to them now resolve to:
+
+| Removed | Now means |
+|---|---|
+| `players:mutate` | `moderate`, `teleport`, `give-item`, `grant`, `reset`, `delete-item`, `edit-item`, `repair`, `recover`, `unclassified` |
+| `guilds:mutate` | `disband`, `membership`, `rank`, `unclassified` |
+| `blueprints:mutate` | `export`, `import`, `delete`, `unclassified` |
+| `addons:mutate` | `remove`, `toggle`, `bridge`, `unclassified` |
+
+A `Deny` on a removed name still denies everything it used to; an `Allow` still grants everything it used to. `players:kick-all` is deliberately **not** in the list — it was already its own action before the split, so an alias must not hand it over.
+
+The asymmetry is the point:
+
+- **On load**, a stored policy naming a removed action is accepted and keeps its meaning. The Console logs one migration notice per name at startup, listing the successors.
+- **On save**, `PUT /api/settings/iam/policy` refuses it, with an error naming the successors so the edit is mechanical.
+
+That way an upgrade never silently re-interprets a policy and never refuses to start, while the next edit forces migration. Aliases are not in the catalog: they cannot be granted to an API key, and `GET /api/settings/iam/policies` does not offer them.
+
 ## Route maintenance
 
 When adding an authenticated API route, add its method/path mapping to `actions.js` in the same change and run:
 
 ```bash
 cd console/api
-node --test test/rbacParity.test.js test/policy.test.js test/auth.test.js test/databaseQueryAuthz.test.js test/policyActionValidation.test.js test/actionSplits.test.js
+node --test test/rbacParity.test.js test/policy.test.js test/auth.test.js test/databaseQueryAuthz.test.js test/policyActionValidation.test.js test/actionSplits.test.js test/databaseReadOnlyEnforcement.integration.test.js
 ```
 
 Parameterized routes use the method-aware and prefix mappings at the bottom of `actions.js`. Prefer exact mappings whenever the route has a fixed path.

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -705,23 +705,25 @@ Layers legend's default-settings mechanism.
 | GET | `/api/database/table/{table}` | Preview table | `table`, `limit?`, `offset?` |
 
 **`/api/database/query` authorizes on the SQL, not just the route.** The route
-resolves to the `database:query` action, which covers read-only SQL (`SELECT`,
-`WITH`, `SHOW`, `EXPLAIN`). Write SQL sent to the same route additionally
-requires `database:execute`, checked inside the handler once the body is parsed
-— a caller holding only `database:query` gets `403` on a write and nothing runs:
-no rate-limit tick, no pre-write backup.
+resolves to `database:query`, which covers read-only SQL (`SELECT`, `WITH`,
+`SHOW`, `EXPLAIN`). SQL the classifier reads as a write additionally requires
+`database:execute`, checked inside the handler once the body is parsed; a caller
+without it gets `403` before the rate-limit tick and before the pre-write backup.
 
-The permission is not the enforcement. `database:execute` is selected by a SQL
-classifier that a mutating `select dune.<fn>(...)` passes, so the read path also
-executes inside a `set transaction read only` transaction and Postgres refuses
-the write regardless of what the classifier concluded. The default `admin` policy grants
-`database:query` and denies `database:execute`; `owner` holds both. Use
-`/api/database/export` for read-only result export.
+**The permission is not the enforcement.** `database:execute` is selected by a
+classifier that a mutating `select dune.<fn>(...)` passes — so a write can be
+routed down the read path. That path executes inside a `set transaction read
+only` transaction, and Postgres refuses the write whatever the classifier
+concluded. The transaction is the guarantee; the action decides which path is
+taken and whether a backup is made.
+
+The default `admin` policy grants `database:query` and denies `database:execute`;
+`owner` holds both. Use `/api/database/export` for read-only result export.
 
 A body with nothing to execute — empty, whitespace, `;`, or entirely
-commented-out SQL — returns `400` before anything else happens. Such input
-does not start with a read keyword, so it used to classify as a write and
-trigger the pre-write backup before the query was ever rejected.
+commented-out SQL — returns `400` first. Such input does not start with a read
+keyword, so without that check it classifies as a write and triggers a full
+pre-write backup before the query is rejected.
 
 ---
 
@@ -848,13 +850,19 @@ Per-tier Allow/Deny documents for the action catalog. Architecture and evaluatio
 | PUT | `/api/settings/iam/policy` | Validate and atomically save the complete policy store | Policy store object (every tier) |
 | POST | `/api/settings/iam/policy/test` | Evaluate one action for one tier without changing policy | `action`, `tier` |
 
-`PUT` refuses a document naming an action that does not exist, returning `400` with
-`unknownActions` listing each offending `{ tier, pattern }`. The test is whether a
-pattern matches at least one catalogued action, so wildcards remain legal
-(`players:*`, `bases:delete-*`) while near-misses that match nothing (`player:*`,
-`players:reset-*`) are rejected. This matters because the failure is asymmetric: a
-misspelled action in an `Allow` grants nothing, but in a `Deny` it withholds nothing
-while reading exactly like a restriction.
+`PUT` refuses two kinds of bad action name, each with its own `400` payload:
+
+- **`unknownActions`** — the name matches nothing in the catalog. The test is
+  whether a pattern matches at least one catalogued action, so wildcards remain
+  legal (`players:*`, `bases:delete-*`) while near-misses that match nothing
+  (`player:*`, `players:reset-*`) are rejected. This matters because the failure
+  is asymmetric: a misspelled action in an `Allow` grants nothing, but in a
+  `Deny` it withholds nothing while reading exactly like a restriction.
+- **`deprecatedActions`** — the name is one the catalog used to have
+  (`players:mutate`, `guilds:mutate`, `blueprints:mutate`, `addons:mutate`). Each
+  entry carries `successors`, so the edit is mechanical. These still evaluate
+  with their original meaning, so a stored policy keeps working; only saving is
+  refused. See [../console-iam.md](../console-iam.md#upgrading-a-policy-that-names-a-removed-action).
 
 `POST .../test` returns `known` alongside `allowed`. A misspelled action answers
 `allowed: false`, which reads as a working `Deny`; `known: false` is what separates a

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -699,10 +699,24 @@ Layers legend's default-settings mechanism.
 | GET | `/api/database/tables/{schema}/{table}/count` | Get row count | `schema`, `table`, `filter?` |
 | PATCH | `/api/database/tables/{schema}/{table}/row` | Update table row | `rowId`, `values` (object) |
 | GET | `/api/database/search` | Search database | `q` or `term` (query param) |
-| POST | `/api/database/query` | Execute SQL query | `query` (read or write) |
+| POST | `/api/database/query` | Execute SQL query | `query` (read or write) — see note below |
 | POST | `/api/database/export` | Export query results | `query` (read-only SELECT/WITH/SHOW/EXPLAIN) |
 | POST | `/api/database/password` | Change database password | `password` |
 | GET | `/api/database/table/{table}` | Preview table | `table`, `limit?`, `offset?` |
+
+**`/api/database/query` authorizes on the SQL, not just the route.** The route
+resolves to the `database:query` action, which covers read-only SQL (`SELECT`,
+`WITH`, `SHOW`, `EXPLAIN`). Write SQL sent to the same route additionally
+requires `database:execute`, checked inside the handler once the body is parsed
+— a caller holding only `database:query` gets `403` on a write and nothing runs:
+no rate-limit tick, no pre-write backup. The default `admin` policy grants
+`database:query` and denies `database:execute`; `owner` holds both. Use
+`/api/database/export` for read-only result export.
+
+A body with nothing to execute — empty, whitespace, `;`, or entirely
+commented-out SQL — returns `400` before anything else happens. Such input
+does not start with a read keyword, so it used to classify as a write and
+trigger the pre-write backup before the query was ever rejected.
 
 ---
 
@@ -816,6 +830,30 @@ Layers legend's default-settings mechanism.
 | GET | `/api/public-directory/status` | Get public directory status | None |
 | POST | `/api/settings/public-directory` | Save public directory and anonymous-count settings | `enabled?`, `anonymousCountEnabled?`, `discordInvite?` |
 | POST | `/api/settings/public-directory/claim` | Claim server listing | `code` |
+
+---
+
+## IAM Policies
+
+Per-tier Allow/Deny documents for the action catalog. Architecture and evaluation order: [../console-iam.md](../console-iam.md).
+
+| Method | Route | Description | Parameters |
+|--------|-------|-------------|------------|
+| GET | `/api/settings/iam/policies` | Active policy store, plus `actions`: the full sorted catalog of valid action names | None |
+| PUT | `/api/settings/iam/policy` | Validate and atomically save the complete policy store | Policy store object (every tier) |
+| POST | `/api/settings/iam/policy/test` | Evaluate one action for one tier without changing policy | `action`, `tier` |
+
+`PUT` refuses a document naming an action that does not exist, returning `400` with
+`unknownActions` listing each offending `{ tier, pattern }`. The test is whether a
+pattern matches at least one catalogued action, so wildcards remain legal
+(`players:*`, `bases:delete-*`) while near-misses that match nothing (`player:*`,
+`players:reset-*`) are rejected. This matters because the failure is asymmetric: a
+misspelled action in an `Allow` grants nothing, but in a `Deny` it withholds nothing
+while reading exactly like a restriction.
+
+`POST .../test` returns `known` alongside `allowed`. A misspelled action answers
+`allowed: false`, which reads as a working `Deny`; `known: false` is what separates a
+real denial from a typo.
 
 ---
 

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -709,7 +709,12 @@ resolves to the `database:query` action, which covers read-only SQL (`SELECT`,
 `WITH`, `SHOW`, `EXPLAIN`). Write SQL sent to the same route additionally
 requires `database:execute`, checked inside the handler once the body is parsed
 — a caller holding only `database:query` gets `403` on a write and nothing runs:
-no rate-limit tick, no pre-write backup. The default `admin` policy grants
+no rate-limit tick, no pre-write backup.
+
+The permission is not the enforcement. `database:execute` is selected by a SQL
+classifier that a mutating `select dune.<fn>(...)` passes, so the read path also
+executes inside a `set transaction read only` transaction and Postgres refuses
+the write regardless of what the classifier concluded. The default `admin` policy grants
 `database:query` and denies `database:execute`; `owner` holds both. Use
 `/api/database/export` for read-only result export.
 

--- a/docs/console/api-keys.md
+++ b/docs/console/api-keys.md
@@ -46,6 +46,52 @@ deliberate omission, not a missing feature.
 The level is stored, not an expanded list of actions, so a read-shaped route added in a later
 release is covered by an existing Read grant without every key needing to be re-saved.
 
+### Per-action scopes
+
+A namespace may hold an **explicit list of actions** instead of a level. `players: "write"` grants
+all twelve player actions at once — kicking, banning, wiping progression, deleting inventory —
+which is exactly what the per-consequence action split was meant to make separable. A list grants
+only what it names:
+
+```json
+{
+  "name": "moderation bot",
+  "scopes": {
+    "players": ["players:read", "players:moderate"],
+    "server":  "read"
+  }
+}
+```
+
+That key can kick and ban, and cannot reset progression, delete an inventory row, grant currency
+or spawn a vehicle. The two forms mix freely across namespaces.
+
+A list carries no implicit floor: listing only `players:moderate` does **not** also grant
+`players:read`. Name every action you want.
+
+**The trade-off is the mirror of the paragraph above.** A level auto-covers actions added in a
+later release; a list does not. A read route added next version is reachable by `players: "read"`
+and *not* by `["players:read"]`. That is the point — you opted into a fixed set — but it means a
+list needs revisiting when the catalog grows. Levels remain the right default for broad, trusted
+keys; lists are for keys handed to something you want tightly bounded.
+
+Unrecognised entries are dropped rather than coerced: an action that does not exist, or belongs to
+another namespace, or is a write action in a write-denied namespace, is removed. If nothing
+survives, the namespace becomes None — never a fallback to Read. A complete list is stored as a
+list and is *not* collapsed into `"write"`, because the two mean different things going forward.
+
+Denied namespaces (`settings`, `database`, `setup`) cannot be reached by naming their actions
+individually; the namespace denial is checked before the scope lookup.
+
+In the Settings UI, each namespace gains a fourth **Custom** segment that opens a checklist of
+that namespace's actions. Switching to Custom seeds the list from whatever the namespace already
+grants, so moving Read+write to Custom starts with everything ticked and you remove what you don't
+want. A namespace with only one action (`logs`) offers no Custom segment, for the same reason one
+with no write actions offers no Read+write: it would be another name for Read.
+
+A Custom row with nothing ticked grants nothing and does not count towards the "grant at least one
+namespace" rule, so Create stays disabled until something is selected.
+
 | Namespace | Read grants | Read+write additionally grants |
 |---|---|---|
 | `players` | `players:read` | `delete-item`, `edit-item`, `give-item`, `grant`, `kick-all`, `moderate`, `recover`, `repair`, `reset`, `teleport`, `unclassified` |

--- a/docs/console/api-keys.md
+++ b/docs/console/api-keys.md
@@ -48,10 +48,10 @@ release is covered by an existing Read grant without every key needing to be re-
 
 | Namespace | Read grants | Read+write additionally grants |
 |---|---|---|
-| `players` | `players:read` | `kick-all`, `mutate` |
+| `players` | `players:read` | `delete-item`, `edit-item`, `give-item`, `grant`, `kick-all`, `moderate`, `recover`, `repair`, `reset`, `teleport`, `unclassified` |
 | `bases` | `bases:read` | `add-item`, `bulk-delete-items`, `delete`, `delete-item`, `fill-item`, `give-item`, `mutate` |
 | `vehicles` | `vehicles:read` | `bulk-delete-items`, `delete`, `delete-item`, `mutate` |
-| `guilds` | `guilds:read` | `mutate` |
+| `guilds` | `guilds:read` | `disband`, `membership`, `rank`, `unclassified` |
 | `storage` | `storage:read` | `mutate` |
 | `blueprints` | `blueprints:read` | `mutate` |
 | `exchange` | `exchange:market`, `exchange:read` | `market-write`, `write-config` |

--- a/docs/console/api-keys.md
+++ b/docs/console/api-keys.md
@@ -71,9 +71,9 @@ A list carries no implicit floor: listing only `players:moderate` does **not** a
 
 **The trade-off is the mirror of the paragraph above.** A level auto-covers actions added in a
 later release; a list does not. A read route added next version is reachable by `players: "read"`
-and *not* by `["players:read"]`. That is the point — you opted into a fixed set — but it means a
-list needs revisiting when the catalog grows. Levels remain the right default for broad, trusted
-keys; lists are for keys handed to something you want tightly bounded.
+and *not* by `["players:read"]` — that is the point of opting into a fixed set, but it means a
+list needs revisiting when the catalog grows. Levels stay the right default for broad, trusted
+keys; lists are for keys you want tightly bounded.
 
 Unrecognised entries are dropped rather than coerced: an action that does not exist, or belongs to
 another namespace, or is a write action in a write-denied namespace, is removed. If nothing

--- a/docs/console/api-keys.md
+++ b/docs/console/api-keys.md
@@ -244,8 +244,8 @@ than on an address; only the recorded last-used IP is affected.
 - Authentication runs before the session gate, so a bearer request never reaches the CSRF check.
 - An unrecognised namespace, an unrecognised level, or a misspelled level such as `"readonly"`
   normalizes to None. Nothing falls back to Read.
-- A `"write"` level on a namespace whose writes are denied (`updates`) or that has no write
-  action (`logs`) is stored and evaluated as Read, never as write.
+- A `"write"` level on a namespace whose writes are denied (`updates`, `addons`) or that has
+  no write action (`logs`) is stored and evaluated as Read, never as write.
 - Updating a key replaces its scopes wholesale. Omitting a namespace revokes it; there is no
   merge that could leave a stale grant behind.
 - An unreadable key store fails closed — no key authenticates — and logs a warning.

--- a/docs/console/api-keys.md
+++ b/docs/console/api-keys.md
@@ -53,7 +53,7 @@ release is covered by an existing Read grant without every key needing to be re-
 | `vehicles` | `vehicles:read` | `bulk-delete-items`, `delete`, `delete-item`, `mutate` |
 | `guilds` | `guilds:read` | `disband`, `membership`, `rank`, `unclassified` |
 | `storage` | `storage:read` | `mutate` |
-| `blueprints` | `blueprints:read` | `mutate` |
+| `blueprints` | `blueprints:read` | `delete`, `export`, `import`, `unclassified` |
 | `exchange` | `exchange:market`, `exchange:read` | `market-write`, `write-config` |
 | `maps` | `maps:read` | `despawn`, `reconcile`, `restart`, `spawn`, `teleport`, `write-config` |
 | `sietches` | `sietches:read` | `write` |


### PR DESCRIPTION
Splits the coarsest IAM actions by consequence, validates policy action names, lets API keys be scoped to individual actions, and makes the SQL read path enforced by Postgres rather than by a regex. Catalog goes 95 → 114 actions across the same 21 namespaces.

- `POST /api/database/query` resolved to the read-shaped `database:query` but accepted write SQL, so admin's `Deny` on `database:mutate` and `database:write-config` was decorative. Write SQL now also requires `database:execute`.

  **The permission is not the enforcement.** `database:execute` is selected by `isReadOnlySql`, which only asks whether a statement starts with a read keyword and avoids a blacklist — and every privileged mutation in this application is shaped `select dune.<fn>(...)`, which passes. So do `SELECT ... INTO` and `select 1; select fn()`. The blacklist cannot be repaired to cover them (`\bdelete\b` does not match `delete_actors`). The read path therefore executes inside `set transaction read only`, so Postgres refuses the write whatever the classifier concluded. Verified behaviourally against a real database in `databaseReadOnlyEnforcement.integration.test.js`.

  Separately, empty or comments-only SQL classified as a write and spawned a full pre-write backup before validation rejected it — both SQL routes now `400` first.

- `players:mutate` was one action over 41 routes: kick, ban, progression wipes, inventory deletion, currency, max-level specializations. There was no way to grant kicking without also granting destruction. Split by consequence into `moderate` / `teleport` / `give-item` / `grant` / `reset` / `delete-item` / `edit-item` / `repair` / `recover`. `guilds:mutate` covered **disband** alongside roster edits, `blueprints:mutate` covered export/import/delete, and `addons:mutate` covered lifecycle alongside the bridge — the route that runs whatever an installed addon's manifest declares. All split.

- **The removed names are kept as aliases**, resolving to exactly the actions they used to cover. Deleting them outright *widened* access rather than narrowing it: `Deny players:mutate` + `Allow players:*` is the idiom `policy.js` itself documents, and with the name gone the `Deny` matched nothing while the surviving wildcard matched all ten successors — a tier gained 22 actions, silently, on upgrade. A `Deny` on an old name still denies everything it used to and an `Allow` still grants everything it used to, while `setPolicies` refuses the old names on save with the successors listed, so operators migrate on their next edit instead of being re-interpreted or having the console refuse to start. `players:kick-all` is excluded — it predates the split. Aliases are not in the catalog and cannot be granted to an API key.

- `setPolicies` refuses any `Action` matching nothing in the catalog. The failure is asymmetric — a typo in an `Allow` grants nothing, but in a `Deny` it withholds nothing while reading exactly like a restriction, and `policy.js` documented such an example. `/policy/test` reports `known` so a typo is distinguishable from a real denial, and `GET /api/settings/iam/policies` returns the catalog to author against.

- API key scopes were namespace-level, so `players: write` handed over all twelve player actions and every carve-out above was invisible to keys. A namespace may now hold an explicit action list; the Settings scope grid gains a **Custom** segment.

Default tiers are unchanged in effect (`owner` and `admin` still reach everything through wildcards; `moderator`/`player`/`observer` are untouched), and existing API keys are not migrated.

### `*:unclassified` sentinels, and where they do not reach

The tier beneath the method-aware rules is method-agnostic and maps `/api/<ns>/` to `<ns>:read`, so a mutating route nobody has classified resolves to a **read** action and runs under a read-only grant. The `*:unclassified` entries are the fail-closed floor against that, and must not be deleted even though `rbacParity.test.js` proves every route today is named.

Coverage is uneven, and this PR does not change that:

| Namespace | Sentinel methods |
|---|---|
| `players` | `POST` `DELETE` `PATCH` |
| `guilds`, `addons`, `blueprints` | `POST` `DELETE` |
| everything else | none |

No namespace has a `PUT` sentinel. Latent today — no such route exists — but it is the fail-open direction, so it is called out in `actions.js` rather than left to be rediscovered.

### Review follow-ups

A four-way review of the branch found one ship-blocker and a set of smaller items, all fixed here:

- `.api-key-scope-action input` had no width, so the global `input, select, textarea { width: 100% }` applied and the checkbox squeezed every action label to **0px** — the Custom checklist rendered as unlabelled boxes. Component tests cannot catch this; jsdom derives accessible names from DOM text, never layout.
- The checklist spans both grid columns, so it began at the same x as the namespace names and the first column stopped reading as "namespace" for that row. It now carries an indent and a `var(--accent)` left rule; `--border-strong` was measured at 1.86:1 against `--panel-muted`, below the 3:1 that a boundary carrying meaning needs.
- The row separator lives on each *cell* (`.api-key-scope-row` is `display: contents`), so a rule was drawn between a namespace and its own action list. Only the fieldset closes the group now. Below 560px the stacked-layout reset also zeroed the fieldset's padding.
- A Custom row with nothing ticked was styled as granted while `grantedCount` excluded it — the grid claimed access the key would not have.

### Comment and doc correctness

A pass over the branch's own comments found three that later commits had made **false**, which no test could catch:

- `actions.js` said a policy naming `players:mutate` is refused "instead of quietly continuing to mean something", pointing at `unknownActions`. Backwards on both counts once the aliases landed.
- `server.js` justified a re-classification as safe because "runner.js's `isReadOnlySql` (used above) is strictly the more conservative of the two" — the same commit switched that import to `db.js`, so both sides call one function.
- `docs/console/API-REFERENCE.md` claimed a caller holding only `database:query` "gets 403 on a write and nothing runs", then two paragraphs later said the classifier is beaten by `select dune.<fn>(...)`.

That section also documented only `unknownActions` on `PUT /api/settings/iam/policy`, so the deprecated-action refusal and its `successors` payload were undocumented. Both are now covered, along with a `console-iam.md` section on upgrading a policy that names a removed action.

### Verification

- Backend: **1910/1910**, 0 failed / cancelled / skipped, in the pinned Postgres 17.4 + Node 22 container.
- Frontend: **755/755** across 226 files, 0 skipped. `tsc --noEmit` clean.
- CSS verified by measurement in a browser against the whole stylesheet — extracting only the component's rules is what let the 0px-label bug ship as "verified" the first time.

**Scope**: principals and tier assignment are handled in a separate PR, so nothing here touches `auth.js`, `integrations/discord/`, or the public auth-route allowlist. The one adjacent line is `req.authApiKey` in the authorization gate, which carries the authenticated key record to the in-handler `database:execute` check. `docs/rw-architecture.md` still names the pre-split actions in its Discord command table — the aliases keep those references working, so it is left for that PR.

