### PR TITLE
Don't serve an expired Coriolis seed to the live map

### DIFF
--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -1465,6 +1465,7 @@ async function liveMapMarkersRoute(res, url) {
       // overmap/survival-1 default.
       coriolisSeed: spice.currentSeed || "",
       coriolisNextCycleAt: spice.nextCycleAt || "",
+      coriolisSeedStaleSince: spice.seedStaleSince || "",
       partitions: partitions.rows || []
     };
   });

--- a/console/api/src/services/coriolisSeed.js
+++ b/console/api/src/services/coriolisSeed.js
@@ -13,6 +13,12 @@ const SEED_LINE = /Current Coriolis World Seed:\s*(\d+)/;
 // "LogCoriolis: Display: Next Coriolis Cycle start date UTC: 2026.08.25-05.00.00".
 const NEXT_CYCLE_LINE = /Next Coriolis Cycle start date UTC:\s*(\d{4})\.(\d{2})\.(\d{2})-(\d{2})\.(\d{2})\.(\d{2})/;
 
+function toIso(match) {
+  if (!match) return null;
+  const [, y, mo, d, h, mi, s] = match;
+  return new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s))).toISOString();
+}
+
 // "overmap" is checked first since it's the cheapest single container to
 // ask and normally always running, but its map mode can be set to
 // "disabled" (see config.js), in which case it never logs anything --
@@ -73,14 +79,39 @@ function parseCoriolisLog(combined) {
   if (combined === null) return { seed: null, nextCycleAt: null };
   const lines = combined.split(/\r?\n/);
   const seedMatch = lastMatch(lines, SEED_LINE);
-  const nextCycleMatch = lastMatch(lines, NEXT_CYCLE_LINE);
-  const [, y, mo, d, h, mi, s] = nextCycleMatch || [];
-  const nextCycleAt = nextCycleMatch ? new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s))).toISOString() : null;
-  return { seed: seedMatch ? `cor-${seedMatch[1]}` : null, nextCycleAt };
+  return {
+    seed: seedMatch ? `cor-${seedMatch[1]}` : null,
+    nextCycleAt: toIso(lastMatch(lines, NEXT_CYCLE_LINE))
+  };
 }
 
 export async function resolveCurrentSeed(options = {}) {
   return (await resolveCoriolisCycle(options)).seed;
+}
+
+// The seed line only prints at container startup, but the Deep Desert world
+// re-rolls at every weekly Coriolis boundary whether or not anything
+// restarts. Between a boundary and the next restart the logs therefore still
+// advertise the *previous* cycle's seed -- confirmed live on dune2, where
+// fields observed the day after the 2026-08-25 boundary were filed under
+// cor-2 and 39% of them later reappeared under cor-3 (against a 2% baseline
+// overlap between genuinely different seeds). Serving that stale seed puts
+// the previous cycle's static pool on the map and poisons the learned pool
+// with the new cycle's fields.
+//
+// The same log block tells us when the seed expires, so a cycle boundary
+// already in the past is proof the logged seed is stale. Treat it as unknown
+// rather than wrong: callers already handle a null seed by dropping the
+// static-pool layer and skipping the learned-pool write, so the map falls
+// back to live active fields only until the container restarts and prints
+// the new seed. When the log has a seed but no boundary line there is
+// nothing to check it against, so it is passed through unchanged.
+function applyCycleExpiry(resolved, now) {
+  const expiresAt = resolved.nextCycleAt ? Date.parse(resolved.nextCycleAt) : NaN;
+  if (Number.isFinite(expiresAt) && expiresAt <= now) {
+    return { seed: null, nextCycleAt: null, staleSince: resolved.nextCycleAt };
+  }
+  return { ...resolved, staleSince: null };
 }
 
 // One combined resolver so a single cached `docker logs` result covers both
@@ -99,7 +130,10 @@ export async function resolveCoriolisCycle({ map, partitionId, services, ...opti
   const cacheKey = candidates.join("\u0000");
   const now = Date.now();
   const cached = cacheable ? cycleCache.get(cacheKey) : null;
-  if (cached && cached.expiresAt > now) return cached.value;
+  // The cache holds the raw parse and expiry is re-evaluated on every read,
+  // so an entry cached seconds before a boundary can't serve a seed that has
+  // since expired.
+  if (cached && cached.expiresAt > now) return applyCycleExpiry(cached.value, now);
 
   let resolved = { seed: null, nextCycleAt: null };
   for (const service of candidates) {
@@ -118,5 +152,5 @@ export async function resolveCoriolisCycle({ map, partitionId, services, ...opti
     }
     cycleCache.set(cacheKey, { expiresAt: now + CYCLE_CACHE_MS, value: resolved });
   }
-  return resolved;
+  return applyCycleExpiry(resolved, now);
 }

--- a/console/api/src/services/liveMapSpice.js
+++ b/console/api/src/services/liveMapSpice.js
@@ -50,7 +50,12 @@ export async function liveMapSpice(db, config, map = "", {
   fetchFlourSandRows = liveMapFlourSandFieldRows,
   persistObservedFields = recordObservedFields
 } = {}) {
-  const { seed: currentSeed, nextCycleAt } = await resolveCycle({ map, partitionId });
+  // staleSince is set when the logged cycle boundary has already passed, i.e.
+  // the world re-rolled but no container has restarted to print the new seed
+  // yet. currentSeed is null in that window, so every static/learned lookup
+  // below short-circuits and nothing is written back -- the map shows only
+  // live active fields rather than the previous cycle's pool.
+  const { seed: currentSeed, nextCycleAt, staleSince } = await resolveCycle({ map, partitionId });
 
   // The archive remains available during lightweight refreshes so active
   // fields still use its ground-truth coordinates; only the static pool rows
@@ -103,6 +108,7 @@ export async function liveMapSpice(db, config, map = "", {
     capabilities: { ...(includeStaticPool ? { spice: poolRows.length > 0 } : {}), spice_active: activeRows.length > 0, flour_sand: flourSandRows.length > 0 },
     currentSeed: currentSeed || "",
     nextCycleAt: nextCycleAt || "",
+    seedStaleSince: staleSince || "",
     generatedAt: archive?.generatedAt || "",
     rows: [...poolRows, ...activeRows, ...flourSandRows]
   };

--- a/console/api/test/coriolisSeed.test.js
+++ b/console/api/test/coriolisSeed.test.js
@@ -40,20 +40,20 @@ test("resolveCoriolisCycle parses both the seed and the next cycle's UTC start",
   const runLogs = async () => ({
     stdout: [
       "LogCoriolis: Display: Current Coriolis World Seed: 2",
-      "LogCoriolis: Display: This Coriolis Cycle start date UTC: 2026.08.18-05.00.00",
-      "LogCoriolis: Display: Next Coriolis Cycle start date UTC: 2026.08.25-05.00.00"
+      "LogCoriolis: Display: This Coriolis Cycle start date UTC: 2099.08.18-05.00.00",
+      "LogCoriolis: Display: Next Coriolis Cycle start date UTC: 2099.08.25-05.00.00"
     ].join("\n"),
     stderr: ""
   });
   const result = await resolveCoriolisCycle({ runLogs });
   assert.equal(result.seed, "cor-2");
-  assert.equal(result.nextCycleAt, "2026-08-25T05:00:00.000Z");
+  assert.equal(result.nextCycleAt, "2099-08-25T05:00:00.000Z");
 });
 
 test("resolveCoriolisCycle returns nulls when the container isn't running", async () => {
   const runLogs = async () => { throw new Error("docker logs failed with exit 1"); };
   const result = await resolveCoriolisCycle({ runLogs });
-  assert.deepEqual(result, { seed: null, nextCycleAt: null });
+  assert.deepEqual(result, { seed: null, nextCycleAt: null, staleSince: null });
 });
 
 test("resolveCoriolisCycle returns a null nextCycleAt when only the seed line is present", async () => {
@@ -68,12 +68,12 @@ test("resolveCoriolisCycle falls back to survival-1 when overmap is running but 
   const runLogs = async (service) => {
     seenServices.push(service);
     if (service === "overmap") return { stdout: "some unrelated log line\n", stderr: "" };
-    return { stdout: "Current Coriolis World Seed: 6\nNext Coriolis Cycle start date UTC: 2026.08.25-05.00.00\n", stderr: "" };
+    return { stdout: "Current Coriolis World Seed: 6\nNext Coriolis Cycle start date UTC: 2099.08.25-05.00.00\n", stderr: "" };
   };
   const result = await resolveCoriolisCycle({ runLogs });
   assert.deepEqual(seenServices, ["overmap", "survival-1"]);
   assert.equal(result.seed, "cor-6");
-  assert.equal(result.nextCycleAt, "2026-08-25T05:00:00.000Z");
+  assert.equal(result.nextCycleAt, "2099-08-25T05:00:00.000Z");
 });
 
 test("resolveCoriolisCycle falls back to survival-1 when the overmap container isn't running at all", async () => {
@@ -96,7 +96,7 @@ test("resolveCoriolisCycle does not query past the fixed fallback list", async (
   };
   const result = await resolveCoriolisCycle({ runLogs });
   assert.deepEqual(seenServices, ["overmap", "survival-1"]);
-  assert.deepEqual(result, { seed: null, nextCycleAt: null });
+  assert.deepEqual(result, { seed: null, nextCycleAt: null, staleSince: null });
 });
 
 test("resolveCoriolisCycle stops at overmap and never queries survival-1 when overmap already answers", async () => {
@@ -183,4 +183,55 @@ test("resolveCoriolisCycle ignores malformed partition IDs instead of constructi
   };
   await resolveCoriolisCycle({ map: "DeepDesert", partitionId: "../../59", runLogs });
   assert.deepEqual(seenServices, ["overmap"]);
+});
+
+// Regression: dune2 kept serving cor-2 after the 2026-08-25 boundary because
+// no container had restarted to print seed 3, putting the previous cycle's
+// static pool on the map and filing new-cycle fields under the old seed.
+test("resolveCoriolisCycle drops a seed whose own cycle boundary has already passed", async () => {
+  const runLogs = async () => ({
+    stdout: [
+      "LogCoriolis: Display: Current Coriolis World Seed: 2",
+      "LogCoriolis: Display: Next Coriolis Cycle start date UTC: 2020.01.01-05.00.00"
+    ].join("\n"),
+    stderr: ""
+  });
+  const result = await resolveCoriolisCycle({ runLogs });
+  assert.equal(result.seed, null);
+  assert.equal(result.nextCycleAt, null);
+  assert.equal(result.staleSince, "2020-01-01T05:00:00.000Z");
+});
+
+test("resolveCoriolisCycle keeps a seed whose cycle boundary is still ahead", async () => {
+  const runLogs = async () => ({
+    stdout: [
+      "LogCoriolis: Display: Current Coriolis World Seed: 7",
+      "LogCoriolis: Display: Next Coriolis Cycle start date UTC: 2999.01.01-05.00.00"
+    ].join("\n"),
+    stderr: ""
+  });
+  const result = await resolveCoriolisCycle({ runLogs });
+  assert.equal(result.seed, "cor-7");
+  assert.equal(result.nextCycleAt, "2999-01-01T05:00:00.000Z");
+  assert.equal(result.staleSince, null);
+});
+
+// Nothing to check the seed against, so it has to be passed through -- a
+// self-hoster on a build that doesn't log the boundary line still gets a pool.
+test("resolveCoriolisCycle passes through a seed logged without a cycle boundary", async () => {
+  const runLogs = async () => ({ stdout: "Current Coriolis World Seed: 4\n", stderr: "" });
+  const result = await resolveCoriolisCycle({ runLogs });
+  assert.equal(result.seed, "cor-4");
+  assert.equal(result.staleSince, null);
+});
+
+test("resolveCurrentSeed reports no seed once the logged cycle has expired", async () => {
+  const runLogs = async () => ({
+    stdout: [
+      "Current Coriolis World Seed: 2",
+      "Next Coriolis Cycle start date UTC: 2020.01.01-05.00.00"
+    ].join("\n"),
+    stderr: ""
+  });
+  assert.equal(await resolveCurrentSeed({ runLogs }), null);
 });

--- a/console/api/test/liveMapSpice.test.js
+++ b/console/api/test/liveMapSpice.test.js
@@ -246,3 +246,37 @@ test("persistObservedFields is not called when the current seed can't be resolve
   await liveMapSpice(null, config, "DeepDesert", { resolveCycle: async () => ({ seed: null, nextCycleAt: null }), fetchLiveRows: noLiveRows, fetchFlourSandRows: noFlourSandRows, persistObservedFields });
   assert.equal(calls.length, 0);
 });
+
+// End-to-end guard for the dune2 regression: once resolveCoriolisCycle
+// reports the logged seed as expired it hands back a null seed plus
+// staleSince, and none of the previous cycle's pool may survive that.
+test("an expired Coriolis seed serves no static pool and records nothing", async () => {
+  const config = configWithArchive(SAMPLE_ARCHIVE);
+  const persisted = [];
+  const liveRows = async () => ({ rows: [{ field_id: "5007190163237080", size: "Large", map: "DeepDesert", partition_id: 59 }] });
+  const result = await liveMapSpice(null, config, "DeepDesert", {
+    resolveCycle: async () => ({ seed: null, nextCycleAt: null, staleSince: "2026-08-25T11:00:00.000Z" }),
+    fetchLiveRows: liveRows,
+    fetchFlourSandRows: noFlourSandRows,
+    persistObservedFields: (file, seed, fields) => persisted.push({ seed, fields })
+  });
+  assert.equal(result.currentSeed, "");
+  assert.equal(result.seedStaleSince, "2026-08-25T11:00:00.000Z");
+  assert.equal(result.rows.filter((r) => r.type === "spice").length, 0);
+  assert.equal(result.capabilities.spice, false);
+  // Active fields still render -- they come from Postgres, not the seed.
+  assert.equal(result.rows.filter((r) => r.type === "spice_active").length, 1);
+  assert.deepEqual(persisted, []);
+});
+
+test("a live seed still reports no staleSince", async () => {
+  const config = configWithArchive(SAMPLE_ARCHIVE);
+  const result = await liveMapSpice(null, config, "DeepDesert", {
+    resolveCycle: async () => ({ seed: "cor-2", nextCycleAt: "2999-01-01T05:00:00.000Z", staleSince: null }),
+    fetchLiveRows: noLiveRows,
+    fetchFlourSandRows: noFlourSandRows,
+    persistObservedFields: noPersist
+  });
+  assert.equal(result.seedStaleSince, "");
+  assert.equal(result.rows.filter((r) => r.type === "spice").length, 2);
+});

--- a/console/web/src/api/liveMap.ts
+++ b/console/web/src/api/liveMap.ts
@@ -47,7 +47,7 @@ export const liveMapApi = {
     if (partitionId) params.set("partitionId", partitionId);
     if (!includeStatic) params.set("static", "0");
     const query = params.toString();
-    return api<{ rows: LiveMapMarker[]; overlays: Record<string, string>; capabilities: Record<string, unknown>; map: LiveMapConfig; maps: Record<string, LiveMapConfig>; defaultMap: string; partitions: LiveMapPartition[]; coriolisSeed?: string; coriolisNextCycleAt?: string }>(`/api/map/markers${query ? `?${query}` : ""}`);
+    return api<{ rows: LiveMapMarker[]; overlays: Record<string, string>; capabilities: Record<string, unknown>; map: LiveMapConfig; maps: Record<string, LiveMapConfig>; defaultMap: string; partitions: LiveMapPartition[]; coriolisSeed?: string; coriolisNextCycleAt?: string; coriolisSeedStaleSince?: string }>(`/api/map/markers${query ? `?${query}` : ""}`);
   },
   teleportPlayer: (body: { playerId: string; x: number; y: number; z: number; yaw?: number; partitionId?: number; online?: boolean }) => post<{ ok?: boolean; task?: Task; message?: string; path?: "live" | "offline"; supported?: boolean; reason?: string }>("/api/map/teleport-player", body),
   partitions: () => api<{ rows: LiveMapPartition[] }>("/api/map/partitions"),

--- a/console/web/src/features/liveMap/LiveMapPanel.tsx
+++ b/console/web/src/features/liveMap/LiveMapPanel.tsx
@@ -181,6 +181,7 @@ export function LiveMapPanel({ onError, confirmAction, waitForTask, taskTechnica
   const layerSettingsRef = useRef<HTMLDivElement | null>(null);
   const [coriolisSeed, setCoriolisSeed] = useState("");
   const [coriolisNextCycleAt, setCoriolisNextCycleAt] = useState("");
+  const [coriolisSeedStaleSince, setCoriolisSeedStaleSince] = useState("");
   const [now, setNow] = useState(() => Date.now());
   const [subtypeFilters, setSubtypeFilters] = useState<Record<string, Record<string, boolean>>>({});
   const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>({});
@@ -251,6 +252,7 @@ export function LiveMapPanel({ onError, confirmAction, waitForTask, taskTechnica
       setPartitions(result.partitions || []);
       setCoriolisSeed(result.coriolisSeed || "");
       setCoriolisNextCycleAt(result.coriolisNextCycleAt || "");
+      setCoriolisSeedStaleSince(result.coriolisSeedStaleSince || "");
       if (!partitionId) {
         const mapName = result.map?.actorMap || result.map?.key;
         const available = (result.partitions || []).filter((row) => row.map === mapName);
@@ -755,6 +757,12 @@ export function LiveMapPanel({ onError, confirmAction, waitForTask, taskTechnica
             <div className="key-value-item"><span>Zoom</span><strong>{zoomDisplayPercent}%</strong></div>
             {coriolisSeed && <div className="key-value-item"><span>Coriolis Seed</span><strong>{coriolisSeedNumber(coriolisSeed)}</strong></div>}
             {coriolisNextCycleAt && <div className="key-value-item"><span>Coriolis Countdown</span><strong>{formatCoriolisCountdown(coriolisNextCycleAt, now)}</strong></div>}
+            {/* The seed is only printed at container startup, so between a
+                Coriolis boundary and the next restart the server can't know
+                which seed is live. Static Spice Spawns is suppressed in that
+                window rather than showing the previous cycle's pool -- say so,
+                otherwise the empty layer reads as a bug. */}
+            {coriolisSeedStaleSince && <div className="key-value-item"><span>Coriolis Seed</span><strong title={`Cycle rolled over at ${coriolisSeedStaleSince}; the new seed is only logged when the map server restarts.`}>Awaiting restart</strong></div>}
           </div>
         </div>
       </div>

--- a/docs/console/live-map.md
+++ b/docs/console/live-map.md
@@ -158,6 +158,42 @@ container names are built from the map/partition
 farm-wide `overmap`/`survival-1` default) and re-validated against the same
 allowlist regex the rest of the console's Docker-log access uses.
 
+### Why a stale seed suppresses the static pool
+
+The seed line is only printed **at container startup**, but the Deep Desert
+world re-rolls at every weekly Coriolis boundary whether or not anything
+restarts. Between a boundary and the next restart the logs therefore still
+advertise the *previous* cycle's seed, and taking that at face value put the
+previous cycle's spice pool on the map -- observed on a live server, where
+fields first seen the day after a boundary were filed under the old seed and
+39% of them later reappeared under the new one (against a 2% baseline overlap
+between genuinely different seeds).
+
+The same log block also prints when the cycle ends, so a boundary that is
+already in the past is proof the logged seed is stale. `resolveCoriolisCycle()`
+treats that seed as **unknown** rather than trusting it: it returns a null seed
+plus a `staleSince` timestamp, which makes every archive and learned-pool
+lookup short-circuit and suppresses the write-back. *Static Spice Spawns*
+therefore disappears until the map server restarts and prints the new seed,
+while *Active Spice Blows* and *Flour Sand* keep working -- they read Postgres
+and never depend on the seed. The Overview strip shows `Coriolis Seed:
+Awaiting restart` during that window so the empty layer does not read as a bug.
+
+A log block that carries a seed but no boundary line is passed through
+unchanged; there is nothing to check it against.
+
+**Anything keyed into a static file must carry the seed it belongs to.** Both
+spice files are keyed `seeds["cor-<n>"]`, and neither is read or written when
+the seed is unknown.
+
+This includes Hagga Basin, whose resources also move at a Coriolis -- so its
+learned entries are keyed by the Deep Desert seed and relearned each cycle by
+design. Measured across one boundary on a live server, Deep Desert re-rolled
+95% of its positions while Hagga Basin's mostly recurred (only 8% new), which
+makes the relearn look redundant for Hagga Basin -- it is not. Some Hagga Basin
+positions genuinely are new each cycle, and there is no way to tell a recurring
+one from a moved one after the fact, so the keying stays conservative.
+
 ## Player teleport
 
 Dragging an **online** player marker previews a new position; releasing


### PR DESCRIPTION
The Coriolis seed is only printed at container startup, but the Deep Desert world re-rolls at every boundary whether or not anything restarts. In between, the logs still advertise the previous cycle's seed — so the live map drew that cycle's static spice pool, and the learned pool filed the new cycle's fields under the old seed.

Measured on a live farm across one boundary: fields first seen the day after the boundary were written to the old seed's bucket, and 39% of them later reappeared under the correct seed, against a 2% baseline overlap between genuinely different seeds.

The same log block prints when the cycle ends, so a boundary already in the past proves the seed is stale. `resolveCoriolisCycle` now treats it as unknown and returns `staleSince`, which short-circuits the archive and learned-pool lookups and suppresses the write-back. Active Spice Blows and Flour Sand are unaffected — they read Postgres and never need the seed. The Overview strip shows `Coriolis Seed: Awaiting restart` so the empty layer doesn't read as a bug.

A log block carrying a seed but no boundary line is passed through unchanged.

Tests: `console/api` 1814/1814, `console/web` 746/746, no skips.