### PR TITLE
fix: stop blank lines accumulating in the Advanced editor

### DIFF
--- a/runtime/scripts/test_profile_override_precedence.py
+++ b/runtime/scripts/test_profile_override_precedence.py
@@ -713,5 +713,135 @@ class PartitionEngineValuesManyCommandTests(ProfilePathTestCase):
         self.assertEqual(result[PARTITION_ID][self.FIELD_ID], "The Kulon Show")
 
 
+class ProfileBlankLineHygieneTests(ProfilePathTestCase):
+    """Blank lines inside a profile block must never accumulate.
+
+    parse_profile_text() attributes the blank line separating a block from the
+    next one to that block's own lines. profile_set_key() used to append new
+    keys after it, so serialize_profile() wrote a fresh separator and the old
+    one stayed trapped inside the block; profile_remove_key() then dropped only
+    the key line, leaving the blank behind. Every add/remove cycle on an array
+    entry (the PvP/PvE partition selectors, the Deep Desert matchmaker
+    override) therefore grew its block by one permanent blank line, and those
+    orphans rode through append_profile_unknown_lines() into the deployed INI.
+    """
+
+    PVP_SECTION = "/Script/DuneSandbox.PvpPveSettings"
+    STORM_SECTION = "/Script/DuneSandbox.SandStormConfig"
+
+    def _save_global(self, values: dict) -> None:
+        usersettings.bulk_save("global", MAP_NAME, "", _encode_bulk_save_payload(values))
+
+    def _block_lines(self, scope: str, section: str) -> list[str]:
+        """A block's lines with any trailing blank dropped.
+
+        Reading back from disk re-attributes the separator blank before the next
+        [Header] to this block, so one trailing blank is normal parse output
+        rather than accumulation -- write_profile() strips it again on the next
+        write. Accumulation shows up as blanks *between* content lines, which is
+        what these assertions pin down.
+        """
+        block = usersettings.find_profile_section(usersettings.read_profile(), scope, section)
+        lines = list(block["lines"]) if block else []
+        while lines and not lines[-1].strip():
+            lines.pop()
+        return lines
+
+    def _global_block_lines(self, section: str) -> list[str]:
+        return self._block_lines("global", section)
+
+    def test_appending_a_key_does_not_trap_the_block_separator_blank(self):
+        # A block that sorts AFTER this one is what gives it a trailing separator
+        # to trip over -- the last block in the file has nothing to trap. Save it
+        # first so the separator is already there by the second write.
+        self._save_global({"outlaw_criminal_score": "9"})
+        self._save_global({"sandstorm_damage_frames_per_overlap_interval": "16"})
+        self._save_global({"sandstorm_auto_spawn_enabled": "False"})
+
+        self.assertEqual(self._global_block_lines(self.STORM_SECTION), [
+            "m_DamageFramesPerOverlapInterval=16",
+            "m_bAutoSpawnEnabled=False",
+        ])
+
+    def test_repeated_array_add_and_remove_does_not_grow_the_block(self):
+        self._save_global({"guild_creation_cost": "500"})
+        self._save_global({"sandstorm_auto_spawn_enabled": "False"})
+        self._save_global({"global_pvp_enabled_partition_add": "60"})
+        settled = self._global_block_lines(self.PVP_SECTION)
+
+        for _ in range(6):
+            self._save_global({"global_pvp_enabled_partition_add": "8"})
+            self._save_global({"global_pvp_enabled_partition_remove": "8"})
+            # Back to exactly the pre-cycle content, not that content plus a blank.
+            self.assertEqual(self._global_block_lines(self.PVP_SECTION), settled)
+
+        self._save_global({"global_pvp_enabled_partition_add": "8"})
+        self.assertEqual(self._global_block_lines(self.PVP_SECTION), [
+            "+m_PvpEnabledPartitions=60",
+            "+m_PvpEnabledPartitions=8",
+        ])
+
+    def test_orphan_blank_runs_from_older_releases_are_collapsed_on_write(self):
+        # What profiles written before the fix actually look like on disk.
+        usersettings.write_profile_text("\n".join([
+            "; UserGame.ini managed by Docker.",
+            "",
+            f"[Global:{self.PVP_SECTION}]",
+            "",
+            "",
+            "+m_PvpEnabledPartitions=60",
+            "",
+            "",
+            "",
+            "+m_PvpEnabledPartitions=8",
+            "",
+            "",
+            f"[Global:{self.STORM_SECTION}]",
+            "m_bAutoSpawnEnabled=False",
+            "",
+        ]) + "\n")
+
+        usersettings.write_profile(usersettings.read_profile())
+
+        # The run collapses to the single blank an admin could legitimately have
+        # typed there -- normalize_profile_blank_lines() deliberately stops short
+        # of removing that last one (see its docstring); what matters is that it
+        # can no longer grow, which the add/remove test above covers.
+        self.assertEqual(self._global_block_lines(self.PVP_SECTION), [
+            "+m_PvpEnabledPartitions=60",
+            "",
+            "+m_PvpEnabledPartitions=8",
+        ])
+        self.assertEqual(self._global_block_lines(self.STORM_SECTION), ["m_bAutoSpawnEnabled=False"])
+        # Values are untouched: only blank lines were ever removed.
+        self.assertEqual(
+            usersettings.profile_global_values(usersettings.read_profile())["sandstorm_auto_spawn_enabled"],
+            "False",
+        )
+
+    def test_a_single_blank_between_comment_paragraphs_survives(self):
+        # The UserEngine Advanced tab renders comment paragraphs separated by one
+        # blank line; collapsing runs must not flatten that deliberate grouping.
+        usersettings.write_profile_text("\n".join([
+            "[Engine:ConsoleVariables]",
+            "; Mining multipliers",
+            "Dune.GlobalMiningOutputMultiplier=2.4",
+            "",
+            "; Durability damage multiplier for vehicles",
+            "dw.VehicleDurabilityDamageMultiplier=0.5",
+        ]) + "\n")
+
+        usersettings.write_profile(usersettings.read_profile())
+
+        block = usersettings.find_profile_section(usersettings.read_profile(), "engine", "ConsoleVariables")
+        self.assertEqual(block["lines"], [
+            "; Mining multipliers",
+            "Dune.GlobalMiningOutputMultiplier=2.4",
+            "",
+            "; Durability damage multiplier for vehicles",
+            "dw.VehicleDurabilityDamageMultiplier=0.5",
+        ])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/runtime/scripts/usersettings.py
+++ b/runtime/scripts/usersettings.py
@@ -927,6 +927,7 @@ def preflight_persisted_settings() -> int:
 
 def write_profile(profile: dict) -> None:
     strip_retired_usergame_profile_lines(profile)
+    normalize_profile_blank_lines(profile)
     prune_empty_profile_sections(profile)
     atomic_write_text(PROFILE_PATH, serialize_profile(profile))
 
@@ -946,6 +947,38 @@ def serialize_profile(profile: dict) -> str:
         lines.append(f"[{section['header']}]")
         lines.extend(section.get("lines", []))
     return "\n".join(lines).rstrip() + "\n"
+
+
+def normalize_profile_blank_lines(profile: dict) -> None:
+    """Clean up blank-line runs inside profile blocks.
+
+    profile_remove_key() drops a key's line but never the blank line an earlier
+    append had trapped beside it, so before the profile_set_key() fix every
+    add/remove cycle on an array entry (the PvP/PvE partition selectors, the Deep
+    Desert matchmaker override) grew its block by one permanent blank line --
+    profiles written by those releases arrive here with long orphan runs.
+
+    A block's leading and trailing blanks carry no meaning -- serialize_profile()
+    owns the single separator between blocks -- so drop them, and collapse
+    interior runs to one.
+
+    Interior runs, not every interior blank: a single blank inside a block is
+    deliberate spacing an admin is entitled to keep, both between the comment
+    paragraphs the UserEngine Advanced tab renders and between their own custom
+    cvars (test_blank_line_between_custom_cvars_survives_round_trip pins that
+    down). Only a *run* is unambiguously machine-made, and with the
+    profile_set_key() fix above no new orphan can appear to grow one.
+    """
+    for block in profile.get("sections", []):
+        cleaned: list[str] = []
+        for raw in block.get("lines", []):
+            if raw.strip():
+                cleaned.append(raw)
+            elif cleaned and cleaned[-1].strip():
+                cleaned.append("")
+        while cleaned and not cleaned[-1].strip():
+            cleaned.pop()
+        block["lines"] = cleaned
 
 
 def prune_empty_profile_sections(profile: dict) -> None:
@@ -1261,10 +1294,18 @@ def profile_set_key(profile: dict, scope: str, section: str, key: str, value: st
         if current_prefix == prefix:
             target_index = index
     line = f"{target_left}={value}"
-    if target_index is None:
-        block["lines"].append(line)
-    else:
+    if target_index is not None:
         block["lines"][target_index] = line
+        return
+    # parse_profile_text() attributes the blank line that separates this block from
+    # the next one to THIS block, so a plain append lands *after* that blank.
+    # serialize_profile() then writes a fresh separator, and the old one is trapped
+    # inside the block for good -- one more orphan blank line for every key ever
+    # appended here. Insert ahead of any trailing blanks so nothing accumulates.
+    insert_at = len(block["lines"])
+    while insert_at and not block["lines"][insert_at - 1].strip():
+        insert_at -= 1
+    block["lines"].insert(insert_at, line)
 
 
 def profile_remove_key(profile: dict, scope: str, section: str, key: str, map_name: str = "", partition_id: str = "", prefixes: set[str] | None = None, value: str | None = None) -> None:


### PR DESCRIPTION
The Maps > Advanced editor grows blank lines without bound. On a live server the profile had 14-line blank runs inside `[Global:/Script/DuneSandbox.PvpPveSettings]` and `[Global:/Script/DuneSandbox.MatchmakerEventsSettings]`.

## Cause

`parse_profile_text()` attributes the blank line separating a block from the next one to that block's own lines, and `profile_set_key()` appended new keys after it. `serialize_profile()` then wrote a fresh separator and the old one stayed trapped inside the block. `profile_remove_key()` drops only the key line, so every add/remove cycle on an array entry — the PvP/PvE partition selectors, the Deep Desert matchmaker override — added one permanent blank line. Those orphans also rode through `append_profile_unknown_lines()` into the deployed INI.

## Change

- `profile_set_key()` inserts ahead of a block's trailing blanks, so no new orphan can appear.
- New `normalize_profile_blank_lines()`, called from `write_profile()`, cleans profiles written by earlier releases: strips each block's leading/trailing blanks and collapses interior runs to one.

Runs only, not every interior blank — a lone blank is spacing an admin may have typed, which `test_blank_line_between_custom_cvars_survives_round_trip` already pins down. With the `profile_set_key()` fix, one can no longer grow into a run.

## Verification

Against a real production profile: 101 → 74 lines, 27 blank lines removed, zero non-blank lines changed, and `compiled_usergame_ini()` output identical for two partitions apart from the blanks.

Four regression tests added to `test_profile_override_precedence.py` (already CI-wired); three of them fail against the current `main` and pass after. Full suite: 114 tests, with the one pre-existing `test_deep_desert_label_resolver_requires_a_complete_pvp_pve_pair` failure unchanged from `main`.

Behavior is unaffected either way — blank lines are inert to Unreal's config parser, and settings in and after the affected sections were confirmed in effect on a live server.
