### PR TITLE
Edit auto-refill thresholds and intervals from the Bases panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,8 +108,20 @@ ADMIN_REFILL_FLUSH_INTERVAL_MS=5000
 ADMIN_REFILL_DOWN_DWELL_MS=30000
 ADMIN_REFILL_MAX_AGE_MS=604800000
 ADMIN_REFILL_RETRY_DELAY_MS=60000
+
+# Auto-refill thresholds and scan intervals. These four are the FALLBACK only:
+# the Bases panel's gear icon writes runtime/generated/auto-refill-settings.json,
+# which wins over anything set here, and each field there has a Reset that drops
+# back to these values. Editing them is only worth it to change the starting
+# point for a fresh install, or to script one. A blank value reads as unset, and
+# an out-of-range one falls back to the documented default.
+#
+# Generators and water are independent: separate enrollment lists, separate
+# schedules, so a base enrolled in one is not enrolled in the other.
 ADMIN_AUTO_REFILL_THRESHOLD_PERCENT=50
 ADMIN_AUTO_REFILL_INTERVAL_HOURS=24
+ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT=50
+ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS=24
 
 # Base-delete queue tuning. Same shape as the generator refill queue above:
 # a delete queued for a live map is dropped after MAX_AGE_MS without applying,

--- a/.env.example
+++ b/.env.example
@@ -113,8 +113,10 @@ ADMIN_REFILL_RETRY_DELAY_MS=60000
 # the Bases panel's gear icon writes runtime/generated/auto-refill-settings.json,
 # which wins over anything set here, and each field there has a Reset that drops
 # back to these values. Editing them is only worth it to change the starting
-# point for a fresh install, or to script one. A blank value reads as unset, and
-# an out-of-range one falls back to the documented default.
+# point for a fresh install, or to script one. An unparseable value falls back to
+# the documented default; an out-of-range one is clamped to the nearest bound.
+# A blank value reads as unset, but note docker-compose.web.yml substitutes its
+# own default for a blank, so that only applies when running outside Docker.
 #
 # Generators and water are independent: separate enrollment lists, separate
 # schedules, so a base enrolled in one is not enrolled in the other.

--- a/console/api/src/actions.js
+++ b/console/api/src/actions.js
@@ -210,11 +210,26 @@ export const ROUTE_ACTIONS = {
   "GET /api/bases":                            "bases:read",
   "GET /api/bases/pending-refills":            "bases:read",
   "GET /api/bases/auto-refill":                "bases:read",
+  "GET /api/bases/auto-refill/settings":       "bases:read",
   "GET /api/bases/pending-water-refills":      "bases:read",
   "GET /api/bases/auto-refill-water":          "bases:read",
   "GET /api/bases/permission-candidates":      "bases:read",
   "GET /api/bases/pending-deletes":            "bases:read",
   "GET /api/bases/pending-child-access":       "bases:read",
+
+  // --- Bases (console-owned settings) ---
+  // POST /api/bases/auto-refill/settings — thresholds and scan intervals for
+  // both scanners. Its own action for the same consent reason as
+  // bases:delete-item below: every other action in the bases:mutate bucket is
+  // scoped to one base, whereas this retunes every enrolled base at once, so a
+  // bases:mutate grant cannot be read as consent to it. Named for the
+  // per-feature settings convention (exchange:write-config, maps:write-config);
+  // owner/admin grant bases:*, so default access is unchanged.
+  //
+  // This entry is also what keeps the route off the "POST /api/bases/" →
+  // bases:mutate prefix rule, where it would resolve silently rather than
+  // failing closed.
+  "POST /api/bases/auto-refill/settings":      "bases:write-config",
 
   // --- Storage (read) ---
   "GET /api/storage":                          "storage:read",

--- a/console/api/src/config.js
+++ b/console/api/src/config.js
@@ -312,6 +312,8 @@ function repairRootOwnedHostState(repoRoot) {
     resolve(repoRoot, "runtime/generated/update-auto.env"),
     resolve(repoRoot, "runtime/generated/usersettings.json"),
     resolve(repoRoot, "runtime/generated/auto-refill-bases.json"),
+    resolve(repoRoot, "runtime/generated/auto-refill-water-bases.json"),
+    resolve(repoRoot, "runtime/generated/auto-refill-settings.json"),
     resolve(repoRoot, "runtime/generated/pending-generator-refills.json"),
     resolve(repoRoot, "runtime/generated/gameplay-profile.ini"),
     resolve(repoRoot, "runtime/generated/care-package.json"),

--- a/console/api/src/server.js
+++ b/console/api/src/server.js
@@ -66,8 +66,9 @@ import { ensureExchangeHistory, listExchangeTransactions } from "./services/exch
 import { listMarketExchanges, marketBotStatus, saveMarketBuybackSchedule, saveMarketSeedSchedule, decodeSeedPlanCsvUpload, exportMarketSeedPlanCsv, importMarketSeedPlanFromCsv, renameMarketSeedPlan, setActiveMarketSeedPlan } from "./services/exchangeMarket.js";
 import { loadMarketSeedPlan } from "./addonSeedJob.js";
 import { readMarketItemOverrides, saveMarketItemOverrides, readUnsafeTemplateIds, listBotItemCatalogPickerItems, getOverrideRow } from "./services/marketItemOverrides.js";
-import { autoRefillPublicState, createAutoRefillScheduler, setBaseAutoRefill } from "./services/autoRefill.js";
-import { autoRefillWaterPublicState, createAutoRefillWaterScheduler, setBaseAutoRefillWater } from "./services/autoRefillWater.js";
+import { autoRefillPublicState, clampAutoRefillNextRun, createAutoRefillScheduler, setBaseAutoRefill } from "./services/autoRefill.js";
+import { autoRefillWaterPublicState, clampAutoRefillWaterNextRun, createAutoRefillWaterScheduler, setBaseAutoRefillWater } from "./services/autoRefillWater.js";
+import { autoRefillSettingsView, saveAutoRefillSettings } from "./services/autoRefillSettings.js";
 import { calculateAlwaysOnHostMemorySafety } from "./services/hostMemorySafety.js";
 import { parseEffectiveGuildMemberLimit } from "./services/guildSettings.js";
 import { parseEffectivePermissionLimit } from "./services/permissionSettings.js";
@@ -924,6 +925,8 @@ async function handleApi(req, res) {
   }));
   if (path === "/api/bases/pending-refills") return pendingGeneratorRefillsRoute(res);
   if (path === "/api/bases/auto-refill") return basesAutoRefillStateRoute(res);
+  if (path === "/api/bases/auto-refill/settings" && req.method === "GET") return basesAutoRefillSettingsRoute(res);
+  if (path === "/api/bases/auto-refill/settings" && req.method === "POST") return basesAutoRefillSettingsSaveRoute(req, res);
   if (path === "/api/bases/pending-water-refills") return pendingWaterRefillsRoute(res);
   if (path === "/api/bases/auto-refill-water") return basesAutoRefillWaterStateRoute(res);
   if (path === "/api/bases/pending-deletes") return pendingBaseDeletesRoute(res);
@@ -4197,6 +4200,36 @@ async function pendingGeneratorRefillsRoute(res) {
 async function basesAutoRefillStateRoute(res) {
   const supported = await duneDb.supportsGeneratorRefillQueue(db).catch(() => false);
   return json(res, 200, { supported, ...autoRefillPublicState(config.repoRoot) });
+}
+
+// Tuning shared by both auto-refill scanners. Answers with the database down,
+// like basesAutoRefillStateRoute above: this is a file, not a query.
+async function basesAutoRefillSettingsRoute(res) {
+  return json(res, 200, autoRefillSettingsView(config.repoRoot));
+}
+
+// Console-owned configuration, so it follows the settings routes (plain handler
+// plus an explicit audit) rather than directDbMutation's confirmation machinery.
+// Unlike the per-base toggles below it IS rate limited, matching
+// exchangeConfigSaveRoute: this retunes every enrolled base at once.
+async function basesAutoRefillSettingsSaveRoute(req, res) {
+  // Before readJson, so a client spamming this never gets its body parsed.
+  if (!applyMutationRateLimit(req, res, "bases.auto-refill-settings")) return;
+  const body = await readJson(req);
+  try {
+    const saved = saveAutoRefillSettings(config.repoRoot, body);
+    // A shortened interval must pull the armed scan in, or the change looks
+    // like it did nothing until the old interval elapses. Both no-op otherwise.
+    const nextRunAt = clampAutoRefillNextRun(config.repoRoot);
+    const waterNextRunAt = clampAutoRefillWaterNextRun(config.repoRoot);
+    audit(config, req, "bases.auto-refill-settings", { ...saved, nextRunAt, waterNextRunAt });
+    return json(res, 200, { ok: true, ...autoRefillSettingsView(config.repoRoot), nextRunAt, waterNextRunAt });
+  } catch (error) {
+    return json(res, error?.statusCode === 400 ? 400 : 500, {
+      ok: false,
+      error: redact(error?.message || "Unexpected error.")
+    });
+  }
 }
 
 // Console-owned configuration rather than a database mutation, so this follows

--- a/console/api/src/services/autoRefill.js
+++ b/console/api/src/services/autoRefill.js
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { audit } from "../audit.js";
 import { redact } from "../redact.js";
 import { clampInt, writeJsonAtomic } from "../jsonStore.js";
+import { resolveAutoRefillSetting } from "./autoRefillSettings.js";
 
 // Opt-in per-base automatic generator refills. This owns only the enrollment
 // list and the daily decision; the refill itself goes through the existing
@@ -24,14 +25,19 @@ const MAX_CONSECUTIVE_QUEUES = 3;
 // How far out an overdue scan is armed at boot. See the note in tick().
 const OVERDUE_ARM_DELAY_MS = 5 * 60 * 1000;
 
-// Fixed in code, env-overridable only -- matching how every other refill
-// tunable (ADMIN_REFILL_*) is exposed rather than adding a settings surface.
-export function autoRefillThresholdPercent(env = process.env) {
-  return clampInt(env.ADMIN_AUTO_REFILL_THRESHOLD_PERCENT, 50, 1, 99);
+// Layered: console settings file > env var > hardcoded default, resolved in
+// services/autoRefillSettings.js. These two are the ones an operator retunes
+// while watching a server, so they got a settings surface; the ADMIN_REFILL_*
+// queue tunables stay env-only.
+//
+// repoRoot is optional only so the env layer stays directly testable -- every
+// production call site passes it.
+export function autoRefillThresholdPercent(env = process.env, repoRoot = "") {
+  return resolveAutoRefillSetting("thresholdPercent", { env, repoRoot });
 }
 
-export function autoRefillIntervalHours(env = process.env) {
-  return clampInt(env.ADMIN_AUTO_REFILL_INTERVAL_HOURS, 24, 1, 168);
+export function autoRefillIntervalHours(env = process.env, repoRoot = "") {
+  return resolveAutoRefillSetting("intervalHours", { env, repoRoot });
 }
 
 function autoRefillFile(repoRoot) {
@@ -128,6 +134,25 @@ export function isAutoRefillEnabled(repoRoot, baseId) {
   return Boolean(readAutoRefillState(repoRoot).bases[String(target)]);
 }
 
+// Called after the interval setting changes. tick() only re-arms once a run
+// completes or when nextRunAt is empty, so a nextRunAt written under the old,
+// longer interval would otherwise stand -- shortening 24h to 4h would look
+// like it did nothing for up to a day.
+//
+// Clamps toward now ONLY: lengthening leaves the armed run alone, because
+// pushing back a scan the operator is already waiting on is the more
+// surprising of the two. The asymmetry is in the overlay copy and the
+// operator guide. No-ops when nothing is enrolled or the interval grew, so it
+// is safe to call on every save.
+export function clampAutoRefillNextRun(repoRoot, { now = () => Date.now(), env = process.env } = {}) {
+  const state = readAutoRefillState(repoRoot);
+  if (!Object.keys(state.bases).length || !state.nextRunAt) return state.nextRunAt;
+  const latest = now() + autoRefillIntervalHours(env, repoRoot) * 3600000;
+  const current = Date.parse(state.nextRunAt);
+  if (Number.isFinite(current) && current <= latest) return state.nextRunAt;
+  return writeAutoRefillState(repoRoot, { ...state, nextRunAt: new Date(latest).toISOString() }).nextRunAt;
+}
+
 // Idempotent in both directions: a double-clicked toggle is not an error.
 export function setBaseAutoRefill(repoRoot, baseId, enabled, { now = () => Date.now(), env = process.env } = {}) {
   const target = Number(baseId);
@@ -155,7 +180,7 @@ export function setBaseAutoRefill(repoRoot, baseId, enabled, { now = () => Date.
   } else if (wasEmpty || !nextRunAt) {
     // Arm a full interval out, so turning auto-refill on never fires an
     // immediate surprise write into a base the operator was still looking at.
-    nextRunAt = new Date(now() + autoRefillIntervalHours(env) * 3600000).toISOString();
+    nextRunAt = new Date(now() + autoRefillIntervalHours(env, repoRoot) * 3600000).toISOString();
   }
 
   const next = writeAutoRefillState(repoRoot, { ...state, bases, nextRunAt });
@@ -166,8 +191,8 @@ export function setBaseAutoRefill(repoRoot, baseId, enabled, { now = () => Date.
 export function autoRefillPublicState(repoRoot, { env = process.env } = {}) {
   const state = readAutoRefillState(repoRoot);
   return {
-    thresholdPercent: autoRefillThresholdPercent(env),
-    intervalHours: autoRefillIntervalHours(env),
+    thresholdPercent: autoRefillThresholdPercent(env, repoRoot),
+    intervalHours: autoRefillIntervalHours(env, repoRoot),
     nextRunAt: state.nextRunAt,
     lastRunAt: state.lastRunAt,
     lastRunStatus: state.lastRunStatus,
@@ -201,7 +226,7 @@ export function createAutoRefillScheduler(options = {}) {
   let armedForThisProcess = false;
 
   function intervalMs() {
-    return autoRefillIntervalHours(env) * 3600000;
+    return autoRefillIntervalHours(env, config.repoRoot) * 3600000;
   }
 
   function auditSafely(action, detail) {
@@ -361,7 +386,7 @@ export function createAutoRefillScheduler(options = {}) {
   }
 
   async function run(baseIds, enrollment) {
-    const threshold = autoRefillThresholdPercent(env);
+    const threshold = autoRefillThresholdPercent(env, config.repoRoot);
     const context = {
       enrollment,
       // Read once per scan: which bases already have an unflushed queue entry.
@@ -454,7 +479,7 @@ export function createAutoRefillScheduler(options = {}) {
   return {
     tick,
     publicState: () => autoRefillPublicState(config.repoRoot, { env }),
-    thresholdPercent: () => autoRefillThresholdPercent(env),
-    intervalHours: () => autoRefillIntervalHours(env)
+    thresholdPercent: () => autoRefillThresholdPercent(env, config.repoRoot),
+    intervalHours: () => autoRefillIntervalHours(env, config.repoRoot)
   };
 }

--- a/console/api/src/services/autoRefillSettings.js
+++ b/console/api/src/services/autoRefillSettings.js
@@ -1,0 +1,138 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { redact } from "../redact.js";
+import { clampInt, writeJsonAtomic } from "../jsonStore.js";
+
+// Operator-editable tuning for the two auto-refill scanners. Owns only the
+// four numbers; enrollment stays in autoRefill.js / autoRefillWater.js, which
+// import from here and not the reverse, so there is no cycle.
+//
+// Layered: this file beats the env var, which beats the hardcoded default.
+const AUTO_REFILL_SETTINGS_PATH = "runtime/generated/auto-refill-settings.json";
+
+// The single place these names, defaults and ranges are written down. The
+// bounds are what the scanners can act on: 0% never fires, 100% always does.
+export const AUTO_REFILL_SETTING_SPECS = Object.freeze({
+  thresholdPercent:      { env: "ADMIN_AUTO_REFILL_THRESHOLD_PERCENT",       fallback: 50, min: 1, max: 99  },
+  intervalHours:         { env: "ADMIN_AUTO_REFILL_INTERVAL_HOURS",          fallback: 24, min: 1, max: 168 },
+  waterThresholdPercent: { env: "ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT", fallback: 50, min: 1, max: 99  },
+  waterIntervalHours:    { env: "ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS",    fallback: 24, min: 1, max: 168 }
+});
+
+export const AUTO_REFILL_SETTING_KEYS = Object.freeze(Object.keys(AUTO_REFILL_SETTING_SPECS));
+
+function settingsFile(repoRoot) {
+  return resolve(repoRoot || "", AUTO_REFILL_SETTINGS_PATH);
+}
+
+function badRequest(message) {
+  return Object.assign(new Error(message), { statusCode: 400 });
+}
+
+// THE TRAP, which both layers below are shaped around: clampInt turns null and
+// "" into 0, which clamps to min rather than to the fallback -- so any blank
+// value silently reads as 1% / 1h instead of the documented default. "Unset"
+// must therefore be an ABSENT key, never null, "" or a sentinel.
+function isStorableValue(key, value) {
+  const spec = AUTO_REFILL_SETTING_SPECS[key];
+  return Number.isInteger(value) && value >= spec.min && value <= spec.max;
+}
+
+// The trap on the env side: `ADMIN_AUTO_REFILL_INTERVAL_HOURS=` is how .env
+// carries a declared-but-unset optional, so blank must read as absent BEFORE
+// clampInt sees it. A real value still clamps, so a typo degrades as before.
+function hasEnvValue(spec, env) {
+  const raw = env?.[spec.env];
+  return raw !== undefined && raw !== null && String(raw).trim() !== "";
+}
+
+function envValue(spec, env) {
+  if (!hasEnvValue(spec, env)) return spec.fallback;
+  return clampInt(env[spec.env], spec.fallback, spec.min, spec.max);
+}
+
+// Lenient, like readExchangeConfig: a corrupt file degrades to "no overrides"
+// rather than blocking the console. An out-of-range value is DROPPED, not
+// clamped -- only saveAutoRefillSettings writes here, so a bad value means a
+// hand edit, and falling through to the env var reads intent more honestly
+// than pinning to the nearest legal number.
+export function readAutoRefillSettings(repoRoot) {
+  const file = settingsFile(repoRoot);
+  if (!existsSync(file)) return {};
+  let raw = null;
+  try {
+    raw = JSON.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    console.warn(`Ignoring unreadable auto-refill settings: ${redact(error?.message || "Unexpected error.")}`);
+    return {};
+  }
+  if (!raw || typeof raw !== "object") return {};
+  const settings = {};
+  for (const key of AUTO_REFILL_SETTING_KEYS) {
+    if (isStorableValue(key, raw[key])) settings[key] = raw[key];
+  }
+  return settings;
+}
+
+// Strict, unlike the read above: this is the only writer, so it is the only
+// place that can keep the file's invariants. A number sets, null resets
+// (deletes the key), an omitted key leaves the stored value alone.
+export function saveAutoRefillSettings(repoRoot, patch) {
+  if (!patch || typeof patch !== "object" || Array.isArray(patch)) {
+    throw badRequest("Auto-refill settings must be an object.");
+  }
+  const next = { ...readAutoRefillSettings(repoRoot) };
+  let touched = false;
+  for (const key of AUTO_REFILL_SETTING_KEYS) {
+    if (!Object.prototype.hasOwnProperty.call(patch, key)) continue;
+    touched = true;
+    const value = patch[key];
+    if (value === null) {
+      delete next[key];
+      continue;
+    }
+    const spec = AUTO_REFILL_SETTING_SPECS[key];
+    if (!Number.isInteger(value) || value < spec.min || value > spec.max) {
+      throw badRequest(`${key} must be a whole number between ${spec.min} and ${spec.max}.`);
+    }
+    next[key] = value;
+  }
+  if (!touched) throw badRequest("No auto-refill settings were supplied.");
+  writeJsonAtomic(settingsFile(repoRoot), next, 0o600);
+  return next;
+}
+
+// Re-read every call rather than cached: config is loaded once per process, so
+// a cached value would be stale from the first save on (see config.js's `ports`
+// getter). The scanners already read their enrollment file every 10s tick.
+export function resolveAutoRefillSetting(key, { repoRoot = "", env = process.env } = {}) {
+  const spec = AUTO_REFILL_SETTING_SPECS[key];
+  if (!spec) throw new Error(`Unknown auto-refill setting: ${key}`);
+  const stored = repoRoot ? readAutoRefillSettings(repoRoot)[key] : undefined;
+  // Only the env layer goes through clampInt; a stored value is already known
+  // in range, so it never meets the trap above.
+  if (stored !== undefined) return stored;
+  return envValue(spec, env);
+}
+
+// Shape returned by GET /api/bases/auto-refill/settings. `defaults` is what
+// Reset restores -- the env value when one is set, otherwise the hardcoded
+// fallback -- so the overlay can offer Reset without knowing the layering.
+export function autoRefillSettingsView(repoRoot, env = process.env) {
+  const stored = readAutoRefillSettings(repoRoot);
+  const settings = {};
+  const sources = {};
+  const defaults = {};
+  const limits = {};
+  const envNames = {};
+  for (const key of AUTO_REFILL_SETTING_KEYS) {
+    const spec = AUTO_REFILL_SETTING_SPECS[key];
+    const fromEnv = envValue(spec, env);
+    settings[key] = stored[key] !== undefined ? stored[key] : fromEnv;
+    sources[key] = stored[key] !== undefined ? "console" : hasEnvValue(spec, env) ? "env" : "default";
+    defaults[key] = fromEnv;
+    limits[key] = { min: spec.min, max: spec.max };
+    envNames[key] = spec.env;
+  }
+  return { settings, sources, defaults, limits, envNames };
+}

--- a/console/api/src/services/autoRefillSettings.js
+++ b/console/api/src/services/autoRefillSettings.js
@@ -11,7 +11,10 @@ import { clampInt, writeJsonAtomic } from "../jsonStore.js";
 const AUTO_REFILL_SETTINGS_PATH = "runtime/generated/auto-refill-settings.json";
 
 // The single place these names, defaults and ranges are written down. The
-// bounds are what the scanners can act on: 0% never fires, 100% always does.
+// bounds are an operating range, not a correctness limit: the scan skips on
+// `lowest >= threshold`, so 0 would never queue anything and 100 would queue on
+// any consumption at all. Note a hand-filled device can read slightly over 100%
+// (real data has a few at 100.2), which only ever causes a skip.
 export const AUTO_REFILL_SETTING_SPECS = Object.freeze({
   thresholdPercent:      { env: "ADMIN_AUTO_REFILL_THRESHOLD_PERCENT",       fallback: 50, min: 1, max: 99  },
   intervalHours:         { env: "ADMIN_AUTO_REFILL_INTERVAL_HOURS",          fallback: 24, min: 1, max: 168 },

--- a/console/api/src/services/autoRefillWater.js
+++ b/console/api/src/services/autoRefillWater.js
@@ -3,9 +3,10 @@ import { resolve } from "node:path";
 import { audit } from "../audit.js";
 import { redact } from "../redact.js";
 import { clampInt, writeJsonAtomic } from "../jsonStore.js";
+import { resolveAutoRefillSetting } from "./autoRefillSettings.js";
 
 // Opt-in per-base automatic water refills. Mirrors autoRefill.js (generator
-// auto-refill) exactly, with its own enrollment file and env-configurable
+// auto-refill) exactly, with its own enrollment file and separately configurable
 // threshold/interval so the two subsystems never share state or interfere
 // with each other. This owns only the enrollment list and the daily
 // decision; the refill itself goes through the pending water-refill queue in
@@ -27,16 +28,14 @@ const MAX_CONSECUTIVE_QUEUES = 3;
 // How far out an overdue scan is armed at boot. See the note in tick().
 const OVERDUE_ARM_DELAY_MS = 5 * 60 * 1000;
 
-// Fixed in code, env-overridable only -- matching how every other refill
-// tunable (ADMIN_REFILL_*) is exposed rather than adding a settings surface.
-// Distinct env vars from the generator version so the two can be tuned
-// independently.
-export function autoRefillWaterThresholdPercent(env = process.env) {
-  return clampInt(env.ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT, 50, 1, 99);
+// Layered like the generator twin in autoRefill.js -- see the note there.
+// Distinct settings keys and env vars, so the two tune independently.
+export function autoRefillWaterThresholdPercent(env = process.env, repoRoot = "") {
+  return resolveAutoRefillSetting("waterThresholdPercent", { env, repoRoot });
 }
 
-export function autoRefillWaterIntervalHours(env = process.env) {
-  return clampInt(env.ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS, 24, 1, 168);
+export function autoRefillWaterIntervalHours(env = process.env, repoRoot = "") {
+  return resolveAutoRefillSetting("waterIntervalHours", { env, repoRoot });
 }
 
 function autoRefillWaterFile(repoRoot) {
@@ -133,6 +132,17 @@ export function isAutoRefillWaterEnabled(repoRoot, baseId) {
   return Boolean(readAutoRefillWaterState(repoRoot).bases[String(target)]);
 }
 
+// Water twin of clampAutoRefillNextRun in autoRefill.js -- see the note there
+// for why this clamps toward now only and why it is safe to call on every save.
+export function clampAutoRefillWaterNextRun(repoRoot, { now = () => Date.now(), env = process.env } = {}) {
+  const state = readAutoRefillWaterState(repoRoot);
+  if (!Object.keys(state.bases).length || !state.nextRunAt) return state.nextRunAt;
+  const latest = now() + autoRefillWaterIntervalHours(env, repoRoot) * 3600000;
+  const current = Date.parse(state.nextRunAt);
+  if (Number.isFinite(current) && current <= latest) return state.nextRunAt;
+  return writeAutoRefillWaterState(repoRoot, { ...state, nextRunAt: new Date(latest).toISOString() }).nextRunAt;
+}
+
 // Idempotent in both directions: a double-clicked toggle is not an error.
 export function setBaseAutoRefillWater(repoRoot, baseId, enabled, { now = () => Date.now(), env = process.env } = {}) {
   const target = Number(baseId);
@@ -161,7 +171,7 @@ export function setBaseAutoRefillWater(repoRoot, baseId, enabled, { now = () => 
   } else if (wasEmpty || !nextRunAt) {
     // Arm a full interval out, so turning auto-refill on never fires an
     // immediate surprise write into a base the operator was still looking at.
-    nextRunAt = new Date(now() + autoRefillWaterIntervalHours(env) * 3600000).toISOString();
+    nextRunAt = new Date(now() + autoRefillWaterIntervalHours(env, repoRoot) * 3600000).toISOString();
   }
 
   const next = writeAutoRefillWaterState(repoRoot, { ...state, bases, nextRunAt });
@@ -178,8 +188,8 @@ export function setBaseAutoRefillWater(repoRoot, baseId, enabled, { now = () => 
 export function autoRefillWaterPublicState(repoRoot, { env = process.env } = {}) {
   const state = readAutoRefillWaterState(repoRoot);
   return {
-    thresholdPercent: autoRefillWaterThresholdPercent(env),
-    intervalHours: autoRefillWaterIntervalHours(env),
+    thresholdPercent: autoRefillWaterThresholdPercent(env, repoRoot),
+    intervalHours: autoRefillWaterIntervalHours(env, repoRoot),
     nextRunAt: state.nextRunAt,
     lastRunAt: state.lastRunAt,
     lastRunStatus: state.lastRunStatus,
@@ -214,7 +224,7 @@ export function createAutoRefillWaterScheduler(options = {}) {
   let armedForThisProcess = false;
 
   function intervalMs() {
-    return autoRefillWaterIntervalHours(env) * 3600000;
+    return autoRefillWaterIntervalHours(env, config.repoRoot) * 3600000;
   }
 
   function auditSafely(action, detail) {
@@ -378,7 +388,7 @@ export function createAutoRefillWaterScheduler(options = {}) {
   }
 
   async function run(baseIds, enrollment, { preserveNextRunAt = false } = {}) {
-    const threshold = autoRefillWaterThresholdPercent(env);
+    const threshold = autoRefillWaterThresholdPercent(env, config.repoRoot);
     const context = {
       enrollment,
       // Read once per scan: which bases already have an unflushed queue entry.
@@ -505,7 +515,7 @@ export function createAutoRefillWaterScheduler(options = {}) {
     tick,
     scanNow,
     publicState: () => autoRefillWaterPublicState(config.repoRoot, { env }),
-    thresholdPercent: () => autoRefillWaterThresholdPercent(env),
-    intervalHours: () => autoRefillWaterIntervalHours(env)
+    thresholdPercent: () => autoRefillWaterThresholdPercent(env, config.repoRoot),
+    intervalHours: () => autoRefillWaterIntervalHours(env, config.repoRoot)
   };
 }

--- a/console/api/test/autoRefill.test.js
+++ b/console/api/test/autoRefill.test.js
@@ -5,12 +5,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   autoRefillPublicState,
+  clampAutoRefillNextRun,
   createAutoRefillScheduler,
   isAutoRefillEnabled,
   readAutoRefillState,
   setBaseAutoRefill,
   writeAutoRefillState
 } from "../src/services/autoRefill.js";
+import { saveAutoRefillSettings } from "../src/services/autoRefillSettings.js";
 import { listQueuedBaseDeletes, listQueuedGeneratorRefills, queueGeneratorRefill } from "../src/duneDb.js";
 
 // Must await fn: without it the finally deletes the directory at the callback's
@@ -676,5 +678,86 @@ test("the enrollment file is written atomically with owner-only permissions", as
     // Pretty-printed and newline-terminated, matching the pending refill queue.
     assert.equal(raw.endsWith("}\n"), true);
     assert.equal(JSON.parse(raw).schemaVersion, 1);
+  });
+});
+
+// --- Settings layering and interval re-arm ---
+
+test("a persisted threshold overrides the env var for the scanner itself", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 80 });
+    // 60% is healthy against the env/default 50 but starved against the saved
+    // 80, so this only queues if run() reads the settings file.
+    const clock = makeClock();
+    const duneDb = fakeDuneDb({ levels: { 482: { lowestPercent: 60, deviceCount: 2 } } });
+    const { scheduler } = makeScheduler(repoRoot, duneDb, clock, {});
+    setBaseAutoRefill(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    // The first tick only arms the schedule; a scan needs a primed scheduler.
+    await primeScheduler(scheduler, repoRoot, clock);
+    forceDue(repoRoot, clock);
+    await scheduler.tick();
+
+    assert.equal(listQueuedGeneratorRefills(repoRoot).length, 1, "queued against the saved threshold");
+  });
+});
+
+test("the public state reports the persisted threshold and interval", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 35, intervalHours: 6 });
+    const state = autoRefillPublicState(repoRoot, { env: { ADMIN_AUTO_REFILL_THRESHOLD_PERCENT: "70" } });
+    assert.equal(state.thresholdPercent, 35);
+    assert.equal(state.intervalHours, 6);
+  });
+});
+
+// Without this, shortening the interval looks like it did nothing until the
+// already-armed run fires -- up to a week away at the maximum interval.
+test("shortening the interval pulls an already-armed scan in", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefill(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    const armed = Date.parse(readAutoRefillState(repoRoot).nextRunAt);
+    assert.equal(armed, clock.at() + 24 * HOUR_MS, "armed a default interval out");
+
+    saveAutoRefillSettings(repoRoot, { intervalHours: 2 });
+    const next = clampAutoRefillNextRun(repoRoot, { now: clock.now, env: TEST_ENV });
+    assert.equal(Date.parse(next), clock.at() + 2 * HOUR_MS);
+    assert.equal(Date.parse(readAutoRefillState(repoRoot).nextRunAt), clock.at() + 2 * HOUR_MS, "persisted, not just returned");
+  });
+});
+
+test("lengthening the interval leaves the armed scan where it is", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefill(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    const armed = readAutoRefillState(repoRoot).nextRunAt;
+
+    saveAutoRefillSettings(repoRoot, { intervalHours: 168 });
+    assert.equal(clampAutoRefillNextRun(repoRoot, { now: clock.now, env: TEST_ENV }), armed);
+    assert.equal(readAutoRefillState(repoRoot).nextRunAt, armed, "no write at all");
+  });
+});
+
+test("the re-arm no-ops with nothing enrolled and with no armed run", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const clock = makeClock();
+    // Nothing enrolled: nextRunAt is "" and must stay that way.
+    assert.equal(clampAutoRefillNextRun(repoRoot, { now: clock.now, env: TEST_ENV }), "");
+
+    setBaseAutoRefill(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    setBaseAutoRefill(repoRoot, 482, false, { now: clock.now, env: TEST_ENV });
+    assert.equal(clampAutoRefillNextRun(repoRoot, { now: clock.now, env: TEST_ENV }), "");
+  });
+});
+
+test("a threshold-only save never rewrites the enrollment file", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefill(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    const before = readFileSync(statePath(repoRoot), "utf8");
+
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 40 });
+    clampAutoRefillNextRun(repoRoot, { now: clock.now, env: TEST_ENV });
+    assert.equal(readFileSync(statePath(repoRoot), "utf8"), before);
   });
 });

--- a/console/api/test/autoRefillSettings.test.js
+++ b/console/api/test/autoRefillSettings.test.js
@@ -1,0 +1,256 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+import {
+  AUTO_REFILL_SETTING_SPECS,
+  autoRefillSettingsView,
+  readAutoRefillSettings,
+  resolveAutoRefillSetting,
+  saveAutoRefillSettings
+} from "../src/services/autoRefillSettings.js";
+
+// Empty env so the host's own ADMIN_AUTO_REFILL_* values cannot change results.
+const TEST_ENV = {};
+
+async function withRepo(run) {
+  const repoRoot = mkdtempSync(join(tmpdir(), "dune-auto-refill-settings-"));
+  try {
+    await run(repoRoot);
+  } finally {
+    rmSync(repoRoot, { recursive: true, force: true });
+  }
+}
+
+function settingsPath(repoRoot) {
+  return resolve(repoRoot, "runtime/generated/auto-refill-settings.json");
+}
+
+function writeRaw(repoRoot, contents) {
+  const file = settingsPath(repoRoot);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, typeof contents === "string" ? contents : JSON.stringify(contents));
+}
+
+// --- Reading ---
+
+test("an absent settings file reads as no overrides", async () => {
+  await withRepo((repoRoot) => {
+    assert.deepEqual(readAutoRefillSettings(repoRoot), {});
+    assert.equal(existsSync(settingsPath(repoRoot)), false, "reading must not create the file");
+  });
+});
+
+test("a corrupt settings file degrades to no overrides rather than throwing", async () => {
+  await withRepo((repoRoot) => {
+    writeRaw(repoRoot, "{ not json");
+    assert.deepEqual(readAutoRefillSettings(repoRoot), {});
+    assert.equal(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env: TEST_ENV }), 50);
+  });
+});
+
+test("a hand-edited out-of-range value is dropped, not clamped", async () => {
+  await withRepo((repoRoot) => {
+    writeRaw(repoRoot, { thresholdPercent: 500, intervalHours: 0 });
+    assert.deepEqual(readAutoRefillSettings(repoRoot), {});
+    // Falls through to the env layer rather than pinning to the nearest legal
+    // value -- 500 was not an instruction to use 99.
+    const env = { ADMIN_AUTO_REFILL_THRESHOLD_PERCENT: "70" };
+    assert.equal(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env }), 70);
+  });
+});
+
+// The whole reason "unset" is an absent key: clampInt turns null and "" into 0,
+// which clamps to min, so a persisted blank would silently read as 1% / 1h.
+test("a persisted null or empty string never resolves to the minimum", async () => {
+  await withRepo((repoRoot) => {
+    writeRaw(repoRoot, { thresholdPercent: null, intervalHours: "", waterThresholdPercent: undefined });
+    assert.deepEqual(readAutoRefillSettings(repoRoot), {});
+    assert.equal(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env: TEST_ENV }), 50);
+    assert.notEqual(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env: TEST_ENV }), AUTO_REFILL_SETTING_SPECS.thresholdPercent.min);
+    assert.equal(resolveAutoRefillSetting("intervalHours", { repoRoot, env: TEST_ENV }), 24);
+    assert.notEqual(resolveAutoRefillSetting("intervalHours", { repoRoot, env: TEST_ENV }), AUTO_REFILL_SETTING_SPECS.intervalHours.min);
+  });
+});
+
+test("a non-object settings file reads as no overrides", async () => {
+  await withRepo((repoRoot) => {
+    writeRaw(repoRoot, [1, 2, 3]);
+    assert.deepEqual(readAutoRefillSettings(repoRoot), {});
+    writeRaw(repoRoot, "null");
+    assert.deepEqual(readAutoRefillSettings(repoRoot), {});
+  });
+});
+
+// --- Layering ---
+
+test("the settings file beats the env var, which beats the hardcoded default", async () => {
+  await withRepo((repoRoot) => {
+    const env = { ADMIN_AUTO_REFILL_THRESHOLD_PERCENT: "70" };
+    assert.equal(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env: TEST_ENV }), 50, "default");
+    assert.equal(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env }), 70, "env beats default");
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 40 });
+    assert.equal(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env }), 40, "file beats env");
+  });
+});
+
+test("an out-of-range env var still clamps rather than being dropped", async () => {
+  await withRepo((repoRoot) => {
+    // Only the env layer goes through clampInt -- an operator's bad env value
+    // is a startup-time typo we survive, not a hand edit of console state.
+    assert.equal(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env: { ADMIN_AUTO_REFILL_THRESHOLD_PERCENT: "500" } }), 99);
+    assert.equal(resolveAutoRefillSetting("intervalHours", { repoRoot, env: { ADMIN_AUTO_REFILL_INTERVAL_HOURS: "0" } }), 1);
+  });
+});
+
+test("the four settings resolve independently of each other", async () => {
+  await withRepo((repoRoot) => {
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 30, waterIntervalHours: 6 });
+    assert.equal(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env: TEST_ENV }), 30);
+    assert.equal(resolveAutoRefillSetting("intervalHours", { repoRoot, env: TEST_ENV }), 24, "untouched key keeps its default");
+    assert.equal(resolveAutoRefillSetting("waterThresholdPercent", { repoRoot, env: TEST_ENV }), 50, "generator setting does not leak into water");
+    assert.equal(resolveAutoRefillSetting("waterIntervalHours", { repoRoot, env: TEST_ENV }), 6);
+  });
+});
+
+// --- Saving ---
+
+test("only the keys actually set are persisted", async () => {
+  await withRepo((repoRoot) => {
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 40 });
+    assert.deepEqual(JSON.parse(readFileSync(settingsPath(repoRoot), "utf8")), { thresholdPercent: 40 });
+  });
+});
+
+test("an omitted key leaves the stored value alone", async () => {
+  await withRepo((repoRoot) => {
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 40, intervalHours: 6 });
+    saveAutoRefillSettings(repoRoot, { intervalHours: 12 });
+    assert.deepEqual(readAutoRefillSettings(repoRoot), { thresholdPercent: 40, intervalHours: 12 });
+  });
+});
+
+// Reset has to DELETE the key, not write the default. Writing the default would
+// persist the current env value and permanently shadow the env var, so a later
+// change to ADMIN_AUTO_REFILL_* would silently stop taking effect.
+test("null resets a key by deleting it, restoring the env layer", async () => {
+  await withRepo((repoRoot) => {
+    const env = { ADMIN_AUTO_REFILL_THRESHOLD_PERCENT: "70" };
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 40 });
+    assert.equal(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env }), 40);
+
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: null });
+    assert.deepEqual(JSON.parse(readFileSync(settingsPath(repoRoot), "utf8")), {}, "key removed, not blanked");
+    assert.equal(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env }), 70, "env layer is live again");
+  });
+});
+
+test("resetting one key leaves the others overridden", async () => {
+  await withRepo((repoRoot) => {
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 40, waterThresholdPercent: 30 });
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: null });
+    assert.deepEqual(readAutoRefillSettings(repoRoot), { waterThresholdPercent: 30 });
+  });
+});
+
+test("saving rejects values the scanners could not act on", async () => {
+  await withRepo((repoRoot) => {
+    for (const key of Object.keys(AUTO_REFILL_SETTING_SPECS)) {
+      const spec = AUTO_REFILL_SETTING_SPECS[key];
+      for (const bad of [spec.min - 1, spec.max + 1, 1.5, "40", true, [], {}, NaN]) {
+        assert.throws(
+          () => saveAutoRefillSettings(repoRoot, { [key]: bad }),
+          (error) => error.statusCode === 400,
+          `${key} should reject ${JSON.stringify(bad) ?? String(bad)}`
+        );
+      }
+    }
+    assert.equal(existsSync(settingsPath(repoRoot)), false, "a rejected save must not create the file");
+  });
+});
+
+test("saving rejects a non-object body and an empty patch", async () => {
+  await withRepo((repoRoot) => {
+    for (const bad of [null, undefined, "x", 5, []]) {
+      assert.throws(() => saveAutoRefillSettings(repoRoot, bad), (error) => error.statusCode === 400);
+    }
+    assert.throws(() => saveAutoRefillSettings(repoRoot, {}), (error) => error.statusCode === 400);
+    assert.throws(() => saveAutoRefillSettings(repoRoot, { notASetting: 5 }), (error) => error.statusCode === 400);
+  });
+});
+
+test("a rejected save leaves existing settings untouched", async () => {
+  await withRepo((repoRoot) => {
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 40 });
+    assert.throws(() => saveAutoRefillSettings(repoRoot, { thresholdPercent: 500 }), (error) => error.statusCode === 400);
+    assert.deepEqual(readAutoRefillSettings(repoRoot), { thresholdPercent: 40 });
+  });
+});
+
+test("the boundary values of each range are accepted", async () => {
+  await withRepo((repoRoot) => {
+    for (const [key, spec] of Object.entries(AUTO_REFILL_SETTING_SPECS)) {
+      saveAutoRefillSettings(repoRoot, { [key]: spec.min });
+      assert.equal(resolveAutoRefillSetting(key, { repoRoot, env: TEST_ENV }), spec.min);
+      saveAutoRefillSettings(repoRoot, { [key]: spec.max });
+      assert.equal(resolveAutoRefillSetting(key, { repoRoot, env: TEST_ENV }), spec.max);
+    }
+  });
+});
+
+// --- The GET payload ---
+
+test("the view reports where each value came from", async () => {
+  await withRepo((repoRoot) => {
+    const env = { ADMIN_AUTO_REFILL_INTERVAL_HOURS: "12" };
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 40 });
+    const view = autoRefillSettingsView(repoRoot, env);
+
+    assert.equal(view.settings.thresholdPercent, 40);
+    assert.equal(view.sources.thresholdPercent, "console");
+    assert.equal(view.settings.intervalHours, 12);
+    assert.equal(view.sources.intervalHours, "env");
+    assert.equal(view.settings.waterThresholdPercent, 50);
+    assert.equal(view.sources.waterThresholdPercent, "default");
+  });
+});
+
+// Reset restores the env value where one is set, so the overlay can offer it
+// without knowing the layering. If this returned the hardcoded fallback, Reset
+// on an env-configured host would visibly change the number.
+test("the view's defaults are what Reset restores, not the hardcoded fallback", async () => {
+  await withRepo((repoRoot) => {
+    const view = autoRefillSettingsView(repoRoot, { ADMIN_AUTO_REFILL_INTERVAL_HOURS: "12" });
+    assert.equal(view.defaults.intervalHours, 12);
+    assert.equal(view.defaults.thresholdPercent, 50, "no env var set, so the fallback is the default");
+  });
+});
+
+test("the view carries the limits and env names the overlay needs", async () => {
+  await withRepo((repoRoot) => {
+    const view = autoRefillSettingsView(repoRoot, TEST_ENV);
+    assert.deepEqual(view.limits.thresholdPercent, { min: 1, max: 99 });
+    assert.deepEqual(view.limits.intervalHours, { min: 1, max: 168 });
+    assert.equal(view.envNames.waterIntervalHours, "ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS");
+    assert.deepEqual(Object.keys(view.settings).sort(), Object.keys(AUTO_REFILL_SETTING_SPECS).sort());
+  });
+});
+
+// A blank env var is how .env carries a declared-but-unset optional. Before
+// this was fixed it read as 0 and clamped to the MINIMUM, so a blank
+// ADMIN_AUTO_REFILL_INTERVAL_HOURS meant hourly scans instead of daily.
+test("a blank env var reads as unset rather than clamping to the minimum", async () => {
+  await withRepo((repoRoot) => {
+    for (const blank of ["", "   "]) {
+      const env = { ADMIN_AUTO_REFILL_INTERVAL_HOURS: blank, ADMIN_AUTO_REFILL_THRESHOLD_PERCENT: blank };
+      assert.equal(resolveAutoRefillSetting("intervalHours", { repoRoot, env }), 24);
+      assert.equal(resolveAutoRefillSetting("thresholdPercent", { repoRoot, env }), 50);
+      const view = autoRefillSettingsView(repoRoot, env);
+      assert.equal(view.sources.intervalHours, "default");
+      assert.equal(view.settings.intervalHours, 24);
+      assert.equal(view.defaults.intervalHours, 24, "Reset must not restore the clamped minimum");
+    }
+  });
+});

--- a/console/api/test/autoRefillWater.test.js
+++ b/console/api/test/autoRefillWater.test.js
@@ -9,8 +9,11 @@ import {
   isAutoRefillWaterEnabled,
   readAutoRefillWaterState,
   setBaseAutoRefillWater,
+  clampAutoRefillWaterNextRun,
   writeAutoRefillWaterState
 } from "../src/services/autoRefillWater.js";
+import { readAutoRefillState, setBaseAutoRefill } from "../src/services/autoRefill.js";
+import { saveAutoRefillSettings } from "../src/services/autoRefillSettings.js";
 import { listQueuedBaseDeletes, listQueuedWaterRefills, queueWaterRefill } from "../src/duneDb.js";
 
 // Mirrors autoRefill.test.js exactly, retargeted at the water auto-refill
@@ -469,5 +472,101 @@ test("the water auto-refill enrollment file is written atomically with owner-onl
     const raw = readFileSync(statePath(repoRoot), "utf8");
     assert.equal(raw.endsWith("}\n"), true);
     assert.equal(JSON.parse(raw).schemaVersion, 1);
+  });
+});
+
+// --- Settings layering and interval re-arm ---
+// Mirrors the generator twin in autoRefill.test.js. Kept as a full parallel set
+// rather than a shared helper so a change to one subsystem's layering cannot
+// quietly pass because the other's still works.
+
+test("a persisted water threshold overrides the env var for the scanner itself", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    saveAutoRefillSettings(repoRoot, { waterThresholdPercent: 80 });
+    const clock = makeClock();
+    const duneDb = fakeDuneDb({ levels: { 482: { lowestPercent: 60, deviceCount: 2 } } });
+    const { scheduler } = makeScheduler(repoRoot, duneDb, clock, {});
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    // The first tick only arms the schedule; a scan needs a primed scheduler.
+    await primeScheduler(scheduler, repoRoot, clock);
+    forceDue(repoRoot, clock);
+    await scheduler.tick();
+
+    assert.equal(listQueuedWaterRefills(repoRoot).length, 1, "queued against the saved threshold");
+  });
+});
+
+// The generator setting must not drive the water scanner, or the two
+// "independent subsystems" claim in the UI is false.
+test("the generator threshold does not affect the water scanner", async () => {
+  await withTempRepoRoot(async (repoRoot) => {
+    saveAutoRefillSettings(repoRoot, { thresholdPercent: 80 });
+    const clock = makeClock();
+    const duneDb = fakeDuneDb({ levels: { 482: { lowestPercent: 60, deviceCount: 2 } } });
+    const { scheduler } = makeScheduler(repoRoot, duneDb, clock, {});
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    // The first tick only arms the schedule; a scan needs a primed scheduler.
+    await primeScheduler(scheduler, repoRoot, clock);
+    forceDue(repoRoot, clock);
+    await scheduler.tick();
+
+    assert.equal(listQueuedWaterRefills(repoRoot).length, 0, "60% is healthy against water's own 50% default");
+  });
+});
+
+test("the water public state reports the persisted threshold and interval", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    saveAutoRefillSettings(repoRoot, { waterThresholdPercent: 35, waterIntervalHours: 6 });
+    const state = autoRefillWaterPublicState(repoRoot, { env: { ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT: "70" } });
+    assert.equal(state.thresholdPercent, 35);
+    assert.equal(state.intervalHours, 6);
+  });
+});
+
+test("shortening the water interval pulls an already-armed scan in", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    assert.equal(Date.parse(readAutoRefillWaterState(repoRoot).nextRunAt), clock.at() + 24 * HOUR_MS);
+
+    saveAutoRefillSettings(repoRoot, { waterIntervalHours: 2 });
+    const next = clampAutoRefillWaterNextRun(repoRoot, { now: clock.now, env: TEST_ENV });
+    assert.equal(Date.parse(next), clock.at() + 2 * HOUR_MS);
+    assert.equal(Date.parse(readAutoRefillWaterState(repoRoot).nextRunAt), clock.at() + 2 * HOUR_MS, "persisted, not just returned");
+  });
+});
+
+test("lengthening the water interval leaves the armed scan where it is", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    const armed = readAutoRefillWaterState(repoRoot).nextRunAt;
+
+    saveAutoRefillSettings(repoRoot, { waterIntervalHours: 168 });
+    assert.equal(clampAutoRefillWaterNextRun(repoRoot, { now: clock.now, env: TEST_ENV }), armed);
+    assert.equal(readAutoRefillWaterState(repoRoot).nextRunAt, armed, "no write at all");
+  });
+});
+
+test("the water re-arm no-ops with nothing enrolled", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const clock = makeClock();
+    assert.equal(clampAutoRefillWaterNextRun(repoRoot, { now: clock.now, env: TEST_ENV }), "");
+  });
+});
+
+// The two subsystems keep separate enrollment files; re-arming one must not
+// touch the other's armed run.
+test("re-arming water leaves the generator enrollment untouched", async () => {
+  await withTempRepoRoot((repoRoot) => {
+    const clock = makeClock();
+    setBaseAutoRefill(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    setBaseAutoRefillWater(repoRoot, 482, true, { now: clock.now, env: TEST_ENV });
+    const generatorArmed = readAutoRefillState(repoRoot).nextRunAt;
+
+    saveAutoRefillSettings(repoRoot, { waterIntervalHours: 1 });
+    clampAutoRefillWaterNextRun(repoRoot, { now: clock.now, env: TEST_ENV });
+
+    assert.equal(readAutoRefillState(repoRoot).nextRunAt, generatorArmed);
   });
 });

--- a/console/api/test/policy.test.js
+++ b/console/api/test/policy.test.js
@@ -121,6 +121,34 @@ test("the container item delete route resolves to bases:delete-item without shad
   assert.equal(actionForRoute("/api/bases/5/containers/9", "GET"), "bases:read");
 });
 
+// Same argument as the container routes above: rbacParity only proves an
+// action exists, not that it is the right one. Without the explicit
+// ROUTE_ACTIONS entry this POST falls through the "POST /api/bases/" prefix
+// rule to bases:mutate, which would silently let every per-base-refill grant
+// retune the global automation policy.
+test("the auto-refill settings routes resolve to their own actions without shadowing their neighbours", () => {
+  assert.equal(actionForRoute("/api/bases/auto-refill/settings", "POST"), "bases:write-config");
+  assert.equal(actionForRoute("/api/bases/auto-refill/settings", "GET"), "bases:read");
+  // The per-base enrollment toggle keeps the shared mutate bucket, and the
+  // enrollment read keeps bases:read -- the new paths sit beside them.
+  assert.equal(actionForRoute("/api/bases/5/auto-refill", "POST"), "bases:mutate");
+  assert.equal(actionForRoute("/api/bases/5/auto-refill-water", "POST"), "bases:mutate");
+  assert.equal(actionForRoute("/api/bases/auto-refill", "GET"), "bases:read");
+  assert.equal(actionForRoute("/api/bases/auto-refill-water", "GET"), "bases:read");
+});
+
+test("bases:write-config is not carried by a bases:mutate grant", () => {
+  const policies = {
+    moderator: { version: 1, tier: "moderator", statements: [{ Effect: "Allow", Action: ["bases:read", "bases:mutate"] }] }
+  };
+  // A hand-authored policy that predates the settings surface must not gain it.
+  assert.equal(evaluate({ tier: "moderator" }, "bases:mutate", policies), true);
+  assert.equal(evaluate({ tier: "moderator" }, "bases:write-config", policies), false);
+  // The shipped tiers grant bases:*, so default access is unchanged.
+  assert.equal(evaluate({ tier: "admin" }, "bases:write-config"), true);
+  assert.equal(evaluate({ tier: "owner" }, "bases:write-config"), true);
+});
+
 test("vehicle permission routes resolve to their own read/mutate actions", () => {
   assert.equal(actionForRoute("/api/vehicles/5/permissions", "GET"), "vehicles:read");
   assert.equal(actionForRoute("/api/vehicles/5/permissions", "PUT"), "vehicles:mutate");

--- a/console/web/src/api/bases.ts
+++ b/console/web/src/api/bases.ts
@@ -63,6 +63,31 @@ export type AutoRefillState = {
   bases: AutoRefillBase[];
 };
 
+// The four tunables shared by both auto-refill scanners. Layered console file
+// > env var > hardcoded default, which is why the payload carries more than
+// the values: `sources` says which layer won, and `defaults` is what Reset
+// restores (the env value where one is set, not the hardcoded fallback).
+export type AutoRefillSettingKey =
+  | "thresholdPercent"
+  | "intervalHours"
+  | "waterThresholdPercent"
+  | "waterIntervalHours";
+
+export type AutoRefillSettingSource = "console" | "env" | "default";
+
+export type AutoRefillSettings = {
+  settings: Record<AutoRefillSettingKey, number>;
+  sources: Record<AutoRefillSettingKey, AutoRefillSettingSource>;
+  defaults: Record<AutoRefillSettingKey, number>;
+  limits: Record<AutoRefillSettingKey, { min: number; max: number }>;
+  envNames: Record<AutoRefillSettingKey, string>;
+};
+
+// null resets a key to the env/default layer; an omitted key is left alone.
+// Sending the number instead of null on a reset would persist the current env
+// value and permanently shadow the env var.
+export type AutoRefillSettingsPatch = Partial<Record<AutoRefillSettingKey, number | null>>;
+
 // Water refill has no fuelName/capped/skipped concepts: it's a plain
 // jsonb_set straight to capacity, not a stack of discrete inventory items.
 export type RefillWaterDeviceResult = {
@@ -497,6 +522,10 @@ export const basesApi = {
   setAutoRefill: (baseId: string, enabled: boolean) =>
     post<{ ok: boolean; baseId: number; enabled: boolean; total: number }>(
       `/api/bases/${encodeURIComponent(baseId)}/auto-refill`, { enabled }),
+  autoRefillSettings: () => api<AutoRefillSettings>("/api/bases/auto-refill/settings"),
+  saveAutoRefillSettings: (patch: AutoRefillSettingsPatch) =>
+    post<AutoRefillSettings & { ok: boolean; nextRunAt: string; waterNextRunAt: string }>(
+      "/api/bases/auto-refill/settings", patch),
   permissions: (baseId: string) =>
     api<BasePermissions>(`/api/bases/${encodeURIComponent(baseId)}/permissions`),
   landClaim: (baseId: string) =>

--- a/console/web/src/features/bases/AutoRefillSettingsOverlay.test.tsx
+++ b/console/web/src/features/bases/AutoRefillSettingsOverlay.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { useState } from "react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { StrictMode, useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AutoRefillSettingsOverlay } from "./AutoRefillSettingsOverlay";
 import { basesApi } from "../../api/bases";
@@ -151,6 +151,44 @@ describe("AutoRefillSettingsOverlay", () => {
     }) as never);
     renderOverlay();
     await waitFor(() => expect(screen.getByText(/ADMIN_AUTO_REFILL_INTERVAL_HOURS \(12\)/)).toBeInTheDocument());
+  });
+
+  // The app mounts under StrictMode, which runs effects mount -> cleanup ->
+  // mount. A mounted-ref that is only cleared on unmount stays false after the
+  // remount, so the load never clears `loading` and the dialog sits on
+  // "Loading..." forever -- which is exactly what it did in the dev server
+  // while every non-StrictMode test passed.
+  it("finishes loading when mounted under StrictMode", async () => {
+    render(<StrictMode><AutoRefillSettingsOverlay onClose={() => {}} onSaved={() => {}} onError={() => {}} /></StrictMode>);
+    await waitFor(() => expect(screen.getAllByRole("spinbutton")).toHaveLength(4));
+    expect(screen.queryByText("Loading…")).not.toBeInTheDocument();
+  });
+
+  // onError alone is not enough: the panel's banner sits behind this dialog's
+  // scrim, so an operator with the overlay open would see nothing at all.
+  it("shows a save failure inside the dialog, not only via onError", async () => {
+    vi.mocked(basesApi.saveAutoRefillSettings).mockRejectedValue(new Error("Too many requests."));
+    renderOverlay();
+    await waitFor(() => expect(fields()).toHaveLength(4));
+    fireEvent.change(generatorThreshold(), { target: { value: "40" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    const dialog = await screen.findByRole("dialog");
+    await waitFor(() => expect(within(dialog).getByText("Too many requests.")).toBeInTheDocument());
+  });
+
+  it("shows a load failure in the dialog with a way to retry", async () => {
+    vi.mocked(basesApi.autoRefillSettings).mockRejectedValueOnce(new Error("Settings could not be read."));
+    renderOverlay();
+
+    const dialog = await screen.findByRole("dialog");
+    await waitFor(() => expect(within(dialog).getByText("Settings could not be read.")).toBeInTheDocument());
+    // Without the retry branch this dialog is a title and nothing else.
+    const retry = within(dialog).getByText("Try again");
+
+    fireEvent.click(retry);
+    await waitFor(() => expect(fields()).toHaveLength(4));
+    expect(within(dialog).queryByText("Settings could not be read.")).not.toBeInTheDocument();
   });
 
   // The settings POST is rate limited where the per-base toggles are not, so a

--- a/console/web/src/features/bases/AutoRefillSettingsOverlay.test.tsx
+++ b/console/web/src/features/bases/AutoRefillSettingsOverlay.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AutoRefillSettingsOverlay } from "./AutoRefillSettingsOverlay";
 import { basesApi } from "../../api/bases";
@@ -179,6 +180,29 @@ describe("AutoRefillSettingsOverlay", () => {
     expect(props.onClose).toHaveBeenCalledTimes(1);
     fireEvent.click(screen.getByLabelText("Close"));
     expect(props.onClose).toHaveBeenCalledTimes(2);
+  });
+
+  // BasesPanel passes onClose as a new inline arrow every render and re-renders
+  // every 10s (usePendingRefills polls on that cadence), so an effect keyed on
+  // onClose re-runs and steals focus out of whatever field is being typed in.
+  it("keeps focus in the field when the parent re-renders", async () => {
+    function Harness() {
+      const [tick, setTick] = useState(0);
+      return (
+        <>
+          <button onClick={() => setTick(tick + 1)}>re-render parent</button>
+          <AutoRefillSettingsOverlay onClose={() => {}} onSaved={() => {}} onError={() => {}} />
+        </>
+      );
+    }
+    render(<Harness />);
+    await waitFor(() => expect(fields()).toHaveLength(4));
+
+    generatorThreshold().focus();
+    expect(document.activeElement).toBe(generatorThreshold());
+
+    fireEvent.click(screen.getByText("re-render parent"));
+    expect(document.activeElement).toBe(generatorThreshold());
   });
 
   it("warns that the two intervals behave differently in each direction", async () => {

--- a/console/web/src/features/bases/AutoRefillSettingsOverlay.test.tsx
+++ b/console/web/src/features/bases/AutoRefillSettingsOverlay.test.tsx
@@ -1,0 +1,200 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AutoRefillSettingsOverlay } from "./AutoRefillSettingsOverlay";
+import { basesApi } from "../../api/bases";
+
+vi.mock("../../api/bases", () => ({
+  basesApi: { autoRefillSettings: vi.fn(), saveAutoRefillSettings: vi.fn() }
+}));
+
+function settingsState(overrides: Record<string, unknown> = {}) {
+  return {
+    settings: { thresholdPercent: 50, intervalHours: 24, waterThresholdPercent: 50, waterIntervalHours: 24 },
+    sources: { thresholdPercent: "default", intervalHours: "default", waterThresholdPercent: "default", waterIntervalHours: "default" },
+    defaults: { thresholdPercent: 50, intervalHours: 24, waterThresholdPercent: 50, waterIntervalHours: 24 },
+    limits: {
+      thresholdPercent: { min: 1, max: 99 },
+      intervalHours: { min: 1, max: 168 },
+      waterThresholdPercent: { min: 1, max: 99 },
+      waterIntervalHours: { min: 1, max: 168 }
+    },
+    envNames: {
+      thresholdPercent: "ADMIN_AUTO_REFILL_THRESHOLD_PERCENT",
+      intervalHours: "ADMIN_AUTO_REFILL_INTERVAL_HOURS",
+      waterThresholdPercent: "ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT",
+      waterIntervalHours: "ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS"
+    },
+    ...overrides
+  };
+}
+
+function renderOverlay() {
+  const props = { onClose: vi.fn(), onSaved: vi.fn(), onError: vi.fn() };
+  render(<AutoRefillSettingsOverlay {...props} />);
+  return props;
+}
+
+// The visible label is identical on both sides, so queries go through the
+// subsystem-qualified accessible name.
+const generatorThreshold = () => screen.getByLabelText("Generators: Queue a refill below (%)");
+const generatorInterval = () => screen.getByLabelText("Generators: Check every (h)");
+const waterThreshold = () => screen.getByLabelText("Water: Queue a refill below (%)");
+const resetGeneratorThreshold = () => screen.getByLabelText("Reset generators queue a refill below");
+const fields = () => screen.getAllByRole("spinbutton");
+
+describe("AutoRefillSettingsOverlay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(basesApi.autoRefillSettings).mockResolvedValue(settingsState() as never);
+    vi.mocked(basesApi.saveAutoRefillSettings).mockResolvedValue({ ok: true, ...settingsState() } as never);
+  });
+
+  it("loads both subsystems' current values", async () => {
+    renderOverlay();
+    await waitFor(() => expect(fields()).toHaveLength(4));
+    expect(screen.getByText("Generators")).toBeInTheDocument();
+    expect(screen.getByText("Water")).toBeInTheDocument();
+    expect(fields().map((input) => (input as HTMLInputElement).value)).toEqual(["50", "24", "50", "24"]);
+  });
+
+  it("sends only edited fields as numbers and leaves the rest reset", async () => {
+    const props = renderOverlay();
+    await waitFor(() => expect(fields()).toHaveLength(4));
+    fireEvent.change(generatorThreshold(), { target: { value: "40" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(vi.mocked(basesApi.saveAutoRefillSettings)).toHaveBeenCalledWith({
+      thresholdPercent: 40,
+      intervalHours: null,
+      waterThresholdPercent: null,
+      waterIntervalHours: null
+    }));
+    expect(props.onSaved).toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  // The single easiest thing to get wrong. Sending the number here would
+  // persist the env value and permanently shadow the env var, so a later change
+  // to ADMIN_AUTO_REFILL_* would silently stop taking effect.
+  it("sends null, not the number, when a field is reset", async () => {
+    vi.mocked(basesApi.autoRefillSettings).mockResolvedValue(settingsState({
+      settings: { thresholdPercent: 40, intervalHours: 24, waterThresholdPercent: 50, waterIntervalHours: 24 },
+      sources: { thresholdPercent: "console", intervalHours: "default", waterThresholdPercent: "default", waterIntervalHours: "default" }
+    }) as never);
+    renderOverlay();
+    await waitFor(() => expect(generatorThreshold()).toHaveValue(40));
+
+    fireEvent.click(resetGeneratorThreshold());
+    expect(generatorThreshold()).toHaveValue(50);
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(vi.mocked(basesApi.saveAutoRefillSettings)).toHaveBeenCalledWith(
+      expect.objectContaining({ thresholdPercent: null })
+    ));
+  });
+
+  it("keeps a console-set value as a number when another field is reset", async () => {
+    vi.mocked(basesApi.autoRefillSettings).mockResolvedValue(settingsState({
+      settings: { thresholdPercent: 40, intervalHours: 6, waterThresholdPercent: 50, waterIntervalHours: 24 },
+      sources: { thresholdPercent: "console", intervalHours: "console", waterThresholdPercent: "default", waterIntervalHours: "default" }
+    }) as never);
+    renderOverlay();
+    await waitFor(() => expect(generatorThreshold()).toHaveValue(40));
+
+    fireEvent.click(resetGeneratorThreshold());
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(vi.mocked(basesApi.saveAutoRefillSettings)).toHaveBeenCalledWith(
+      expect.objectContaining({ thresholdPercent: null, intervalHours: 6 })
+    ));
+  });
+
+  it("Reset is disabled for a field that is not overridden", async () => {
+    renderOverlay();
+    await waitFor(() => expect(fields()).toHaveLength(4));
+    expect(resetGeneratorThreshold()).toBeDisabled();
+    fireEvent.change(generatorThreshold(), { target: { value: "40" } });
+    expect(resetGeneratorThreshold()).toBeEnabled();
+  });
+
+  it("blocks saving an out-of-range or non-numeric value", async () => {
+    renderOverlay();
+    await waitFor(() => expect(fields()).toHaveLength(4));
+
+    for (const bad of ["0", "100", ""]) {
+      fireEvent.change(generatorThreshold(), { target: { value: bad } });
+      expect(screen.getByText("Must be a whole number, 1-99.")).toBeInTheDocument();
+      expect(screen.getByText("Save")).toBeDisabled();
+    }
+
+    fireEvent.change(generatorThreshold(), { target: { value: "40" } });
+    expect(screen.queryByText("Must be a whole number, 1-99.")).not.toBeInTheDocument();
+    expect(screen.getByText("Save")).toBeEnabled();
+    expect(vi.mocked(basesApi.saveAutoRefillSettings)).not.toHaveBeenCalled();
+  });
+
+  it("uses each field's own range", async () => {
+    renderOverlay();
+    await waitFor(() => expect(fields()).toHaveLength(4));
+    // 100 is out of range for a percentage but fine for an interval.
+    fireEvent.change(generatorInterval(), { target: { value: "100" } });
+    expect(screen.queryByText(/Must be a whole number, 1-168\./)).not.toBeInTheDocument();
+    expect(screen.getByText("Save")).toBeEnabled();
+  });
+
+  it("names the env var when a value comes from the environment", async () => {
+    vi.mocked(basesApi.autoRefillSettings).mockResolvedValue(settingsState({
+      settings: { thresholdPercent: 50, intervalHours: 12, waterThresholdPercent: 50, waterIntervalHours: 24 },
+      sources: { thresholdPercent: "default", intervalHours: "env", waterThresholdPercent: "default", waterIntervalHours: "default" },
+      defaults: { thresholdPercent: 50, intervalHours: 12, waterThresholdPercent: 50, waterIntervalHours: 24 }
+    }) as never);
+    renderOverlay();
+    await waitFor(() => expect(screen.getByText(/ADMIN_AUTO_REFILL_INTERVAL_HOURS \(12\)/)).toBeInTheDocument());
+  });
+
+  // The settings POST is rate limited where the per-base toggles are not, so a
+  // rapid second save can 429. It has to surface, not leave the dialog sitting.
+  it("surfaces a save failure and keeps the overlay open", async () => {
+    vi.mocked(basesApi.saveAutoRefillSettings).mockRejectedValue(new Error("Too many requests."));
+    const props = renderOverlay();
+    await waitFor(() => expect(fields()).toHaveLength(4));
+    fireEvent.change(generatorThreshold(), { target: { value: "40" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    await waitFor(() => expect(props.onError).toHaveBeenCalledWith("Too many requests."));
+    expect(props.onClose).not.toHaveBeenCalled();
+    expect(props.onSaved).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a load failure", async () => {
+    vi.mocked(basesApi.autoRefillSettings).mockRejectedValue(new Error("Settings could not be read."));
+    const props = renderOverlay();
+    await waitFor(() => expect(props.onError).toHaveBeenCalledWith("Settings could not be read."));
+  });
+
+  it("closes on Escape and on the close button", async () => {
+    const props = renderOverlay();
+    await waitFor(() => expect(fields()).toHaveLength(4));
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByLabelText("Close"));
+    expect(props.onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("warns that the two intervals behave differently in each direction", async () => {
+    renderOverlay();
+    await waitFor(() => expect(fields()).toHaveLength(4));
+    expect(screen.getByText(/A shorter interval pulls the next scan in/)).toBeInTheDocument();
+  });
+
+  // The generator and water fields carry the same visible label; without a
+  // qualified accessible name a screen-reader user cannot tell which is which.
+  it("gives the two subsystems' identical labels distinct accessible names", async () => {
+    renderOverlay();
+    await waitFor(() => expect(fields()).toHaveLength(4));
+    expect(generatorThreshold()).not.toBe(waterThreshold());
+    fireEvent.change(waterThreshold(), { target: { value: "30" } });
+    expect(generatorThreshold()).toHaveValue(50);
+    expect(waterThreshold()).toHaveValue(30);
+  });
+});

--- a/console/web/src/features/bases/AutoRefillSettingsOverlay.tsx
+++ b/console/web/src/features/bases/AutoRefillSettingsOverlay.tsx
@@ -41,25 +41,44 @@ export function AutoRefillSettingsOverlay({ onClose, onSaved, onError }: AutoRef
   const [overridden, setOverridden] = useState<Record<string, boolean>>({});
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  // Reported inside the modal, not only through onError: the panel's error
+  // banner is a static div in the page behind this dialog's z-index:1000 scrim,
+  // so an operator with the overlay open cannot see it. onError is still called
+  // so the banner carries the message once the dialog is closed.
+  const [requestError, setRequestError] = useState("");
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-
+  // Set on mount as well as cleared on unmount: StrictMode runs effects
+  // mount -> cleanup -> mount, so a cleanup-only ref stays false after the
+  // remount and every later load() bails out of its finally, leaving the
+  // dialog stuck on "Loading...".
+  const mountedRef = useRef(true);
   useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const loaded = await basesApi.autoRefillSettings();
-        if (cancelled) return;
-        setState(loaded);
-        setDrafts(Object.fromEntries(ALL_KEYS.map((key) => [key, String(loaded.settings[key])])));
-        setOverridden(Object.fromEntries(ALL_KEYS.map((key) => [key, loaded.sources[key] === "console"])));
-      } catch (error) {
-        if (!cancelled) onError(errorText(error));
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [onError]);
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setRequestError("");
+    try {
+      const loaded = await basesApi.autoRefillSettings();
+      if (!mountedRef.current) return;
+      setState(loaded);
+      setDrafts(Object.fromEntries(ALL_KEYS.map((key) => [key, String(loaded.settings[key])])));
+      setOverridden(Object.fromEntries(ALL_KEYS.map((key) => [key, loaded.sources[key] === "console"])));
+    } catch (error) {
+      if (!mountedRef.current) return;
+      setRequestError(errorText(error));
+      onErrorRef.current(errorText(error));
+    } finally {
+      if (mountedRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
 
   // Held in a ref so this effect can run once. BasesPanel passes onClose as a
   // new inline arrow every render and re-renders every 10s (usePendingRefills
@@ -102,6 +121,7 @@ export function AutoRefillSettingsOverlay({ onClose, onSaved, onError }: AutoRef
   const save = async () => {
     if (!state || !canSave) return;
     setSaving(true);
+    setRequestError("");
     onError("");
     try {
       const patch: AutoRefillSettingsPatch = {};
@@ -112,6 +132,7 @@ export function AutoRefillSettingsOverlay({ onClose, onSaved, onError }: AutoRef
     } catch (error) {
       // Only on failure: the success path has already unmounted via onClose().
       setSaving(false);
+      setRequestError(errorText(error));
       onError(errorText(error));
     }
   };
@@ -174,6 +195,18 @@ export function AutoRefillSettingsOverlay({ onClose, onSaved, onError }: AutoRef
           Applies to every enrolled base. Stored in the console only — no game data is changed,
           and the change applies without a restart.
         </p>
+
+
+        {requestError && <p className="danger-note" role="alert">{requestError}</p>}
+
+        {/* A failed load leaves `state` null; without this branch the dialog
+            renders a title and nothing else, which reads as broken rather than
+            as failed. */}
+        {!loading && !state && (
+          <div className="auto-refill-settings-group">
+            <button onClick={() => void load()}>Try again</button>
+          </div>
+        )}
 
         {loading ? <p className="muted">Loading…</p> : state && (
           <>

--- a/console/web/src/features/bases/AutoRefillSettingsOverlay.tsx
+++ b/console/web/src/features/bases/AutoRefillSettingsOverlay.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+import { basesApi } from "../../api/bases";
+import type { AutoRefillSettingKey, AutoRefillSettings, AutoRefillSettingsPatch } from "../../api/bases";
+
+function errorText(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+// Tuning for both auto-refill scanners. Fetches its own state rather than
+// taking it from BasesPanel: it needs the sources/defaults/limits/envNames the
+// panel never loads, and it opens rarely enough for one request on open.
+type AutoRefillSettingsOverlayProps = {
+  onClose: () => void;
+  onSaved: () => void;
+  onError: (text: string) => void;
+};
+
+// `group` exists so the accessible name distinguishes the two subsystems --
+// the visible label is identical on both sides.
+type FieldSpec = { key: AutoRefillSettingKey; label: string; unit: string; group: string };
+
+const GENERATOR_FIELDS: FieldSpec[] = [
+  { key: "thresholdPercent", label: "Queue a refill below", unit: "%", group: "Generators" },
+  { key: "intervalHours", label: "Check every", unit: "h", group: "Generators" }
+];
+
+const WATER_FIELDS: FieldSpec[] = [
+  { key: "waterThresholdPercent", label: "Queue a refill below", unit: "%", group: "Water" },
+  { key: "waterIntervalHours", label: "Check every", unit: "h", group: "Water" }
+];
+
+const ALL_KEYS: AutoRefillSettingKey[] = [...GENERATOR_FIELDS, ...WATER_FIELDS].map((field) => field.key);
+
+export function AutoRefillSettingsOverlay({ onClose, onSaved, onError }: AutoRefillSettingsOverlayProps) {
+  const [state, setState] = useState<AutoRefillSettings | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
+  // Which fields the operator has actually set. Reset clears the flag so Save
+  // sends null (delete the override); sending the number would persist the env
+  // value and permanently shadow the env var.
+  const [overridden, setOverridden] = useState<Record<string, boolean>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const loaded = await basesApi.autoRefillSettings();
+        if (cancelled) return;
+        setState(loaded);
+        setDrafts(Object.fromEntries(ALL_KEYS.map((key) => [key, String(loaded.settings[key])])));
+        setOverridden(Object.fromEntries(ALL_KEYS.map((key) => [key, loaded.sources[key] === "console"])));
+      } catch (error) {
+        if (!cancelled) onError(errorText(error));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [onError]);
+
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+    const onKeyDown = (event: KeyboardEvent) => { if (event.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const errorFor = useCallback((key: AutoRefillSettingKey): string => {
+    if (!state) return "";
+    const limits = state.limits[key];
+    const draft = drafts[key] ?? "";
+    const value = Number(draft);
+    if (draft.trim() === "" || !Number.isInteger(value) || value < limits.min || value > limits.max) {
+      return `Must be a whole number, ${limits.min}-${limits.max}.`;
+    }
+    return "";
+  }, [state, drafts]);
+
+  const canSave = Boolean(state) && !saving && !loading && ALL_KEYS.every((key) => !errorFor(key));
+
+  const setDraft = (key: AutoRefillSettingKey, value: string) => {
+    setDrafts((previous) => ({ ...previous, [key]: value }));
+    setOverridden((previous) => ({ ...previous, [key]: true }));
+  };
+
+  const reset = (key: AutoRefillSettingKey) => {
+    if (!state) return;
+    setDrafts((previous) => ({ ...previous, [key]: String(state.defaults[key]) }));
+    setOverridden((previous) => ({ ...previous, [key]: false }));
+  };
+
+  const save = async () => {
+    if (!state || !canSave) return;
+    setSaving(true);
+    onError("");
+    try {
+      const patch: AutoRefillSettingsPatch = {};
+      for (const key of ALL_KEYS) patch[key] = overridden[key] ? Number(drafts[key]) : null;
+      await basesApi.saveAutoRefillSettings(patch);
+      onSaved();
+      onClose();
+    } catch (error) {
+      onError(errorText(error));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const renderField = (field: FieldSpec) => {
+    if (!state) return null;
+    const limits = state.limits[field.key];
+    const error = errorFor(field.key);
+    const isOverridden = Boolean(overridden[field.key]);
+    const showEnvHint = !isOverridden && state.sources[field.key] === "env";
+    return (
+      <div className="auto-refill-settings-field-row" key={field.key}>
+        <label className="auto-refill-settings-field">
+          <span>{field.label}</span>
+          <input
+            type="number"
+            min={limits.min}
+            max={limits.max}
+            step={1}
+            aria-label={`${field.group}: ${field.label} (${field.unit})`}
+            value={drafts[field.key] ?? ""}
+            onChange={(event) => setDraft(field.key, event.target.value)}
+          />
+          <span className="auto-refill-settings-unit">{field.unit}</span>
+        </label>
+        <button
+          type="button"
+          className="auto-refill-settings-reset"
+          aria-label={`Reset ${field.group.toLowerCase()} ${field.label.toLowerCase()}`}
+          disabled={!isOverridden}
+          onClick={() => reset(field.key)}
+        >Reset</button>
+        {error && <p className="danger-note" role="alert">{error}</p>}
+        {showEnvHint && (
+          <p className="muted auto-refill-settings-hint">
+            Set by {state.envNames[field.key]} ({state.defaults[field.key]}). Saving here overrides it.
+          </p>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="modal-overlay" role="presentation" onMouseDown={onClose}>
+      <section
+        className="confirm-modal auto-refill-settings-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="auto-refill-settings-title"
+        onMouseDown={(event) => event.stopPropagation()}
+      >
+        <div className="confirm-modal-title">
+          <h3 id="auto-refill-settings-title">Auto-refill settings</h3>
+          <button ref={closeButtonRef} className="icon-action" aria-label="Close" onClick={onClose}><X size={16} /></button>
+        </div>
+
+        <p className="muted">
+          Applies to every enrolled base. Stored in the console only — no game data is changed,
+          and the change applies without a restart.
+        </p>
+
+        {loading ? <p className="muted">Loading…</p> : state && (
+          <>
+            <div className="auto-refill-settings-group">
+              <span className="auto-refill-settings-group-title">Generators</span>
+              {GENERATOR_FIELDS.map(renderField)}
+            </div>
+            <div className="auto-refill-settings-group auto-refill-settings-group-divided">
+              <span className="auto-refill-settings-group-title">Water</span>
+              {WATER_FIELDS.map(renderField)}
+            </div>
+            <p className="muted auto-refill-settings-note">
+              A shorter interval pulls the next scan in. A longer one applies after the next scan.
+              A changed threshold is used by the next scan, not immediately.
+            </p>
+          </>
+        )}
+
+        <div className="confirm-modal-actions">
+          <button onClick={onClose} disabled={saving}>Cancel</button>
+          <button className="primary" onClick={() => void save()} disabled={!canSave}>
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/console/web/src/features/bases/AutoRefillSettingsOverlay.tsx
+++ b/console/web/src/features/bases/AutoRefillSettingsOverlay.tsx
@@ -61,12 +61,19 @@ export function AutoRefillSettingsOverlay({ onClose, onSaved, onError }: AutoRef
     return () => { cancelled = true; };
   }, [onError]);
 
+  // Held in a ref so this effect can run once. BasesPanel passes onClose as a
+  // new inline arrow every render and re-renders every 10s (usePendingRefills
+  // polls on that cadence), so keying the effect on onClose would re-focus the
+  // close button roughly mid-sentence while an operator is typing in a field.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
     closeButtonRef.current?.focus();
-    const onKeyDown = (event: KeyboardEvent) => { if (event.key === "Escape") onClose(); };
+    const onKeyDown = (event: KeyboardEvent) => { if (event.key === "Escape") onCloseRef.current(); };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onClose]);
+  }, []);
 
   const errorFor = useCallback((key: AutoRefillSettingKey): string => {
     if (!state) return "";
@@ -103,9 +110,9 @@ export function AutoRefillSettingsOverlay({ onClose, onSaved, onError }: AutoRef
       onSaved();
       onClose();
     } catch (error) {
-      onError(errorText(error));
-    } finally {
+      // Only on failure: the success path has already unmounted via onClose().
       setSaving(false);
+      onError(errorText(error));
     }
   };
 
@@ -125,6 +132,8 @@ export function AutoRefillSettingsOverlay({ onClose, onSaved, onError }: AutoRef
             max={limits.max}
             step={1}
             aria-label={`${field.group}: ${field.label} (${field.unit})`}
+            aria-invalid={error ? true : undefined}
+            aria-describedby={error ? `${field.key}-error` : undefined}
             value={drafts[field.key] ?? ""}
             onChange={(event) => setDraft(field.key, event.target.value)}
           />
@@ -137,7 +146,7 @@ export function AutoRefillSettingsOverlay({ onClose, onSaved, onError }: AutoRef
           disabled={!isOverridden}
           onClick={() => reset(field.key)}
         >Reset</button>
-        {error && <p className="danger-note" role="alert">{error}</p>}
+        {error && <p className="danger-note" id={`${field.key}-error`}>{error}</p>}
         {showEnvHint && (
           <p className="muted auto-refill-settings-hint">
             Set by {state.envNames[field.key]} ({state.defaults[field.key]}). Saving here overrides it.

--- a/console/web/src/features/bases/BasesPanel.test.tsx
+++ b/console/web/src/features/bases/BasesPanel.test.tsx
@@ -16,6 +16,8 @@ vi.mock("../../api/bases", () => ({
     cancelQueuedDelete: vi.fn(),
     pendingDeletes: vi.fn(),
     autoRefill: vi.fn(),
+    autoRefillSettings: vi.fn(),
+    saveAutoRefillSettings: vi.fn(),
     setAutoRefill: vi.fn(),
     landClaim: vi.fn(),
     updateLandClaim: vi.fn(),
@@ -682,9 +684,44 @@ describe("BasesPanel auto-refill", () => {
     };
   }
 
+  function autoRefillSettingsState() {
+    const keys = ["thresholdPercent", "intervalHours", "waterThresholdPercent", "waterIntervalHours"] as const;
+    const byKey = <T,>(value: T) => Object.fromEntries(keys.map((key) => [key, value])) as Record<typeof keys[number], T>;
+    return {
+      settings: { thresholdPercent: 50, intervalHours: 24, waterThresholdPercent: 50, waterIntervalHours: 24 },
+      sources: byKey("default" as const),
+      defaults: { thresholdPercent: 50, intervalHours: 24, waterThresholdPercent: 50, waterIntervalHours: 24 },
+      limits: byKey({ min: 1, max: 168 }),
+      envNames: byKey("ADMIN_AUTO_REFILL_THRESHOLD_PERCENT")
+    };
+  }
+
   beforeEach(() => {
     vi.mocked(basesApi.pendingRefills).mockResolvedValue({ supported: true, total: 0, pending: [], byTarget: [] });
     vi.mocked(basesApi.autoRefill).mockResolvedValue(autoRefillState());
+    vi.mocked(basesApi.autoRefillSettings).mockResolvedValue(autoRefillSettingsState());
+  });
+
+  it("puts the settings gear left of Refresh and opens the overlay", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue(queueCapableList({ base_id: "3002", name: "Sietch Enroll" }));
+    renderPanel();
+    const gear = await screen.findByRole("button", { name: "Auto-refill settings" });
+    expect(gear.nextElementSibling?.textContent).toBe("Refresh");
+
+    fireEvent.click(gear);
+    expect(await screen.findByText("Auto-refill settings", { selector: "h3" })).toBeInTheDocument();
+  });
+
+  // Without the refill queue there is no scanner to tune, so the gear goes --
+  // matching how the per-base toggles hide entirely in the same situation.
+  it("hides the settings gear when the database has no refill queue", async () => {
+    vi.mocked(basesApi.list).mockResolvedValue({
+      ...queueCapableList({ base_id: "3002", name: "Sietch NoQueue" }),
+      capabilities: { bases: true, generatorRefill: true }
+    });
+    renderPanel();
+    await screen.findByText("Sietch NoQueue");
+    expect(screen.queryByRole("button", { name: "Auto-refill settings" })).not.toBeInTheDocument();
   });
 
   async function expandRow(name: string) {

--- a/console/web/src/features/bases/BasesPanel.tsx
+++ b/console/web/src/features/bases/BasesPanel.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Boxes, ChevronDown, ChevronUp, Download, Droplet, Fuel, Grid3X3, KeyRound, Lock, Trash2, Users, X, Zap } from "lucide-react";
+import { Boxes, ChevronDown, ChevronUp, Download, Droplet, Fuel, Grid3X3, KeyRound, Lock, Settings, Trash2, Users, X, Zap } from "lucide-react";
 import { BaseInventoryTab } from "./BaseInventoryTab";
 import { BaseChildPermissionsTab } from "./BaseChildPermissionsTab";
 import { BaseLandClaimTab } from "./BaseLandClaimTab";
 import { BasePermissionsTab } from "./BasePermissionsTab";
 import { BaseWaterTab } from "./BaseWaterTab";
+import { AutoRefillSettingsOverlay } from "./AutoRefillSettingsOverlay";
 import { basesApi, type AutoRefillBase, type AutoRefillWaterBase, type RefillDeviceResult, type RefillWaterDeviceResult } from "../../api/bases";
 import { friendlyMapName } from "../maps/mapNames";
 import { mapsApi } from "../../api/maps";
@@ -422,6 +423,7 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
   const [autoRefillWaterIntervalHours, setAutoRefillWaterIntervalHours] = useState(24);
   const [savingAutoRefillWaterId, setSavingAutoRefillWaterId] = useState("");
   const [autoRefillWaterUnavailable, setAutoRefillWaterUnavailable] = useState(false);
+  const [autoRefillSettingsOpen, setAutoRefillSettingsOpen] = useState(false);
   const requestIdRef = useRef(0);
   const lastExpandedRef = useRef<string | null>(null);
   const skipNextSearchReset = useRef(true);
@@ -1344,6 +1346,17 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
           {playerId && <p className="playerAdmin_note">Bases owned by or shared with {playerName}. Expand a row to use the same tools available on the main Bases page.</p>}
         </div>
         <div className="action-row">
+          {/* Hidden in the per-player embed -- that view is one player's lens
+              and these settings are global -- and hidden without a refill
+              queue, matching the per-base toggles. */}
+          {!playerId && (canQueue || canQueueWater) && (
+            <button
+              className="bases-settings-button"
+              title="Auto-refill settings"
+              aria-label="Auto-refill settings"
+              onClick={() => setAutoRefillSettingsOpen(true)}
+            ><Settings size={16} /></button>
+          )}
           <button onClick={() => void load({ q: submittedQ, page, pageSize, sortColumn, sortDirection })}>Refresh</button>
         </div>
       </div>
@@ -1866,6 +1879,13 @@ export function BasesPanel({ onError, confirmAction, restartGate, formatMutation
           <button disabled={!hasNextPage} onClick={() => setPage(totalPages - 1)}>Last</button>
         </div>
       </div>}
+      {autoRefillSettingsOpen && <AutoRefillSettingsOverlay
+        onClose={() => setAutoRefillSettingsOpen(false)}
+        // Both tooltips interpolate these values, so they read stale until
+        // the two enrollment GETs are refetched.
+        onSaved={() => { void refreshAutoRefill(); void refreshAutoRefillWater(); }}
+        onError={onError}
+      />}
     </section>
   );
 }

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -18,6 +18,13 @@
      differently-tinted surfaces these sit on. 8.40:1, still brighter than
      the labels beneath it so title > subtitle > label survives. */
   --text-subtle: #bebcb6;
+  /* The same neutral one step further down: --text blended ~58% toward the
+     card background rather than 75%. Supporting micro-copy sat at --muted
+     (#ad9f89), which is the same warm family as the field labels above it at
+     only a few points of saturation apart, so the two ran together. A dimmer
+     NEUTRAL separates by hue instead of fighting for lightness. 5.6:1 -- still
+     AA for the 11px it is used at. */
+  --text-faint: #979692;
   --title: #ffd08a;
   --accent: #c68b4a;
   --accent-strong: #d49a5c;
@@ -2118,11 +2125,12 @@ body.debug .technical-details { display: block; }
   line-height: 1.4;
   color: var(--danger-text);
 }
-/* Square icon button in the Bases panel title, sized to match the Refresh
-   button beside it. Not a reuse of .exchange-config-button: that one is 43px
-   to line up with the Exchange search row's taller inputs, and lives in the
-   exchange section of this file. */
-.bases-settings-button { width: 41px; height: 41px; min-width: 0; padding: 0; display: inline-grid; place-items: center; }
+/* Square icon button in the Bases panel title. 43px is the measured height of
+   the Refresh button beside it (global button rule: 10px padding + 16px line
+   box + 1px border, doubled) -- anything less sits visibly inset in the
+   centre-aligned .action-row. Not a reuse of .exchange-config-button, which is
+   the same size for a different reason and lives in the exchange section. */
+.bases-settings-button { width: 43px; height: 43px; min-width: 0; padding: 0; display: inline-grid; place-items: center; }
 .auto-refill-settings-modal { width: min(500px, calc(100vw - 32px)); }
 /* .primary has no global styling inside a modal -- .exchange-config-modal
    scopes its own. Same treatment here rather than leaving Save unstyled. */
@@ -2134,7 +2142,13 @@ body.debug .technical-details { display: block; }
 .auto-refill-settings-modal .confirm-modal-actions .primary:hover:not(:disabled) { background: var(--accent-strong); border-color: var(--accent-strong); }
 .auto-refill-settings-group { display: grid; gap: 9px; }
 .auto-refill-settings-group-divided { border-top: 1px solid var(--border); padding-top: 13px; }
-.auto-refill-settings-group-title { font-size: 12px; font-weight: 500; color: var(--muted-warm); }
+.auto-refill-settings-group-title {
+  color: var(--accent);
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
 .auto-refill-settings-field-row { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 4px 10px; }
 .auto-refill-settings-field { display: flex; align-items: center; gap: 10px; font-size: 13px; }
 .auto-refill-settings-field > span:first-child { flex: 1; }
@@ -2143,6 +2157,26 @@ body.debug .technical-details { display: block; }
 .auto-refill-settings-reset { padding: 6px 10px; font-size: 12px; min-width: 0; }
 /* Errors and hints span both columns so they sit under the field, not beside
    the Reset button. */
+/* `.confirm-modal p` (0,1,1) sets its own colour, so the .danger-note and
+   .muted class rules (both 0,1,0) lose inside this modal and the validation
+   error renders in ordinary body text. Re-assert here, where the selector
+   outranks it -- and use the re-assertion to separate four tiers.
+   The title, section headings and muted copy were previously three steps of
+   the same warm amber, which reads as one blurred block however good the
+   contrast ratio is. So each tier differs from its neighbour in hue OR
+   treatment, not only in lightness:
+     title      h1-h5 -> --title  #ffd08a  amber, 18px      (unchanged)
+     subtitle   --text-subtle     #bebcb6  NEUTRAL grey     (breaks the family)
+     category   --accent          #c68b4a  amber, UPPERCASE + tracked
+     label      --text            #f3efe7  near-white body
+     footnote   --text-faint      #979692  NEUTRAL, dimmest, 11px            */
+.auto-refill-settings-modal .danger-note { color: var(--danger-text); }
+/* Direct children only: the lede and the "Loading..." line. The note is also a
+   direct child and also carries .muted, so it has to win on the same class
+   count -- hence `p.` on the two rules below and their order after this one. */
+.auto-refill-settings-modal > p.muted { color: var(--text-subtle); }
+.auto-refill-settings-modal p.auto-refill-settings-hint,
+.auto-refill-settings-modal p.auto-refill-settings-note { color: var(--text-faint); }
 .auto-refill-settings-field-row .danger-note,
 .auto-refill-settings-hint { grid-column: 1 / -1; margin: 0; font-size: 11px; line-height: 1.4; }
 .auto-refill-settings-note { margin: 0; font-size: 11px; line-height: 1.5; border-top: 1px solid var(--border); padding-top: 12px; }

--- a/console/web/src/styles.css
+++ b/console/web/src/styles.css
@@ -2118,6 +2118,34 @@ body.debug .technical-details { display: block; }
   line-height: 1.4;
   color: var(--danger-text);
 }
+/* Square icon button in the Bases panel title, sized to match the Refresh
+   button beside it. Not a reuse of .exchange-config-button: that one is 43px
+   to line up with the Exchange search row's taller inputs, and lives in the
+   exchange section of this file. */
+.bases-settings-button { width: 41px; height: 41px; min-width: 0; padding: 0; display: inline-grid; place-items: center; }
+.auto-refill-settings-modal { width: min(500px, calc(100vw - 32px)); }
+/* .primary has no global styling inside a modal -- .exchange-config-modal
+   scopes its own. Same treatment here rather than leaving Save unstyled. */
+.auto-refill-settings-modal .confirm-modal-actions .primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #1a130a;
+}
+.auto-refill-settings-modal .confirm-modal-actions .primary:hover:not(:disabled) { background: var(--accent-strong); border-color: var(--accent-strong); }
+.auto-refill-settings-group { display: grid; gap: 9px; }
+.auto-refill-settings-group-divided { border-top: 1px solid var(--border); padding-top: 13px; }
+.auto-refill-settings-group-title { font-size: 12px; font-weight: 500; color: var(--muted-warm); }
+.auto-refill-settings-field-row { display: grid; grid-template-columns: 1fr auto; align-items: center; gap: 4px 10px; }
+.auto-refill-settings-field { display: flex; align-items: center; gap: 10px; font-size: 13px; }
+.auto-refill-settings-field > span:first-child { flex: 1; }
+.auto-refill-settings-field input { width: 74px; text-align: right; }
+.auto-refill-settings-unit { width: 14px; color: var(--muted); }
+.auto-refill-settings-reset { padding: 6px 10px; font-size: 12px; min-width: 0; }
+/* Errors and hints span both columns so they sit under the field, not beside
+   the Reset button. */
+.auto-refill-settings-field-row .danger-note,
+.auto-refill-settings-hint { grid-column: 1 / -1; margin: 0; font-size: 11px; line-height: 1.4; }
+.auto-refill-settings-note { margin: 0; font-size: 11px; line-height: 1.5; border-top: 1px solid var(--border); padding-top: 12px; }
 @media (max-width: 760px) {
   .blueprint-file-field { flex-basis: 100%; max-width: none; }
   .blueprint-list-toolbar, .blueprint-list-toolbar .service-actions { align-items: stretch; }

--- a/console/web/vite.config.ts
+++ b/console/web/vite.config.ts
@@ -8,7 +8,12 @@ export default defineConfig({
     // points this at a docker-network API hostname). Defaults are unchanged from
     // the historical hardcoded values, so a plain `npm run dev` behaves exactly
     // as before.
-    port: Number(process.env.VITE_DEV_PORT) || 5173,
+    //
+    // VITE_DEV_PORT wins over PORT so live-test.sh's explicit choice is never
+    // overridden by a PORT that happens to be set in the environment; PORT is
+    // then honoured so two worktrees can each run a dev server without both
+    // trying to bind 5173.
+    port: Number(process.env.VITE_DEV_PORT || process.env.PORT) || 5173,
     proxy: {
       "/api": process.env.VITE_API_TARGET || "http://127.0.0.1:8088"
     }

--- a/docker-compose.web.yml
+++ b/docker-compose.web.yml
@@ -39,6 +39,15 @@ services:
       ADMIN_SECURE_COOKIES: "${ADMIN_SECURE_COOKIES:-0}"
       ADMIN_PASSWORD: "${ADMIN_PASSWORD:-}"
       ADMIN_TASK_RETENTION: "${ADMIN_TASK_RETENTION:-200}"
+      # Seed values for the Bases auto-refill settings. The console settings
+      # overlay writes runtime/generated/auto-refill-settings.json, which wins
+      # over these; they are the fallback when nothing has been set there.
+      # Without this passthrough the console never sees them at all -- there is
+      # no env_file here, so .env reaches the container only via this map.
+      ADMIN_AUTO_REFILL_THRESHOLD_PERCENT: "${ADMIN_AUTO_REFILL_THRESHOLD_PERCENT:-50}"
+      ADMIN_AUTO_REFILL_INTERVAL_HOURS: "${ADMIN_AUTO_REFILL_INTERVAL_HOURS:-24}"
+      ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT: "${ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT:-50}"
+      ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS: "${ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS:-24}"
       ADMIN_MARKET_HISTORY_RETENTION_DAYS: "${ADMIN_MARKET_HISTORY_RETENTION_DAYS:-0}"
       ADMIN_COMMAND_TIMEOUT_MS: "${ADMIN_COMMAND_TIMEOUT_MS:-1800000}"
       ADMIN_MAX_JSON_BYTES: "${ADMIN_MAX_JSON_BYTES:-2097152}"

--- a/docs/console-iam.md
+++ b/docs/console-iam.md
@@ -116,6 +116,20 @@ Updates that remove the owner's `settings:write` access are rejected so the loca
 
 Add and remove stay one action deliberately: two directions of the same roster knob. Both `DELETE` patterns are anchored regexes rather than prefix rules, because `/api/guilds/{id}` and `/api/guilds/{id}/members/{playerId}` share a prefix and the variable segment comes before the part that distinguishes them — the same reason `bases:delete` needs a real regex.
 
+`bases:mutate` keeps the per-base knobs — refills, permissions, custodian, auto-refill enrollment, queue cancellations — and everything below was carved out of it for consequence or consent. Unlike the namespaces above, `bases:mutate` still exists and is still the bucket most base routes resolve to.
+
+| Action | Covers |
+|---|---|
+| `bases:delete` | delete the base and everything on it |
+| `bases:delete-item` | delete one stored item |
+| `bases:bulk-delete-items` | delete several selected stacks, or clear a container |
+| `bases:add-item` | create a new stored item |
+| `bases:give-item` | give-item, give-items |
+| `bases:fill-item` | fill an existing stack to its cap |
+| `bases:write-config` | the auto-refill thresholds and scan intervals |
+
+`bases:write-config` is the consent case rather than the blast-radius one: every other action here acts on one base and is reversible on that base, whereas the thresholds and intervals govern the automation for *every* enrolled base at once. An operator granted `bases:mutate` agreed to enroll bases, not to retune the policy behind all of them. It follows the per-feature settings convention (`exchange:write-config`, `maps:write-config`). Shipped defaults are unchanged: `owner` (`*`) and `admin` (`bases:*`) reach it, and `moderator`/`player`/`observer` keep `bases:read` only, so they can read the settings but not save them.
+
 `blueprints:mutate` and `addons:mutate` were split on the same grounds.
 
 | Action | Covers |

--- a/docs/console/API-REFERENCE.md
+++ b/docs/console/API-REFERENCE.md
@@ -257,6 +257,8 @@ Player rows include `total_playtime_seconds`. The console samples `player_state.
 | DELETE | `/api/bases/{baseId}/queued-refill` | Cancel a base's queued generator refill | `baseId` |
 | GET | `/api/bases/auto-refill` | Get per-base auto-refill enrollment state | None |
 | POST | `/api/bases/{baseId}/auto-refill` | Enable/disable auto-refill for a base | `baseId`, `enabled` |
+| GET | `/api/bases/auto-refill/settings` | Get the threshold and scan interval for both auto-refill subsystems, with the source (`console`/`env`/`default`), reset value, and range of each | None |
+| POST | `/api/bases/auto-refill/settings` | Save auto-refill thresholds/intervals. A number sets, `null` resets to the env/default layer, an omitted key is unchanged. Rate limited; requires `bases:write-config`, not `bases:mutate` | `thresholdPercent?`, `intervalHours?`, `waterThresholdPercent?`, `waterIntervalHours?` |
 | GET | `/api/bases/{baseId}/water` | Get a base's water storage containers (count, volume, fill %; blood volume/fill for Blood Purifiers) | `baseId` |
 | POST | `/api/bases/{baseId}/refill-water` | Refill all base water storage (queued instead if the map isn't safely writable right now). Water only -- blood is never touched | `baseId` |
 | GET | `/api/bases/pending-water-refills` | List queued water refills, grouped by restart target | None |

--- a/docs/console/api-keys.md
+++ b/docs/console/api-keys.md
@@ -95,7 +95,7 @@ namespace" rule, so Create stays disabled until something is selected.
 | Namespace | Read grants | Read+write additionally grants |
 |---|---|---|
 | `players` | `players:read` | `delete-item`, `edit-item`, `give-item`, `grant`, `kick-all`, `moderate`, `recover`, `repair`, `reset`, `teleport`, `unclassified` |
-| `bases` | `bases:read` | `add-item`, `bulk-delete-items`, `delete`, `delete-item`, `fill-item`, `give-item`, `mutate` |
+| `bases` | `bases:read` | `add-item`, `bulk-delete-items`, `delete`, `delete-item`, `fill-item`, `give-item`, `mutate`, `write-config` |
 | `vehicles` | `vehicles:read` | `bulk-delete-items`, `delete`, `delete-item`, `mutate` |
 | `guilds` | `guilds:read` | `disband`, `membership`, `rank`, `unclassified` |
 | `storage` | `storage:read` | `mutate` |

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -97,6 +97,50 @@ Claim Editor not covered here):
   live map is queued and written at that map's next restart. See
   [`docs/console/base-child-permissions.md`](console/base-child-permissions.md).
 
+**Auto-refill** is opt-in per base, enabled from the Power tab (generators)
+and the Water tab (water storage). An enrolled base is scanned on a fixed
+interval and queued for a refill when its lowest device falls below a
+threshold; the refill itself goes through the same queue as a manual one, so
+it applies at the next safe window rather than immediately. The two
+subsystems are independent — separate enrollment lists, separate schedules —
+so enrolling a base in one does not enroll it in the other.
+
+Both are tuned from one place: the **gear icon** to the left of Refresh at the
+top of the Bases panel. It opens a settings overlay with a threshold and a scan
+interval for each subsystem. Changes apply without restarting the console, and
+are stored console-side in `runtime/generated/auto-refill-settings.json` — no
+game data is touched.
+
+| Setting | Default | Range |
+|---|---:|---|
+| Generators — queue a refill below | 50 | 1-99 % |
+| Generators — check every | 24 | 1-168 h |
+| Water — queue a refill below | 50 | 1-99 % |
+| Water — check every | 24 | 1-168 h |
+
+Each field has a **Reset**, which clears the console override and falls back to
+the environment variable (`ADMIN_AUTO_REFILL_THRESHOLD_PERCENT`,
+`ADMIN_AUTO_REFILL_INTERVAL_HOURS`, `ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT`,
+`ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS`) if one is set, or the default above.
+The precedence is settings page, then environment variable, then default. An
+out-of-range or unparseable environment variable falls back to the default
+rather than failing startup, and a blank one reads as unset.
+
+Two timing details worth knowing. **A shortened interval pulls the next scan
+in**; a lengthened one applies only after the currently scheduled scan runs.
+And **a changed threshold is used by the next scan**, not immediately — at a
+168-hour interval that can be a week away.
+
+Saving these settings is a separate permission (`bases:write-config`) from the
+per-base on/off toggle (`bases:mutate`), so an operator can be allowed to enroll
+bases without being allowed to retune the policy for all of them. The shipped
+Owner and Admin roles have both.
+
+A base that stays low after three consecutive queued refills is marked stalled
+and stops being retried (audited as `bases.auto-refill-stalled` /
+`bases.auto-refill-water-stalled`); a healthy scan clears that. A base that no
+longer exists is un-enrolled automatically.
+
 **Deleting a base** is a separate, row-level action (trash icon) — it is
 permanent and irreversible. The console shows a danger-styled confirmation
 dialog you must click through, and automatically takes a full database

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -123,8 +123,11 @@ the environment variable (`ADMIN_AUTO_REFILL_THRESHOLD_PERCENT`,
 `ADMIN_AUTO_REFILL_INTERVAL_HOURS`, `ADMIN_AUTO_REFILL_WATER_THRESHOLD_PERCENT`,
 `ADMIN_AUTO_REFILL_WATER_INTERVAL_HOURS`) if one is set, or the default above.
 The precedence is settings page, then environment variable, then default. An
-out-of-range or unparseable environment variable falls back to the default
-rather than failing startup, and a blank one reads as unset.
+unparseable environment variable falls back to the default rather than failing
+startup; an out-of-range one is clamped to the nearest bound. A blank one reads
+as unset — though on the standard Docker deployment `docker-compose.web.yml`
+substitutes its own default for a variable that is blank or missing, so a blank
+never reaches the console there.
 
 Two timing details worth knowing. **A shortened interval pulls the next scan
 in**; a lengthened one applies only after the currently scheduled scan runs.

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -129,6 +129,15 @@ as unset — though on the standard Docker deployment `docker-compose.web.yml`
 substitutes its own default for a variable that is blank or missing, so a blank
 never reaches the console there.
 
+**Upgrade note.** Until this release the four `ADMIN_AUTO_REFILL_*` variables
+never reached the console in the standard Docker deployment: the console
+service passes an explicit list of variables and these were not on it, and
+nothing loads `.env` directly. They worked only when the console was run
+outside Docker. They are now passed through, so a value you set in `.env` and
+never saw take effect **will** apply after this upgrade. If you set one while
+troubleshooting and forgot about it, check it before deploying — or set the
+value you want from the gear icon, which overrides the variable either way.
+
 Two timing details worth knowing. **A shortened interval pulls the next scan
 in**; a lengthened one applies only after the currently scheduled scan runs.
 And **a changed threshold is used by the next scan**, not immediately — at a


### PR DESCRIPTION
A gear icon left of Refresh opens a settings overlay for the four auto-refill tunables (generator and water threshold + scan interval). They were env-only and needed a console restart to change.

Settings persist to `runtime/generated/auto-refill-settings.json`, layered console file > env var > default. Both scanners already re-read these on every use, so a change applies with no restart. Reset deletes a key rather than writing the current value, so the env var is not permanently shadowed. Shortening an interval pulls the armed scan in; lengthening applies after the next scan.

Saving is gated on a new `bases:write-config` action rather than `bases:mutate`: every other action in that bucket is scoped to one base, whereas this retunes every enrolled base at once. Shipped owner/admin policies grant `bases:*`, so default access is unchanged.

Three pre-existing bugs fixed along the way:

- A blank env var resolved to the range **minimum** rather than the default — `clampInt("")` is `Number("")` → 0 → clamped to 1 — so a declared-but-blank `ADMIN_AUTO_REFILL_INTERVAL_HOURS` meant hourly scans instead of daily.
- `config.js` repaired ownership of `auto-refill-bases.json` but never `auto-refill-water-bases.json`.
- The four `ADMIN_AUTO_REFILL_*` variables never reached the console under Docker: there is no `env_file` in the compose stack and they were not in the console service's `environment:` list, so they only ever worked bare-host. They are now passed through, which means a value an operator set and never saw take effect will apply after this upgrade — called out as an upgrade note in the operator guide.

API suite 1951 pass, web 774 pass, `tsc -b` and build clean.