### PR TITLE
Stop reporting a lone Postgres as a starting Battlegroup

### DIFF
--- a/console/web/src/features/server/ServerPanels.battlegroupState.test.ts
+++ b/console/web/src/features/server/ServerPanels.battlegroupState.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { getHomeServerState, isGameStackDown } from "./ServerPanels";
+
+// Verbatim from a host after a system restore: the console started Postgres
+// itself, and nothing else in the Battlegroup is up. Every field the state
+// functions read is present, so this pins the real case rather than a sketch.
+const restoredHostStatus = [
+  "=== Dune status ===",
+  "Overall:     ISSUE",
+  "Title:       SteelHeart",
+  "Battlegroup: sh-372e084875362ee5-krlquy",
+  "",
+  "=== Containers ===",
+  "SERVICE                    STATUS",
+  "dune-postgres              Up 31 minutes",
+  "dune-rmq-admin             missing",
+  "dune-rmq-game              missing",
+  "dune-text-router           missing",
+  "dune-director              missing",
+  "dune-server-gateway        missing",
+  "dune-server-survival-1     missing",
+  "dune-server-overmap        missing",
+  "dune-coriolis-coordinator  Up 31 minutes",
+  "dune-orchestrator          Up 33 minutes",
+  "",
+  "=== Game servers ===",
+  "MAP          STATE        UPTIME",
+  "Survival_1   NOT RUNNING  missing",
+  "Overmap      NOT RUNNING  missing"
+].join("\n");
+
+const runningStatus = restoredHostStatus
+  .replace(/dune-rmq-admin             missing/, "dune-rmq-admin             Up 5 minutes")
+  .replace(/dune-server-survival-1     missing/, "dune-server-survival-1     Up 4 minutes")
+  .replace(/dune-server-overmap        missing/, "dune-server-overmap        Up 4 minutes");
+
+describe("Battlegroup state on a host where only Postgres is up", () => {
+  it("reports the Battlegroup stopped, not starting", () => {
+    // Postgres, the orchestrator and the coordinator all run without a
+    // Battlegroup, so on their own they were enough to report "starting"
+    // forever -- which disabled Start on a host that was not running.
+    const state = getHomeServerState(restoredHostStatus, "");
+    expect(state.stopped).toBe(true);
+    expect(state.starting).toBe(false);
+    expect(state.running).toBe(false);
+  });
+
+  it("names the state rather than reporting a bare Stopped over a live database", () => {
+    // The console starts Postgres itself for backups and restores and leaves it
+    // up, so this is a state it creates on purpose.
+    expect(getHomeServerState(restoredHostStatus, "").databaseOnly).toBe(true);
+  });
+
+  it("is not database-only once the game stack is up", () => {
+    expect(getHomeServerState(runningStatus, "").databaseOnly).toBe(false);
+  });
+
+  it("is not database-only when Postgres is down too", () => {
+    const allDown = restoredHostStatus.replace("dune-postgres              Up 31 minutes", "dune-postgres              missing");
+    const state = getHomeServerState(allDown, "");
+    expect(state.databaseOnly).toBe(false);
+    expect(state.stopped).toBe(true);
+  });
+
+  it("still sees a starting Battlegroup once the game stack comes up", () => {
+    const state = getHomeServerState(runningStatus, "");
+    expect(state.stopped).toBe(false);
+    expect(state.starting || state.running).toBe(true);
+  });
+});
+
+describe("isGameStackDown", () => {
+  it("is true when every game container is missing, whatever else is up", () => {
+    expect(isGameStackDown(restoredHostStatus)).toBe(true);
+  });
+
+  it("is false as soon as one game container is up", () => {
+    expect(isGameStackDown(runningStatus)).toBe(false);
+  });
+
+  it("is false when the container list is partial, rather than guessing", () => {
+    const partial = [
+      "=== Containers ===",
+      "SERVICE                    STATUS",
+      "dune-postgres              Up 2 minutes",
+      "dune-rmq-admin             missing"
+    ].join("\n");
+    expect(isGameStackDown(partial)).toBe(false);
+  });
+});

--- a/console/web/src/features/server/ServerPanels.tsx
+++ b/console/web/src/features/server/ServerPanels.tsx
@@ -1431,7 +1431,7 @@ function summarizeHomeStatus(status: string, readiness: string, readinessWarning
     ? restartStartObserved ? "Starting" : "Restarting Battlegroup"
     : runningAction === "stop" ? "Stopping" : isStarting ? "Starting" : "";
   const warmingOverall = /^Warming$/i.test(rawGames.label) ? "Warming" : "";
-  const overall = readinessReady && !runningAction ? "OK" : isStarting ? transitionOverall : runningAction ? transitionOverall : serverState.stopped || actionStopped ? "Stopped" : coreReadyWithReview ? "Needs Review" : warmingOverall || liveOverall;
+  const overall = readinessReady && !runningAction ? "OK" : isStarting ? transitionOverall : runningAction ? transitionOverall : serverState.databaseOnly && !actionStopped ? "Database Only" : serverState.stopped || actionStopped ? "Stopped" : coreReadyWithReview ? "Needs Review" : warmingOverall || liveOverall;
   const attentionHealth = !isStarting && !restartSuccessAwaitingFreshStatus && (serverState.stopped || actionStopped || actionFailed) ? attentionHomeHealthCards() : null;
   const transitionAction: "start" | "stop" | "restart" | "" = restartStartObserved
     ? "start"
@@ -1692,6 +1692,29 @@ function isHomeStartComplete(status: string, readiness: string) {
   return containersReady && listenersReady && databaseReady && flsReady && rabbitReady;
 }
 
+// dune-postgres, dune-orchestrator and dune-coriolis-coordinator all run
+// without a Battlegroup -- the console starts Postgres by itself for backups
+// and restores -- so none of them says whether the Battlegroup is up. Only the
+// game stack does.
+const gameStackContainers = [
+  "dune-rmq-admin",
+  "dune-rmq-game",
+  "dune-text-router",
+  "dune-director",
+  "dune-server-gateway",
+  "dune-server-survival-1",
+  "dune-server-overmap"
+];
+
+export function isGameStackDown(status: string) {
+  const containerLines = sectionLines(status, "Containers").filter((line) => !/^SERVICE\s+STATUS/i.test(line));
+  const reported = gameStackContainers.filter((name) => containerLines.some((line) => containerStatusLineHas(name, line, /.*/)));
+  // A partial container list is not evidence of anything.
+  if (reported.length < gameStackContainers.length) return false;
+  return gameStackContainers.every((name) => containerLines.some((line) =>
+    containerStatusLineHas(name, line, /\b(missing|stopped|exited|dead|not running)\b/i)));
+}
+
 export function containerStatusLineHas(containerName: string, line: string, statusPattern: RegExp) {
   const trimmed = line.trim();
   const firstSpace = trimmed.search(/\s/);
@@ -1733,7 +1756,7 @@ function preferKnownHomeHealth(primary: { label: string; status: string; detail:
   return /^Unknown$/i.test(primary.label) && !/^Unknown$/i.test(fallback.label) ? fallback : primary;
 }
 
-function getHomeServerState(status: string, readiness: string) {
+export function getHomeServerState(status: string, readiness: string) {
   const text = `${status}\n${readiness}`;
   const overall = findLineValue(status, ["overall"]);
   const containerLines = sectionLines(status, "Containers").filter((line) => !/^SERVICE\s+STATUS/i.test(line));
@@ -1758,12 +1781,19 @@ function getHomeServerState(status: string, readiness: string) {
     /\bNo\s+(running\s+)?containers\b/i.test(text),
     /\b(all|dune)\s+containers\s+(are\s+)?(stopped|down)\b/i.test(text),
     allContainersMissing,
-    publishOnlyPartialState
+    publishOnlyPartialState,
+    isGameStackDown(status)
   ];
+  // A state the console creates on purpose: it starts Postgres by itself for
+  // backups and restores, and leaves it up. Calling that plainly "stopped"
+  // hides a running database, and calling it "starting" was the bug this
+  // replaces -- nothing is starting.
+  const databaseUp = containerLines.some((line) => containerStatusLineHas("dune-postgres", line, /^Up\b/i));
+  const databaseOnly = databaseUp && isGameStackDown(status);
   const stopped = !bootStarting && stoppedSignals.some(Boolean);
   const running = !stopped && runningSignals.some(Boolean);
   const starting = bootStarting || (!stopped && !running && coreRuntimeContainerUp && (/\bUp\s+\d+/i.test(text) || /\b(WARMING|WAIT|STARTING)\b/i.test(text)));
-  return { running, stopped, starting };
+  return { running, stopped, starting, databaseOnly };
 }
 
 function isHomeBootStarting(status: string, readiness: string) {
@@ -1771,6 +1801,7 @@ function isHomeBootStarting(status: string, readiness: string) {
   if (!text.trim()) return false;
   if (/\b(server|stack)\s+(is\s+)?(stopped|offline)\b/i.test(text) || /\bNo\s+(running\s+)?containers\b/i.test(text)) return false;
   if (/Overall:\s*(READY|STOPPED|OFFLINE)/i.test(status) || /^READY:/m.test(readiness)) return false;
+  if (isGameStackDown(status)) return false;
   const containerLines = sectionLines(status, "Containers").filter((line) => !/^SERVICE\s+STATUS/i.test(line));
   const anyContainerUp = containerLines.some((line) => /\bUp\b/i.test(line));
   const coreStartupContainerUp = containerLines.some((line) =>
@@ -1795,6 +1826,7 @@ function homeOverallBadge(value: string) {
   const normalized = String(value || "").trim().toLowerCase();
   if (/\b(restarting|restart|stopping|starting)\b/.test(normalized)) return "WARN";
   if (/^stopped$/i.test(value)) return "WARN";
+  if (/^database only$/i.test(value)) return "WARN";
   if (/^issue(?: detected)?$/i.test(value)) return "WARN";
   if (/warming/i.test(value)) return "Info";
   if (/stopped|not running|offline/i.test(value)) return "WARN";


### PR DESCRIPTION
On a host where Postgres is up but the Battlegroup is not, the console reported the Battlegroup as **starting** — permanently — and disabled Start. There was then no way to start the server from the console, and every appearance that something was wrong.

`isHomeBootStarting` ends in `return coreStartupContainerUp || …`, and that pattern lists `dune-postgres`. A lone database made it true, which forces `stopped` to false and `starting` to true in `getHomeServerState` regardless of everything else.

`getHomeServerState` could not correct it either: its only route to `stopped` required *every* container to be missing, including `dune-orchestrator` and `dune-coriolis-coordinator` — which the console keeps running by design, so on a console-managed host that is close to unreachable.

### Changes

- `isGameStackDown()` decides on the seven game containers alone (`rmq-admin`, `rmq-game`, `text-router`, `director`, `server-gateway`, `server-survival-1`, `server-overmap`). Both functions consult it. It returns false on a partial container list rather than guessing.
- Home reports **"Database Only"** rather than a bare "Stopped" when the database is up and the game stack is not. That state is one the console creates on purpose — it starts Postgres itself for backups and restores and leaves it up — so flattening it into "Stopped" hides a running database, and calling it "starting" was the bug.

### How to reproduce on a real host

Any state where Postgres is up and the game stack is not: after a backup or restore, or after `runtime/scripts/start-postgres.sh` on its own. Home shows `Overall: ISSUE` with Start greyed out.

### Testing

`console/web` 909/909, typecheck and build clean. The new test uses a real `dune status` capture verbatim rather than a sketch, so it pins the actual case; removing either call site of `isGameStackDown` fails exactly the case that owns it.
